### PR TITLE
[DATA-1720] Add Product DB to ER prematch candidacy stages

### DIFF
--- a/dbt/project/CLAUDE.md
+++ b/dbt/project/CLAUDE.md
@@ -111,9 +111,9 @@ etc.
 *   Example: "Seattle Mayor 2026" (the entire election)
 *   An Election comprises multiple Stages
 **Election-Stage**
-*   A single phase within an election (primary, general, primary runoff, or general runoff)
+*   A single phase within an election (primary, general, runoff, or special variants)
 *   Example: "Seattle Mayor 2026 Primary" or "Seattle Mayor 2026 General"
-*   Values: Primary, General, Primary Runoff, General Runoff
+*   Values: Primary, General, Primary Runoff, General Runoff, Primary Special, General Special, Primary Special Runoff, General Special Runoff
 **Candidacy-Stage**
 *   The intersection of a candidacy and a specific stage
 *   Contains vendor-specific IDs and stage-specific results

--- a/dbt/project/macros/parse_party_affiliation.sql
+++ b/dbt/project/macros/parse_party_affiliation.sql
@@ -1,5 +1,7 @@
 {% macro parse_party_affiliation(column) %}
     case
+        when nullif(trim({{ column }}), '') is null
+        then null
         when {{ column }} ilike '%independent%'
         then 'Independent'
         when {{ column }} ilike '%nonpartisan%'

--- a/dbt/project/macros/variable_standardization/ballotready_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/ballotready_standardizations.sql
@@ -245,3 +245,37 @@
         else {{ normalized_position_name_col }}
     end
 {% endmacro %}
+
+
+{#
+  Derives election_stage from BallotReady is_primary/is_runoff flags and
+  election name. BR election names consistently contain "Special" for
+  special elections (e.g. "Georgia Special General", "Florida House Special
+  Primary") — set by BallotReady's editorial team. False positives are
+  guarded by a race_count <= 10 test on the upstream BR election staging
+  model.
+
+  Usage: {{ derive_election_stage("br.is_primary", "br.is_runoff", "br.election_name") }}
+#}
+{% macro derive_election_stage(is_primary_col, is_runoff_col, election_name_col) %}
+    case
+        when
+            {{ is_primary_col }}
+            and {{ is_runoff_col }}
+            and lower({{ election_name_col }}) like '%special%'
+        then 'Primary Special Runoff'
+        when {{ is_primary_col }} and {{ is_runoff_col }}
+        then 'Primary Runoff'
+        when {{ is_primary_col }} and lower({{ election_name_col }}) like '%special%'
+        then 'Primary Special'
+        when {{ is_primary_col }}
+        then 'Primary'
+        when {{ is_runoff_col }} and lower({{ election_name_col }}) like '%special%'
+        then 'General Special Runoff'
+        when {{ is_runoff_col }}
+        then 'General Runoff'
+        when lower({{ election_name_col }}) like '%special%'
+        then 'General Special'
+        else 'General'
+    end
+{% endmacro %}

--- a/dbt/project/macros/variable_standardization/ballotready_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/ballotready_standardizations.sql
@@ -192,11 +192,11 @@
     position_name_col, normalized_position_name_col
 ) %}
     case
-        when {{ position_name_col }} like '%Village President%'
+        when {{ position_name_col }} ilike '%Village President%'
         then 'Village President'
-        when {{ position_name_col }} like '%Town Chair%'
+        when {{ position_name_col }} ilike '%Town Chair%'
         then 'Town Chair'
-        when {{ position_name_col }} like '%Water Supply District%'
+        when {{ position_name_col }} ilike '%Water Supply District%'
         then 'Water Supply Board'
         when {{ normalized_position_name_col }} = 'City Legislature'
         then 'City Council'

--- a/dbt/project/macros/variable_standardization/office_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/office_standardizations.sql
@@ -43,7 +43,6 @@
                 'city clerk',
                 'township clerk',
                 'clerk/treasurer',
-                'county clerk',
                 'county court clerk'
             )
         then 'Clerk/Treasurer'
@@ -76,7 +75,6 @@
             lower({{ column_name }}) in (
                 'circuit court',
                 'circuit court judge',
-                'county court judge',
                 'district court',
                 'judge',
                 'probate court',
@@ -105,9 +103,7 @@
         when lower({{ column_name }}) in ('board of education', 'school board')
         then 'School Board'
         -- Sheriff
-        when
-            lower({{ column_name }})
-            in ('constable', 'county constable', 'county sheriff', 'sheriff')
+        when lower({{ column_name }}) in ('constable', 'county constable', 'sheriff')
         then 'Sheriff'
         when lower({{ column_name }}) like 'county sheriff%'
         then 'Sheriff'

--- a/dbt/project/macros/variable_standardization/office_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/office_standardizations.sql
@@ -138,6 +138,24 @@
                 'village trustee'
             )
         then 'Town Council'
+        -- Explicitly mapped to Other (not just else fallthrough)
+        when
+            lower({{ column_name }}) in (
+                'board of trustees',
+                'community college board',
+                'dependent district board',
+                'elections supervisor',
+                'fire board',
+                'hawaiian affairs board',
+                'highway superintendent',
+                'insurance commissioner',
+                'library board',
+                'parks and recreation board',
+                'port board',
+                'township assessor',
+                'water supply board'
+            )
+        then 'Other'
         else 'Other'
     end
 {% endmacro %}

--- a/dbt/project/macros/variable_standardization/office_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/office_standardizations.sql
@@ -18,12 +18,8 @@
         -- Alderman
         when lower({{ column_name }}) in ('alderman', 'alderperson')
         then 'Alderman'
-        -- Attorney
-        when
-            lower({{ column_name }})
-            in ('attorney', 'district attorney', 'county attorney')
-        then 'Attorney'
-        when lower({{ column_name }}) like 'state attorney%'
+        -- Attorney (catch all variants: City Attorney, County Attorney, etc.)
+        when lower({{ column_name }}) like '%attorney%'
         then 'Attorney'
         -- City Council
         when
@@ -70,27 +66,17 @@
         then 'County Supervisor'
         when lower({{ column_name }}) like 'board of supervisor%'
         then 'County Supervisor'
-        -- Judge
+        -- Judge (catch all variants: magistrate, appellate, etc.)
         when
-            lower({{ column_name }}) in (
-                'circuit court',
-                'circuit court judge',
-                'district court',
-                'judge',
-                'probate court',
-                'supreme court',
-                'trial court judge'
-            )
+            lower({{ column_name }}) like '%judge%'
+            or lower({{ column_name }}) like '%magistrate%'
+            or lower({{ column_name }}) like '%justice of the peace%'
+            or lower({{ column_name }})
+            in ('circuit court', 'district court', 'probate court', 'supreme court')
         then 'Judge'
-        when lower({{ column_name }}) like 'justice of the peace%'
+        when lower({{ column_name }}) like '%appellate court%'
         then 'Judge'
-        when lower({{ column_name }}) like 'state trial court%'
-        then 'Judge'
-        when lower({{ column_name }}) like 'state appellate court%'
-        then 'Judge'
-        when lower({{ column_name }}) like 'state supreme court%'
-        then 'Judge'
-        when lower({{ column_name }}) like 'county court judge%'
+        when lower({{ column_name }}) like '%supreme court%'
         then 'Judge'
         -- Mayor
         when

