### PR TITLE
Add L2 uniform schema preflight and self-contained drift remediation skill

### DIFF
--- a/.claude/skills/l2-uniform-drift-remediator/SKILL.md
+++ b/.claude/skills/l2-uniform-drift-remediator/SKILL.md
@@ -5,36 +5,40 @@ description: Triage and safely remediate L2 uniform schema drift using `l2_unifo
 
 # L2 Uniform Drift Remediator
 
-Use this workflow to convert preflight output into safe actions.
+Use this workflow to convert post-failure preflight output into safe actions.
 
 ## Workflow
 
 All script paths below are repo-root-relative.
 
-1. Locate the preflight or dbt run log that contains `L2_PREFLIGHT|` JSON lines.
-2. Run the failure handler (recommended):
+1. If a build fails, run preflight to collect full drift visibility:
+```bash
+dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'
+```
+2. Download the preflight log containing `L2_PREFLIGHT|` JSON lines.
+3. Run the failure handler (recommended):
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
-  --log-file /path/to/dbt_failure.log \
+  --log-file /path/to/preflight.log \
   --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler
 ```
-3. Parse and classify findings (manual mode):
+4. Parse and classify findings (manual mode):
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py analyze --log-file /path/to/log
 ```
-4. Generate the concrete remediation plan:
+5. Generate the concrete remediation plan:
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py plan --log-file /path/to/log
 ```
-5. Execute safe fixes only when findings are limited to state staging drift (`stg_minus_src`, `src_minus_stg`):
+6. Execute safe fixes only when findings are limited to state staging drift (`stg_minus_src`, `src_minus_stg`):
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py plan \
   --log-file /path/to/log \
   --execute-safe \
   --dbt-project-path /path/to/gp-data-platform/dbt/project
 ```
-6. If `target_minus_src` or `relation_missing` exists, stop auto-fix and produce manual remediation steps.
-7. If `target_minus_src` includes `int__l2_nationwide_uniform`, apply approved column deprecations to both:
+7. If `target_minus_src` or `relation_missing` exists, stop auto-fix and produce manual remediation steps.
+8. If `target_minus_src` includes `int__l2_nationwide_uniform`, apply approved column deprecations to both:
 - `int__l2_nationwide_uniform`
 - `int__l2_nationwide_uniform_w_haystaq`
 Then rerun strict preflight.
@@ -47,7 +51,6 @@ Then rerun strict preflight.
 - Auto-execute only:
   - targeted staging rebuilds for impacted states
   - strict preflight rerun
-  - downstream model rerun only when manual gate conditions are absent
 
 ## Inputs and Outputs
 
@@ -64,17 +67,6 @@ Output:
 This skill itself does not run inside dbt Cloud unless you call its script from a dbt Cloud job command environment that has Python and this repo checked out.
 
 To surface drift context directly in dbt Cloud logs, rely on the preflight macro logging (`L2_PREFLIGHT|...`).
-
-`agents/openai.yaml` is intentionally UI metadata only (display name, description, default prompt), not a runtime execution config.
-
-## Daily dbt Cloud Job Integration
-
-Use this command order in the dbt Cloud job:
-
-1. `dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'`
-2. `dbt build --exclude="tag:dbt_source tag:l2_s3 tag:weekly write__l2_databricks_to_gp_api"`
-
-If command 1 fails, dbt Cloud logs already contain parseable `L2_PREFLIGHT|` lines for triage.
 
 ## Log Capture and PR Guidance
 

--- a/.claude/skills/l2-uniform-drift-remediator/SKILL.md
+++ b/.claude/skills/l2-uniform-drift-remediator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: l2-uniform-drift-remediator
-description: Triage and safely remediate L2 uniform schema drift using `l2_uniform_schema_preflight` output. Use when dbt runs touching `int__l2_nationwide_uniform` or `int__l2_nationwide_uniform_w_haystaq` fail, or when `L2_PREFLIGHT|` lines report drift (`stg_minus_src`, `src_minus_stg`, `target_minus_src`, `relation_missing`). Parse preflight logs, generate deterministic fix plans, optionally execute only non-destructive staging rebuild fixes, and produce operator-ready next steps.
+description: Triage and remediate L2 uniform schema drift using `l2_uniform_schema_preflight` output. Use when dbt runs touching `int__l2_nationwide_uniform` or `int__l2_nationwide_uniform_w_haystaq` fail, or when `L2_PREFLIGHT|` lines report drift (`stg_minus_src`, `src_minus_stg`, `target_minus_src`, `relation_missing`). Parse preflight logs, generate deterministic safe commands and manual instructions, and produce operator-ready next steps.
 ---
 
 # L2 Uniform Drift Remediator
@@ -16,29 +16,15 @@ All script paths below are repo-root-relative.
 dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'
 ```
 2. Download the preflight log containing `L2_PREFLIGHT|` JSON lines.
-3. Run the failure handler (recommended):
+3. Run the failure handler:
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
   --log-file /path/to/preflight.log \
   --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler
 ```
-4. Parse and classify findings (manual mode):
-```bash
-python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py analyze --log-file /path/to/log
-```
-5. Generate the concrete remediation plan:
-```bash
-python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py plan --log-file /path/to/log
-```
-6. Execute safe fixes only when findings are limited to state staging drift (`stg_minus_src`, `src_minus_stg`):
-```bash
-python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py plan \
-  --log-file /path/to/log \
-  --execute-safe \
-  --dbt-project-path /path/to/gp-data-platform/dbt/project
-```
-7. If `target_minus_src` or `relation_missing` exists, stop auto-fix and produce manual remediation steps.
-8. If `target_minus_src` includes `int__l2_nationwide_uniform`, apply approved column deprecations to both:
+4. Review `summary.md`, run safe commands manually in a one-off dbt Cloud job (or equivalent), and complete follow-up steps.
+5. If `target_minus_src` or `relation_missing` exists, follow manual remediation steps in the summary.
+6. If `target_minus_src` includes `int__l2_nationwide_uniform`, apply approved column deprecations to both:
 - `int__l2_nationwide_uniform`
 - `int__l2_nationwide_uniform_w_haystaq`
 Then rerun strict preflight.
@@ -48,9 +34,7 @@ Then rerun strict preflight.
 - Keep `on_schema_change="append_new_columns"` as-is.
 - Do not switch to `sync_all_columns`.
 - Do not execute destructive DDL automatically.
-- Auto-execute only:
-  - targeted staging rebuilds for impacted states
-  - preflight rerun (`strict=true` when no manual actions remain; `strict=false` when manual actions remain so full instructions can still be generated)
+- This skill generates instructions only; it does not execute dbt commands.
 
 ## Inputs and Outputs
 
@@ -60,7 +44,7 @@ Input:
 Output:
 - Deterministic triage summary.
 - Command plan for safe fixes.
-- Optional generated shell script with executable safe fix commands.
+- Generated shell script containing safe commands to run manually.
 
 ## Notes for dbt Cloud
 

--- a/.claude/skills/l2-uniform-drift-remediator/SKILL.md
+++ b/.claude/skills/l2-uniform-drift-remediator/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: l2-uniform-drift-remediator
+description: Triage and safely remediate L2 uniform schema drift using `l2_uniform_schema_preflight` output. Use when dbt runs touching `int__l2_nationwide_uniform` or `int__l2_nationwide_uniform_w_haystaq` fail, or when `L2_PREFLIGHT|` lines report drift (`stg_minus_src`, `src_minus_stg`, `target_minus_src`, `relation_missing`). Parse preflight logs, generate deterministic fix plans, optionally execute only non-destructive staging rebuild fixes, and produce operator-ready next steps.
+---
+
+# L2 Uniform Drift Remediator
+
+Use this workflow to convert preflight output into safe actions.
+
+## Workflow
+
+All script paths below are repo-root-relative.
+
+1. Locate the preflight or dbt run log that contains `L2_PREFLIGHT|` JSON lines.
+2. Run the failure handler (recommended):
+```bash
+python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
+  --log-file /path/to/dbt_failure.log \
+  --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler
+```
+3. Parse and classify findings (manual mode):
+```bash
+python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py analyze --log-file /path/to/log
+```
+4. Generate the concrete remediation plan:
+```bash
+python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py plan --log-file /path/to/log
+```
+5. Execute safe fixes only when findings are limited to state staging drift (`stg_minus_src`, `src_minus_stg`):
+```bash
+python .claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py plan \
+  --log-file /path/to/log \
+  --execute-safe \
+  --dbt-project-path /path/to/gp-data-platform/dbt/project
+```
+6. If `target_minus_src` or `relation_missing` exists, stop auto-fix and produce manual remediation steps.
+7. If `target_minus_src` includes `int__l2_nationwide_uniform`, apply approved column deprecations to both:
+- `int__l2_nationwide_uniform`
+- `int__l2_nationwide_uniform_w_haystaq`
+Then rerun strict preflight.
+
+## Guardrails
+
+- Keep `on_schema_change="append_new_columns"` as-is.
+- Do not switch to `sync_all_columns`.
+- Do not execute destructive DDL automatically.
+- Auto-execute only:
+  - targeted staging rebuilds for impacted states
+  - strict preflight rerun
+  - downstream model rerun only when manual gate conditions are absent
+
+## Inputs and Outputs
+
+Input:
+- dbt Cloud CLI log or local dbt log containing `L2_PREFLIGHT|{...}` lines.
+
+Output:
+- Deterministic triage summary.
+- Command plan for safe fixes.
+- Optional generated shell script with executable safe fix commands.
+
+## Notes for dbt Cloud
+
+This skill itself does not run inside dbt Cloud unless you call its script from a dbt Cloud job command environment that has Python and this repo checked out.
+
+To surface drift context directly in dbt Cloud logs, rely on the preflight macro logging (`L2_PREFLIGHT|...`).
+
+`agents/openai.yaml` is intentionally UI metadata only (display name, description, default prompt), not a runtime execution config.
+
+## Daily dbt Cloud Job Integration
+
+Use this command order in the dbt Cloud job:
+
+1. `dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'`
+2. `dbt build --exclude="tag:dbt_source tag:l2_s3 tag:weekly write__l2_databricks_to_gp_api"`
+
+If command 1 fails, dbt Cloud logs already contain parseable `L2_PREFLIGHT|` lines for triage.
+
+## Log Capture and PR Guidance
+
+- You can download dbt Cloud run logs and pass them to the failure handler.
+- Store raw logs in `.claude/skills/l2-uniform-drift-remediator/dbt_logs/` (local, untracked) or incident tooling.
+- For PR context, commit only sanitized summaries/command plans (not raw operational logs with secrets/tokens).
+
+Detailed operational steps are in:
+- `references/l2_uniform_schema_drift_runbook.md`

--- a/.claude/skills/l2-uniform-drift-remediator/SKILL.md
+++ b/.claude/skills/l2-uniform-drift-remediator/SKILL.md
@@ -50,7 +50,7 @@ Then rerun strict preflight.
 - Do not execute destructive DDL automatically.
 - Auto-execute only:
   - targeted staging rebuilds for impacted states
-  - strict preflight rerun
+  - preflight rerun (`strict=true` when no manual actions remain; `strict=false` when manual actions remain so full instructions can still be generated)
 
 ## Inputs and Outputs
 

--- a/.claude/skills/l2-uniform-drift-remediator/agents/openai.yaml
+++ b/.claude/skills/l2-uniform-drift-remediator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "L2 Drift Remediator"
+  short_description: "Triage and safe-fix L2 uniform drift findings"
+  default_prompt: "Use $l2-uniform-drift-remediator to parse L2 preflight output and produce a safe remediation plan."

