### PR TITLE
[WEB-4100, WEB-4104] fix: handle position-place by rolling up to parent

### DIFF
--- a/dbt/project/models/intermediate/int__enhanced_race.sql
+++ b/dbt/project/models/intermediate/int__enhanced_race.sql
@@ -89,6 +89,10 @@ with
                 then left(tbl_position.geo_id, 2)  -- District Court
                 when tbl_position.mtfcc = 'X0027'
                 then left(tbl_position.geo_id, 5)  -- Fire District
+                when tbl_position.mtfcc = 'X0026'
+                then left(tbl_position.geo_id, 5)  -- Justice Precinct
+                when tbl_position.mtfcc = 'X0025'
+                then left(tbl_position.geo_id, 7)  -- Neighborhood Council District; Washington, DC
                 else tbl_position.geo_id
             end as position_to_place_geo_id,
             tbl_position.mtfcc as position_mtfcc,

--- a/dbt/project/models/intermediate/int__enhanced_race.sql
+++ b/dbt/project/models/intermediate/int__enhanced_race.sql
@@ -109,7 +109,7 @@ with
                 when tbl_position.mtfcc = 'G5210'
                 then left(tbl_position.geo_id, 2)  -- State Legistlative District (upper)
                 when tbl_position.mtfcc = 'X0102'
-                then left(tbl_position.geo_id, 7)  -- Secondary School District Subdistrict
+                then left(tbl_position.geo_id, 7)  -- Unified School District Subdistrict
                 when tbl_position.mtfcc = 'X0010'
                 then left(tbl_position.geo_id, 2)  -- Circuit Court
                 else tbl_position.geo_id

--- a/dbt/project/models/intermediate/int__enhanced_race.sql
+++ b/dbt/project/models/intermediate/int__enhanced_race.sql
@@ -197,6 +197,7 @@ with
             tbl_race.position_to_place_geo_id,
             tbl_place.id as place_id,
             tbl_place.name as place_name,
+            tbl_place.place_name_slug,
             tbl_race.position_names
         from enhanced_race as tbl_race
         left join
@@ -236,6 +237,7 @@ select
     position_to_place_geo_id,
     place_id,
     place_name,
+    place_name_slug,
     -- place_id_by_pos_geo_id,
     -- place_name_by_pos_geo_id,
     -- place_id_most_specific_geo_id,

--- a/dbt/project/models/intermediate/int__enhanced_race.sql
+++ b/dbt/project/models/intermediate/int__enhanced_race.sql
@@ -36,35 +36,35 @@ with
         lateral view explode(filing_periods) as fp
         group by race_database_id
     ),