--- a/dbt/project/macros/variable_standardization/office_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/office_standardizations.sql
@@ -1,131 +1,143 @@
 {#
   Maps candidate_office values to standardized office_type categories.
-  Shared across all sources (BallotReady, TechSpeed, DDHQ).
+  Shared across all sources (BallotReady, TechSpeed, DDHQ, GP API).
 
   Each source has its own extraction macro to produce candidate_office:
     - BR: generate_candidate_office_from_position (ballotready_standardizations.sql)
     - DDHQ: parse_ddhq_candidate_office (ddhq_standardizations.sql)
     - TS: pre-populated in upstream model
+    - GP API: generate_candidate_office_from_position via campaigns mart
 
   This macro normalizes those values into a consistent office_type.
+  All comparisons use lower() so casing differences (e.g. from initcap
+  capitalizing prepositions) don't cause mismatches.
   Usage: {{ map_office_type(column_name) }}
 #}
 {% macro map_office_type(column_name) %}
     case
-        when {{ column_name }} = 'Alderman'
+        -- Alderman
+        when lower({{ column_name }}) in ('alderman', 'alderperson')
         then 'Alderman'
-        when {{ column_name }} = 'Alderperson'
-        then 'Alderman'
-        when {{ column_name }} = 'Attorney'
-        then 'Attorney'
-        when {{ column_name }} = 'City Commission'
-        then 'City Council'
-        when {{ column_name }} = 'City Commissioner'
-        then 'City Council'
-        when {{ column_name }} = 'City Council'
-        then 'City Council'
-        when {{ column_name }} = 'Town Chair'
-        then 'City Council'
-        when {{ column_name }} = 'Township Council'
-        then 'City Council'
-        when {{ column_name }} = 'Clerk'
-        then 'Clerk/Treasurer'
-        when {{ column_name }} = 'Treasurer'
-        then 'Clerk/Treasurer'
-        when {{ column_name }} = 'City Clerk'
-        then 'Clerk/Treasurer'
-        when {{ column_name }} = 'Township Clerk'
-        then 'Clerk/Treasurer'
-        when {{ column_name }} = 'Clerk/Treasurer'
-        then 'Clerk/Treasurer'
-        when {{ column_name }} = 'Congressional'
-        then 'Congressional'
-        when {{ column_name }} = 'County Commissioner'
-        then 'County Supervisor'
-        when {{ column_name }} = 'County Council'
-        then 'County Supervisor'
-        when {{ column_name }} = 'County Trustee'
-        then 'County Supervisor'
-        when {{ column_name }} = 'County Legislature'
-        then 'County Supervisor'
-        when {{ column_name }} = 'Circuit Court'
-        then 'Judge'
-        when {{ column_name }} = 'Circuit Court Judge'
-        then 'Judge'
-        when {{ column_name }} = 'County Court Judge'
-        then 'Judge'
-        when {{ column_name }} = 'District Court'
-        then 'Judge'
-        when {{ column_name }} = 'Justice of the Peace'
-        then 'Judge'
-        when {{ column_name }} = 'Probate Court'
-        then 'Judge'
-        when {{ column_name }} = 'Supreme Court'
-        then 'Judge'
-        when {{ column_name }} = 'Trial Court Judge'
-        then 'Judge'
-        when {{ column_name }} = 'Judge'
-        then 'Judge'
-        when {{ column_name }} = 'Mayor'
-        then 'Mayor'
-        when {{ column_name }} = 'Village President'
-        then 'Mayor'
-        when {{ column_name }} = 'President'
-        then 'President'
-        when {{ column_name }} = 'Board of Education'
-        then 'School Board'
-        when {{ column_name }} = 'School Board'
-        then 'School Board'
-        when {{ column_name }} = 'Constable'
-        then 'Sheriff'
-        when {{ column_name }} = 'County Sheriff'
-        then 'Sheriff'
-        when {{ column_name }} = 'Sheriff'
-        then 'Sheriff'
-        when {{ column_name }} = 'House of Delegates'
-        then 'State House'
-        when {{ column_name }} = 'House of Representatives'
-        then 'State House'
-        when {{ column_name }} = 'State Assembly'
-        then 'State House'
-        when {{ column_name }} = 'State House'
-        then 'State House'
-        when {{ column_name }} = 'State Senate'
-        then 'State Senate'
-        when {{ column_name }} = 'Governor'
-        then 'Statewide/Governor'
-        when {{ column_name }} = 'Lieutenant Governor'
-        then 'Statewide/Governor'
-        when {{ column_name }} = 'Town Council'
-        then 'Town Council'
-        when {{ column_name }} = 'Town Trustee'
-        then 'Town Council'
-        when {{ column_name }} = 'Township Supervisor'
-        then 'Town Council'
-        when {{ column_name }} = 'Village Board'
-        then 'Town Council'
-        when {{ column_name }} = 'Village Council'
-        then 'Town Council'
-        when {{ column_name }} = 'Village Trustee'
-        then 'Town Council'
-        -- Explicitly mapped to Other (not just else fallthrough)
+        -- Attorney
         when
-            {{ column_name }} in (
-                'Board of Trustees',
-                'Community College Board',
-                'Dependent District Board',
-                'Elections Supervisor',
-                'Fire Board',
-                'Hawaiian Affairs Board',
-                'Highway Superintendent',
-                'Insurance Commissioner',
-                'Library Board',
-                'Parks and Recreation Board',
-                'Port Board',
-                'Township Assessor',
-                'Water Supply Board'
+            lower({{ column_name }})
+            in ('attorney', 'district attorney', 'county attorney')
+        then 'Attorney'
+        when lower({{ column_name }}) like 'state attorney%'
+        then 'Attorney'
+        -- City Council
+        when
+            lower({{ column_name }}) in (
+                'city commission',
+                'city commissioner',
+                'city council',
+                'town chair',
+                'township council'
             )
-        then 'Other'
+        then 'City Council'
+        -- Clerk/Treasurer
+        when
+            lower({{ column_name }}) in (
+                'clerk',
+                'treasurer',
+                'city clerk',
+                'township clerk',
+                'clerk/treasurer',
+                'county clerk',
+                'county court clerk'
+            )
+        then 'Clerk/Treasurer'
+        when lower({{ column_name }}) like 'county clerk%'
+        then 'Clerk/Treasurer'
+        when lower({{ column_name }}) like 'county treasurer%'
+        then 'Clerk/Treasurer'
+        -- Congressional
+        when
+            lower({{ column_name }})
+            in ('congressional', 'u.s. representative', 'u.s. senator')
+        then 'Congressional'
+        -- County Supervisor
+        when
+            lower({{ column_name }}) in (
+                'county commissioner',
+                'county council',
+                'county trustee',
+                'county legislature'
+            )
+        then 'County Supervisor'
+        when lower({{ column_name }}) like 'county executive%'
+        then 'County Supervisor'
+        when lower({{ column_name }}) like 'county legislat%'
+        then 'County Supervisor'
+        when lower({{ column_name }}) like 'board of supervisor%'
+        then 'County Supervisor'
+        -- Judge
+        when
+            lower({{ column_name }}) in (
+                'circuit court',
+                'circuit court judge',
+                'county court judge',
+                'district court',
+                'judge',
+                'probate court',
+                'supreme court',
+                'trial court judge'
+            )
+        then 'Judge'
+        when lower({{ column_name }}) like 'justice of the peace%'
+        then 'Judge'
+        when lower({{ column_name }}) like 'state trial court%'
+        then 'Judge'
+        when lower({{ column_name }}) like 'state appellate court%'
+        then 'Judge'
+        when lower({{ column_name }}) like 'state supreme court%'
+        then 'Judge'
+        when lower({{ column_name }}) like 'county court judge%'
+        then 'Judge'
+        -- Mayor
+        when
+            lower({{ column_name }}) in ('mayor', 'village president', 'township mayor')
+        then 'Mayor'
+        -- President
+        when lower({{ column_name }}) = 'president'
+        then 'President'
+        -- School Board
+        when lower({{ column_name }}) in ('board of education', 'school board')
+        then 'School Board'
+        -- Sheriff
+        when
+            lower({{ column_name }})
+            in ('constable', 'county constable', 'county sheriff', 'sheriff')
+        then 'Sheriff'
+        when lower({{ column_name }}) like 'county sheriff%'
+        then 'Sheriff'
+        -- State House
+        when
+            lower({{ column_name }}) in (
+                'house of delegates',
+                'house of representatives',
+                'state assembly',
+                'state house',
+                'state representative'
+            )
+        then 'State House'
+        -- State Senate
+        when lower({{ column_name }}) in ('state senate', 'state senator')
+        then 'State Senate'
+        -- Statewide/Governor
+        when lower({{ column_name }}) in ('governor', 'lieutenant governor')
+        then 'Statewide/Governor'
+        -- Town Council
+        when
+            lower({{ column_name }}) in (
+                'town council',
+                'town trustee',
+                'township supervisor',
+                'village board',
+                'village council',
+                'village trustee'
+            )
+        then 'Town Council'
         else 'Other'
     end
 {% endmacro %}

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1165,13 +1165,11 @@ models:
 
       - name: election_stage
         description: >
-          Type of election stage (Primary, General, Runoff).
-          Null for gp_api records without a BallotReady position link
-          or without a matching 2026 race for their position.
+          Type of election stage (Primary, General, Runoff, etc.).
+          GP API records without a BallotReady position link or matching
+          2026 race are excluded from this table.
         data_tests:
-          - not_null:
-              config:
-                where: "source_name != 'gp_api'"
+          - not_null
           - accepted_values:
               arguments:
                 values:

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1135,8 +1135,8 @@ models:
       - name: source_id
         description: >
           Source-specific identifier. BR: br_candidacy_id; TS: techspeed_candidate_code;
-          DDHQ: candidate_id_race_id; Product DB: campaign_id__election_stage
-          (e.g. 12345__general, 12345__unknown for unlinked campaigns).
+          DDHQ: candidate_id_race_id; GP API: campaign_id__election_stage
+          (e.g. 12345__general, 12345__primary).
         data_tests:
           - not_null
 
@@ -1165,9 +1165,11 @@ models:
 
       - name: election_stage
         description: >
-          Type of election stage (Primary, General, Runoff, etc.).
-          GP API records without a BallotReady position link or matching
-          2026 race are excluded from this table.
+          Type of election stage. Values: Primary, General, Runoff,
+          Primary Runoff, General Runoff, Primary Special, General Special,
+          Primary Special Runoff, General Special Runoff. GP API records
+          without a BallotReady position link or matching 2026 race are
+          excluded from this table.
         data_tests:
           - not_null
           - accepted_values:

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1133,7 +1133,8 @@ models:
       - name: source_id
         description: >
           Source-specific identifier. BR: br_candidacy_id; TS: techspeed_candidate_code;
-          DDHQ: candidate_id_race_id; Product DB: campaign_id.
+          DDHQ: candidate_id_race_id; Product DB: campaign_id__election_stage
+          (e.g. 12345__general, 12345__unknown for unlinked campaigns).
         data_tests:
           - not_null
 

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1164,7 +1164,8 @@ models:
       - name: election_stage
         description: >
           Type of election stage (Primary, General, Runoff).
-          Null for product_db records without a BallotReady position link.
+          Null for product_db records without a BallotReady position link
+          or without a matching 2026 race for their position.
         data_tests:
           - not_null:
               config:

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1165,7 +1165,7 @@ models:
 
       - name: election_stage
         description: >
-          Type of election stage. Values: Primary, General, Runoff,
+          Type of election stage. Values: Primary, General,
           Primary Runoff, General Runoff, Primary Special, General Special,
           Primary Special Runoff, General Special Runoff. GP API records
           without a BallotReady position link or matching 2026 race are

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1097,17 +1097,17 @@ models:
 
   - name: int__er_prematch_candidacy_stages
     description: >
-      Entity resolution prematch table: BallotReady x TechSpeed x DDHQ
-      candidacy-stages unioned into a standardized schema for Splink
-      probabilistic matching.
+      Entity resolution prematch table: BallotReady x TechSpeed x DDHQ x
+      Product DB candidacy-stages unioned into a standardized schema for
+      Splink probabilistic matching.
 
       Grain: One row per source candidacy-stage record (candidate + office + election date).
 
       Sources: stg_airbyte_source__ballotready_s3_candidacies_v3 (BR staging),
       stg_airbyte_source__techspeed_gdrive_candidates (TS),
-      stg_airbyte_source__ddhq_gdrive_election_results (DDHQ), with
-      clean_states for state standardization and int__ballotready_person for
-      API contact data.
+      stg_airbyte_source__ddhq_gdrive_election_results (DDHQ),
+      campaigns mart (Product DB), with clean_states for state standardization
+      and int__ballotready_person for API contact data.
 
     columns:
       - name: unique_id
@@ -1119,7 +1119,7 @@ models:
           - not_null
 
       - name: source_name
-        description: Origin of the record ('ballotready', 'techspeed', or 'ddhq')
+        description: Origin of the record ('ballotready', 'techspeed', 'ddhq', or 'product_db')
         data_tests:
           - not_null
           - accepted_values:
@@ -1128,11 +1128,12 @@ models:
                   - ballotready
                   - techspeed
                   - ddhq
+                  - product_db
 
       - name: source_id
         description: >
           Source-specific identifier. BR: br_candidacy_id; TS: techspeed_candidate_code;
-          DDHQ: candidate_id_race_id.
+          DDHQ: candidate_id_race_id; Product DB: campaign_id.
         data_tests:
           - not_null
 
@@ -1160,9 +1161,13 @@ models:
           - not_null
 
       - name: election_stage
-        description: Type of election stage (Primary, General, Runoff)
+        description: >
+          Type of election stage (Primary, General, Runoff).
+          Null for product_db records which lack stage info.
         data_tests:
-          - not_null
+          - not_null:
+              config:
+                where: "source_name != 'product_db'"
           - accepted_values:
               arguments:
                 values:

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1180,6 +1180,10 @@ models:
                   - Runoff
                   - Primary Runoff
                   - General Runoff
+                  - Primary Special
+                  - General Special
+                  - Primary Special Runoff
+                  - General Special Runoff
 
   - name: int__er_prematch_elected_officials
     description: >

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1098,7 +1098,7 @@ models:
   - name: int__er_prematch_candidacy_stages
     description: >
       Entity resolution prematch table: BallotReady x TechSpeed x DDHQ x
-      Product DB candidacy-stages unioned into a standardized schema for
+      GP API candidacy-stages unioned into a standardized schema for
       Splink probabilistic matching.
 
       Grain: One row per source candidacy-stage record (candidate + office + election date).
@@ -1106,8 +1106,10 @@ models:
       Sources: stg_airbyte_source__ballotready_s3_candidacies_v3 (BR staging),
       stg_airbyte_source__techspeed_gdrive_candidates (TS),
       stg_airbyte_source__ddhq_gdrive_election_results (DDHQ),
-      campaigns mart (Product DB), with clean_states for state standardization
-      and int__ballotready_person for API contact data.
+      campaigns mart (GP API) enriched with BallotReady API data for
+      election stages, race IDs, and normalized position names. Also uses
+      clean_states for state standardization and int__ballotready_person
+      for API contact data.
 
     columns:
       - name: unique_id
@@ -1119,7 +1121,7 @@ models:
           - not_null
 
       - name: source_name
-        description: Origin of the record ('ballotready', 'techspeed', 'ddhq', or 'product_db')
+        description: Origin of the record ('ballotready', 'techspeed', 'ddhq', or 'gp_api')
         data_tests:
           - not_null
           - accepted_values:
@@ -1128,7 +1130,7 @@ models:
                   - ballotready
                   - techspeed
                   - ddhq
-                  - product_db
+                  - gp_api
 
       - name: source_id
         description: >
@@ -1164,18 +1166,20 @@ models:
       - name: election_stage
         description: >
           Type of election stage (Primary, General, Runoff).
-          Null for product_db records without a BallotReady position link
+          Null for gp_api records without a BallotReady position link
           or without a matching 2026 race for their position.
         data_tests:
           - not_null:
               config:
-                where: "source_name != 'product_db'"
+                where: "source_name != 'gp_api'"
           - accepted_values:
               arguments:
                 values:
                   - Primary
                   - General
                   - Runoff
+                  - Primary Runoff
+                  - General Runoff
 
   - name: int__er_prematch_elected_officials
     description: >

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1163,7 +1163,7 @@ models:
       - name: election_stage
         description: >
           Type of election stage (Primary, General, Runoff).
-          Null for product_db records which lack stage info.
+          Null for product_db records without a BallotReady position link.
         data_tests:
           - not_null:
               config:

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1177,7 +1177,6 @@ models:
                 values:
                   - Primary
                   - General
-                  - Runoff
                   - Primary Runoff
                   - General Runoff
                   - Primary Special

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -60,6 +60,8 @@ with
         select
             br.*,
             br_position.partisan_type,
+            -- BR S3 candidacies sometimes lack emails; fill gaps from the
+            -- BR API person entity when available
             coalesce(br.email, pe.api_email) as _email,
             {{
                 generate_candidate_office_from_position(

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -325,6 +325,7 @@ with
             and is_latest_version
             and user_first_name is not null
             and user_last_name is not null
+            and campaign_office is not null
     ),
 
     -- BR API race: position x stage with stage-specific election dates.
@@ -370,7 +371,7 @@ with
                         "c.normalized_position_name",
                     )
                 }},
-                trim(c.campaign_office)
+                initcap(trim(c.campaign_office))
             ) as candidate_office,
             case
                 when lower(c.election_level) in ('city', 'local')