--- a/.claude/skills/l2-uniform-drift-remediator/agents/openai.yaml
+++ b/.claude/skills/l2-uniform-drift-remediator/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "L2 Drift Remediator"
-  short_description: "Triage and safe-fix L2 uniform drift findings"
-  default_prompt: "Use $l2-uniform-drift-remediator to parse L2 preflight output and produce a safe remediation plan."

--- a/.claude/skills/l2-uniform-drift-remediator/dbt_logs/README.md
+++ b/.claude/skills/l2-uniform-drift-remediator/dbt_logs/README.md
@@ -3,7 +3,7 @@
 Local working directory for downloaded dbt Cloud logs and generated remediation artifacts.
 
 Usage pattern:
-- download failed dbt Cloud log(s) into this folder
+- download failed-run preflight log(s) into this folder
 - run the L2 drift failure handler with `--output-dir .claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler`
 - copy sanitized summaries into PR descriptions or tracked runbook files
 

--- a/.claude/skills/l2-uniform-drift-remediator/dbt_logs/README.md
+++ b/.claude/skills/l2-uniform-drift-remediator/dbt_logs/README.md
@@ -1,0 +1,10 @@
+# dbt_logs
+
+Local working directory for downloaded dbt Cloud logs and generated remediation artifacts.
+
+Usage pattern:
+- download failed dbt Cloud log(s) into this folder
+- run the L2 drift failure handler with `--output-dir .claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler`
+- copy sanitized summaries into PR descriptions or tracked runbook files
+
+Do not commit raw operational logs from this folder.

--- a/.claude/skills/l2-uniform-drift-remediator/references/l2_uniform_schema_drift_runbook.md
+++ b/.claude/skills/l2-uniform-drift-remediator/references/l2_uniform_schema_drift_runbook.md
@@ -1,0 +1,53 @@
+# L2 Uniform Schema Drift Runbook
+
+## Daily dbt Cloud Job Commands
+
+Run preflight before the existing daily build command:
+
+1. `dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'`
+2. `dbt build --exclude="tag:dbt_source tag:l2_s3 tag:weekly write__l2_databricks_to_gp_api"`
+
+## Failure Triage Workflow
+
+1. Download the dbt Cloud log for the failed run.
+2. Run the failure handler in this repo:
+
+```bash
+python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
+  --log-file /absolute/path/to/downloaded_dbt_log.txt \
+  --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler \
+  --dbt-project-path /path/to/gp-data-platform/dbt/project
+```
+
+3. Review generated artifacts in the timestamped output directory:
+- `analysis.txt`
+- `analysis.json`
+- `plan.txt`
+- `plan.json`
+- `safe_fix_plan.sh`
+- `summary.md`
+
+4. If only staging drift is present (`stg_minus_src`, `src_minus_stg`), optionally rerun with safe execution:
+
+```bash
+python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
+  --log-file /absolute/path/to/downloaded_dbt_log.txt \
+  --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler \
+  --dbt-project-path /path/to/gp-data-platform/dbt/project \
+  --execute-safe
+```
+
+5. If `target_minus_src` appears, do not run destructive DDL automatically; follow manual deprecation workflow.
+6. If deprecating target-only columns from `int__l2_nationwide_uniform`, apply equivalent removals to `int__l2_nationwide_uniform_w_haystaq`, then rerun strict preflight.
+
+## PR Hygiene
+
+- Keep raw logs/artifacts in `.claude/skills/l2-uniform-drift-remediator/dbt_logs/` (local, untracked by default).
+- Put concise remediation summaries and command outputs in PR description or a tracked runbook update.
+- Do not commit raw logs containing sensitive metadata or tokens.
+
+## Troubleshooting
+
+- If dbt Cloud CLI reports `Session occupied. Please wait until your invocation has been completed.` and Databricks run has already finished, cancel the stale invocation and retry:
+  - `dbt cancel --id <invocation_id>`
+  - rerun preflight or the intended dbt command.

--- a/.claude/skills/l2-uniform-drift-remediator/references/l2_uniform_schema_drift_runbook.md
+++ b/.claude/skills/l2-uniform-drift-remediator/references/l2_uniform_schema_drift_runbook.md
@@ -1,20 +1,19 @@
 # L2 Uniform Schema Drift Runbook
 
-## Daily dbt Cloud Job Commands
+## Post-Failure Workflow
 
-Run preflight before the existing daily build command:
+When a dbt build fails, run preflight to gather complete schema drift visibility:
 
 1. `dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'`
-2. `dbt build --exclude="tag:dbt_source tag:l2_s3 tag:weekly write__l2_databricks_to_gp_api"`
 
 ## Failure Triage Workflow
 
-1. Download the dbt Cloud log for the failed run.
+1. Download the dbt Cloud log for the preflight run.
 2. Run the failure handler in this repo:
 
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
-  --log-file /absolute/path/to/downloaded_dbt_log.txt \
+  --log-file /absolute/path/to/downloaded_preflight_log.txt \
   --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler \
   --dbt-project-path /path/to/gp-data-platform/dbt/project
 ```
@@ -31,14 +30,15 @@ python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
 
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
-  --log-file /absolute/path/to/downloaded_dbt_log.txt \
+  --log-file /absolute/path/to/downloaded_preflight_log.txt \
   --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler \
   --dbt-project-path /path/to/gp-data-platform/dbt/project \
   --execute-safe
 ```
 
-5. If `target_minus_src` appears, do not run destructive DDL automatically; follow manual deprecation workflow.
-6. If deprecating target-only columns from `int__l2_nationwide_uniform`, apply equivalent removals to `int__l2_nationwide_uniform_w_haystaq`, then rerun strict preflight.
+5. Kick off a one-off dbt Cloud job/command to apply the safe commands from `plan.txt` or `safe_fix_plan.sh`.
+6. If `target_minus_src` appears, do not run destructive DDL automatically; follow manual deprecation workflow.
+7. If deprecating target-only columns from `int__l2_nationwide_uniform`, apply equivalent removals to `int__l2_nationwide_uniform_w_haystaq`, then rerun strict preflight.
 
 ## PR Hygiene
 

--- a/.claude/skills/l2-uniform-drift-remediator/references/l2_uniform_schema_drift_runbook.md
+++ b/.claude/skills/l2-uniform-drift-remediator/references/l2_uniform_schema_drift_runbook.md
@@ -14,31 +14,18 @@ When a dbt build fails, run preflight to gather complete schema drift visibility
 ```bash
 python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
   --log-file /absolute/path/to/downloaded_preflight_log.txt \
-  --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler \
-  --dbt-project-path /path/to/gp-data-platform/dbt/project
+  --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler
 ```
 
 3. Review generated artifacts in the timestamped output directory:
-- `analysis.txt`
-- `analysis.json`
-- `plan.txt`
-- `plan.json`
+- `triage.txt`
+- `triage.json`
 - `safe_fix_plan.sh`
 - `summary.md`
 
-4. If only staging drift is present (`stg_minus_src`, `src_minus_stg`), optionally rerun with safe execution:
-
-```bash
-python .claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
-  --log-file /absolute/path/to/downloaded_preflight_log.txt \
-  --output-dir /path/to/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler \
-  --dbt-project-path /path/to/gp-data-platform/dbt/project \
-  --execute-safe
-```
-
-5. Kick off a one-off dbt Cloud job/command to apply the safe commands from `plan.txt` or `safe_fix_plan.sh`.
-6. If `target_minus_src` appears, do not run destructive DDL automatically; follow manual deprecation workflow.
-7. If deprecating target-only columns from `int__l2_nationwide_uniform`, apply equivalent removals to `int__l2_nationwide_uniform_w_haystaq`, then rerun strict preflight.
+4. Kick off a one-off dbt Cloud job/command to apply the safe commands from `summary.md` or `safe_fix_plan.sh`.
+5. If `target_minus_src` appears, do not run destructive DDL automatically; follow manual deprecation workflow.
+6. If deprecating target-only columns from `int__l2_nationwide_uniform`, apply equivalent removals to `int__l2_nationwide_uniform_w_haystaq`, then rerun strict preflight.
 
 ## PR Hygiene
 

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
@@ -110,19 +110,15 @@ def main() -> int:
     if rc != 0:
         print(out, file=sys.stderr)
         print(
-            "Hint: run preflight before build so logs include L2_PREFLIGHT lines.",
+            "Hint: this log does not contain preflight output.",
             file=sys.stderr,
         )
         print(
-            "Recommended dbt Cloud command order:",
+            "Run preflight after the failed build, download that preflight log, then rerun this handler:",
             file=sys.stderr,
         )
         print(
-            "1) dbt run-operation l2_uniform_schema_preflight --args '{\"strict\": true}'",
-            file=sys.stderr,
-        )
-        print(
-            '2) dbt build --exclude="tag:dbt_source tag:l2_s3 tag:weekly write__l2_databricks_to_gp_api"',
+            "dbt run-operation l2_uniform_schema_preflight --args '{\"strict\": true}'",
             file=sys.stderr,
         )
         print(f"Analyze step failed. See: {analysis_text}", file=sys.stderr)
@@ -189,6 +185,13 @@ def main() -> int:
     ]
     for command in plan.get("safe_commands", []):
         summary_lines.append(f"- `{command}`")