-    position_to_place as (
-        select
-            tbl_pos.database_id as position_database_id,
-            tbl_place.database_id as place_database_id,
-            tbl_place.geo_id as place_geo_id,
-            tbl_place.mtfcc as place_mtfcc,
-            tbl_place.name as place_name
-        from {{ ref("stg_airbyte_source__ballotready_api_position") }} as tbl_pos
-        left join
-            {{ ref("int__ballotready_position_to_place") }} as tbl_pos2place
-            on tbl_pos.database_id = tbl_pos2place.position_database_id
-        left join
-            {{ ref("stg_airbyte_source__ballotready_api_place") }} as tbl_place
-            on tbl_pos2place.place_database_id = tbl_place.database_id
-    ),
-    position_to_most_specific_place as (
-        select
-            position_database_id,
-            place_database_id,
-            place_geo_id,
-            place_mtfcc,
-            place_name
-        from position_to_place
-        qualify
-            row_number() over (
-                partition by position_database_id order by len(place_geo_id) desc
-            )
-            = 1
-    ),
+    -- position_to_place as (
+    -- select
+    -- tbl_pos.database_id as position_database_id,
+    -- tbl_place.database_id as place_database_id,
+    -- tbl_place.geo_id as place_geo_id,
+    -- tbl_place.mtfcc as place_mtfcc,
+    -- tbl_place.name as place_name
+    -- from {{ ref("stg_airbyte_source__ballotready_api_position") }} as tbl_pos
+    -- left join
+    -- {{ ref("int__ballotready_position_to_place") }} as tbl_pos2place
+    -- on tbl_pos.database_id = tbl_pos2place.position_database_id
+    -- left join
+    -- {{ ref("stg_airbyte_source__ballotready_api_place") }} as tbl_place
+    -- on tbl_pos2place.place_database_id = tbl_place.database_id
+    -- ),
+    -- position_to_most_specific_place as (
+    -- select
+    -- position_database_id,
+    -- place_database_id,
+    -- place_geo_id,
+    -- place_mtfcc,
+    -- place_name
+    -- from position_to_place
+    -- qualify
+    -- row_number() over (
+    -- partition by position_database_id order by len(place_geo_id) desc
+    -- )
+    -- = 1
+    -- ),
     enhanced_race as (
         select
             {{ generate_salted_uuid(fields=["tbl_race.id"], salt="ballotready") }}
@@ -95,14 +95,34 @@ with
             tbl_filing_period.start_on as filing_date_start,
             tbl_filing_period.end_on as filing_date_end,
             tbl_position.geo_id as position_geo_id,
-            tbl_place_by_position_geo_id.id as place_id_by_pos_geo_id,
-            tbl_place_by_position_geo_id.name as place_name_by_pos_geo_id,
-            tbl_place_by_position_geo_id.place_name_slug as place_slug_by_pos_geo_id,
-            tbl_position_to_place.place_geo_id as geo_id_most_specific_geo_id,
-            tbl_position_to_place.place_name as place_name_most_specific_geo_id,
-            tbl_place_most_specific_geo_id.id as place_id_most_specific_geo_id,
-            tbl_place_most_specific_geo_id.place_name_slug
-            as place_slug_most_specific_geo_id,
+            -- For some MTFCCs, need to roll up to parent geo_id of the position to
+            -- get the correct place by geo_id
+            -- see:
+            -- https://docs.google.com/spreadsheets/d/1t1U2oECqFRKPUVO7HYI2me-YzDgtvjbPzp5h9BqKHcU/edit?gid=0#gid=0
+            case
+                when tbl_position.mtfcc = 'X0005'
+                then left(tbl_position.geo_id, 5)  -- County Legislative District
+                when tbl_position.mtfcc = 'G5220'
+                then left(tbl_position.geo_id, 2)  -- State Legislative District (lower)
+                when tbl_position.mtfcc = 'X0001'
+                then left(tbl_position.geo_id, 7)  -- City Council District
+                when tbl_position.mtfcc = 'G5210'
+                then left(tbl_position.geo_id, 2)  -- State Legistlative District (upper)
+                when tbl_position.mtfcc = 'X0102'
+                then left(tbl_position.geo_id, 7)  -- Secondary School District Subdistrict
+                when tbl_position.mtfcc = 'X0010'
+                then left(tbl_position.geo_id, 2)  -- Circuit Court
+                else tbl_position.geo_id
+            end as position_to_place_geo_id,
+            tbl_position.mtfcc as position_mtfcc,
+            -- tbl_place_by_position_geo_id.id as place_id_by_pos_geo_id,
+            -- tbl_place_by_position_geo_id.name as place_name_by_pos_geo_id,
+            -- tbl_place_by_position_geo_id.place_name_slug as place_slug_by_pos_geo_id,
+            -- tbl_position_to_place.place_geo_id as geo_id_most_specific_geo_id,
+            -- tbl_position_to_place.place_name as place_name_most_specific_geo_id,
+            -- tbl_place_most_specific_geo_id.id as place_id_most_specific_geo_id,
+            -- tbl_place_most_specific_geo_id.place_name_slug
+            -- as place_slug_most_specific_geo_id,
             tbl_race_to_positions.position_names
         from {{ ref("stg_airbyte_source__ballotready_api_race") }} as tbl_race
         left join
@@ -111,9 +131,10 @@ with
         left join
             {{ ref("stg_airbyte_source__ballotready_api_position") }} as tbl_position
             on tbl_race.position.databaseid = tbl_position.database_id
-        left join
-            {{ ref("int__enhanced_place") }} as tbl_place_by_position_geo_id
-            on tbl_position.geo_id = tbl_place_by_position_geo_id.geo_id
+        -- left join
+        -- {{ ref("int__enhanced_place") }} as tbl_place_by_position_geo_id
+        -- on tbl_position.geo_id = tbl_place_by_position_geo_id.geo_id
+        -- and tbl_position.mtfcc = tbl_place_by_position_geo_id.mtfcc
         left join
             {{ ref("int__ballotready_normalized_position") }} as tbl_normalized_position
             on tbl_position.normalized_position.`databaseId`
@@ -127,19 +148,60 @@ with
         left join
             {{ ref("int__ballotready_filing_period") }} as tbl_filing_period
             on tbl_fp.filing_period_database_id = tbl_filing_period.database_id
-        left join
-            position_to_most_specific_place as tbl_position_to_place
-            on tbl_position.database_id = tbl_position_to_place.position_database_id
-        left join
-            {{ ref("int__enhanced_place") }} as tbl_place_most_specific_geo_id
-            on tbl_position_to_place.place_database_id
-            = tbl_place_most_specific_geo_id.br_database_id
+        -- left join
+        -- position_to_most_specific_place as tbl_position_to_place
+        -- on tbl_position.database_id = tbl_position_to_place.position_database_id
+        -- left join
+        -- {{ ref("int__enhanced_place") }} as tbl_place_most_specific_geo_id
+        -- on tbl_position_to_place.place_database_id
+        -- = tbl_place_most_specific_geo_id.br_database_id
         left join
             {{ ref("int__race_to_positions") }} as tbl_race_to_positions
             on tbl_race.database_id = tbl_race_to_positions.race_database_id
         {% if is_incremental() %}
             where tbl_race.updated_at > (select max(updated_at) from {{ this }})
         {% endif %}
+    ),
+    -- TODO: use the position_geo_id to get the place_id_by_pos_geo_id after
+    -- constructing on cases above
+    race_w_place as (
+        select
+            tbl_race.id,
+            tbl_race.br_hash_id,
+            tbl_race.br_database_id,
+            tbl_race.is_primary,
+            tbl_race.is_runoff,
+            tbl_race.created_at,
+            tbl_race.updated_at,
+            tbl_race.election_date,
+            tbl_race.`state`,
+            tbl_race.position_level,
+            tbl_race.normalized_position_name,
+            tbl_race.position_name,
+            tbl_race.position_description,
+            tbl_race.filing_office_address,
+            tbl_race.filing_phone_number,
+            tbl_race.paperwork_instructions,
+            tbl_race.filing_requirements,
+            tbl_race.partisan_type,
+            tbl_race.employment_type,
+            tbl_race.eligibility_requirements,
+            tbl_race.salary,
+            tbl_race.sub_area_name,
+            tbl_race.sub_area_value,
+            tbl_race.frequency,
+            tbl_race.filing_date_start,
+            tbl_race.filing_date_end,
+            tbl_race.position_geo_id,
+            tbl_race.position_mtfcc,
+            tbl_race.position_to_place_geo_id,
+            tbl_place.id as place_id,
+            tbl_place.name as place_name,
+            tbl_race.position_names
+        from enhanced_race as tbl_race
+        left join
+            {{ ref("int__enhanced_place") }} as tbl_place
+            on tbl_race.position_to_place_geo_id = tbl_place.geo_id
     )
 
 select