@@ -390,7 +391,7 @@ with
                         "c.campaign_office",
                         "c.normalized_position_name",
                     )
-                    ~ ", trim(c.campaign_office))"
+                    ~ ", initcap(trim(c.campaign_office)))"
                 )
             }} as office_type,
             cast(null as string) as district_raw,

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -1,6 +1,6 @@
 {{ config(materialized="table", tags=["civics", "entity_resolution"]) }}
 
--- Entity Resolution prematch: BallotReady x TechSpeed x DDHQ x Product DB
+-- Entity Resolution prematch: BallotReady x TechSpeed x DDHQ x GP API
 -- candidacy-stages. Unions candidacy-stage records from all sources into a
 -- standardized schema for Splink matching.
 --
@@ -336,10 +336,12 @@ with
             race.position.databaseid as br_position_id,
             race.database_id as br_race_id,
             case
+                when race.is_primary and race.is_runoff
+                then 'Primary Runoff'
                 when race.is_primary
                 then 'Primary'
                 when race.is_runoff
-                then 'Runoff'
+                then 'General Runoff'
                 else 'General'
             end as election_stage,
             election.election_day
@@ -352,9 +354,9 @@ with
             and election.election_day >= '2026-01-01'
     ),
 
-    product_db_stages as (
+    gp_api_stages as (
         select
-            'product_db' as source_name,
+            'gp_api' as source_name,
             cast(c.campaign_id as string)
             || '__'
             || lower(coalesce(r.election_stage, 'unknown')) as source_id,
@@ -435,7 +437,7 @@ with
         from ddhq_stages
         union all
         select *
-        from product_db_stages
+        from gp_api_stages
     )
 
 -- Splink treats empty strings as real values for exact matching, so convert

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -81,12 +81,28 @@ with
             as district_identifier,
             -- Single election date at candidacy-stage grain
             br.election_day as election_date,
-            -- Derive election stage from is_primary / is_runoff flags
+            -- Derive election stage from is_primary / is_runoff flags and
+            -- election_name. BR election names consistently contain "Special"
+            -- for special elections (e.g. "Georgia Special General", "Florida
+            -- House Special Primary") — set by BallotReady's editorial team.
             case
+                when
+                    br.is_primary
+                    and br.is_runoff
+                    and lower(br.election_name) like '%special%'
+                then 'Primary Special Runoff'
+                when br.is_primary and br.is_runoff
+                then 'Primary Runoff'
+                when br.is_primary and lower(br.election_name) like '%special%'
+                then 'Primary Special'
                 when br.is_primary
                 then 'Primary'
+                when br.is_runoff and lower(br.election_name) like '%special%'
+                then 'General Special Runoff'
                 when br.is_runoff
-                then 'Runoff'
+                then 'General Runoff'
+                when lower(br.election_name) like '%special%'
+                then 'General Special'
                 else 'General'
             end as election_stage,
             coalesce(br.email, pe.api_email) as email,
@@ -330,18 +346,30 @@ with
 
     -- BR API race: position x stage with stage-specific election dates.
     -- Joined to BR election for the actual date per stage. Excludes
-    -- disabled races and pre-2026 elections.
+    -- disabled races and pre-2026 elections. Detects special elections
+    -- via election name (see ballotready_stages comment for rationale).
     br_race as (
         select
             race.position.databaseid as br_position_id,
             race.database_id as br_race_id,
             case
+                when
+                    race.is_primary
+                    and race.is_runoff
+                    and lower(election.name) like '%special%'
+                then 'Primary Special Runoff'
                 when race.is_primary and race.is_runoff
                 then 'Primary Runoff'
+                when race.is_primary and lower(election.name) like '%special%'
+                then 'Primary Special'
                 when race.is_primary
                 then 'Primary'
+                when race.is_runoff and lower(election.name) like '%special%'
+                then 'General Special Runoff'
                 when race.is_runoff
                 then 'General Runoff'
+                when lower(election.name) like '%special%'
+                then 'General Special'
                 else 'General'
             end as election_stage,
             election.election_day

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -438,7 +438,7 @@ with
             cast(null as string) as seat_name,
             cast(null as string) as partisan_type
         from pd_campaigns as c
-        left join
+        inner join
             br_race as r
             on c.ballotready_position_id = r.br_position_id
             and year(r.election_day) = year(c.election_date)

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -83,34 +83,11 @@ with
             as district_identifier,
             -- Single election date at candidacy-stage grain
             br.election_day as election_date,
-            -- Derive election stage from is_primary / is_runoff flags and
-            -- election_name. BR election names consistently contain "Special"
-            -- for special elections (e.g. "Georgia Special General", "Florida
-            -- House Special Primary") — set by BallotReady's editorial team.
-            -- False positives (e.g. a city named "Special City") are guarded
-            -- by a race_count <= 10 test on the upstream BR election staging
-            -- model: real special elections have 1-6 races, while a regular
-            -- election mismatched by name would have hundreds.
-            case
-                when
-                    br.is_primary
-                    and br.is_runoff
-                    and lower(br.election_name) like '%special%'
-                then 'Primary Special Runoff'
-                when br.is_primary and br.is_runoff
-                then 'Primary Runoff'
-                when br.is_primary and lower(br.election_name) like '%special%'
-                then 'Primary Special'
-                when br.is_primary
-                then 'Primary'
-                when br.is_runoff and lower(br.election_name) like '%special%'
-                then 'General Special Runoff'
-                when br.is_runoff
-                then 'General Runoff'
-                when lower(br.election_name) like '%special%'
-                then 'General Special'
-                else 'General'
-            end as election_stage,
+            {{
+                derive_election_stage(
+                    "br.is_primary", "br.is_runoff", "br.election_name"
+                )
+            }} as election_stage,
             coalesce(br.email, pe.api_email) as email,
             br.phone as phone,
             cast(br.br_race_id as string) as br_race_id,
@@ -336,8 +313,8 @@ with
     -- GP API: campaign data from the GP platform (joins already resolved
     -- in the campaigns mart: campaign + user + organization + position).
     -- Fanned out by election stage via BR API race table so each campaign
-    -- produces one row per stage (Primary, General, Runoff, Special, etc.).
-    pd_campaigns as (
+    -- produces one row per stage (Primary, General, Runoff, Special variants).
+    gp_api_campaigns as (
         select *
         from {{ ref("campaigns") }}
         where
@@ -358,26 +335,11 @@ with
         select
             race.position.databaseid as br_position_id,
             race.database_id as br_race_id,
-            case
-                when
-                    race.is_primary
-                    and race.is_runoff
-                    and lower(election.name) like '%special%'
-                then 'Primary Special Runoff'
-                when race.is_primary and race.is_runoff
-                then 'Primary Runoff'
-                when race.is_primary and lower(election.name) like '%special%'
-                then 'Primary Special'
-                when race.is_primary
-                then 'Primary'
-                when race.is_runoff and lower(election.name) like '%special%'
-                then 'General Special Runoff'
-                when race.is_runoff
-                then 'General Runoff'
-                when lower(election.name) like '%special%'
-                then 'General Special'
-                else 'General'
-            end as election_stage,
+            {{
+                derive_election_stage(
+                    "race.is_primary", "race.is_runoff", "election.name"
+                )
+            }} as election_stage,
             election.election_day
         from {{ ref("stg_airbyte_source__ballotready_api_race") }} as race
         inner join
@@ -388,16 +350,15 @@ with
             and election.election_day >= '2026-01-01'
     ),
 
-    gp_api_stages as (
+    -- Compute candidate_office once so map_office_type can reference it
+    -- without re-evaluating the full CASE expression (same pattern as
+    -- ddhq_with_office above).
+    gp_api_with_office as (
         select
-            'gp_api' as source_name,
-            cast(c.campaign_id as string)
-            || '__'
-            || lower(coalesce(r.election_stage, 'unknown')) as source_id,
-            lower(trim(c.user_first_name)) as first_name,
-            lower(trim(c.user_last_name)) as last_name,
-            upper(trim(c.campaign_state)) as state,
-            {{ parse_party_affiliation("c.campaign_party") }} as party,
+            c.*,
+            r.br_race_id,
+            r.election_stage,
+            r.election_day,
             -- Use the same normalization as BallotReady when we have the
             -- normalized_position_name; fall back to raw campaign_office
             coalesce(
@@ -408,42 +369,8 @@ with
                     )
                 }},
                 initcap(trim(c.campaign_office))
-            ) as candidate_office,
-            case
-                when lower(c.election_level) in ('city', 'local')
-                then 'Local'
-                when lower(c.election_level) = 'county'
-                then 'County'
-                when lower(c.election_level) = 'state'
-                then 'State'
-                when lower(c.election_level) = 'federal'
-                then 'Federal'
-                else null
-            end as office_level,
-            {{
-                map_office_type(
-                    "coalesce("
-                    ~ generate_candidate_office_from_position(
-                        "c.campaign_office",
-                        "c.normalized_position_name",
-                    )
-                    ~ ", initcap(trim(c.campaign_office)))"
-                )
-            }} as office_type,
-            cast(null as string) as district_raw,
-            cast(null as int) as district_identifier,
-            -- Use stage-specific date from BR election when available;
-            -- fall back to campaign's generic date for unlinked campaigns
-            coalesce(r.election_day, c.election_date) as election_date,
-            r.election_stage,
-            c.user_email as email,
-            c.user_phone as phone,
-            cast(r.br_race_id as string) as br_race_id,
-            trim(c.campaign_office) as official_office_name,
-            cast(null as string) as br_candidacy_id,
-            cast(null as string) as seat_name,
-            cast(null as string) as partisan_type
-        from pd_campaigns as c
+            ) as candidate_office
+        from gp_api_campaigns as c
         inner join
             br_race as r
             on c.ballotready_position_id = r.br_position_id
@@ -458,6 +385,43 @@ with
                     r.br_race_id desc nulls last
             )
             = 1
+    ),
+
+    gp_api_stages as (
+        select
+            'gp_api' as source_name,
+            cast(g.campaign_id as string)
+            || '__'
+            || lower(g.election_stage) as source_id,
+            lower(trim(g.user_first_name)) as first_name,
+            lower(trim(g.user_last_name)) as last_name,
+            upper(trim(g.campaign_state)) as state,
+            {{ parse_party_affiliation("g.campaign_party") }} as party,
+            g.candidate_office,
+            case
+                when lower(g.election_level) in ('city', 'local')
+                then 'Local'
+                when lower(g.election_level) = 'county'
+                then 'County'
+                when lower(g.election_level) = 'state'
+                then 'State'
+                when lower(g.election_level) = 'federal'
+                then 'Federal'
+                else null
+            end as office_level,
+            {{ map_office_type("g.candidate_office") }} as office_type,
+            cast(null as string) as district_raw,
+            cast(null as int) as district_identifier,
+            g.election_day as election_date,
+            g.election_stage,
+            g.user_email as email,
+            g.user_phone as phone,
+            cast(g.br_race_id as string) as br_race_id,
+            trim(g.campaign_office) as official_office_name,
+            cast(null as string) as br_candidacy_id,
+            cast(null as string) as seat_name,
+            cast(null as string) as partisan_type
+        from gp_api_with_office as g
     ),
 
     unioned as (

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -293,7 +293,24 @@ with
                 try_cast(regexp_extract(d.race_name, ' ([0-9]+)$') as int)
             ) as district_identifier,
             d.election_date,
+            -- DDHQ election_type contains both stage and special indicators
+            -- (e.g. "Special Election Primary", "Special General Election")
             case
+                when
+                    lower(d.election_type) like '%special%'
+                    and lower(d.election_type) like '%runoff%'
+                    and lower(d.election_type) like '%primary%'
+                then 'Primary Special Runoff'
+                when
+                    lower(d.election_type) like '%special%'
+                    and lower(d.election_type) like '%runoff%'
+                then 'General Special Runoff'
+                when
+                    lower(d.election_type) like '%special%'
+                    and lower(d.election_type) like '%primary%'
+                then 'Primary Special'
+                when lower(d.election_type) like '%special%'
+                then 'General Special'
                 when lower(d.election_type) like '%runoff%'
                 then 'Runoff'
                 when lower(d.election_type) like '%primary%'

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -368,7 +368,17 @@ with
             lower(trim(c.user_last_name)) as last_name,
             upper(trim(c.campaign_state)) as state,
             {{ parse_party_affiliation("c.campaign_party") }} as party,
-            trim(c.campaign_office) as candidate_office,
+            -- Use the same normalization as BallotReady when we have the
+            -- normalized_position_name; fall back to raw campaign_office
+            coalesce(
+                {{
+                    generate_candidate_office_from_position(
+                        "c.campaign_office",
+                        "c.normalized_position_name",
+                    )
+                }},
+                trim(c.campaign_office)
+            ) as candidate_office,
             case
                 when lower(c.election_level) in ('city', 'local')
                 then 'Local'
@@ -380,7 +390,16 @@ with
                 then 'Federal'
                 else null
             end as office_level,
-            {{ map_office_type("trim(c.campaign_office)") }} as office_type,
+            {{
+                map_office_type(
+                    "coalesce("
+                    ~ generate_candidate_office_from_position(
+                        "c.campaign_office",
+                        "c.normalized_position_name",
+                    )
+                    ~ ", trim(c.campaign_office))"
+                )
+            }} as office_type,
             cast(null as string) as district_raw,
             cast(null as int) as district_identifier,
             c.election_date,

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -53,6 +53,25 @@ with
         where database_id is not null
     ),
 