+
+    follow_up_commands = plan.get("follow_up_commands", [])
+    if follow_up_commands:
+        summary_lines.append("")
+        summary_lines.append("## Follow-up Commands")
+        for command in follow_up_commands:
+            summary_lines.append(f"- {command}")
 
     if manual_actions:
         summary_lines.append("")

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Handle failed dbt runs by parsing preflight logs and generating fix artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_OUTPUT_DIR = (
+    Path(__file__).resolve().parent.parent / "dbt_logs" / "failure_handler"
+)
+
+
+def _run_cmd(cmd: list[str], cwd: Path | None = None) -> tuple[int, str]:
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    return result.returncode, output
+
+
+def _format_command(cmd: list[str]) -> str:
+    return shlex.join(cmd)
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate and optionally execute L2 uniform drift remediation steps from a dbt log."
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        required=True,
+        help="Path to dbt Cloud/log output containing L2_PREFLIGHT JSON lines.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory where generated artifacts are written.",
+    )
+    parser.add_argument(
+        "--dbt-project-path",
+        type=Path,
+        default=Path("dbt/project"),
+        help="Path to dbt project root for safe command execution.",
+    )
+    parser.add_argument(
+        "--execute-safe",
+        action="store_true",
+        help="Execute safe, non-destructive commands after generating the plan.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    if not args.log_file.exists():
+        print(f"Log file not found: {args.log_file}", file=sys.stderr)
+        return 1
+
+    tool_path = Path(__file__).with_name("l2_uniform_preflight_tool.py")
+    if not tool_path.exists():
+        print(f"Preflight tool not found: {tool_path}", file=sys.stderr)
+        return 1
+
+    started_at = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    run_dir = args.output_dir / started_at
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    copied_log = run_dir / "dbt_failure.log"
+    shutil.copy2(args.log_file, copied_log)
+
+    analysis_text = run_dir / "analysis.txt"
+    analysis_json = run_dir / "analysis.json"
+    plan_text = run_dir / "plan.txt"
+    plan_json = run_dir / "plan.json"
+    plan_shell = run_dir / "safe_fix_plan.sh"
+    summary_md = run_dir / "summary.md"
+
+    analyze_cmd = [
+        sys.executable,
+        str(tool_path),
+        "analyze",
+        "--log-file",
+        str(copied_log),
+        "--json-out",
+        str(analysis_json),
+    ]
+    rc, out = _run_cmd(analyze_cmd)
+    _write_text(analysis_text, out)
+    if rc != 0:
+        print(out, file=sys.stderr)
+        print(
+            "Hint: run preflight before build so logs include L2_PREFLIGHT lines.",
+            file=sys.stderr,
+        )
+        print(
+            "Recommended dbt Cloud command order:",
+            file=sys.stderr,
+        )
+        print(
+            "1) dbt run-operation l2_uniform_schema_preflight --args '{\"strict\": true}'",
+            file=sys.stderr,
+        )
+        print(
+            '2) dbt build --exclude="tag:dbt_source tag:l2_s3 tag:weekly write__l2_databricks_to_gp_api"',
+            file=sys.stderr,
+        )
+        print(f"Analyze step failed. See: {analysis_text}", file=sys.stderr)
+        return rc
+
+    plan_cmd = [
+        sys.executable,
+        str(tool_path),
+        "plan",
+        "--log-file",
+        str(copied_log),
+        "--json-out",
+        str(plan_json),
+        "--shell-out",
+        str(plan_shell),
+    ]
+    if args.execute_safe:
+        plan_cmd.extend(
+            [
+                "--execute-safe",
+                "--dbt-project-path",
+                str(args.dbt_project_path),
+            ]
+        )
+
+    rc, out = _run_cmd(plan_cmd)
+    _write_text(plan_text, out)
+
+    if not plan_json.exists():
+        print("Plan output JSON was not created.", file=sys.stderr)
+        print(f"Plan/execute step failed. See: {plan_text}", file=sys.stderr)
+        print(f"Command: {_format_command(plan_cmd)}", file=sys.stderr)
+        return rc if rc != 0 else 1
+
+    try:
+        plan_payload = _load_json(plan_json)
+    except json.JSONDecodeError as exc:
+        print(f"Plan output JSON is invalid: {exc}", file=sys.stderr)
+        print(f"Plan/execute step failed. See: {plan_text}", file=sys.stderr)
+        return rc if rc != 0 else 1
+    summary = plan_payload.get("summary", {})
+    plan = plan_payload.get("plan", {})
+    manual_actions = plan.get("manual_actions", [])
+
+    summary_lines = [
+        "# L2 Uniform Failure Handler Summary",
+        "",
+        f"- source_log: `{args.log_file}`",
+        f"- copied_log: `{copied_log}`",
+        f"- status: `{summary.get('status')}`",
+        f"- finding_count: `{summary.get('finding_count')}`",
+        f"- impacted_states: `{', '.join(summary.get('impacted_states', [])) or '(none)'}`",
+        f"- execute_safe: `{str(args.execute_safe).lower()}`",
+        f"- manual_actions_count: `{len(manual_actions)}`",
+        "",
+        "## Generated Artifacts",
+        f"- `{analysis_text}`",
+        f"- `{analysis_json}`",
+        f"- `{plan_text}`",
+        f"- `{plan_json}`",
+        f"- `{plan_shell}`",
+        "",
+        "## Safe Commands",
+    ]
+    for command in plan.get("safe_commands", []):
+        summary_lines.append(f"- `{command}`")
+
+    if manual_actions:
+        summary_lines.append("")
+        summary_lines.append("## Manual Actions Required")
+        for action in manual_actions:
+            summary_lines.append(f"- {action}")
+
+    summary_lines.append("")
+    summary_lines.append("## Notes")
+    summary_lines.append(
+        "- Keep raw logs under `.claude/skills/l2-uniform-drift-remediator/dbt_logs/` locally and copy sanitized summaries to PR description or tracked runbooks."
+    )
+    _write_text(summary_md, "\n".join(summary_lines) + "\n")
+
+    print(f"Wrote failure-handler artifacts to: {run_dir}")
+    print(f"Summary: {summary_md}")
+
+    if rc == 0:
+        return 0
+    if rc == 2:
+        print("Safe commands completed, but manual actions remain.", file=sys.stderr)
+        return 2
+
+    print(f"Plan/execute step failed. See: {plan_text}", file=sys.stderr)
+    print(f"Command: {_format_command(plan_cmd)}", file=sys.stderr)
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
@@ -43,7 +43,7 @@ def _load_json(path: Path) -> dict:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Generate and optionally execute L2 uniform drift remediation steps from a dbt log."
+        description="Generate deterministic L2 uniform remediation instructions from a preflight log."
     )
     parser.add_argument(
         "--log-file",
@@ -56,17 +56,6 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=DEFAULT_OUTPUT_DIR,
         help="Directory where generated artifacts are written.",
-    )
-    parser.add_argument(
-        "--dbt-project-path",
-        type=Path,
-        default=Path("dbt/project"),
-        help="Path to dbt project root for safe command execution.",
-    )
-    parser.add_argument(
-        "--execute-safe",
-        action="store_true",
-        help="Execute safe, non-destructive commands after generating the plan.",
     )
     return parser
 
@@ -86,81 +75,60 @@ def main() -> int:
     run_dir = args.output_dir / started_at
     run_dir.mkdir(parents=True, exist_ok=False)
 
-    copied_log = run_dir / "dbt_failure.log"
+    copied_log = run_dir / "dbt_preflight.log"
     shutil.copy2(args.log_file, copied_log)
 
-    analysis_text = run_dir / "analysis.txt"
-    analysis_json = run_dir / "analysis.json"
-    plan_text = run_dir / "plan.txt"
-    plan_json = run_dir / "plan.json"
+    triage_text = run_dir / "triage.txt"
+    triage_json = run_dir / "triage.json"
     plan_shell = run_dir / "safe_fix_plan.sh"
     summary_md = run_dir / "summary.md"
 
-    analyze_cmd = [
+    triage_cmd = [
         sys.executable,
         str(tool_path),
-        "analyze",
         "--log-file",
         str(copied_log),
         "--json-out",
-        str(analysis_json),
+        str(triage_json),
+        "--shell-out",
+        str(plan_shell),
     ]
-    rc, out = _run_cmd(analyze_cmd)
-    _write_text(analysis_text, out)
-    if rc != 0:
+
+    rc, out = _run_cmd(triage_cmd)
+    _write_text(triage_text, out)
+
+    if rc == 1:
         print(out, file=sys.stderr)
         print(
-            "Hint: this log does not contain preflight output.",
+            "Hint: this log does not contain complete preflight output.",
             file=sys.stderr,
         )
         print(
-            "Run preflight after the failed build, download that preflight log, then rerun this handler:",
+            "Run preflight after the failed build, download the full preflight log, then rerun this handler:",
             file=sys.stderr,
         )
         print(
             "dbt run-operation l2_uniform_schema_preflight --args '{\"strict\": true}'",
             file=sys.stderr,
         )
-        print(f"Analyze step failed. See: {analysis_text}", file=sys.stderr)
-        return rc
+        print(f"Triage step failed. See: {triage_text}", file=sys.stderr)
+        return 1
 
-    plan_cmd = [
-        sys.executable,
-        str(tool_path),
-        "plan",
-        "--log-file",
-        str(copied_log),
-        "--json-out",
-        str(plan_json),
-        "--shell-out",
-        str(plan_shell),
-    ]
-    if args.execute_safe:
-        plan_cmd.extend(
-            [
-                "--execute-safe",
-                "--dbt-project-path",
-                str(args.dbt_project_path),
-            ]
-        )
-
-    rc, out = _run_cmd(plan_cmd)
-    _write_text(plan_text, out)
-
-    if not plan_json.exists():
-        print("Plan output JSON was not created.", file=sys.stderr)
-        print(f"Plan/execute step failed. See: {plan_text}", file=sys.stderr)
-        print(f"Command: {_format_command(plan_cmd)}", file=sys.stderr)
+    if not triage_json.exists():
+        print("Triage output JSON was not created.", file=sys.stderr)
+        print(f"Triage step failed. See: {triage_text}", file=sys.stderr)
+        print(f"Command: {_format_command(triage_cmd)}", file=sys.stderr)
         return rc if rc != 0 else 1
 
     try:
-        plan_payload = _load_json(plan_json)
+        triage_payload = _load_json(triage_json)
     except json.JSONDecodeError as exc:
-        print(f"Plan output JSON is invalid: {exc}", file=sys.stderr)
-        print(f"Plan/execute step failed. See: {plan_text}", file=sys.stderr)
+        print(f"Triage output JSON is invalid: {exc}", file=sys.stderr)
+        print(f"Triage step failed. See: {triage_text}", file=sys.stderr)
         return rc if rc != 0 else 1
-    summary = plan_payload.get("summary", {})
-    plan = plan_payload.get("plan", {})
+
+    summary = triage_payload.get("summary", {})
+    plan = triage_payload.get("plan", {})
     manual_actions = plan.get("manual_actions", [])
 
     summary_lines = [
@@ -171,15 +139,14 @@ def main() -> int:
         f"- status: `{summary.get('status')}`",
         f"- finding_count: `{summary.get('finding_count')}`",
         f"- impacted_states: `{', '.join(summary.get('impacted_states', [])) or '(none)'}`",
-        f"- execute_safe: `{str(args.execute_safe).lower()}`",
         f"- manual_actions_count: `{len(manual_actions)}`",
+        f"- triage_exit_code: `{rc}`",
         "",
         "## Generated Artifacts",
-        f"- `{analysis_text}`",
-        f"- `{analysis_json}`",
-        f"- `{plan_text}`",
-        f"- `{plan_json}`",
+        f"- `{triage_text}`",
+        f"- `{triage_json}`",
         f"- `{plan_shell}`",
+        f"- `{summary_md}`",
         "",
         "## Safe Commands",
     ]
@@ -202,6 +169,9 @@ def main() -> int:
     summary_lines.append("")
     summary_lines.append("## Notes")
     summary_lines.append(
+        "- This handler does not execute dbt commands. Run safe commands manually in an ad hoc dbt Cloud job (or equivalent controlled run)."
+    )
+    summary_lines.append(
         "- Keep raw logs under `.claude/skills/l2-uniform-drift-remediator/dbt_logs/` locally and copy sanitized summaries to PR description or tracked runbooks."
     )
     _write_text(summary_md, "\n".join(summary_lines) + "\n")
@@ -209,15 +179,16 @@ def main() -> int:
     print(f"Wrote failure-handler artifacts to: {run_dir}")
     print(f"Summary: {summary_md}")
 
-    if rc == 0:
-        return 0
     if rc == 2:
-        print("Safe commands completed, but manual actions remain.", file=sys.stderr)
+        print("Manual actions remain. See summary for required steps.", file=sys.stderr)
         return 2
 
-    print(f"Plan/execute step failed. See: {plan_text}", file=sys.stderr)
-    print(f"Command: {_format_command(plan_cmd)}", file=sys.stderr)
-    return rc
+    if rc != 0:
+        print(f"Triage step failed. See: {triage_text}", file=sys.stderr)
+        print(f"Command: {_format_command(triage_cmd)}", file=sys.stderr)
+        return rc
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
@@ -74,13 +74,15 @@ def _command_to_string(command_argv: list[str]) -> str:
     return shlex.join(command_argv)
 
 
-def _preflight_command_argv(metadata_catalog: str | None) -> list[str]:
+def _preflight_command_argv(
+    metadata_catalog: str | None, strict: bool = True
+) -> list[str]:
     command_argv = [
         "dbt",
         "run-operation",
         "l2_uniform_schema_preflight",
         "--args",
-        '{"strict": true}',
+        json.dumps({"strict": strict}, separators=(",", ":")),
     ]
     if metadata_catalog:
         vars_json = json.dumps(
@@ -108,8 +110,6 @@ def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
             ]
         )
 
