### PR TITLE
Register TS Officeholder stream in dbt 

### DIFF
--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -208,6 +208,8 @@ sources:
           freshness: null
       - name: techspeed_gdrive_candidates
         description: raw data load from Techspeed Google Drive
+      - name: techspeed_gdrive_officeholders
+        description: raw data load from Techspeed Google Drive
       - name: techspeed_gdrive_marketing_data_enrichment
         description: raw data load from Techspeed Google Drive
         config:

--- a/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive.yaml
+++ b/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive.yaml
@@ -6,6 +6,14 @@ models:
         data_tests:
           - not_null
           - unique
+  - name: stg_airbyte_source__techspeed_gdrive_officeholders
+    description: Officeholders data load from TechSpeed Google Drive
+    # TODO: Add person-level office_holder_id tests if/when candidates moves to id-based key tests.
+    columns:
+      - name: _airbyte_raw_id
+        data_tests:
+          - not_null
+          - unique
   - name: stg_airbyte_source__techspeed_gdrive_marketing_data_enrichment
     description: Marketing data enrichment load from TechSpeed Google Drive
     columns:

--- a/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive_officeholders.sql
+++ b/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive_officeholders.sql
@@ -1,0 +1,57 @@
+-- TODO: Keep raw string types to match the current TechSpeed candidates staging
+-- pattern.
+-- If we later add safe typed casts in candidates, mirror those casts here.
+with
+    source as (
+        select * from {{ source("airbyte_source", "techspeed_gdrive_officeholders") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("_ab_source_file_url") }},
+            {{ adapter.quote("_ab_source_file_last_modified") }},
+            {{ adapter.quote("office_holder_id") }},
+            {{ adapter.quote("first_name") }},
+            {{ adapter.quote("last_name") }},
+            {{ adapter.quote("email") }},
+            {{ adapter.quote("email_source") }},
+            {{ adapter.quote("phone") }},
+            {{ adapter.quote("phone_source") }},
+            {{ adapter.quote("city") }},
+            {{ adapter.quote("state") }},
+            {{ adapter.quote("postal_code") }},
+            {{ adapter.quote("street_address") }},
+            {{ adapter.quote("county_municipality") }},
+            {{ adapter.quote("district_name") }},
+            {{ adapter.quote("office_name") }},
+            {{ adapter.quote("office_type") }},
+            {{ adapter.quote("office_level") }},
+            {{ adapter.quote("office_normalized") }},
+            {{ adapter.quote("position_id") }},
+            {{ adapter.quote("normalized_position_id") }},
+            {{ adapter.quote("normalized_location") }},
+            {{ adapter.quote("level") }},
+            {{ adapter.quote("tier") }},
+            {{ adapter.quote("party") }},
+            {{ adapter.quote("partisan") }},
+            {{ adapter.quote("is_incumbent") }},
+            {{ adapter.quote("is_uncontested") }},
+            {{ adapter.quote("seats_available") }},
+            {{ adapter.quote("general_election_day") }},
+            {{ adapter.quote("primary_election_day") }},
+            {{ adapter.quote("filing_deadline") }},
+            {{ adapter.quote("date_processed") }},
+            {{ adapter.quote("running_for_re_election_2025") }},
+            {{ adapter.quote("running_for_re_election_2026") }},
+            {{ adapter.quote("url_for_running_for_re_election_2025") }},
+            {{ adapter.quote("url_for_running_for_re_election_2026") }},
+            {{ adapter.quote("ts_status") }},
+            {{ adapter.quote("ts_comment") }}
+
+        from source
+    )
+select *
+from renamed


### PR DESCRIPTION
## Summary
Registers the new TechSpeed Airbyte officeholders stream in dbt and adds a matching staging model using the existing candidates ingestion pattern.

## What Changed
- Added new Airbyte source table registration for `techspeed_gdrive_officeholders` in [__sources.yaml](/Users/sanjay/Desktop/workspaces/gp-data-platform/dbt/project/models/staging/__sources.yaml).
- Added new staging model [stg_airbyte_source__techspeed_gdrive_officeholders.sql](/Users/sanjay/Desktop/workspaces/gp-data-platform/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive_officeholders.sql) as a sibling to candidates.
- Updated model docs/tests in [stg_airbyte_source__techspeed_gdrive.yaml](/Users/sanjay/Desktop/workspaces/gp-data-platform/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive.yaml) with the same ingestion-level test pattern as candidates (`_airbyte_raw_id` `not_null` + `unique`).

## Implementation Notes
- Mirrored candidates staging conventions closely:
  - `source` CTE + `renamed` CTE pattern
  - `adapter.quote(...)` field selection style
  - no new business logic at staging
- Preserved only `partisan` (did not introduce `Partisan` case-duplicate).
- Left staged values as landed strings to stay consistent with current candidates ingestion behavior.
- Added TODO notes for future typed casts/person-key testing if candidates pattern evolves.

## Validation
- `dbt ls --select stg_airbyte_source__techspeed_gdrive_officeholders` resolves successfully.
- New model and tests are discoverable:
  - `goodparty_data_catalog.staging.airbyte_source.techspeed_grive.stg_airbyte_source__techspeed_gdrive_officeholders`
  - `not_null_stg_airbyte_source__techspeed_gdrive_officeholders__airbyte_raw_id`
  - `unique_stg_airbyte_source__techspeed_gdrive_officeholders__airbyte_raw_id`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive dbt changes that register a new Airbyte source table and introduce a new staging model with basic `_airbyte_raw_id` uniqueness/null tests. Main risk is build failures if the upstream `techspeed_gdrive_officeholders` table or expected columns are missing/renamed.
> 
> **Overview**
> Registers the new Airbyte source table `techspeed_gdrive_officeholders` in `__sources.yaml` so dbt can reference the stream.
> 
> Adds a new staging model `stg_airbyte_source__techspeed_gdrive_officeholders` that mirrors the existing TechSpeed candidates pattern by selecting/quoting the raw stream columns without additional transformations, and documents it in `stg_airbyte_source__techspeed_gdrive.yaml` with `not_null` + `unique` tests on `_airbyte_raw_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49ef9d37ebf8ec9c707a83467fdcc92711f4c6fd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->