+    -- Compute candidate_office once so map_office_type can reference it
+    -- without re-evaluating the full CASE expression (same pattern as
+    -- ddhq_with_office and gp_api_with_office below).
+    br_with_office as (
+        select
+            br.*,
+            br_position.partisan_type,
+            coalesce(br.email, pe.api_email) as _email,
+            {{
+                generate_candidate_office_from_position(
+                    "br.position_name",
+                    "br.normalized_position_name",
+                )
+            }} as candidate_office
+        from br_staging as br
+        left join br_position on br.br_position_id = br_position.database_id
+        left join person_emails as pe on br.br_candidate_id = pe.person_database_id
+    ),
+
     ballotready_stages as (
         select
             'ballotready' as source_name,
@@ -61,48 +80,32 @@ with
             lower(trim(br.last_name)) as last_name,
             br.state,
             {{ parse_party_affiliation("br.parties") }} as party,
-            {{
-                generate_candidate_office_from_position(
-                    "br.position_name",
-                    "br.normalized_position_name",
-                )
-            }} as candidate_office,
+            br.candidate_office,
             case
                 when lower(br.level) = 'city' then 'Local' else initcap(br.level)
             end as office_level,
-            {{
-                map_office_type(
-                    generate_candidate_office_from_position(
-                        "br.position_name",
-                        "br.normalized_position_name",
-                    )
-                )
-            }} as office_type,
+            {{ map_office_type("br.candidate_office") }} as office_type,
             {{ extract_district_raw("br.position_name") }} as district_raw,
             {{ extract_district_identifier("br.position_name") }}
             as district_identifier,
-            -- Single election date at candidacy-stage grain
             br.election_day as election_date,
             {{
                 derive_election_stage(
                     "br.is_primary", "br.is_runoff", "br.election_name"
                 )
             }} as election_stage,
-            coalesce(br.email, pe.api_email) as email,
+            br._email as email,
             br.phone as phone,
             cast(br.br_race_id as string) as br_race_id,
             br.position_name as official_office_name,
             br.br_candidacy_id,
-            -- Derive seat_name from position_name (same regex as candidacy model)
             coalesce(
                 regexp_extract(br.position_name, '[-, ] (?:Seat|Group) ([^,]+)'),
                 regexp_extract(br.position_name, ' - Position ([^\\s(]+)'),
                 ''
             ) as seat_name,
-            br_position.partisan_type
-        from br_staging as br
-        left join br_position on br.br_position_id = br_position.database_id
-        left join person_emails as pe on br.br_candidate_id = pe.person_database_id
+            br.partisan_type
+        from br_with_office as br
     ),
 
     -- State name → 2-letter code mapping (used by DDHQ section)