-    safe_command_argv.append(_preflight_command_argv(summary["metadata_catalog"]))
-
     manual_actions: list[str] = []
     if summary["target_minus_src"]:
         for item in summary["target_minus_src"]:
@@ -133,6 +133,14 @@ def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
             )
 
     can_auto_complete = len(manual_actions) == 0
+    # When manual steps remain, run preflight in warn-only mode so the safe phase
+    # can complete and callers can receive an explicit "manual actions remain" signal.
+    safe_command_argv.append(
+        _preflight_command_argv(
+            summary["metadata_catalog"],
+            strict=can_auto_complete,
+        )
+    )
     follow_up_commands = [
         "Rerun the originally failed dbt command/job after safe fixes succeed."
     ]

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
@@ -53,6 +53,13 @@ def _derive_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
     status = summary.get("status")
     if not status:
         status = "clean" if not findings else "unknown"
+    declared_finding_count: int | None = None
+    raw_finding_count: object = summary.get("finding_count")
+    if raw_finding_count is not None:
+        try:
+            declared_finding_count = int(str(raw_finding_count))
+        except (TypeError, ValueError):
+            declared_finding_count = None
 
     return {
         "metadata_catalog": str(metadata_catalog) if metadata_catalog else None,
@@ -62,12 +69,29 @@ def _derive_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
         "source_relations_found": summary.get("source_relations_found"),
         "staging_relations_found": summary.get("staging_relations_found"),
         "finding_count": len(findings),
+        "summary_finding_count": declared_finding_count,
         "findings_by_kind": dict(sorted(counts.items())),
         "impacted_states": impacted_states,
         "target_minus_src": target_minus_src,
         "relation_missing": relation_missing,
         "findings": findings,
     }
+
+
+def _validate_summary(summary: dict[str, Any]) -> str | None:
+    declared_finding_count = summary.get("summary_finding_count")
+    observed_finding_count = summary.get("finding_count")
+    if (
+        isinstance(declared_finding_count, int)
+        and isinstance(observed_finding_count, int)
+        and declared_finding_count > observed_finding_count
+    ):
+        return (
+            "Preflight log appears incomplete: parsed "
+            f"{observed_finding_count} finding line(s), but summary reports "
+            f"{declared_finding_count}. Download the full preflight log and retry."
+        )
+    return None
 
 
 def _command_to_string(command_argv: list[str]) -> str:
@@ -237,6 +261,10 @@ def _analyze(args: argparse.Namespace) -> int:
         return 1
 
     summary = _derive_summary(records)
+    validation_error = _validate_summary(summary)
+    if validation_error:
+        print(validation_error, file=sys.stderr)
+        return 1
     _print_analysis(summary)
 
     if args.json_out:
@@ -258,6 +286,10 @@ def _plan(args: argparse.Namespace) -> int:
         return 1
 
     summary = _derive_summary(records)
+    validation_error = _validate_summary(summary)
+    if validation_error:
+        print(validation_error, file=sys.stderr)
+        return 1
     plan = _build_plan(summary)
     _print_plan(summary, plan)
 

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 
 PREFIX = "L2_PREFLIGHT|"
-DEFAULT_CATALOG = "goodparty_data_catalog"
 
 
 def _load_records(log_file: Path) -> list[dict[str, Any]]:
@@ -50,17 +49,13 @@ def _derive_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
     target_minus_src = [f for f in findings if f.get("kind") == "target_minus_src"]
     relation_missing = [f for f in findings if f.get("kind") == "relation_missing"]
 
