### PR TITLE
Add income as integer to people api mart

### DIFF
--- a/dbt/project/models/mart/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/mart/people_api/m_people_api__voter.sql
@@ -34,7 +34,7 @@ with
             `ConsumerData_Estimated_Income_Amount` as `Estimated_Income_Amount`,
             cast(
                 regexp_replace(
-                    `ConsumerData_Estimated_Income_Amount`, '[^0-9]', ''
+                    `ConsumerData_Estimated_Income_Amount`, '[^0-9.]', ''
                 ) as int
             ) as `Estimated_Income_Amount_Int`,
             `EthnicGroups_EthnicGroup1Desc`,

--- a/dbt/project/models/mart/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/mart/people_api/m_people_api__voter.sql
@@ -32,6 +32,11 @@ with
             `Voters_CountyVoterID` as `CountyVoterID`,
             `ConsumerData_Education_Of_Person` as `Education_Of_Person`,
             `ConsumerData_Estimated_Income_Amount` as `Estimated_Income_Amount`,
+            cast(
+                regexp_replace(
+                    `ConsumerData_Estimated_Income_Amount`, '[^0-9]', ''
+                ) as int
+            ) as `Estimated_Income_Amount_Int`,
             `EthnicGroups_EthnicGroup1Desc`,
             `Ethnic_Description`,
             `ConsumerData_Homeowner_Probability_Model` as `Homeowner_Probability_Model`,
@@ -449,6 +454,7 @@ with
             tbl_updated.`CountyVoterID`,
             tbl_updated.`Education_Of_Person`,
             tbl_updated.`Estimated_Income_Amount`,
+            tbl_updated.`Estimated_Income_Amount_Int`,
             tbl_updated.`EthnicGroups_EthnicGroup1Desc`,
             tbl_updated.`Ethnic_Description`,
             tbl_updated.`Homeowner_Probability_Model`,

--- a/dbt/project/models/write/write__l2_databricks_to_people_api.py
+++ b/dbt/project/models/write/write__l2_databricks_to_people_api.py
@@ -35,6 +35,7 @@ VOTER_COLUMN_LIST: list = [
     "CountyVoterID",
     "Education_Of_Person",
     "Estimated_Income_Amount",
+    "Estimated_Income_Amount_Int",
     "EthnicGroups_EthnicGroup1Desc",
     "Ethnic_Description",
     "Homeowner_Probability_Model",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `Estimated_Income_Amount_Int` (cleaned/casted from `Estimated_Income_Amount`) to the voter mart and includes it in the write pipeline.
> 
> - **People API – Voter mart**:
>   - Add `Estimated_Income_Amount_Int` by regex-cleaning and casting `Estimated_Income_Amount` to int in `models/mart/people_api/m_people_api__voter.sql` and select it in the final output.
> - **Write pipeline**:
>   - Include `Estimated_Income_Amount_Int` in `VOTER_COLUMN_LIST` in `models/write/write__l2_databricks_to_people_api.py` for upsert to `Voter` table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 184cab079b2cf20e283f60a40d78c227469e58cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->