@@ -312,7 +315,7 @@ with
                 when lower(d.election_type) like '%special%'
                 then 'General Special'
                 when lower(d.election_type) like '%runoff%'
-                then 'Runoff'
+                then 'General Runoff'
                 when lower(d.election_type) like '%primary%'
                 then 'Primary'
                 else 'General'

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -312,11 +312,58 @@ with
     ),
 
     -- Product Database: GP platform campaign data (joins already resolved
-    -- in the campaigns mart: campaign + user + organization + position)
+    -- in the campaigns mart: campaign + user + organization + position).
+    -- Fanned out by election stage via BR API race table so each campaign
+    -- produces one row per stage (Primary, General, Runoff).
+    pd_campaigns as (
+        select *
+        from {{ ref("campaigns") }}
+        where
+            election_date >= '2026-01-01'
+            and campaign_state is not null
+            and not coalesce(is_demo, false)
+            and is_latest_version
+            and user_first_name is not null
+            and user_last_name is not null
+    ),
+
+    -- BR API race: one row per position x stage, gives us br_race_id
+    -- and election_stage for the fan-out. Deduped to one race per
+    -- position+stage (a position may have multiple races of the same type).
+    br_race as (
+        select
+            position.databaseid as br_position_id,
+            database_id as br_race_id,
+            case
+                when is_primary
+                then 'Primary'
+                when is_runoff
+                then 'Runoff'
+                else 'General'
+            end as election_stage
+        from {{ ref("stg_airbyte_source__ballotready_api_race") }}
+        qualify
+            row_number() over (
+                partition by
+                    position.databaseid,
+                    case
+                        when is_primary
+                        then 'Primary'
+                        when is_runoff
+                        then 'Runoff'
+                        else 'General'
+                    end
+                order by database_id desc
+            )
+            = 1
+    ),
+
     product_db_stages as (
         select
             'product_db' as source_name,
-            cast(c.campaign_id as string) as source_id,
+            cast(c.campaign_id as string)
+            || '__'
+            || lower(coalesce(r.election_stage, 'unknown')) as source_id,
             lower(trim(c.user_first_name)) as first_name,
             lower(trim(c.user_last_name)) as last_name,
             upper(trim(c.campaign_state)) as state,
@@ -337,22 +384,16 @@ with
             cast(null as string) as district_raw,
             cast(null as int) as district_identifier,
             c.election_date,
-            cast(null as string) as election_stage,
+            r.election_stage,
             c.user_email as email,
             c.user_phone as phone,
-            cast(null as string) as br_race_id,
+            cast(r.br_race_id as string) as br_race_id,
             trim(c.campaign_office) as official_office_name,
             cast(null as string) as br_candidacy_id,
             cast(null as string) as seat_name,
             cast(null as string) as partisan_type
-        from {{ ref("campaigns") }} as c
-        where
-            c.election_date >= '2026-01-01'
-            and c.campaign_state is not null
-            and not coalesce(c.is_demo, false)
-            and c.is_latest_version
-            and c.user_first_name is not null
-            and c.user_last_name is not null
+        from pd_campaigns as c
+        left join br_race as r on c.ballotready_position_id = r.br_position_id
     ),
 
     unioned as (

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -314,6 +314,10 @@ with
                 then 'Primary Special'
                 when lower(d.election_type) like '%special%'
                 then 'General Special'
+                when
+                    lower(d.election_type) like '%runoff%'
+                    and lower(d.election_type) like '%primary%'
+                then 'Primary Runoff'
                 when lower(d.election_type) like '%runoff%'
                 then 'General Runoff'
                 when lower(d.election_type) like '%primary%'

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -413,11 +413,13 @@ with
             on c.ballotready_position_id = r.br_position_id
             and year(r.election_day) = year(c.election_date)
         -- Dedup: a position may have multiple races of the same stage type
-        -- in the same year; keep the one with the latest race ID
+        -- in the same year; pick the race closest to the campaign's date
         qualify
             row_number() over (
                 partition by c.campaign_id, r.election_stage
-                order by r.br_race_id desc nulls last
+                order by
+                    abs(datediff(r.election_day, c.election_date)) asc,
+                    r.br_race_id desc nulls last
             )
             = 1
     ),

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -320,12 +320,12 @@ with
         from {{ ref("campaigns") }}
         where
             election_date >= '2026-01-01'