@@ -170,12 +232,16 @@ select
     filing_date_start,
     filing_date_end,
     position_geo_id,
-    place_id_by_pos_geo_id,
-    place_name_by_pos_geo_id,
-    place_id_most_specific_geo_id,
-    place_slug_by_pos_geo_id,
-    geo_id_most_specific_geo_id,
-    place_name_most_specific_geo_id,
-    place_slug_most_specific_geo_id,
+    position_mtfcc,
+    position_to_place_geo_id,
+    place_id,
+    place_name,
+    -- place_id_by_pos_geo_id,
+    -- place_name_by_pos_geo_id,
+    -- place_id_most_specific_geo_id,
+    -- place_slug_by_pos_geo_id,
+    -- geo_id_most_specific_geo_id,
+    -- place_name_most_specific_geo_id,
+    -- place_slug_most_specific_geo_id,
     position_names
-from enhanced_race
+from race_w_place

--- a/dbt/project/models/mart/election_api/m_election_api.yaml
+++ b/dbt/project/models/mart/election_api/m_election_api.yaml
@@ -46,7 +46,11 @@ models:
           - unique
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-
+      - name: slug
+        description: "Slug of the place"
+        tests:
+          - not_null
+          - unique
       - name: br_database_id
         description: "Database ID of the `place` from BallotReady"
         tests:

--- a/dbt/project/models/mart/election_api/m_election_api.yaml
+++ b/dbt/project/models/mart/election_api/m_election_api.yaml
@@ -57,3 +57,8 @@ models:
           - relationships:
               to: ref('int__enhanced_place')
               field: br_database_id
+      - name: geoid
+        description: "Geo ID of the place"
+        tests:
+          - not_null
+          - unique