-    metadata_catalog = (
-        summary.get("metadata_catalog")
-        or config.get("metadata_catalog")
-        or DEFAULT_CATALOG
-    )
+    metadata_catalog = summary.get("metadata_catalog") or config.get("metadata_catalog")
     status = summary.get("status")
     if not status:
         status = "clean" if not findings else "unknown"
 
     return {
-        "metadata_catalog": str(metadata_catalog),
+        "metadata_catalog": str(metadata_catalog) if metadata_catalog else None,
         "strict": bool(summary.get("strict", config.get("strict", True))),
         "status": str(status),
         "states_evaluated": summary.get("states_evaluated"),
@@ -79,7 +74,7 @@ def _command_to_string(command_argv: list[str]) -> str:
     return shlex.join(command_argv)
 
 
-def _preflight_command_argv(metadata_catalog: str) -> list[str]:
+def _preflight_command_argv(metadata_catalog: str | None) -> list[str]:
     command_argv = [
         "dbt",
         "run-operation",
@@ -87,7 +82,7 @@ def _preflight_command_argv(metadata_catalog: str) -> list[str]:
         "--args",
         '{"strict": true}',
     ]
-    if metadata_catalog != DEFAULT_CATALOG:
+    if metadata_catalog:
         vars_json = json.dumps(
             {"preflight_metadata_catalog": metadata_catalog},
             separators=(",", ":"),
@@ -138,22 +133,16 @@ def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
             )
 
     can_auto_complete = len(manual_actions) == 0
-    if can_auto_complete:
-        safe_command_argv.append(
-            [
-                "dbt",
-                "run",
-                "--select",
-                "int__l2_nationwide_uniform",
-                "int__l2_nationwide_uniform_w_haystaq",
-            ]
-        )
+    follow_up_commands = [
+        "Rerun the originally failed dbt command/job after safe fixes succeed."
+    ]
 
     safe_commands = [_command_to_string(command) for command in safe_command_argv]
 
     return {
         "safe_commands": safe_commands,
         "safe_command_argv": safe_command_argv,
+        "follow_up_commands": follow_up_commands,
         "manual_actions": manual_actions,
         "can_auto_complete": can_auto_complete,
         "staging_selectors": staging_selectors,
@@ -164,7 +153,9 @@ def _print_analysis(summary: dict[str, Any]) -> None:
     print("# L2 Uniform Preflight Analysis")
     print(f"- status: {summary['status']}")
     print(f"- strict: {summary['strict']}")
-    print(f"- metadata_catalog: {summary['metadata_catalog']}")
+    print(
+        f"- metadata_catalog: {summary['metadata_catalog'] or '(not provided in log)'}"
+    )
     print(f"- finding_count: {summary['finding_count']}")
     print(f"- impacted_states: {', '.join(summary['impacted_states']) or '(none)'}")
     print("")
@@ -190,6 +181,12 @@ def _print_plan(summary: dict[str, Any], plan: dict[str, Any]) -> None:
         print("## Manual Actions Required")
         for idx, action in enumerate(plan["manual_actions"], start=1):
             print(f"{idx}. {action}")
+
+    if plan["follow_up_commands"]:
+        print("")
+        print("## Follow-up Commands")
+        for idx, command in enumerate(plan["follow_up_commands"], start=1):
+            print(f"{idx}. {command}")
 
     print("")
     print(f"- can_auto_complete: {str(plan['can_auto_complete']).lower()}")

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Parse L2 preflight JSON lines and produce safe remediation plans."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+PREFIX = "L2_PREFLIGHT|"
+DEFAULT_CATALOG = "goodparty_data_catalog"
+
+
+def _load_records(log_file: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for raw_line in log_file.read_text(encoding="utf-8", errors="replace").splitlines():
+        idx = raw_line.find(PREFIX)
+        if idx == -1:
+            continue
+        payload = raw_line[idx + len(PREFIX) :].strip()
+        if not payload:
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            records.append(obj)
+    return records
+
+
+def _derive_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    config = next((r for r in records if r.get("kind") == "config"), {})
+    summary = next((r for r in reversed(records) if r.get("kind") == "summary"), {})
+    findings = [r for r in records if r.get("kind") not in {"config", "summary"}]
+
+    counts = Counter(str(f.get("kind", "unknown")) for f in findings)
+    impacted_states = sorted(
+        {
+            str(f.get("state")).upper()
+            for f in findings
+            if f.get("kind") in {"stg_minus_src", "src_minus_stg"} and f.get("state")
+        }
+    )
+    target_minus_src = [f for f in findings if f.get("kind") == "target_minus_src"]
+    relation_missing = [f for f in findings if f.get("kind") == "relation_missing"]
+
+    metadata_catalog = (
+        summary.get("metadata_catalog")
+        or config.get("metadata_catalog")
+        or DEFAULT_CATALOG
+    )
+    status = summary.get("status")
+    if not status:
+        status = "clean" if not findings else "unknown"
+
+    return {
+        "metadata_catalog": str(metadata_catalog),
+        "strict": bool(summary.get("strict", config.get("strict", True))),
+        "status": str(status),
+        "states_evaluated": summary.get("states_evaluated"),
+        "source_relations_found": summary.get("source_relations_found"),
+        "staging_relations_found": summary.get("staging_relations_found"),
+        "finding_count": len(findings),
+        "findings_by_kind": dict(sorted(counts.items())),
+        "impacted_states": impacted_states,
+        "target_minus_src": target_minus_src,
+        "relation_missing": relation_missing,
+        "findings": findings,
+    }
+
+
+def _command_to_string(command_argv: list[str]) -> str:
+    return shlex.join(command_argv)
+
+
+def _preflight_command_argv(metadata_catalog: str) -> list[str]:
+    command_argv = [
+        "dbt",
+        "run-operation",
+        "l2_uniform_schema_preflight",
+        "--args",
+        '{"strict": true}',
+    ]
+    if metadata_catalog != DEFAULT_CATALOG:
+        vars_json = json.dumps(
+            {"preflight_metadata_catalog": metadata_catalog},
+            separators=(",", ":"),
+        )
+        command_argv.extend(["--vars", vars_json])
+    return command_argv
+
+
+def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
+    impacted_states: list[str] = summary["impacted_states"]
+    staging_selectors = [
+        f"stg_dbt_source__l2_s3_{state.lower()}_uniform" for state in impacted_states
+    ]
+
+    safe_command_argv: list[list[str]] = []
+    if staging_selectors:
+        safe_command_argv.append(
+            [
+                "dbt",
+                "run",
+                "--select",
+                *staging_selectors,
+            ]
+        )
+
+    safe_command_argv.append(_preflight_command_argv(summary["metadata_catalog"]))
+
+    manual_actions: list[str] = []
+    if summary["target_minus_src"]:
+        for item in summary["target_minus_src"]:
+            target_model = item.get("target_model", "unknown_target")
+            cols = item.get("columns", [])
+            manual_actions.append(
+                f"Manual deprecation required for {target_model}: target_minus_src columns={cols}"
+            )
+            if target_model == "int__l2_nationwide_uniform":
+                manual_actions.append(
+                    "When deprecating target-only columns on int__l2_nationwide_uniform, "
+                    "apply the same removals to int__l2_nationwide_uniform_w_haystaq and rerun preflight."
+                )
+
+    if summary["relation_missing"]:
+        for item in summary["relation_missing"]:
+            relation = item.get("relation", "unknown_relation")
+            scope = item.get("scope", "unknown_scope")
+            manual_actions.append(
+                f"Relation missing ({scope}): {relation}. Verify permissions/catalog/schema."
+            )
+
+    can_auto_complete = len(manual_actions) == 0
+    if can_auto_complete:
+        safe_command_argv.append(
+            [
+                "dbt",
+                "run",
+                "--select",
+                "int__l2_nationwide_uniform",
+                "int__l2_nationwide_uniform_w_haystaq",
+            ]
+        )
+
+    safe_commands = [_command_to_string(command) for command in safe_command_argv]
+
+    return {
+        "safe_commands": safe_commands,
+        "safe_command_argv": safe_command_argv,
+        "manual_actions": manual_actions,
+        "can_auto_complete": can_auto_complete,
+        "staging_selectors": staging_selectors,
+    }
+
+
+def _print_analysis(summary: dict[str, Any]) -> None:
+    print("# L2 Uniform Preflight Analysis")
+    print(f"- status: {summary['status']}")
+    print(f"- strict: {summary['strict']}")
+    print(f"- metadata_catalog: {summary['metadata_catalog']}")
+    print(f"- finding_count: {summary['finding_count']}")
+    print(f"- impacted_states: {', '.join(summary['impacted_states']) or '(none)'}")
+    print("")
+    print("## Findings by Kind")
+    if not summary["findings_by_kind"]:
+        print("- none")
+    else:
+        for kind, count in summary["findings_by_kind"].items():
+            print(f"- {kind}: {count}")
+
+
+def _print_plan(summary: dict[str, Any], plan: dict[str, Any]) -> None:
+    print("# L2 Uniform Safe Remediation Plan")
+    print(f"- status: {summary['status']}")
+    print(f"- impacted_states: {', '.join(summary['impacted_states']) or '(none)'}")
+    print("")
+    print("## Safe Commands")
+    for idx, command in enumerate(plan["safe_commands"], start=1):
+        print(f"{idx}. {command}")
+
+    if plan["manual_actions"]:
+        print("")
+        print("## Manual Actions Required")
+        for idx, action in enumerate(plan["manual_actions"], start=1):
+            print(f"{idx}. {action}")
+
+    print("")
+    print(f"- can_auto_complete: {str(plan['can_auto_complete']).lower()}")
+
+
+def _write_shell_script(shell_out: Path, plan: dict[str, Any]) -> None:
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "",
+        "# Generated by l2_uniform_preflight_tool.py",
+    ]
+    for command_argv in plan["safe_command_argv"]:
+        lines.append(_command_to_string(command_argv))
+    shell_out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    shell_out.chmod(0o755)
+
+
+def _execute_safe_commands(plan: dict[str, Any], dbt_project_path: Path) -> int:
+    for command_argv in plan["safe_command_argv"]:
+        print(f"$ {_command_to_string(command_argv)}", flush=True)
+        result = subprocess.run(
+            command_argv,
+            cwd=dbt_project_path,
+            shell=False,
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
+def _analyze(args: argparse.Namespace) -> int:
+    records = _load_records(args.log_file)
+    if not records:
+        print(
+            f"No {PREFIX} JSON lines found in {args.log_file}",
+            file=sys.stderr,
+        )
+        return 1
+
+    summary = _derive_summary(records)
+    _print_analysis(summary)
+
+    if args.json_out:
+        args.json_out.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+def _plan(args: argparse.Namespace) -> int:
+    records = _load_records(args.log_file)
+    if not records:
+        print(
+            f"No {PREFIX} JSON lines found in {args.log_file}",
+            file=sys.stderr,
+        )
+        return 1
+
+    summary = _derive_summary(records)
+    plan = _build_plan(summary)
+    _print_plan(summary, plan)
+
+    if args.json_out:
+        args.json_out.write_text(
+            json.dumps({"summary": summary, "plan": plan}, indent=2, sort_keys=True)
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if args.shell_out:
+        _write_shell_script(args.shell_out, plan)
+        print(f"\nWrote shell plan: {args.shell_out}")
+
+    if args.execute_safe:
+        exit_code = _execute_safe_commands(plan, args.dbt_project_path)
+        if exit_code != 0:
+            return exit_code
+        if plan["manual_actions"]:
+            return 2
+
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Parse L2 preflight output and generate safe remediation plans."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    analyze_parser = subparsers.add_parser("analyze", help="Analyze preflight output.")
+    analyze_parser.add_argument("--log-file", type=Path, required=True)
+    analyze_parser.add_argument("--json-out", type=Path)
+    analyze_parser.set_defaults(func=_analyze)
+
+    plan_parser = subparsers.add_parser("plan", help="Generate remediation plan.")
+    plan_parser.add_argument("--log-file", type=Path, required=True)
+    plan_parser.add_argument("--json-out", type=Path)
+    plan_parser.add_argument("--shell-out", type=Path)
+    plan_parser.add_argument("--execute-safe", action="store_true")
+    plan_parser.add_argument(
+        "--dbt-project-path",
+        type=Path,
+        default=Path.cwd(),
+        help="Path where dbt commands should run when --execute-safe is used.",
+    )
+    plan_parser.set_defaults(func=_plan)
+
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
@@ -1,18 +1,32 @@
 #!/usr/bin/env python3
-"""Parse L2 preflight JSON lines and produce safe remediation plans."""
+"""Parse L2 preflight JSON lines and produce deterministic remediation instructions."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import shlex
-import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
 from typing import Any
 
 PREFIX = "L2_PREFLIGHT|"
+
+
+def _coerce_bool(value: object, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "t", "true", "y", "yes", "on"}:
+            return True
+        if normalized in {"0", "f", "false", "n", "no", "off"}:
+            return False
+        return default
+    if isinstance(value, int):
+        return value != 0
+    return default
 
 
 def _load_records(log_file: Path) -> list[dict[str, Any]]:
@@ -53,6 +67,7 @@ def _derive_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
     status = summary.get("status")
     if not status:
         status = "clean" if not findings else "unknown"
+
     declared_finding_count: int | None = None
     raw_finding_count: object = summary.get("finding_count")
     if raw_finding_count is not None:
@@ -61,9 +76,11 @@ def _derive_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
         except (TypeError, ValueError):
             declared_finding_count = None
 
+    strict_value = summary.get("strict", config.get("strict", True))
+
     return {
         "metadata_catalog": str(metadata_catalog) if metadata_catalog else None,
-        "strict": bool(summary.get("strict", config.get("strict", True))),
+        "strict": _coerce_bool(strict_value, default=True),
         "status": str(status),
         "states_evaluated": summary.get("states_evaluated"),
         "source_relations_found": summary.get("source_relations_found"),
@@ -98,15 +115,13 @@ def _command_to_string(command_argv: list[str]) -> str:
     return shlex.join(command_argv)
 
 
-def _preflight_command_argv(
-    metadata_catalog: str | None, strict: bool = True
-) -> list[str]:
+def _preflight_command_argv(metadata_catalog: str | None) -> list[str]:
     command_argv = [
         "dbt",
         "run-operation",
         "l2_uniform_schema_preflight",
         "--args",
-        json.dumps({"strict": strict}, separators=(",", ":")),
+        '{"strict": true}',
     ]
     if metadata_catalog:
         vars_json = json.dumps(
@@ -125,14 +140,9 @@ def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
 
     safe_command_argv: list[list[str]] = []
     if staging_selectors:
-        safe_command_argv.append(
-            [
-                "dbt",
-                "run",
-                "--select",
-                *staging_selectors,
-            ]
-        )
+        safe_command_argv.append(["dbt", "run", "--select", *staging_selectors])
+
+    safe_command_argv.append(_preflight_command_argv(summary["metadata_catalog"]))
 
     manual_actions: list[str] = []
     if summary["target_minus_src"]:
@@ -145,7 +155,7 @@ def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
             if target_model == "int__l2_nationwide_uniform":
                 manual_actions.append(
                     "When deprecating target-only columns on int__l2_nationwide_uniform, "
-                    "apply the same removals to int__l2_nationwide_uniform_w_haystaq and rerun preflight."
+                    "apply the same removals to int__l2_nationwide_uniform_w_haystaq and rerun strict preflight."
                 )
 
     if summary["relation_missing"]:
@@ -156,27 +166,17 @@ def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
                 f"Relation missing ({scope}): {relation}. Verify permissions/catalog/schema."
             )
 
-    can_auto_complete = len(manual_actions) == 0
-    # When manual steps remain, run preflight in warn-only mode so the safe phase
-    # can complete and callers can receive an explicit "manual actions remain" signal.
-    safe_command_argv.append(
-        _preflight_command_argv(
-            summary["metadata_catalog"],
-            strict=can_auto_complete,
-        )
-    )
     follow_up_commands = [
-        "Rerun the originally failed dbt command/job after safe fixes succeed."
+        "Run the safe commands above in a one-off dbt Cloud job (or equivalent manual run).",
+        "After strict preflight is clean, rerun the originally failed dbt command/job.",
     ]
 
-    safe_commands = [_command_to_string(command) for command in safe_command_argv]
-
     return {
-        "safe_commands": safe_commands,
+        "safe_commands": [_command_to_string(command) for command in safe_command_argv],
         "safe_command_argv": safe_command_argv,
         "follow_up_commands": follow_up_commands,
         "manual_actions": manual_actions,
-        "can_auto_complete": can_auto_complete,
+        "can_auto_complete": len(manual_actions) == 0,
         "staging_selectors": staging_selectors,
     }
 
@@ -200,7 +200,8 @@ def _print_analysis(summary: dict[str, Any]) -> None:
 
 
 def _print_plan(summary: dict[str, Any], plan: dict[str, Any]) -> None:
-    print("# L2 Uniform Safe Remediation Plan")
+    print("")
+    print("# L2 Uniform Remediation Plan")
     print(f"- status: {summary['status']}")
     print(f"- impacted_states: {', '.join(summary['impacted_states']) or '(none)'}")
     print("")
@@ -237,21 +238,19 @@ def _write_shell_script(shell_out: Path, plan: dict[str, Any]) -> None:
     shell_out.chmod(0o755)
 
 
-def _execute_safe_commands(plan: dict[str, Any], dbt_project_path: Path) -> int:
-    for command_argv in plan["safe_command_argv"]:
-        print(f"$ {_command_to_string(command_argv)}", flush=True)
-        result = subprocess.run(
-            command_argv,
-            cwd=dbt_project_path,
-            shell=False,
-            check=False,
-        )
-        if result.returncode != 0:
-            return result.returncode
-    return 0
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Parse L2 preflight output and generate deterministic remediation instructions."
+    )
+    parser.add_argument("--log-file", type=Path, required=True)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--shell-out", type=Path)
+    return parser
 
 
-def _analyze(args: argparse.Namespace) -> int:
+def main() -> int:
+    args = _build_parser().parse_args()
+
     records = _load_records(args.log_file)
     if not records:
         print(
@@ -265,32 +264,9 @@ def _analyze(args: argparse.Namespace) -> int:
     if validation_error:
         print(validation_error, file=sys.stderr)
         return 1
-    _print_analysis(summary)
 
-    if args.json_out:
-        args.json_out.write_text(
-            json.dumps(summary, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-
-    return 0
-
-
-def _plan(args: argparse.Namespace) -> int:
-    records = _load_records(args.log_file)
-    if not records:
-        print(
-            f"No {PREFIX} JSON lines found in {args.log_file}",
-            file=sys.stderr,
-        )
-        return 1
-
-    summary = _derive_summary(records)
-    validation_error = _validate_summary(summary)
-    if validation_error:
-        print(validation_error, file=sys.stderr)
-        return 1
     plan = _build_plan(summary)
+    _print_analysis(summary)
     _print_plan(summary, plan)
 
     if args.json_out:
@@ -304,47 +280,7 @@ def _plan(args: argparse.Namespace) -> int:
         _write_shell_script(args.shell_out, plan)
         print(f"\nWrote shell plan: {args.shell_out}")
 
-    if args.execute_safe:
-        exit_code = _execute_safe_commands(plan, args.dbt_project_path)
-        if exit_code != 0:
-            return exit_code
-        if plan["manual_actions"]:
-            return 2
-
-    return 0
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Parse L2 preflight output and generate safe remediation plans."
-    )
-    subparsers = parser.add_subparsers(dest="command", required=True)
-
-    analyze_parser = subparsers.add_parser("analyze", help="Analyze preflight output.")
-    analyze_parser.add_argument("--log-file", type=Path, required=True)
-    analyze_parser.add_argument("--json-out", type=Path)
-    analyze_parser.set_defaults(func=_analyze)
-
-    plan_parser = subparsers.add_parser("plan", help="Generate remediation plan.")
-    plan_parser.add_argument("--log-file", type=Path, required=True)
-    plan_parser.add_argument("--json-out", type=Path)
-    plan_parser.add_argument("--shell-out", type=Path)
-    plan_parser.add_argument("--execute-safe", action="store_true")
-    plan_parser.add_argument(
-        "--dbt-project-path",
-        type=Path,
-        default=Path.cwd(),
-        help="Path where dbt commands should run when --execute-safe is used.",
-    )
-    plan_parser.set_defaults(func=_plan)
-
-    return parser
-
-
-def main() -> int:
-    parser = _build_parser()
-    args = parser.parse_args()
-    return args.func(args)
+    return 2 if plan["manual_actions"] else 0
 
 
 if __name__ == "__main__":

--- a/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
+++ b/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
@@ -40,52 +40,30 @@ def sample_truncated_preflight_log() -> str:
     return "\n".join(lines) + "\n"
 
 
+def sample_preflight_log_with_string_strict_false() -> str:
+    lines = [
+        'L2_PREFLIGHT|{"kind":"config","metadata_catalog":"prod_catalog","strict":"false","states_expected":51}',
+        'L2_PREFLIGHT|{"kind":"summary","metadata_catalog":"prod_catalog","strict":"false","status":"warn","states_evaluated":51,"source_relations_found":51,"staging_relations_found":51,"finding_count":0}',
+    ]
+    return "\n".join(lines) + "\n"
+
+
 class TestL2UniformPreflightTool(unittest.TestCase):
-    """Tests for the preflight log analyzer and planner CLI."""
+    """Tests for the preflight triage CLI."""
 
-    def test_analyze_outputs_expected_summary(self) -> None:
-        """`analyze` should summarize metadata and impacted states from logs."""
+    def test_tool_outputs_expected_summary_and_plan(self) -> None:
+        """Tool should output summary and safe plan for staging drift."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             log_file = tmp_path / "preflight.log"
             log_file.write_text(sample_preflight_log(), encoding="utf-8")
-            json_out = tmp_path / "analysis.json"
-
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(PREFLIGHT_TOOL),
-                    "analyze",
-                    "--log-file",
-                    str(log_file),
-                    "--json-out",
-                    str(json_out),
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-
-            self.assertEqual(result.returncode, 0, result.stderr)
-            payload = json.loads(json_out.read_text(encoding="utf-8"))
-            self.assertEqual(payload["metadata_catalog"], "prod_catalog")
-            self.assertEqual(payload["finding_count"], 1)
-            self.assertEqual(payload["impacted_states"], ["ME"])
-
-    def test_plan_includes_staging_fix_and_follow_up(self) -> None:
-        """`plan` should include safe staging refresh and follow-up commands."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            log_file = tmp_path / "preflight.log"
-            log_file.write_text(sample_preflight_log(), encoding="utf-8")
-            json_out = tmp_path / "plan.json"
+            json_out = tmp_path / "triage.json"
             shell_out = tmp_path / "plan.sh"
 
             result = subprocess.run(
                 [
                     sys.executable,
                     str(PREFLIGHT_TOOL),
-                    "plan",
                     "--log-file",
                     str(log_file),
                     "--json-out",
@@ -100,37 +78,88 @@ class TestL2UniformPreflightTool(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             payload = json.loads(json_out.read_text(encoding="utf-8"))
+            summary = payload["summary"]
             plan = payload["plan"]
+            self.assertEqual(summary["metadata_catalog"], "prod_catalog")
+            self.assertEqual(summary["finding_count"], 1)
+            self.assertEqual(summary["impacted_states"], ["ME"])
             self.assertTrue(
                 any(
                     "stg_dbt_source__l2_s3_me_uniform" in command
                     for command in plan["safe_commands"]
                 )
             )
-            self.assertFalse(
+            self.assertTrue(
                 any(
-                    "int__l2_nationwide_uniform int__l2_nationwide_uniform_w_haystaq"
-                    in command
+                    "l2_uniform_schema_preflight" in command
                     for command in plan["safe_commands"]
                 )
             )
-            self.assertTrue(plan["follow_up_commands"])
 
-    def test_plan_uses_warn_preflight_when_manual_actions_exist(self) -> None:
-        """Plans with manual actions should rerun preflight with strict=false."""
+    def test_tool_returns_2_when_manual_actions_exist(self) -> None:
+        """Tool should return 2 when manual actions remain."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             log_file = tmp_path / "preflight.log"
             log_file.write_text(
                 sample_preflight_log_with_manual_actions(), encoding="utf-8"
             )
-            json_out = tmp_path / "plan.json"
+            json_out = tmp_path / "triage.json"
 
             result = subprocess.run(
                 [
                     sys.executable,
                     str(PREFLIGHT_TOOL),
-                    "plan",
+                    "--log-file",
+                    str(log_file),
+                    "--json-out",
+                    str(json_out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2, result.stderr)
+            payload = json.loads(json_out.read_text(encoding="utf-8"))
+            self.assertTrue(payload["plan"]["manual_actions"])
+
+    def test_tool_fails_when_log_is_incomplete(self) -> None:
+        """Tool should fail when summary count exceeds parsed findings."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(sample_truncated_preflight_log(), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT_TOOL),
+                    "--log-file",
+                    str(log_file),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("appears incomplete", result.stderr)
+
+    def test_tool_parses_string_false_strict_flag(self) -> None:
+        """Tool should parse string 'false' strict values as False."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(
+                sample_preflight_log_with_string_strict_false(), encoding="utf-8"
+            )
+            json_out = tmp_path / "triage.json"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT_TOOL),
                     "--log-file",
                     str(log_file),
                     "--json-out",
@@ -143,34 +172,7 @@ class TestL2UniformPreflightTool(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             payload = json.loads(json_out.read_text(encoding="utf-8"))
-            plan = payload["plan"]
-            self.assertTrue(plan["manual_actions"])
-            self.assertTrue(
-                any('{"strict":false}' in command for command in plan["safe_commands"])
-            )
-
-    def test_analyze_fails_when_log_is_incomplete(self) -> None:
-        """`analyze` should fail when summary count exceeds parsed findings."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir)
-            log_file = tmp_path / "preflight.log"
-            log_file.write_text(sample_truncated_preflight_log(), encoding="utf-8")
-
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(PREFLIGHT_TOOL),
-                    "analyze",
-                    "--log-file",
-                    str(log_file),
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-
-            self.assertEqual(result.returncode, 1)
-            self.assertIn("appears incomplete", result.stderr)
+            self.assertIs(payload["summary"]["strict"], False)
 
 
 class TestFailureHandler(unittest.TestCase):
@@ -192,8 +194,6 @@ class TestFailureHandler(unittest.TestCase):
                     str(log_file),
                     "--output-dir",
                     str(output_dir),
-                    "--dbt-project-path",
-                    str(tmp_path),
                 ],
                 check=False,
                 capture_output=True,
@@ -207,6 +207,37 @@ class TestFailureHandler(unittest.TestCase):
             self.assertTrue(summary_path.exists())
             summary = summary_path.read_text(encoding="utf-8")
             self.assertIn("Generated Artifacts", summary)
+
+    def test_failure_handler_returns_2_when_manual_actions_exist(self) -> None:
+        """Handler should return 2 when triage finds manual actions."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(
+                sample_preflight_log_with_manual_actions(), encoding="utf-8"
+            )
+            output_dir = tmp_path / "out"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(FAILURE_HANDLER),
+                    "--log-file",
+                    str(log_file),
+                    "--output-dir",
+                    str(output_dir),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            run_dirs = [p for p in output_dir.iterdir() if p.is_dir()]
+            self.assertEqual(len(run_dirs), 1)
+            summary_path = run_dirs[0] / "summary.md"
+            summary = summary_path.read_text(encoding="utf-8")
+            self.assertIn("Manual Actions Required", summary)
 
     def test_failure_handler_returns_hint_when_no_preflight_lines(self) -> None:
         """Handler should return a clear hint when logs lack preflight entries."""
@@ -224,8 +255,6 @@ class TestFailureHandler(unittest.TestCase):
                     str(log_file),
                     "--output-dir",
                     str(output_dir),
-                    "--dbt-project-path",
-                    str(tmp_path),
                 ],
                 check=False,
                 capture_output=True,
@@ -233,7 +262,7 @@ class TestFailureHandler(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 1)
-            self.assertIn("does not contain preflight output", result.stderr)
+            self.assertIn("does not contain complete preflight output", result.stderr)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
+++ b/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
@@ -32,6 +32,14 @@ def sample_preflight_log_with_manual_actions() -> str:
     return "\n".join(lines) + "\n"
 
 
+def sample_truncated_preflight_log() -> str:
+    lines = [
+        'L2_PREFLIGHT|{"kind":"config","metadata_catalog":"prod_catalog","strict":true,"states_expected":51}',
+        'L2_PREFLIGHT|{"kind":"summary","metadata_catalog":"prod_catalog","strict":true,"status":"fail","states_evaluated":51,"source_relations_found":51,"staging_relations_found":51,"finding_count":2}',
+    ]
+    return "\n".join(lines) + "\n"
+
+
 class TestL2UniformPreflightTool(unittest.TestCase):
     """Tests for the preflight log analyzer and planner CLI."""
 
@@ -140,6 +148,29 @@ class TestL2UniformPreflightTool(unittest.TestCase):
             self.assertTrue(
                 any('{"strict":false}' in command for command in plan["safe_commands"])
             )
+
+    def test_analyze_fails_when_log_is_incomplete(self) -> None:
+        """`analyze` should fail when summary count exceeds parsed findings."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(sample_truncated_preflight_log(), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT_TOOL),
+                    "analyze",
+                    "--log-file",
+                    str(log_file),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("appears incomplete", result.stderr)
 
 
 class TestFailureHandler(unittest.TestCase):

--- a/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
+++ b/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
@@ -22,6 +22,16 @@ def sample_preflight_log() -> str:
     return "\n".join(lines) + "\n"
 
 
+def sample_preflight_log_with_manual_actions() -> str:
+    lines = [
+        'L2_PREFLIGHT|{"kind":"config","metadata_catalog":"prod_catalog","strict":true,"states_expected":51}',
+        'L2_PREFLIGHT|{"kind":"stg_minus_src","state":"ME","columns":["old_col"]}',
+        'L2_PREFLIGHT|{"kind":"target_minus_src","target_model":"int__l2_nationwide_uniform","columns":["legacy_col"]}',
+        'L2_PREFLIGHT|{"kind":"summary","metadata_catalog":"prod_catalog","strict":true,"status":"fail","states_evaluated":51,"source_relations_found":51,"staging_relations_found":51,"finding_count":2}',
+    ]
+    return "\n".join(lines) + "\n"
+
+
 class TestL2UniformPreflightTool(unittest.TestCase):
     """Tests for the preflight log analyzer and planner CLI."""
 
@@ -97,6 +107,39 @@ class TestL2UniformPreflightTool(unittest.TestCase):
                 )
             )
             self.assertTrue(plan["follow_up_commands"])
+
+    def test_plan_uses_warn_preflight_when_manual_actions_exist(self) -> None:
+        """Plans with manual actions should rerun preflight with strict=false."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(
+                sample_preflight_log_with_manual_actions(), encoding="utf-8"
+            )
+            json_out = tmp_path / "plan.json"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT_TOOL),
+                    "plan",
+                    "--log-file",
+                    str(log_file),
+                    "--json-out",
+                    str(json_out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(json_out.read_text(encoding="utf-8"))
+            plan = payload["plan"]
+            self.assertTrue(plan["manual_actions"])
+            self.assertTrue(
+                any('{"strict":false}' in command for command in plan["safe_commands"])
+            )
 
 
 class TestFailureHandler(unittest.TestCase):

--- a/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
+++ b/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+PREFLIGHT_TOOL = SKILL_ROOT / "scripts" / "l2_uniform_preflight_tool.py"
+FAILURE_HANDLER = SKILL_ROOT / "scripts" / "dbt_failure_handler.py"
+
+
+def sample_preflight_log() -> str:
+    lines = [
+        "noise line",
+        'L2_PREFLIGHT|{"kind":"config","metadata_catalog":"prod_catalog","strict":true,"states_expected":51}',
+        'L2_PREFLIGHT|{"kind":"stg_minus_src","state":"ME","columns":["old_col"]}',
+        'L2_PREFLIGHT|{"kind":"summary","metadata_catalog":"prod_catalog","strict":true,"status":"fail","states_evaluated":51,"source_relations_found":51,"staging_relations_found":51,"finding_count":1}',
+    ]
+    return "\n".join(lines) + "\n"
+
+
+class TestL2UniformPreflightTool(unittest.TestCase):
+    """Tests for the preflight log analyzer and planner CLI."""
+
+    def test_analyze_outputs_expected_summary(self) -> None:
+        """`analyze` should summarize metadata and impacted states from logs."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(sample_preflight_log(), encoding="utf-8")
+            json_out = tmp_path / "analysis.json"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT_TOOL),
+                    "analyze",
+                    "--log-file",
+                    str(log_file),
+                    "--json-out",
+                    str(json_out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(json_out.read_text(encoding="utf-8"))
+            self.assertEqual(payload["metadata_catalog"], "prod_catalog")
+            self.assertEqual(payload["finding_count"], 1)
+            self.assertEqual(payload["impacted_states"], ["ME"])
+
+    def test_plan_includes_staging_fix_and_follow_up(self) -> None:
+        """`plan` should include safe staging refresh and follow-up commands."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(sample_preflight_log(), encoding="utf-8")
+            json_out = tmp_path / "plan.json"
+            shell_out = tmp_path / "plan.sh"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(PREFLIGHT_TOOL),
+                    "plan",
+                    "--log-file",
+                    str(log_file),
+                    "--json-out",
+                    str(json_out),
+                    "--shell-out",
+                    str(shell_out),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(json_out.read_text(encoding="utf-8"))
+            plan = payload["plan"]
+            self.assertTrue(
+                any(
+                    "stg_dbt_source__l2_s3_me_uniform" in command
+                    for command in plan["safe_commands"]
+                )
+            )
+            self.assertFalse(
+                any(
+                    "int__l2_nationwide_uniform int__l2_nationwide_uniform_w_haystaq"
+                    in command
+                    for command in plan["safe_commands"]
+                )
+            )
+            self.assertTrue(plan["follow_up_commands"])
+
+
+class TestFailureHandler(unittest.TestCase):
+    """Tests for end-to-end failure handler artifact generation."""
+
+    def test_failure_handler_writes_artifacts(self) -> None:
+        """Handler should create one run directory with summary artifacts."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "preflight.log"
+            log_file.write_text(sample_preflight_log(), encoding="utf-8")
+            output_dir = tmp_path / "out"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(FAILURE_HANDLER),
+                    "--log-file",
+                    str(log_file),
+                    "--output-dir",
+                    str(output_dir),
+                    "--dbt-project-path",
+                    str(tmp_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            run_dirs = [p for p in output_dir.iterdir() if p.is_dir()]
+            self.assertEqual(len(run_dirs), 1)
+            summary_path = run_dirs[0] / "summary.md"
+            self.assertTrue(summary_path.exists())
+            summary = summary_path.read_text(encoding="utf-8")
+            self.assertIn("Generated Artifacts", summary)
+
+    def test_failure_handler_returns_hint_when_no_preflight_lines(self) -> None:
+        """Handler should return a clear hint when logs lack preflight entries."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            log_file = tmp_path / "build.log"
+            log_file.write_text("no preflight lines\n", encoding="utf-8")
+            output_dir = tmp_path / "out"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(FAILURE_HANDLER),
+                    "--log-file",
+                    str(log_file),
+                    "--output-dir",
+                    str(output_dir),
+                    "--dbt-project-path",
+                    str(tmp_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("does not contain preflight output", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ logs/
 
 # Local dev files
 .tickets/
+.claude/skills/l2-uniform-drift-remediator/dbt_logs/*
+!.claude/skills/l2-uniform-drift-remediator/dbt_logs/.gitkeep
+!.claude/skills/l2-uniform-drift-remediator/dbt_logs/README.md
 .pre-commit-cache/
 test_data/
 

--- a/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
+++ b/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
@@ -1,0 +1,355 @@
+{% macro _l2_uniform_preflight_emit(payload) %}
+    {{ log("L2_PREFLIGHT|" ~ (payload | tojson), info=true) }}
+{% endmacro %}
+
+
+{% macro _l2_uniform_preflight_get_column_names(relation) %}
+    {% set column_names = [] %}
+    {% for column in adapter.get_columns_in_relation(relation) %}
+        {% set normalized_name = column.name | lower %}
+        {% if normalized_name not in column_names %}
+            {% do column_names.append(normalized_name) %}
+        {% endif %}
+    {% endfor %}
+    {{ return(column_names | sort) }}
+{% endmacro %}
+
+
+{% macro _l2_uniform_preflight_list_diff(left_columns, right_columns) %}
+    {% set diff = [] %}
+    {% for column_name in left_columns | sort %}
+        {% if column_name not in right_columns %}
+            {% do diff.append(column_name) %}
+        {% endif %}
+    {% endfor %}
+    {{ return(diff) }}
+{% endmacro %}
+
+
+{% macro l2_uniform_schema_preflight(strict=true) %}
+    {% set strict_mode = strict %}
+    {% if strict_mode is none %} {% set strict_mode = true %}
+    {% elif strict_mode is string %}
+        {% set strict_mode = strict_mode | trim | lower in [
+            "1",
+            "t",
+            "true",
+            "y",
+            "yes",
+        ] %}
+    {% endif %}
+
+    {% set metadata_catalog = var(
+        "preflight_metadata_catalog", "goodparty_data_catalog"
+    ) %}
+    {% set states = get_us_states_list(include_DC=true, include_US=false) %}
+    {% set ns = namespace(source_found_count=0, stg_found_count=0, findings=[]) %}
+    {% set all_source_columns = [] %}
+
+    {% if states | length != 51 %}
+        {{
+            exceptions.raise_compiler_error(
+                "L2 uniform preflight expected 51 jurisdictions (50 states + DC), got "
+                ~ (states | length)
+                ~ ". Check get_us_states_list(include_DC=true, include_US=false)."
+            )
+        }}
+    {% endif %}
+
+    {% do _l2_uniform_preflight_emit(
+        {
+            "kind": "config",
+            "metadata_catalog": metadata_catalog,
+            "strict": strict_mode,
+            "states_expected": states | length,
+        }
+    ) %}
+
+    {% for state in states %}
+        {% set state_lower = state | lower %}
+        {% set source_identifier = "l2_s3_" ~ state_lower ~ "_uniform" %}
+        {% set stg_identifier = "stg_dbt_source__l2_s3_" ~ state_lower ~ "_uniform" %}
+
+        {% set source_relation_name = (
+            metadata_catalog ~ ".dbt_source." ~ source_identifier
+        ) %}
+        {% set stg_relation_name = metadata_catalog ~ ".dbt." ~ stg_identifier %}
+
+        {% set source_relation = adapter.get_relation(
+            database=metadata_catalog,
+            schema="dbt_source",
+            identifier=source_identifier,
+        ) %}
+        {% set stg_relation = adapter.get_relation(
+            database=metadata_catalog, schema="dbt", identifier=stg_identifier
+        ) %}
+
+        {% if source_relation is none %}
+            {% set finding = {
+                "kind": "relation_missing",
+                "scope": "state_source",
+                "state": state,
+                "relation": source_relation_name,
+            } %}
+            {% do ns.findings.append(finding) %}
+            {% do _l2_uniform_preflight_emit(finding) %}
+            {% set source_columns = [] %}
+        {% else %}
+            {% set ns.source_found_count = ns.source_found_count + 1 %}
+            {% set source_columns = _l2_uniform_preflight_get_column_names(
+                source_relation
+            ) %}
+            {% for source_column_name in source_columns %}
+                {% if source_column_name not in all_source_columns %}
+                    {% do all_source_columns.append(source_column_name) %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+
+        {% if stg_relation is none %}
+            {% set finding = {
+                "kind": "relation_missing",
+                "scope": "state_staging",
+                "state": state,
+                "relation": stg_relation_name,
+            } %}
+            {% do ns.findings.append(finding) %}
+            {% do _l2_uniform_preflight_emit(finding) %}
+            {% set stg_columns = [] %}
+        {% else %}
+            {% set ns.stg_found_count = ns.stg_found_count + 1 %}
+            {% set stg_columns = _l2_uniform_preflight_get_column_names(stg_relation) %}
+        {% endif %}
+
+        {% if source_relation is not none and stg_relation is not none %}
+            {% set stg_minus_src = _l2_uniform_preflight_list_diff(
+                stg_columns, source_columns
+            ) %}
+            {% if stg_minus_src | length > 0 %}
+                {% set finding = {
+                    "kind": "stg_minus_src",
+                    "state": state,
+                    "source_relation": source_relation_name,
+                    "staging_relation": stg_relation_name,
+                    "columns": stg_minus_src,
+                } %}
+                {% do ns.findings.append(finding) %}
+                {% do _l2_uniform_preflight_emit(finding) %}
+            {% endif %}
+
+            {% set src_minus_stg = _l2_uniform_preflight_list_diff(
+                source_columns, stg_columns
+            ) %}
+            {% if src_minus_stg | length > 0 %}
+                {% set finding = {
+                    "kind": "src_minus_stg",
+                    "state": state,
+                    "source_relation": source_relation_name,
+                    "staging_relation": stg_relation_name,
+                    "columns": src_minus_stg,
+                } %}
+                {% do ns.findings.append(finding) %}
+                {% do _l2_uniform_preflight_emit(finding) %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {% if ns.source_found_count == 0 or ns.stg_found_count == 0 %}
+        {% set permission_msg %}
+L2 uniform preflight could not read required metadata relations in catalog '{{ metadata_catalog }}'.
+This usually indicates missing permissions or a wrong catalog.
+Fallback: override catalog with --vars '{"preflight_metadata_catalog":"<catalog>"}', or request read access on {{ metadata_catalog }}.dbt_source and {{ metadata_catalog }}.dbt.
+        {% endset %}
+        {{ exceptions.raise_compiler_error(permission_msg | trim) }}
+    {% endif %}
+
+    {% set expected_primary_columns = [] %}
+    {% for source_column_name in all_source_columns %}
+        {% if source_column_name not in expected_primary_columns %}
+            {% do expected_primary_columns.append(source_column_name) %}
+        {% endif %}
+    {% endfor %}
+    {% for derived_column_name in ["state_postal_code", "state_from_lalvoterid"] %}
+        {% if derived_column_name not in expected_primary_columns %}
+            {% do expected_primary_columns.append(derived_column_name) %}
+        {% endif %}
+    {% endfor %}
+
+    {% set primary_target_identifier = "int__l2_nationwide_uniform" %}
+    {% set primary_target_relation_name = (
+        metadata_catalog ~ ".dbt." ~ primary_target_identifier
+    ) %}
+    {% set primary_target_relation = adapter.get_relation(
+        database=metadata_catalog,
+        schema="dbt",
+        identifier=primary_target_identifier,
+    ) %}
+    {% set primary_target_columns = [] %}
+
+    {% if primary_target_relation is none %}
+        {% set finding = {
+            "kind": "relation_missing",
+            "scope": "target_primary",
+            "relation": primary_target_relation_name,
+        } %}
+        {% do ns.findings.append(finding) %}
+        {% do _l2_uniform_preflight_emit(finding) %}
+    {% else %}
+        {% set primary_target_columns = _l2_uniform_preflight_get_column_names(
+            primary_target_relation
+        ) %}
+        {% set primary_target_minus_src = _l2_uniform_preflight_list_diff(
+            primary_target_columns, expected_primary_columns
+        ) %}
+        {% if primary_target_minus_src | length > 0 %}
+            {% set finding = {
+                "kind": "target_minus_src",
+                "target_model": primary_target_identifier,
+                "target_relation": primary_target_relation_name,
+                "upstream_contract": "state_sources_plus_derived_columns",
+                "columns": primary_target_minus_src,
+            } %}
+            {% do ns.findings.append(finding) %}
+            {% do _l2_uniform_preflight_emit(finding) %}
+        {% endif %}
+    {% endif %}
+
+    {% set downstream_contract_columns = [] %}
+    {% for column_name in primary_target_columns %}
+        {% if column_name not in downstream_contract_columns %}
+            {% do downstream_contract_columns.append(column_name) %}
+        {% endif %}
+    {% endfor %}
+
+    {% set flags_identifier = "int__l2_nationwide_haystaq_flags" %}
+    {% set flags_relation_name = metadata_catalog ~ ".dbt." ~ flags_identifier %}
+    {% set flags_relation = adapter.get_relation(
+        database=metadata_catalog, schema="dbt", identifier=flags_identifier
+    ) %}
+    {% if flags_relation is none %}
+        {% set finding = {
+            "kind": "relation_missing",
+            "scope": "upstream_haystaq_flags",
+            "relation": flags_relation_name,
+        } %}
+        {% do ns.findings.append(finding) %}
+        {% do _l2_uniform_preflight_emit(finding) %}
+    {% else %}
+        {% set flags_columns = _l2_uniform_preflight_get_column_names(flags_relation) %}
+        {% for flags_column_name in flags_columns %}
+            {% if flags_column_name[
+                :3
+            ] == "hf_" and flags_column_name not in downstream_contract_columns %}
+                {% do downstream_contract_columns.append(flags_column_name) %}
+            {% endif %}
+        {% endfor %}
+        {% if "haystaq_flags_loaded_at" not in downstream_contract_columns %}
+            {% do downstream_contract_columns.append("haystaq_flags_loaded_at") %}
+        {% endif %}
+    {% endif %}
+
+    {% set scores_identifier = "int__l2_nationwide_haystaq_scores" %}
+    {% set scores_relation_name = metadata_catalog ~ ".dbt." ~ scores_identifier %}
+    {% set scores_relation = adapter.get_relation(
+        database=metadata_catalog, schema="dbt", identifier=scores_identifier
+    ) %}
+    {% if scores_relation is none %}
+        {% set finding = {
+            "kind": "relation_missing",
+            "scope": "upstream_haystaq_scores",
+            "relation": scores_relation_name,
+        } %}
+        {% do ns.findings.append(finding) %}
+        {% do _l2_uniform_preflight_emit(finding) %}
+    {% else %}
+        {% set scores_columns = _l2_uniform_preflight_get_column_names(
+            scores_relation
+        ) %}
+        {% for scores_column_name in scores_columns %}
+            {% if scores_column_name[
+                :3
+            ] == "hs_" and scores_column_name not in downstream_contract_columns %}
+                {% do downstream_contract_columns.append(scores_column_name) %}
+            {% endif %}
+        {% endfor %}
+        {% if "haystaq_scores_loaded_at" not in downstream_contract_columns %}
+            {% do downstream_contract_columns.append("haystaq_scores_loaded_at") %}
+        {% endif %}
+    {% endif %}
+
+    {% set downstream_target_identifier = "int__l2_nationwide_uniform_w_haystaq" %}
+    {% set downstream_target_relation_name = (
+        metadata_catalog ~ ".dbt." ~ downstream_target_identifier
+    ) %}
+    {% set downstream_target_relation = adapter.get_relation(
+        database=metadata_catalog,
+        schema="dbt",
+        identifier=downstream_target_identifier,
+    ) %}
+
+    {% if downstream_target_relation is none %}
+        {% set finding = {
+            "kind": "relation_missing",
+            "scope": "target_downstream",
+            "relation": downstream_target_relation_name,
+        } %}
+        {% do ns.findings.append(finding) %}
+        {% do _l2_uniform_preflight_emit(finding) %}
+    {% else %}
+        {% set downstream_target_columns = _l2_uniform_preflight_get_column_names(
+            downstream_target_relation
+        ) %}
+        {% set downstream_target_minus_src = _l2_uniform_preflight_list_diff(
+            downstream_target_columns, downstream_contract_columns
+        ) %}
+        {% if downstream_target_minus_src | length > 0 %}
+            {% set finding = {
+                "kind": "target_minus_src",
+                "target_model": downstream_target_identifier,
+                "target_relation": downstream_target_relation_name,
+                "upstream_contract": "uniform_plus_hf_hs_aliases",
+                "columns": downstream_target_minus_src,
+            } %}
+            {% do ns.findings.append(finding) %}
+            {% do _l2_uniform_preflight_emit(finding) %}
+        {% endif %}
+    {% endif %}
+
+    {% if ns.findings | length == 0 %} {% set status = "clean" %}
+    {% elif strict_mode %} {% set status = "fail" %}
+    {% else %} {% set status = "warn" %}
+    {% endif %}
+
+    {% do _l2_uniform_preflight_emit(
+        {
+            "kind": "summary",
+            "metadata_catalog": metadata_catalog,
+            "strict": strict_mode,
+            "status": status,
+            "states_evaluated": states | length,
+            "source_relations_found": ns.source_found_count,
+            "staging_relations_found": ns.stg_found_count,
+            "finding_count": ns.findings | length,
+        }
+    ) %}
+
+    {% if ns.findings | length > 0 and strict_mode %}
+        {{
+            exceptions.raise_compiler_error(
+                "L2 uniform schema preflight failed with "
+                ~ (ns.findings | length)
+                ~ " finding(s). See L2_PREFLIGHT| JSON lines for details."
+            )
+        }}
+    {% endif %}
+
+    {{
+        return(
+            {
+                "finding_count": ns.findings | length,
+                "strict": strict_mode,
+                "status": status,
+            }
+        )
+    }}
+{% endmacro %}

--- a/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
+++ b/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
@@ -40,7 +40,12 @@
     {% endif %}
 
     {% set metadata_catalog = var(
-        "preflight_metadata_catalog", "goodparty_data_catalog"
+        "preflight_metadata_catalog",
+        (
+            target.database
+            if target.database is not none
+            else "goodparty_data_catalog"
+        ),
     ) %}
     {% set states = get_us_states_list(include_DC=true, include_US=false) %}
     {% set ns = namespace(source_found_count=0, stg_found_count=0, findings=[]) %}

--- a/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
+++ b/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
@@ -220,7 +220,7 @@ Fallback: override catalog with --vars '{"preflight_metadata_catalog":"<catalog>
     {% endif %}
 
     {% set downstream_contract_columns = [] %}
-    {% for column_name in primary_target_columns %}
+    {% for column_name in expected_primary_columns %}
         {% if column_name not in downstream_contract_columns %}
             {% do downstream_contract_columns.append(column_name) %}
         {% endif %}

--- a/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
+++ b/dbt/project/macros/l2/l2_uniform_schema_preflight.sql
@@ -39,13 +39,13 @@
         ] %}
     {% endif %}
 
+    {% set target_database = target.database %}
+    {% if target_database is string %}
+        {% set target_database = target_database | trim %}
+    {% endif %}
     {% set metadata_catalog = var(
         "preflight_metadata_catalog",
-        (
-            target.database
-            if target.database is not none
-            else "goodparty_data_catalog"
-        ),
+        (target_database if target_database else "goodparty_data_catalog"),
     ) %}
     {% set states = get_us_states_list(include_DC=true, include_US=false) %}
     {% set ns = namespace(source_found_count=0, stg_found_count=0, findings=[]) %}


### PR DESCRIPTION
## Summary

Implements macro for L2 uniform schema drift handling (fail-fast + manual deprecation), and adds a self-contained remediation skill for **post-failure triage and safe fixes**.

## Problem

`int__l2_nationwide_uniform` failures can recur when state-level source schema changes cause stale staging views and target drift. We need reliable visibility into drift and an easy, low-risk remediation workflow.

## Use Case:

1. Build fails (for example `UNRESOLVED_COLUMN` in L2 uniform flow).

2. Run strict preflight:
```bash
dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'
```

3. Download that preflight run log from dbt Cloud (must include `L2_PREFLIGHT|...` lines).

4. Run the single handler command:
```bash
python /Users/sanjay/Desktop/workspaces/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py \
  --log-file /absolute/path/to/preflight.log \
  --output-dir /Users/sanjay/Desktop/workspaces/gp-data-platform/.claude/skills/l2-uniform-drift-remediator/dbt_logs/failure_handler
```

5. Open the generated timestamped folder and use:
- `summary.md` as operator instructions
- `safe_fix_plan.sh` as copy/pasteable safe dbt commands
- `triage.json` for structured details

6. Run safe commands manually in a one-off dbt Cloud job (or equivalent controlled run).

7. If `summary.md` lists manual actions (`target_minus_src` / `relation_missing`), do those controlled steps (no destructive auto-fix).

8. Rerun strict preflight to confirm clean:
```bash
dbt run-operation l2_uniform_schema_preflight --args '{"strict": true}'
```

9. Rerun the original failed build command.

**Exit codes (handler/tool)**
- `0`: safe-only remediation path
- `2`: manual actions required
- `1`: invalid/incomplete log (re-download full preflight log)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new dbt macro that can fail runs in `strict` mode and introduces new operational tooling/workflow; risk is mainly around build stability if the preflight is adopted broadly or run with incorrect catalog/permissions.
> 
> **Overview**
> Adds a new `l2_uniform_schema_preflight` dbt macro that scans all state `l2_s3_*_uniform` source vs staging relations and checks downstream targets (`int__l2_nationwide_uniform`, `int__l2_nationwide_uniform_w_haystaq`) for schema drift, emitting structured `L2_PREFLIGHT|{...}` JSON log lines and optionally failing the run in *strict* mode.
> 
> Introduces a self-contained “L2 uniform drift remediator” skill: a Python log parser that turns `L2_PREFLIGHT|` output into a deterministic safe command plan (re-run impacted staging models + rerun preflight), plus a failure-handler wrapper that writes timestamped artifacts (`summary.md`, `safe_fix_plan.sh`, `triage.json/txt`) and returns exit code `2` when manual actions (e.g., `target_minus_src`/missing relations) remain.
> 
> Updates `.gitignore` to keep generated/downloaded logs under `.claude/skills/l2-uniform-drift-remediator/dbt_logs/` untracked (except docs), and adds runbook/docs + unit tests for the new scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0e2d374b3a1f9c28a52a2549b825f16a4221cdb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->