-            and campaign_state is not null
+            and nullif(trim(campaign_state), '') is not null
             and not coalesce(is_demo, false)
             and is_latest_version
-            and user_first_name is not null
-            and user_last_name is not null
-            and campaign_office is not null
+            and nullif(trim(user_first_name), '') is not null
+            and nullif(trim(user_last_name), '') is not null
+            and nullif(trim(campaign_office), '') is not null
     ),
 
     -- BR API race: position x stage with stage-specific election dates.

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -1,8 +1,8 @@
 {{ config(materialized="table", tags=["civics", "entity_resolution"]) }}
 
--- Entity Resolution prematch: BallotReady x TechSpeed x DDHQ candidacy-stages
--- Unions candidacy-stage records from all sources into a standardized schema
--- for Splink matching.
+-- Entity Resolution prematch: BallotReady x TechSpeed x DDHQ x Product DB
+-- candidacy-stages. Unions candidacy-stage records from all sources into a
+-- standardized schema for Splink matching.
 --
 -- Grain: One row per source candidacy-stage record (candidate + office + election date)
 -- Key: unique_id (source_name || '|' || source_id)
@@ -311,6 +311,48 @@ with
         from ddhq_with_office as d
     ),
 
+    -- Product Database: GP platform campaign data (joins already resolved
+    -- in the campaigns mart: campaign + user + organization + position)
+    product_db_stages as (
+        select
+            'product_db' as source_name,
+            cast(c.campaign_id as string) as source_id,
+            lower(trim(c.user_first_name)) as first_name,
+            lower(trim(c.user_last_name)) as last_name,
+            upper(trim(c.campaign_state)) as state,
+            {{ parse_party_affiliation("c.campaign_party") }} as party,
+            trim(c.campaign_office) as candidate_office,
+            case
+                when lower(c.election_level) in ('city', 'county')
+                then 'Local'
+                when lower(c.election_level) = 'state'
+                then 'State'
+                when lower(c.election_level) = 'federal'
+                then 'Federal'
+                else null
+            end as office_level,
+            {{ map_office_type("trim(c.campaign_office)") }} as office_type,
+            cast(null as string) as district_raw,
+            cast(null as int) as district_identifier,
+            c.election_date,
+            cast(null as string) as election_stage,
+            c.user_email as email,
+            c.user_phone as phone,
+            cast(null as string) as br_race_id,
+            trim(c.campaign_office) as official_office_name,
+            cast(null as string) as br_candidacy_id,
+            cast(null as string) as seat_name,
+            cast(null as string) as partisan_type
+        from {{ ref("campaigns") }} as c
+        where
+            c.election_date >= '2026-01-01'
+            and c.campaign_state is not null
+            and not coalesce(c.is_demo, false)
+            and c.is_latest_version
+            and c.user_first_name is not null
+            and c.user_last_name is not null
+    ),
+
     unioned as (
         select *
         from ballotready_stages
@@ -320,6 +362,9 @@ with
         union all
         select *
         from ddhq_stages
+        union all
+        select *
+        from product_db_stages
     )
 
 -- Splink treats empty strings as real values for exact matching, so convert

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -327,35 +327,28 @@ with
             and user_last_name is not null
     ),
 
-    -- BR API race: one row per position x stage, gives us br_race_id
-    -- and election_stage for the fan-out. Deduped to one race per
-    -- position+stage (a position may have multiple races of the same type).
+    -- BR API race: position x stage with stage-specific election dates.
+    -- Joined to BR election for the actual date per stage. Excludes
+    -- disabled races and pre-2026 elections.
     br_race as (
         select
-            position.databaseid as br_position_id,
-            database_id as br_race_id,
+            race.position.databaseid as br_position_id,
+            race.database_id as br_race_id,
             case
-                when is_primary
+                when race.is_primary
                 then 'Primary'
-                when is_runoff
+                when race.is_runoff
                 then 'Runoff'
                 else 'General'
-            end as election_stage
-        from {{ ref("stg_airbyte_source__ballotready_api_race") }}
-        qualify
-            row_number() over (
-                partition by
-                    position.databaseid,
-                    case
-                        when is_primary
-                        then 'Primary'
-                        when is_runoff
-                        then 'Runoff'
-                        else 'General'
-                    end
-                order by database_id desc
-            )
-            = 1
+            end as election_stage,
+            election.election_day
+        from {{ ref("stg_airbyte_source__ballotready_api_race") }} as race
+        inner join
+            {{ ref("stg_airbyte_source__ballotready_api_election") }} as election
+            on race.election.databaseid = election.database_id
+        where
+            not coalesce(race.is_disabled, false)
+            and election.election_day >= '2026-01-01'
     ),
 
     product_db_stages as (
@@ -402,7 +395,9 @@ with
             }} as office_type,
             cast(null as string) as district_raw,
             cast(null as int) as district_identifier,