--- a/dbt/project/models/mart/election_api/m_election_api__place.sql
+++ b/dbt/project/models/mart/election_api/m_election_api__place.sql
@@ -9,11 +9,12 @@
 
 with
     place_ids_in_races as (
-        select distinct place_id_by_pos_geo_id as place_id
-        from {{ ref("int__enhanced_race") }}
-        union
-        select distinct place_id_most_specific_geo_id as place_id
-        from {{ ref("int__enhanced_race") }}
+        select distinct place_id from {{ ref("int__enhanced_race") }}
+    -- select distinct place_id_by_pos_geo_id as place_id
+    -- from {{ ref("int__enhanced_race") }}
+    -- union
+    -- select distinct place_id_most_specific_geo_id as place_id
+    -- from {{ ref("int__enhanced_race") }}
     ),
     parent_ids as (
         select distinct parent_id

--- a/dbt/project/models/mart/election_api/m_election_api__place.sql
+++ b/dbt/project/models/mart/election_api/m_election_api__place.sql
@@ -10,11 +10,6 @@
 with
     place_ids_in_races as (
         select distinct place_id from {{ ref("int__enhanced_race") }}
-    -- select distinct place_id_by_pos_geo_id as place_id
-    -- from {{ ref("int__enhanced_race") }}
-    -- union
-    -- select distinct place_id_most_specific_geo_id as place_id
-    -- from {{ ref("int__enhanced_race") }}
     ),
     parent_ids as (
         select distinct parent_id

--- a/dbt/project/models/mart/election_api/m_election_api__race.sql
+++ b/dbt/project/models/mart/election_api/m_election_api__race.sql
@@ -38,9 +38,8 @@ select
     place_id,
     replace(
         concat(
-            coalesce(place_slug_by_pos_geo_id, place_slug_most_specific_geo_id),
-            '/',
-            {{ slugify("normalized_position_name") }}
+            -- coalesce(place_slug_by_pos_geo_id, place_slug_most_specific_geo_id),
+            place_name_slug, '/', {{ slugify("normalized_position_name") }}
         ),
         '-ccd',
         ''

--- a/dbt/project/models/mart/election_api/m_election_api__race.sql
+++ b/dbt/project/models/mart/election_api/m_election_api__race.sql
@@ -34,7 +34,8 @@ select
     sub_area_name,
     sub_area_value,
     frequency,
-    coalesce(place_id_by_pos_geo_id, place_id_most_specific_geo_id) as place_id,
+    -- coalesce(place_id_by_pos_geo_id, place_id_most_specific_geo_id) as place_id,
+    place_id,
     replace(
         concat(
             coalesce(place_slug_by_pos_geo_id, place_slug_most_specific_geo_id),
@@ -47,8 +48,8 @@ select
     position_names
 from {{ ref("int__enhanced_race") }}
 where
-    coalesce(place_id_by_pos_geo_id, place_id_most_specific_geo_id)
-    in (select id from {{ ref("m_election_api__place") }})
+    -- coalesce(place_id_by_pos_geo_id, place_id_most_specific_geo_id)
+    place_id in (select id from {{ ref("m_election_api__place") }})
     and election_date > current_date()
     {% if is_incremental() %}
         and updated_at > (select max(updated_at) from {{ this }})

--- a/dbt/project/models/mart/election_api/m_election_api__race.sql
+++ b/dbt/project/models/mart/election_api/m_election_api__race.sql
@@ -34,20 +34,15 @@ select
     sub_area_name,
     sub_area_value,
     frequency,
-    -- coalesce(place_id_by_pos_geo_id, place_id_most_specific_geo_id) as place_id,
     place_id,
     replace(
-        concat(
-            -- coalesce(place_slug_by_pos_geo_id, place_slug_most_specific_geo_id),
-            place_name_slug, '/', {{ slugify("normalized_position_name") }}
-        ),
+        concat(place_name_slug, '/', {{ slugify("normalized_position_name") }}),
         '-ccd',
         ''
     ) as slug,
     position_names
 from {{ ref("int__enhanced_race") }}
 where
-    -- coalesce(place_id_by_pos_geo_id, place_id_most_specific_geo_id)
     place_id in (select id from {{ ref("m_election_api__place") }})
     and election_date > current_date()
     {% if is_incremental() %}


### PR DESCRIPTION
I clicked around in dev to confirm that state level positions don't fall under a county or municipality level.

* Example 1: Let's take `State Representative` in Arkansas as an example. Currently in prod it falls under the county level (https://goodparty.org/elections/ar/arkansas-county). In dev, it now falls under the state level (https://dev.goodparty.org/elections/ar)

* Example 2: Under Tennessee in prod, we only see 2 state positions (https://goodparty.org/elections/tn). In dev, we see 5 (https://dev.goodparty.org/elections/tn). I couldn't track down exactly where those state positions got pushed down in prod, but we were taking the "most specific place by geo_id", which essentially means it got pushed down somewhere into a district municipality.

This implementation reduced the number of races by a small amount from 247k -> 241k, but the associated place matches are of higher quality.

After merging to prod, I'll need to truncate the data in the prod db and rerun the loading job.