-            c.election_date,
+            -- Use stage-specific date from BR election when available;
+            -- fall back to campaign's generic date for unlinked campaigns
+            coalesce(r.election_day, c.election_date) as election_date,
             r.election_stage,
             c.user_email as email,
             c.user_phone as phone,
@@ -412,7 +407,18 @@ with
             cast(null as string) as seat_name,
             cast(null as string) as partisan_type
         from pd_campaigns as c
-        left join br_race as r on c.ballotready_position_id = r.br_position_id
+        left join
+            br_race as r
+            on c.ballotready_position_id = r.br_position_id
+            and year(r.election_day) = year(c.election_date)
+        -- Dedup: a position may have multiple races of the same stage type
+        -- in the same year; keep the one with the latest race ID
+        qualify
+            row_number() over (
+                partition by c.campaign_id, r.election_stage
+                order by r.br_race_id desc nulls last
+            )
+            = 1
     ),
 
     unioned as (

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -409,7 +409,7 @@ with
             'gp_api' as source_name,
             cast(g.campaign_id as string)
             || '__'
-            || lower(g.election_stage) as source_id,
+            || replace(lower(g.election_stage), ' ', '_') as source_id,
             lower(trim(g.user_first_name)) as first_name,
             lower(trim(g.user_last_name)) as last_name,
             upper(trim(g.campaign_state)) as state,

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -299,33 +299,16 @@ with
             ) as district_identifier,
             d.election_date,
             -- DDHQ election_type contains both stage and special indicators
-            -- (e.g. "Special Election Primary", "Special General Election")
-            case
-                when
-                    lower(d.election_type) like '%special%'
-                    and lower(d.election_type) like '%runoff%'
-                    and lower(d.election_type) like '%primary%'
-                then 'Primary Special Runoff'
-                when
-                    lower(d.election_type) like '%special%'
-                    and lower(d.election_type) like '%runoff%'
-                then 'General Special Runoff'
-                when
-                    lower(d.election_type) like '%special%'
-                    and lower(d.election_type) like '%primary%'
-                then 'Primary Special'
-                when lower(d.election_type) like '%special%'
-                then 'General Special'
-                when
-                    lower(d.election_type) like '%runoff%'
-                    and lower(d.election_type) like '%primary%'
-                then 'Primary Runoff'
-                when lower(d.election_type) like '%runoff%'
-                then 'General Runoff'
-                when lower(d.election_type) like '%primary%'
-                then 'Primary'
-                else 'General'
-            end as election_stage,
+            -- (e.g. "Special Election Primary", "Special General Election").
+            -- Derive boolean-like expressions from the string to reuse the
+            -- shared derive_election_stage macro.
+            {{
+                derive_election_stage(
+                    "lower(d.election_type) like '%primary%'",
+                    "lower(d.election_type) like '%runoff%'",
+                    "d.election_type",
+                )
+            }} as election_stage,
             cast(null as string) as email,
             cast(null as string) as phone,
             cast(null as string) as br_race_id,

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -85,6 +85,10 @@ with
             -- election_name. BR election names consistently contain "Special"
             -- for special elections (e.g. "Georgia Special General", "Florida
             -- House Special Primary") — set by BallotReady's editorial team.
+            -- False positives (e.g. a city named "Special City") are guarded
+            -- by a race_count <= 10 test on the upstream BR election staging
+            -- model: real special elections have 1-6 races, while a regular
+            -- election mismatched by name would have hundreds.
             case
                 when
                     br.is_primary

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -368,6 +368,7 @@ with
             r.br_race_id,
             r.election_stage,
             r.election_day,
+            brp.level as br_position_level,
             -- Use the same normalization as BallotReady when we have the
             -- normalized_position_name; fall back to raw campaign_office
             coalesce(
@@ -384,6 +385,9 @@ with
             br_race as r
             on c.ballotready_position_id = r.br_position_id
             and year(r.election_day) = year(c.election_date)
+        left join
+            {{ ref("stg_airbyte_source__ballotready_api_position") }} as brp
+            on c.ballotready_position_id = brp.database_id
         -- Dedup: a position may have multiple races of the same stage type
         -- in the same year; pick the race closest to the campaign's date
         qualify
@@ -407,6 +411,7 @@ with
             upper(trim(g.campaign_state)) as state,
             {{ parse_party_affiliation("g.campaign_party") }} as party,
             g.candidate_office,
+            -- Prefer campaign election_level; fall back to BR position level
             case
                 when lower(g.election_level) in ('city', 'local')
                 then 'Local'
@@ -416,11 +421,20 @@ with
                 then 'State'
                 when lower(g.election_level) = 'federal'
                 then 'Federal'
+                when lower(g.br_position_level) in ('city', 'local', 'township')
+                then 'Local'
+                when lower(g.br_position_level) in ('county', 'regional')
+                then 'County'
+                when lower(g.br_position_level) = 'state'
+                then 'State'
+                when lower(g.br_position_level) = 'federal'
+                then 'Federal'
                 else null
             end as office_level,
             {{ map_office_type("g.candidate_office") }} as office_type,
-            cast(null as string) as district_raw,
-            cast(null as int) as district_identifier,
+            {{ extract_district_raw("g.campaign_office") }} as district_raw,
+            {{ extract_district_identifier("g.campaign_office") }}
+            as district_identifier,
             g.election_day as election_date,
             g.election_stage,
             g.user_email as email,

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -12,6 +12,8 @@
 -- - TechSpeed staging: dates/state pre-parsed, unpivoted into primary/general
 -- stage rows, deduped per candidate-stage
 -- - DDHQ election results: one row per candidate per race
+-- - GP API: campaigns mart fanned out by BR API race into one row per stage,
+-- enriched with normalized position names and stage-specific dates
 --
 with
     -- Nickname aliases: aggregate nicknames per canonical name into an array
@@ -331,10 +333,10 @@ with
         from ddhq_with_office as d
     ),
 
-    -- Product Database: GP platform campaign data (joins already resolved
+    -- GP API: campaign data from the GP platform (joins already resolved
     -- in the campaigns mart: campaign + user + organization + position).
     -- Fanned out by election stage via BR API race table so each campaign
-    -- produces one row per stage (Primary, General, Runoff).
+    -- produces one row per stage (Primary, General, Runoff, Special, etc.).
     pd_campaigns as (
         select *
         from {{ ref("campaigns") }}

--- a/dbt/project/models/marts/civics/campaigns.sql
+++ b/dbt/project/models/marts/civics/campaigns.sql
@@ -11,6 +11,26 @@ with
 
     positions as (select * from {{ ref("m_election_api__position") }}),
 
+    -- Lookup: BR position database_id → normalized_position_name
+    -- Uses BR API position to get the normalized_position ref, then
+    -- resolves the name from the candidacies S3 data.
+    br_normalized_lookup as (
+        select
+            brp.database_id as br_database_id,
+            brp.name as br_position_name,
+            npn.normalized_position_name
+        from {{ ref("stg_airbyte_source__ballotready_api_position") }} as brp
+        inner join
+            (
+                select distinct br_normalized_position_id, normalized_position_name
+                from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
+                where
+                    normalized_position_name is not null
+                    and br_normalized_position_id is not null
+            ) as npn
+            on brp.normalized_position.databaseid = npn.br_normalized_position_id
+    ),
+
     versioned as (
         select
             c.*,
@@ -40,6 +60,22 @@ with
         left join users u on c.user_id = u.id
         left join organizations o on c.organization_slug = o.slug
         left join positions p on o.position_id = p.id
+    ),
+
+    -- Resolve normalized_position_name via both org and legacy paths
+    with_normalized as (
+        select
+            v.*,
+            coalesce(
+                bnl_org.normalized_position_name, bnl_legacy.normalized_position_name
+            ) as _normalized_position_name
+        from versioned as v
+        left join
+            br_normalized_lookup as bnl_org
+            on v._position_br_database_id = bnl_org.br_database_id
+        left join
+            br_normalized_lookup as bnl_legacy
+            on v._legacy_br_position_id = bnl_legacy.br_database_id
     ),
 
     final as (
@@ -87,9 +123,10 @@ with
                 then coalesce(_position_br_database_id, _legacy_br_position_id)
                 else _legacy_br_position_id
             end as ballotready_position_id,
+            _normalized_position_name as normalized_position_name,
 
             is_latest_version
-        from versioned
+        from with_normalized
     )
 
 select *

--- a/dbt/project/models/marts/civics/campaigns.sql
+++ b/dbt/project/models/marts/civics/campaigns.sql
@@ -63,10 +63,11 @@ with
             case
                 when v.is_latest_version
                 then
-                    coalesce(
-                        bnl_org.normalized_position_name,
-                        bnl_legacy.normalized_position_name
-                    )
+                    case
+                        when v._position_br_database_id is not null
+                        then bnl_org.normalized_position_name
+                        else bnl_legacy.normalized_position_name
+                    end
                 else bnl_legacy.normalized_position_name
             end as _normalized_position_name
         from versioned as v

--- a/dbt/project/models/marts/civics/campaigns.sql
+++ b/dbt/project/models/marts/civics/campaigns.sql
@@ -12,26 +12,17 @@ with
     positions as (select * from {{ ref("m_election_api__position") }}),
 
     -- Lookup: BR position database_id → normalized_position_name
-    -- Uses BR API position to get the normalized_position ref, then
-    -- resolves the name from the candidacies S3 data.
+    -- Resolves via BR API position's normalized_position ref to the
+    -- normalized position model (fetched from CivicEngine API).
     br_normalized_lookup as (
         select
             brp.database_id as br_database_id,
             brp.name as br_position_name,
-            npn.normalized_position_name
+            np.name as normalized_position_name
         from {{ ref("stg_airbyte_source__ballotready_api_position") }} as brp
         inner join
-            (
-                select
-                    br_normalized_position_id,
-                    min(normalized_position_name) as normalized_position_name
-                from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
-                where
-                    normalized_position_name is not null
-                    and br_normalized_position_id is not null
-                group by br_normalized_position_id
-            ) as npn
-            on brp.normalized_position.databaseid = npn.br_normalized_position_id
+            {{ ref("int__ballotready_normalized_position") }} as np
+            on brp.normalized_position.databaseid = np.database_id
     ),
 
     versioned as (

--- a/dbt/project/models/marts/civics/campaigns.sql
+++ b/dbt/project/models/marts/civics/campaigns.sql
@@ -60,9 +60,15 @@ with
     with_normalized as (
         select
             v.*,
-            coalesce(
-                bnl_org.normalized_position_name, bnl_legacy.normalized_position_name
-            ) as _normalized_position_name
+            case
+                when v.is_latest_version
+                then
+                    coalesce(
+                        bnl_org.normalized_position_name,
+                        bnl_legacy.normalized_position_name
+                    )
+                else bnl_legacy.normalized_position_name
+            end as _normalized_position_name
         from versioned as v
         left join
             br_normalized_lookup as bnl_org

--- a/dbt/project/models/marts/civics/campaigns.sql
+++ b/dbt/project/models/marts/civics/campaigns.sql
@@ -22,11 +22,14 @@ with
         from {{ ref("stg_airbyte_source__ballotready_api_position") }} as brp
         inner join
             (
-                select distinct br_normalized_position_id, normalized_position_name
+                select
+                    br_normalized_position_id,
+                    min(normalized_position_name) as normalized_position_name
                 from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
                 where
                     normalized_position_name is not null
                     and br_normalized_position_id is not null
+                group by br_normalized_position_id
             ) as npn
             on brp.normalized_position.databaseid = npn.br_normalized_position_id
     ),

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -222,6 +222,14 @@ models:
 
       - name: election_level
         description: Level of election (city, county, state, federal)
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - city
+                  - county
+                  - state
+                  - federal
 
       - name: campaign_office
         description: >

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -234,6 +234,13 @@ models:
           election-api position. Replaces the deprecated base64-decoded
           campaign.details.positionId field.
 
+      - name: normalized_position_name
+        description: >
+          BallotReady normalized position name (e.g. "City Legislature",
+          "Governor") resolved via the BR API position's normalized_position
+          reference. Used for standardizing candidate_office across sources
+          in entity resolution.
+
       - name: is_latest_version
         description: >
           Whether this is the most recent version of the campaign (true) or a

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -221,7 +221,7 @@ models:
         description: Political party affiliation
 
       - name: election_level
-        description: Level of election (local, state, federal)
+        description: Level of election (city, county, state, federal)
 
       - name: campaign_office
         description: >

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -212,6 +212,10 @@ sources:
         description: raw data load from Techspeed Google Drive
       - name: techspeed_gdrive_officeholders
         description: raw data load from Techspeed Google Drive
+        config:
+          freshness:
+            warn_after: { count: 90, period: day }
+            error_after: { count: 180, period: day }
         columns:
           - name: is_incumbent
             data_tests:

--- a/dbt/project/models/staging/airbyte_source/ballotready_api/stg_airbyte_source__ballotready_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/ballotready_api/stg_airbyte_source__ballotready_api.yaml
@@ -18,15 +18,13 @@ models:
           have very low race counts (1-6 observed).
         data_tests:
           - dbt_utils.expression_is_true:
+              # Guard against false positives in special election detection.
+              # BallotReady special elections in 2026+ have 1-6 races; a
+              # match with >10 races likely indicates a regular election
+              # whose name coincidentally contains "special".
               expression: "<= 10"
               config:
                 where: "lower(name) like '%special%' and election_day >= '2026-01-01'"
-                description: >
-                  Guard against false positives in special election
-                  detection. BallotReady special elections in 2026+ have
-                  1-6 races; a match with >10 races likely indicates a
-                  regular election whose name coincidentally contains
-                  "special".
   - name: stg_airbyte_source__ballotready_api_issue
     description: Issue data scan from [`issues` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/issues)
     columns:

--- a/dbt/project/models/staging/airbyte_source/ballotready_api/stg_airbyte_source__ballotready_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/ballotready_api/stg_airbyte_source__ballotready_api.yaml
@@ -12,6 +12,21 @@ models:
         data_tests:
           - not_null
           - unique
+      - name: race_count
+        description: >
+          Number of races in this election. Special elections consistently
+          have very low race counts (1-6 observed).
+        data_tests:
+          - dbt_utils.expression_is_true:
+              expression: "<= 10"
+              config:
+                where: "lower(name) like '%special%' and election_day >= '2026-01-01'"
+                description: >
+                  Guard against false positives in special election
+                  detection. BallotReady special elections in 2026+ have
+                  1-6 races; a match with >10 races likely indicates a
+                  regular election whose name coincidentally contains
+                  "special".
   - name: stg_airbyte_source__ballotready_api_issue
     description: Issue data scan from [`issues` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/issues)
     columns:


### PR DESCRIPTION
## Summary
- Adds **GP API** as a 4th source in `int__er_prematch_candidacy_stages` (alongside BallotReady, TechSpeed, DDHQ)
- Adds `normalized_position_name` to the **campaigns mart** via BallotReady's normalized position API
- Detects **special elections** across BallotReady, DDHQ, and GP API sources
- Refactors `map_office_type` to case-insensitive `lower()` comparisons with expanded mappings

## Key decisions
- **Sources from campaigns mart** (not staging) — joins to user, org, and position are already resolved
- **Fanned out by election stage** via BR API race table — one row per campaign per stage, with stage-specific dates from BR election (not the campaign's generic date)
- **GP API campaigns without a BR race link are excluded** — no `election_stage`, `br_race_id`, or stage-specific date makes them too low-quality for Splink
- **Special elections** detected via `%special%` in election names (BR/GP API) and election_type (DDHQ); guarded by an upstream `race_count <= 10` test on BR elections

## Stats

| Source | Records | Special elections detected |
|--|--|--|
| BallotReady | 35,552 | 213 |
| TechSpeed | 30,064 | — (no indicator) |
| GP API | 20,828 | 76 |
| DDHQ | 2,397 | 162 |

`office_type` "Other" reduced from ~30% → 9% across all sources after `map_office_type` refactor.

## Test plan
- [x] `dbt build` passes for campaigns + prematch (20 pass, 1 pre-existing warn)
- [x] `unique_id` uniqueness verified across all 4 sources
- [x] Special election false positive guard passes on BR election staging
- [x] Stage-specific dates verified (Primary gets March date, not November)

🤖 Generated with [Claude Code](https://claude.com/claude-code)