### PR TITLE
[DATA-1715] Add intermediate DDHQ models for civics mart

### DIFF
--- a/dbt/project/CLAUDE.md
+++ b/dbt/project/CLAUDE.md
@@ -2,23 +2,20 @@
 
 Use the `gh` cli to make pull-requests and interact with GitHub.
 
-Assume we're using the dbt *cloud* cli, not the dbt-core cli. As such you do
-not need to specify `--defer` or the location of a state file, as it's
-configured in dbt cloud. Unless instructed otherwise, do not invoke dbt via
-`poetry`, as the dbt cloud cli should be installed at the system level, and
-invoking dbt via `poetry` risks invoking the dbt-core cli unintentionally.
-
-When adding or modifying models and/or tests, run `dbt build` on the modified
+- We use the dbt *cloud* cli, not the dbt-core cli.
+- You do not need to specify `--defer` or the location of a state file in dbt cloud.
+- Do not invoke dbt via `poetry`.dbt cloud cli is installed at the system level
+- When adding or modifying models and/or tests, run `dbt build` on the modified
 objects to ensure they build as exected.
 
 When building multiple models, use quotes around the models in the `--select` argument:
     - Bad: `dbt build --select my_model1 my_model2`
     - Good: `dbt build --select "my_model1 my_model2"`
 
-**IMPORTANT** - When working on dbt models, it may be helpful to inspect
-existing sources/models in Databricks, as well as models that you have added
-and modified after creating them. Do so by running `dbt show` for custom
-queries or the `inspect_data` utility macro, which includes:
+**IMPORTANT** - When working on dbt models, inspect existing sources/models in
+Databricks, as well as models that you have added and modified after creating
+them. Do so by running `dbt show` for custom queries or the `inspect_data`
+utility macro, which includes:
 
   - Relation name and type
   - Total row count
@@ -29,26 +26,16 @@ queries or the `inspect_data` utility macro, which includes:
 ## Helpful Commands
 
 ```
-# dbt (must be run from in dbt/project/ directory
+# dbt (must be run from in dbt/project/ directory)
 dbt run                               # Run transformations
 dbt test                              # Data quality tests
 dbt build                             # Run + test
 dbt show                              # Query the data in databricks
 
 # Inpect models/sources:
-dbt run-operation inspect_data --args '{"model": "model_name"}'
+dbt show --inline "select distinct candidate_office from {{ ref('int__civics_candidacy_ballotready') }} order by candidate_office" --limit 50
 ```
 
-```
-# For models
-dbt run-operation inspect_data --args '{"model": "my_model_name"}'
-
-# For sources
-dbt run-operation inspect_data --args '{"source_name": "airbyte_source", "table_name": "gp_api_db_campaign"}'
-
-# With custom sample size
-dbt run-operation inspect_data --args '{"source_name": "airbyte_source", "table_name": "gp_api_db_user", "sample_size": 10}'
-```
 ## Code Conventions
 
 - Most dbt tests do *not* need a `config.where: some_column_is_not_null`. For
@@ -67,6 +54,12 @@ dbt run-operation inspect_data --args '{"source_name": "airbyte_source", "table_
   subquery is NULL (the entire expression evaluates to UNKNOWN).
     - Good: `where main.id not in (select id from other_table where id is not null)`
     - Bad: `where main.id not in (select id from other_table)`
+- Utilize Databrick's support for lateral column references to reduce the number
+  of chained CTEs by referencing a modified column lower in the same select
+  block
+- Avoid subqueries in favor of CTEs
+- Prefer to keep join blocks flat with minimal transformations in the join
+  condition by moving the needed transformation up to the SELECT clause
 
 ## Building and Testing Models
 

--- a/dbt/project/CLAUDE.md
+++ b/dbt/project/CLAUDE.md
@@ -4,7 +4,7 @@ Use the `gh` cli to make pull-requests and interact with GitHub.
 
 - We use the dbt *cloud* cli, not the dbt-core cli.
 - You do not need to specify `--defer` or the location of a state file in dbt cloud.
-- Do not invoke dbt via `poetry`.dbt cloud cli is installed at the system level
+- Do not invoke dbt via `poetry`.dbt cloud cli is installed at the system level.
 - When adding or modifying models and/or tests, run `dbt build` on the modified
 objects to ensure they build as exected.
 

--- a/dbt/project/dbt_project.yml
+++ b/dbt/project/dbt_project.yml
@@ -60,6 +60,10 @@ models:
         +tags: ["mart", "analytics"]
       mban2026:
         +schema: mart_mban2026
+    write:
+      write__people_api_db:
+        # Disabled due to performance issues (timing out)
+        +enabled: false
     staging:
       airbyte_source:
         stripe_api:

--- a/dbt/project/macros/variable_standardization/ddhq_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/ddhq_standardizations.sql
@@ -112,17 +112,31 @@
         then 'City Council'
 
         -- Special districts and other offices
-        when lower({{ race_name_col }}) like '%library%'
+        when
+            lower({{ race_name_col }}) like '%library board%'
+            or lower({{ race_name_col }}) like '%library district%'
+            or lower({{ race_name_col }}) like '%library trustee%'
         then 'Library Board'
-        when lower({{ race_name_col }}) like '%fire%'
+        when
+            lower({{ race_name_col }}) like '%fire district%'
+            or lower({{ race_name_col }}) like '%fire board%'
+            or lower({{ race_name_col }}) like '%fire commission%'
+            or lower({{ race_name_col }}) like '%fire department%'
         then 'Fire Board'
         when
-            lower({{ race_name_col }}) like '%park%'
-            or lower({{ race_name_col }}) like '%recreation%'
+            lower({{ race_name_col }}) like '%park district%'
+            or lower({{ race_name_col }}) like '%park board%'
+            or lower({{ race_name_col }}) like '%parks and recreation%'
+            or lower({{ race_name_col }}) like '%recreation district%'
+            or lower({{ race_name_col }}) like '%recreation board%'
         then 'Parks and Recreation Board'
         when
-            lower({{ race_name_col }}) like '%water%'
-            or lower({{ race_name_col }}) like '%sewer%'
+            lower({{ race_name_col }}) like '%water district%'
+            or lower({{ race_name_col }}) like '%water board%'
+            or lower({{ race_name_col }}) like '%water authority%'
+            or lower({{ race_name_col }}) like '%sewer district%'
+            or lower({{ race_name_col }}) like '%sewer board%'
+            or lower({{ race_name_col }}) like '%water supply%'
         then 'Water Supply Board'
         when
             lower({{ race_name_col }}) like '%drainage%'
@@ -144,6 +158,8 @@
             lower({{ race_name_col }}) like '%state senate%'
             or lower({{ race_name_col }}) like '%state house%'
             or lower({{ race_name_col }}) like '%state assembly%'
+            or lower({{ race_name_col }}) like '%state circuit court%'
+            or lower({{ race_name_col }}) like '%court of appeals%'
         then 'State'
         else 'Local'
     end

--- a/dbt/project/macros/variable_standardization/ddhq_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/ddhq_standardizations.sql
@@ -5,11 +5,22 @@
 #}
 {% macro parse_ddhq_candidate_office(race_name_col) %}
     {# Derives candidate_office from DDHQ race_name keywords.
-       County branches checked first to prevent %commission board%
-       from short-circuiting before %county commission%. #}
+       Order matters: more-specific patterns (county sheriff, county clerk) must
+       precede broad county/city catch-alls so they aren't swallowed. #}
     case
+        -- Mayor
         when lower({{ race_name_col }}) like '%mayor%'
         then 'Mayor'
+        when lower({{ race_name_col }}) like '%village president%'
+        then 'Village President'
+
+        -- County-level offices (specific before general)
+        when lower({{ race_name_col }}) like '%county sheriff%'
+        then 'County Sheriff'
+        when lower({{ race_name_col }}) like '%county clerk%'
+        then 'Clerk'
+        when lower({{ race_name_col }}) like '%county treasurer%'
+        then 'Treasurer'
         when lower({{ race_name_col }}) like '%county commission%'
         then 'County Commissioner'
         when
@@ -18,45 +29,108 @@
             or lower({{ race_name_col }}) like '%county board%'
             or lower({{ race_name_col }}) like '%county supervisor%'
         then 'County Legislature'
-        when lower({{ race_name_col }}) like '%county treasurer%'
-        then 'Clerk/Treasurer'
+        when lower({{ race_name_col }}) like '%county court%'
+        then 'Judge'
+        when lower({{ race_name_col }}) like '%county constable%'
+        then 'Constable'
+
+        -- City-level legislative bodies
         when
             lower({{ race_name_col }}) like '%city council%'
             or lower({{ race_name_col }}) like '%city commission%'
             or lower({{ race_name_col }}) like '%common council%'
             or lower({{ race_name_col }}) like '%council member%'
             or lower({{ race_name_col }}) like '%councilmember%'
+            or lower({{ race_name_col }}) like '%councilor%'
+            or lower({{ race_name_col }}) like '%councillor%'
             or lower({{ race_name_col }}) like '%commission board%'
+            or lower({{ race_name_col }}) like '%borough council%'
         then 'City Council'
+
+        -- Alderman
         when
             lower({{ race_name_col }}) like '%alderperson%'
             or lower({{ race_name_col }}) like '%alderman%'
             or lower({{ race_name_col }}) rlike '\\balder\\b'
         then 'Alderman'
+
+        -- Town/village-level legislative bodies
         when
             lower({{ race_name_col }}) like '%town council%'
             or lower({{ race_name_col }}) like '%town board%'
             or lower({{ race_name_col }}) like '%village board%'
             or lower({{ race_name_col }}) like '%village trustee%'
+            or lower({{ race_name_col }}) like '%village council%'
             or lower({{ race_name_col }}) like '%selectperson%'
+            or lower({{ race_name_col }}) like '%selectman%'
+            or lower({{ race_name_col }}) like '%selectmen%'
+            or lower({{ race_name_col }}) like '%select board%'
         then 'Town Council'
+
+        -- Township offices
+        when lower({{ race_name_col }}) like '%township trustee%'
+        then 'Township Supervisor'
+        when lower({{ race_name_col }}) like '%township clerk%'
+        then 'Township Clerk'
+
+        -- Judicial
         when
             lower({{ race_name_col }}) like '%circuit court%'
             or lower({{ race_name_col }}) like '%municipal judge%'
             or lower({{ race_name_col }}) like '%municipal court%'
+            or lower({{ race_name_col }}) like '%justice of the peace%'
+            or lower({{ race_name_col }}) like '%town justice%'
         then 'Judge'
+
+        -- Education
         when
             lower({{ race_name_col }}) like '%school board%'
             or lower({{ race_name_col }}) like '%public school%'
             or lower({{ race_name_col }}) like '%school district%'
+            or lower({{ race_name_col }}) like '%school committee%'
+            or lower({{ race_name_col }}) like '%board of education%'
         then 'School Board'
         when lower({{ race_name_col }}) like '%board of trustees%'
         then 'Board of Trustees'
+
+        -- Clerk/Treasurer (general, after county-specific)
+        when
+            lower({{ race_name_col }}) like '%town clerk%'
+            or lower({{ race_name_col }}) like '%city clerk%'
+        then 'Clerk'
+        when lower({{ race_name_col }}) like '%treasurer%'
+        then 'Treasurer'
+
+        -- Constable / Sheriff (general, after county-specific)
+        when lower({{ race_name_col }}) like '%constable%'
+        then 'Constable'
+        when lower({{ race_name_col }}) like '%sheriff%'
+        then 'County Sheriff'
+
+        -- Assembly / representative bodies
+        when lower({{ race_name_col }}) like '%representative town meeting%'
+        then 'City Council'
+
+        -- Special districts and other offices
+        when lower({{ race_name_col }}) like '%library%'
+        then 'Library Board'
+        when lower({{ race_name_col }}) like '%fire%'
+        then 'Fire Board'
+        when
+            lower({{ race_name_col }}) like '%park%'
+            or lower({{ race_name_col }}) like '%recreation%'
+        then 'Parks and Recreation Board'
+        when
+            lower({{ race_name_col }}) like '%water%'
+            or lower({{ race_name_col }}) like '%sewer%'
+        then 'Water Supply Board'
         when
             lower({{ race_name_col }}) like '%drainage%'
             or lower({{ race_name_col }}) like '%conservation%'
             or lower({{ race_name_col }}) like '%utility district%'
         then 'Other'
+
+        else 'Other'
     end
 {% endmacro %}
 

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -653,6 +653,303 @@ models:
         data_tests:
           - not_null
 
+  - name: int__civics_election_stage_ddhq
+    description: >
+      DDHQ election results transformed into civics mart election_stage schema.
+
+      Grain: One row per DDHQ race (ddhq_race_id).
+
+      Derived from int__civics_candidacy_stage_ddhq, aggregated from
+      candidate-level to race-level.
+
+    columns:
+      - name: gp_election_stage_id
+        description: Primary key - internally generated unique identifier for election stages
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+
+      - name: gp_election_id
+        description: Foreign key to election table
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('int__civics_election_ddhq')
+                field: gp_election_id
+
+      - name: ddhq_race_id
+        description: DDHQ race identifier
+        data_tests:
+          - not_null
+
+      - name: state
+        description: U.S. state (human-readable name)
+        data_tests:
+          - not_null
+
+      - name: state_postal_code
+        description: U.S. state (2-letter postal code)
+        data_tests:
+          - not_null
+          - is_state_abbreviation
+
+      - name: stage_type
+        description: Type of election stage
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - primary
+                  - general
+                  - primary runoff
+                  - general runoff
+
+      - name: election_date
+        description: Date of the election stage
+        data_tests:
+          - not_null
+
+      - name: is_primary
+        description: Whether this stage is a primary election
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_runoff
+        description: Whether this stage is a runoff election
+
+      - name: is_retention
+        description: Whether this stage is a retention election (always false for DDHQ)
+
+      - name: created_at
+        data_tests:
+          - not_null
+
+      - name: updated_at
+        data_tests:
+          - not_null
+
+  - name: int__civics_election_ddhq
+    description: >
+      DDHQ elections transformed into civics mart election schema.
+
+      Grain: One row per election (position + election year).
+
+      Derived from int__civics_candidacy_stage_ddhq, representative-row
+      approach preferring general stage.
+
+    columns:
+      - name: gp_election_id
+        description: Primary key - internally generated unique identifier for elections
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+
+      - name: state
+        description: U.S. state (human-readable name)
+        data_tests:
+          - not_null
+
+      - name: state_postal_code
+        description: U.S. state (2-letter postal code)
+        data_tests:
+          - not_null
+          - is_state_abbreviation
+
+      - name: election_date
+        description: Date of the election
+        data_tests:
+          - not_null
+
+      - name: election_year
+        description: Year of the election
+
+      - name: has_ddhq_match
+        description: Whether there is a DDHQ match (always true for DDHQ data)
+
+      - name: created_at
+        data_tests:
+          - not_null
+
+      - name: updated_at
+        data_tests:
+          - not_null
+
+  - name: int__civics_candidate_ddhq
+    description: >
+      DDHQ candidates transformed into civics mart candidate schema.
+
+      Grain: One row per unique person (deduplicated on gp_candidate_id).
+
+      Derived from int__civics_candidacy_stage_ddhq.
+
+      UUID fields aligned with int__civics_candidate_2025 for cross-source consistency:
+      first_name, last_name, state (birth_date, email, phone are NULL for DDHQ).
+
+    columns:
+      - name: gp_candidate_id
+        description: >
+          Primary key - internally generated UUID for candidates.
+          Generated from: first_name, last_name, state, null, null, null.
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+
+      - name: first_name
+        description: Candidate's first name
+        data_tests:
+          - not_null
+
+      - name: last_name
+        description: Candidate's last name
+        data_tests:
+          - not_null
+
+      - name: state
+        description: U.S. state (human-readable name)
+        data_tests:
+          - not_null
+
+      - name: state_postal_code
+        description: U.S. state (2-letter postal code)
+        data_tests:
+          - not_null
+          - is_state_abbreviation
+
+      - name: created_at
+        data_tests:
+          - not_null
+
+      - name: updated_at
+        data_tests:
+          - not_null
+
+  - name: int__civics_candidacy_ddhq
+    description: >
+      DDHQ candidacies transformed into civics mart candidacy schema.
+
+      Grain: One row per candidacy (candidate + position + election year).
+
+      Derived from int__civics_candidacy_stage_ddhq, rolled up from
+      candidacy-stage grain with stage-specific dates and results.
+
+    columns:
+      - name: gp_candidacy_id
+        description: >
+          Primary key - internally generated UUID for candidacies.
+          Generated from: first_name, last_name, state, party, candidate_office,
+          election_date, district.
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+
+      - name: gp_candidate_id
+        description: Foreign key to candidate table
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('int__civics_candidate_ddhq')
+                field: gp_candidate_id
+
+      - name: candidate_id_source
+        description: Source system identifier
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["ddhq"]
+
+      - name: candidacy_result
+        description: Result of the candidacy (Won or Lost)
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - Won
+                  - Lost
+
+      - name: created_at
+        data_tests:
+          - not_null
+
+      - name: updated_at
+        data_tests:
+          - not_null
+
+  - name: int__civics_candidacy_stage_ddhq
+    description: >
+      DDHQ candidacy stages — the foundational DDHQ intermediate model.
+
+      Grain: One row per candidacy stage (candidate + race), 1:1 with staging rows.
+
+      Reads from staging, computes all five GP IDs, and carries through all
+      columns needed by the four downstream DDHQ models (candidate, candidacy,
+      election_stage, election).
+
+    columns:
+      - name: gp_candidacy_stage_id
+        description: Primary key - internally generated unique identifier for candidacy stages
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+
+      - name: gp_candidacy_id
+        description: Candidacy ID (candidate + position + year)
+        data_tests:
+          - not_null
+
+      - name: gp_candidate_id
+        description: Candidate ID (person-level)
+        data_tests:
+          - not_null
+
+      - name: gp_election_stage_id
+        description: Election stage ID (one per DDHQ race)
+        data_tests:
+          - not_null
+
+      - name: gp_election_id
+        description: Election ID (position + year)
+        data_tests:
+          - not_null
+
+      - name: election_result
+        description: Result of the election stage (Won or Lost)
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - Won
+                  - Lost
+
+      - name: is_winner
+        description: Whether the candidate won the election stage
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: election_date
+        description: Date of the election stage
+        data_tests:
+          - not_null
+
+      - name: created_at
+        data_tests:
+          - not_null
+
+      - name: updated_at
+        data_tests:
+          - not_null
+
   - name: int__civics_candidate_ballotready
     description: >
       BallotReady candidates transformed into civics mart candidate schema.

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_ddhq.sql
@@ -1,0 +1,62 @@
+-- DDHQ → Civics mart candidacy
+-- Derived from: int__civics_candidacy_stage_ddhq
+--
+-- Grain: One row per candidacy (candidate + position + election year)
+--
+-- Rolls up from candidacy-stage grain: groups by gp_candidacy_id,
+-- extracting stage-specific dates and overall candidacy result.
+with
+    source as (select * from {{ ref("int__civics_candidacy_stage_ddhq") }}),
+
+    candidacies as (
+        select
+            gp_candidacy_id,
+            any_value(gp_candidate_id) as gp_candidate_id,
+            any_value(gp_election_id) as gp_election_id,
+
+            cast(null as string) as br_candidacy_id,
+            cast(null as string) as product_campaign_id,
+            cast(null as string) as hubspot_contact_id,
+            cast(null as string) as hubspot_company_ids,
+
+            'ddhq' as candidate_id_source,
+            any_value(source_candidate_id) as candidate_code,
+
+            any_value(party_affiliation) as party_affiliation,
+            cast(null as boolean) as is_incumbent,
+            cast(null as boolean) as is_open_seat,
+            any_value(candidate_office) as candidate_office,
+            any_value(official_office_name) as official_office_name,
+            any_value(office_level) as office_level,
+            any_value(office_type) as office_type,
+
+            cast(null as boolean) as is_pledged,
+            cast(null as boolean) as is_verified,
+            cast(null as string) as verification_status_reason,
+            cast(null as boolean) as is_partisan,
+
+            -- Candidacy result: prefer general, then primary
+            coalesce(
+                max(case when election_stage = 'general' then election_result end),
+                max(case when election_stage = 'primary' then election_result end)
+            ) as candidacy_result,
+
+            -- Stage-specific dates (already computed at candidacy level)
+            any_value(candidacy_primary_date) as primary_election_date,
+            any_value(candidacy_general_date) as general_election_date,
+            any_value(candidacy_primary_runoff_date) as primary_runoff_election_date,
+            any_value(candidacy_general_runoff_date) as general_runoff_election_date,
+
+            cast(null as float) as viability_score,
+            cast(null as int) as win_number,
+            cast(null as string) as win_number_model,
+
+            min(created_at) as created_at,
+            max(updated_at) as updated_at
+
+        from source
+        group by gp_candidacy_id
+    )
+
+select *
+from candidacies

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_ddhq.sql
@@ -35,9 +35,15 @@ with
             cast(null as string) as verification_status_reason,
             cast(null as boolean) as is_partisan,
 
-            -- Candidacy result: prefer general, then primary
+            -- Candidacy result: runoff is the final determination
             coalesce(
+                max(
+                    case when election_stage = 'general runoff' then election_result end
+                ),
                 max(case when election_stage = 'general' then election_result end),
+                max(
+                    case when election_stage = 'primary runoff' then election_result end
+                ),
                 max(case when election_stage = 'primary' then election_result end)
             ) as candidacy_result,
 

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
@@ -1,0 +1,265 @@
+-- DDHQ election results → Civics mart candidacy_stage (base model)
+-- Source: stg_airbyte_source__ddhq_gdrive_election_results
+--
+-- Grain: One row per candidacy stage (candidate + race), 1:1 with staging rows.
+--
+-- This is the foundational DDHQ intermediate model. It computes all five
+-- GP IDs and carries through all staging columns so the other four DDHQ
+-- models (candidate, candidacy, election_stage, election) can derive from it
+-- without re-reading the staging table.
+with
+    source as (
+        select *
+        from {{ ref("stg_airbyte_source__ddhq_gdrive_election_results") }}
+        where
+            election_date >= '2026-01-01'
+            and ddhq_race_id is not null
+            and candidate_id is not null
+            and candidate_first_name is not null
+            and candidate_last_name is not null
+            and state_postal_code is not null
+    ),
+
+    -- General election date lookup: find the general-stage election date per
+    -- position+year so primary/runoff stages get the same gp_election_id.
+    general_election_dates as (
+        select
+            official_office_name,
+            candidate_office,
+            office_level,
+            office_type,
+            state_postal_code as state,
+            district,
+            year(election_date) as election_year,
+            max(election_date) as general_election_date,
+            any_value(number_of_seats_in_election) as general_seats
+        from source
+        where election_stage = 'general'
+        group by
+            official_office_name,
+            candidate_office,
+            office_level,
+            office_type,
+            state_postal_code,
+            district,
+            year(election_date)
+    ),
+
+    -- Candidacy-level date lookup: coalesce general > primary > runoff dates
+    -- per candidate+position+year for stable gp_candidacy_id generation.
+    candidacy_dates as (
+        select
+            candidate_first_name,
+            candidate_last_name,
+            state_postal_code,
+            party_affiliation,
+            candidate_office,
+            official_office_name,
+            office_level,
+            district,
+            year(election_date) as election_year,
+            max(
+                case when election_stage = 'general' then election_date end
+            ) as general_date,
+            max(
+                case when election_stage = 'primary' then election_date end
+            ) as primary_date,
+            max(
+                case when election_stage = 'general runoff' then election_date end
+            ) as general_runoff_date,
+            max(
+                case when election_stage = 'primary runoff' then election_date end
+            ) as primary_runoff_date
+        from source
+        group by
+            candidate_first_name,
+            candidate_last_name,
+            state_postal_code,
+            party_affiliation,
+            candidate_office,
+            official_office_name,
+            office_level,
+            district,
+            year(election_date)
+    ),
+
+    with_ids as (
+        select
+            -- === Computed IDs ===
+            {{
+                generate_salted_uuid(
+                    fields=[
+                        "s.candidate_first_name",
+                        "s.candidate_last_name",
+                        "s.state_postal_code",
+                        "cast(null as string)",
+                        "cast(null as string)",
+                        "cast(null as string)",
+                    ]
+                )
+            }} as gp_candidate_id,
+
+            {{
+                generate_salted_uuid(
+                    fields=[
+                        "s.candidate_first_name",
+                        "s.candidate_last_name",
+                        "s.state_postal_code",
+                        "s.party_affiliation",
+                        "s.candidate_office",
+                        "cast(coalesce(cd.general_date, cd.primary_date, cd.general_runoff_date, cd.primary_runoff_date) as string)",
+                        "s.district",
+                    ]
+                )
+            }}
+            as gp_candidacy_id,
+
+            {{ generate_salted_uuid(fields=["cast(s.ddhq_race_id as string)"]) }}
+            as gp_election_stage_id,
+
+            {{ generate_gp_election_id("elec_lookup") }} as gp_election_id,
+
+            -- === Staging passthrough ===
+            s.candidate as candidate_full_name,
+            s.candidate_first_name,
+            s.candidate_last_name,
+            cast(s.candidate_id as string) as source_candidate_id,
+            cast(s.ddhq_race_id as string) as source_race_id,
+            s.ddhq_race_id,
+            s.state_name,
+            s.state_postal_code,
+            s.party_affiliation,
+            s.candidate_office,
+            s.official_office_name,
+            s.office_level,
+            s.office_type,
+            s.district,
+            s.election_stage,
+            s.election_date,
+            s.race_name,
+            s.is_winner,
+            s.is_uncontested,
+            s.votes,
+            s.number_of_seats_in_election,
+            s.total_number_of_ballots_in_race,
+            s._airbyte_extracted_at,
+
+            -- === Candidacy-level dates (for candidacy rollup) ===
+            cd.general_date as candidacy_general_date,
+            cd.primary_date as candidacy_primary_date,
+            cd.general_runoff_date as candidacy_general_runoff_date,
+            cd.primary_runoff_date as candidacy_primary_runoff_date,
+
+            -- === Candidacy-stage-specific derived columns ===
+            case when s.is_winner then 'Won' else 'Lost' end as election_result,
+            'ddhq' as election_result_source
+
+        from source as s
+        inner join
+            candidacy_dates as cd
+            on s.candidate_first_name <=> cd.candidate_first_name
+            and s.candidate_last_name <=> cd.candidate_last_name
+            and s.state_postal_code <=> cd.state_postal_code
+            and s.party_affiliation <=> cd.party_affiliation
+            and s.candidate_office <=> cd.candidate_office
+            and s.official_office_name <=> cd.official_office_name
+            and s.office_level <=> cd.office_level
+            and s.district <=> cd.district
+            and year(s.election_date) = cd.election_year
+        left join
+            general_election_dates as ged
+            on s.official_office_name <=> ged.official_office_name
+            and s.candidate_office <=> ged.candidate_office
+            and s.office_level <=> ged.office_level
+            and s.office_type <=> ged.office_type
+            and s.state_postal_code <=> ged.state
+            and s.district <=> ged.district
+            and year(s.election_date) = ged.election_year
+        cross join
+            lateral(
+                select
+                    s.official_office_name,
+                    s.candidate_office,
+                    s.office_level,
+                    s.office_type,
+                    s.state_postal_code as state,
+                    cast(null as string) as city,
+                    s.district,
+                    cast(null as string) as seat_name,
+                    coalesce(
+                        ged.general_election_date, s.election_date
+                    ) as election_date,
+                    coalesce(
+                        ged.general_seats, s.number_of_seats_in_election
+                    ) as seats_available
+            ) as elec_lookup
+    ),
+
+    candidacy_stages as (
+        select
+            {{
+                generate_salted_uuid(
+                    fields=["gp_candidacy_id", "gp_election_stage_id"]
+                )
+            }} as gp_candidacy_stage_id, *
+        from with_ids
+    ),
+
+    deduplicated as (
+        select *
+        from candidacy_stages
+        qualify
+            row_number() over (
+                partition by gp_candidacy_stage_id order by _airbyte_extracted_at desc
+            )
+            = 1
+    )
+
+select
+    -- IDs
+    gp_candidacy_stage_id,
+    gp_candidacy_id,
+    gp_candidate_id,
+    gp_election_stage_id,
+    gp_election_id,
+
+    -- Candidate fields
+    candidate_full_name,
+    candidate_first_name,
+    candidate_last_name,
+    source_candidate_id,
+
+    -- Race / election fields
+    source_race_id,
+    ddhq_race_id,
+    state_name,
+    state_postal_code,
+    party_affiliation,
+    candidate_office,
+    official_office_name,
+    office_level,
+    office_type,
+    district,
+    election_stage,
+    election_date,
+    race_name,
+    is_winner,
+    is_uncontested,
+    votes,
+    number_of_seats_in_election,
+    total_number_of_ballots_in_race,
+
+    -- Candidacy-level dates
+    candidacy_general_date,
+    candidacy_primary_date,
+    candidacy_general_runoff_date,
+    candidacy_primary_runoff_date,
+
+    -- Candidacy-stage derived
+    election_result,
+    election_result_source,
+
+    -- Timestamps
+    _airbyte_extracted_at as created_at,
+    _airbyte_extracted_at as updated_at
+from deduplicated

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
@@ -151,7 +151,13 @@ with
             cd.primary_runoff_date as candidacy_primary_runoff_date,
 
             -- === Candidacy-stage-specific derived columns ===
-            case when s.is_winner then 'Won' else 'Lost' end as election_result,
+            case
+                when s.is_winner
+                then 'Won'
+                when s.is_winner = false
+                then 'Lost'
+                else null
+            end as election_result,
             'ddhq' as election_result_source
 
         from source as s

--- a/dbt/project/models/intermediate/civics/int__civics_candidate_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidate_ddhq.sql
@@ -1,0 +1,38 @@
+-- DDHQ → Civics mart candidate
+-- Derived from: int__civics_candidacy_stage_ddhq
+--
+-- Grain: One row per unique person (deduplicated on gp_candidate_id)
+--
+-- CRITICAL: UUID fields MUST match int__civics_candidate_2025.sql pattern
+-- to ensure same person from different sources gets same gp_candidate_id
+with
+    deduplicated as (
+        select *
+        from {{ ref("int__civics_candidacy_stage_ddhq") }}
+        qualify
+            row_number() over (partition by gp_candidate_id order by updated_at desc)
+            = 1
+    )
+
+select
+    gp_candidate_id,
+    cast(null as string) as hubspot_contact_id,
+    cast(null as string) as prod_db_user_id,
+    cast(null as string) as candidate_id_tier,
+    candidate_first_name as first_name,
+    candidate_last_name as last_name,
+    candidate_full_name as full_name,
+    cast(null as date) as birth_date,
+    state_name as state,
+    state_postal_code,
+    cast(null as string) as email,
+    cast(null as string) as phone_number,
+    cast(null as string) as street_address,
+    cast(null as string) as website_url,
+    cast(null as string) as linkedin_url,
+    cast(null as string) as twitter_handle,
+    cast(null as string) as facebook_url,
+    cast(null as string) as instagram_handle,
+    created_at,
+    updated_at
+from deduplicated

--- a/dbt/project/models/intermediate/civics/int__civics_election_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_ddhq.sql
@@ -1,0 +1,52 @@
+-- DDHQ → Civics mart election
+-- Derived from: int__civics_candidacy_stage_ddhq
+--
+-- Grain: One row per election (position + election year)
+--
+-- Uses a representative-row approach: picks one candidacy_stage row per
+-- gp_election_id, preferring general stage and the latest timestamp.
+with
+    source as (select * from {{ ref("int__civics_candidacy_stage_ddhq") }}),
+
+    representative_row as (
+        select *
+        from source
+        qualify
+            row_number() over (
+                partition by gp_election_id
+                order by
+                    case when election_stage = 'general' then 0 else 1 end,
+                    updated_at desc,
+                    candidate_full_name
+            )
+            = 1
+    )
+
+select
+    gp_election_id,
+    official_office_name,
+    candidate_office,
+    office_level,
+    office_type,
+    state_name as state,
+    state_postal_code,
+    cast(null as string) as city,
+    district,
+    cast(null as string) as seat_name,
+    election_date,
+    year(election_date) as election_year,
+    cast(null as date) as filing_deadline,
+    cast(null as int) as population,
+    number_of_seats_in_election as seats_available,
+    cast(null as date) as term_start_date,
+    is_uncontested,
+    cast(null as string) as number_of_opponents,
+    cast(null as boolean) as is_open_seat,
+    true as has_ddhq_match,
+    cast(null as bigint) as br_position_database_id,
+    cast(null as boolean) as is_judicial,
+    cast(null as boolean) as is_appointed,
+    cast(null as string) as br_normalized_position_type,
+    created_at,
+    updated_at
+from representative_row

--- a/dbt/project/models/intermediate/civics/int__civics_election_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_stage_ddhq.sql
@@ -1,0 +1,53 @@
+-- DDHQ → Civics mart election_stage
+-- Derived from: int__civics_candidacy_stage_ddhq
+--
+-- Grain: One row per DDHQ race (gp_election_stage_id / ddhq_race_id)
+--
+-- Aggregates from candidate-level candidacy_stage rows to race-level.
+with
+    source as (select * from {{ ref("int__civics_candidacy_stage_ddhq") }}),
+
+    election_stages as (
+        select
+            gp_election_stage_id,
+            any_value(gp_election_id) as gp_election_id,
+
+            cast(null as string) as br_race_id,
+            cast(null as string) as br_election_id,
+            cast(null as bigint) as br_position_id,
+            any_value(source_race_id) as ddhq_race_id,
+
+            any_value(election_stage) as stage_type,
+            any_value(election_date) as election_date,
+
+            any_value(state_name) as state,
+            any_value(state_postal_code) as state_postal_code,
+
+            any_value(state_postal_code)
+            || ' '
+            || cast(year(any_value(election_date)) as string)
+            || ' '
+            || initcap(any_value(election_stage)) as election_name,
+            any_value(state_postal_code) || ' ' || any_value(race_name) as race_name,
+
+            any_value(election_stage) in ('primary', 'primary runoff') as is_primary,
+            any_value(election_stage)
+            in ('general runoff', 'primary runoff') as is_runoff,
+            false as is_retention,
+            any_value(number_of_seats_in_election) as number_of_seats,
+            any_value(total_number_of_ballots_in_race) as total_votes_cast,
+            cast(null as string) as partisan_type,
+            cast(null as date) as filing_period_start_on,
+            cast(null as date) as filing_period_end_on,
+            cast(null as string) as filing_requirements,
+            cast(null as string) as filing_address,
+            cast(null as string) as filing_phone,
+            min(created_at) as created_at,
+            max(updated_at) as updated_at
+
+        from source
+        group by gp_election_stage_id
+    )
+
+select *
+from election_stages

--- a/dbt/project/models/intermediate/civics/int__civics_election_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_stage_ddhq.sql
@@ -28,7 +28,7 @@ with
             || cast(year(any_value(election_date)) as string)
             || ' '
             || initcap(any_value(election_stage)) as election_name,
-            any_value(state_postal_code) || ' ' || any_value(race_name) as race_name,
+            any_value(race_name) as race_name,
 
             any_value(election_stage) in ('primary', 'primary runoff') as is_primary,
             any_value(election_stage)

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -106,9 +106,6 @@ with
         left join person_emails as pe on br.br_candidate_id = pe.person_database_id
     ),
 
-    -- State name → 2-letter code mapping (used by DDHQ section)
-    clean_states as (select * from {{ ref("clean_states") }}),
-
     -- TechSpeed: sourced from staging (dates and state already parsed),
     -- unpivoted into primary/general stage rows
     ts_staging as (
@@ -190,7 +187,9 @@ with
             = 1
     ),
 
-    -- DDHQ election results: each row is a candidate x race (candidacy-stage)
+    -- DDHQ election results: each row is a candidate x race (candidacy-stage).
+    -- State resolution, office derivation, and district extraction now come
+    -- from the staging model.
     ddhq_staging as (
         select *
         from {{ ref("stg_airbyte_source__ddhq_gdrive_election_results") }}
@@ -205,57 +204,7 @@ with
             and candidate_last_name is not null
             and election_date is not null
             and election_date >= '2026-01-01'
-    ),
-
-    -- Compute candidate_office once so map_office_type can reference it
-    -- without re-evaluating the full CASE expression
-    ddhq_with_office as (
-        select
-            ddhq.*,
-            coalesce(
-                cs_two.state_cleaned_postal_code, cs_one.state_cleaned_postal_code
-            ) as state,
-            {{ parse_ddhq_candidate_office("ddhq.race_name") }} as candidate_office,
-            -- Strip state prefix from race_name so office names align with
-            -- BR/TS for Splink JW matching (e.g. "New York Senate District 5"
-            -- → "Senate District 5")
-            trim(
-                case
-                    when cs_two.state_cleaned_postal_code is not null
-                    then
-                        substring(
-                            ddhq.race_name,
-                            length(
-                                concat(
-                                    split(ddhq.race_name, ' ')[0],
-                                    ' ',
-                                    split(ddhq.race_name, ' ')[1]
-                                )
-                            )
-                            + 2
-                        )
-                    when cs_one.state_cleaned_postal_code is not null
-                    then
-                        substring(
-                            ddhq.race_name, length(split(ddhq.race_name, ' ')[0]) + 2
-                        )
-                end
-            ) as official_office_name
-        from ddhq_staging as ddhq
-        left join
-            clean_states as cs_one
-            on upper(split(ddhq.race_name, ' ')[0]) = upper(trim(cs_one.state_raw))
-        left join
-            clean_states as cs_two
-            on upper(
-                concat(
-                    split(ddhq.race_name, ' ')[0], ' ', split(ddhq.race_name, ' ')[1]
-                )
-            )
-            = upper(trim(cs_two.state_raw))
-        where
-            coalesce(cs_two.state_cleaned_postal_code, cs_one.state_cleaned_postal_code)
-            is not null
+            and state_postal_code is not null
     ),
 
     ddhq_stages as (
@@ -266,38 +215,22 @@ with
             || cast(d.ddhq_race_id as string) as source_id,
             lower(trim(d.candidate_first_name)) as first_name,
             lower(trim(d.candidate_last_name)) as last_name,
-            d.state,
-            {{ parse_party_affiliation("d.candidate_party") }} as party,
+            d.state_postal_code as state,
+            d.party_affiliation as party,
             d.candidate_office,
-            {{ parse_ddhq_office_level("d.race_name") }} as office_level,
-            {{ map_office_type("d.candidate_office") }} as office_type,
-            -- Extract district/ward from race_name
-            -- Try keyword-prefixed first (Ward 3, District 5), then fall back
-            -- to any trailing number (Board of Supervisors 19)
+            d.office_level,
+            d.office_type,
+            d.district as district_raw,
             coalesce(
-                nullif(
-                    regexp_extract(
-                        d.race_name,
-                        '(?i)(?:ward|district|seat|place|position|zone) ([^ ]+)$'
-                    ),
-                    ''
-                ),
-                nullif(regexp_extract(d.race_name, ' ([0-9]+)$'), '')
-            ) as district_raw,
-            coalesce(
-                try_cast(
-                    regexp_extract(
-                        d.race_name,
-                        '(?i)(?:ward|district|seat|place|position|zone) ([0-9]+)$'
-                    ) as int
-                ),
+                try_cast(regexp_extract(d.district, '([0-9]+)') as int),
                 try_cast(regexp_extract(d.race_name, ' ([0-9]+)$') as int)
             ) as district_identifier,
             d.election_date,
+            -- ER prematch uses 3-value stage format
             case
-                when lower(d.election_type) like '%runoff%'
+                when d.election_stage like '%runoff%'
                 then 'Runoff'
-                when lower(d.election_type) like '%primary%'
+                when d.election_stage = 'primary'
                 then 'Primary'
                 else 'General'
             end as election_stage,
@@ -308,7 +241,7 @@ with
             cast(null as string) as br_candidacy_id,
             cast(null as string) as seat_name,
             cast(null as string) as partisan_type
-        from ddhq_with_office as d
+        from ddhq_staging as d
     ),
 
     unioned as (

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -64,6 +64,14 @@ sources:
         description: raw data load from s3 data dump sent from ballotready
       - name: ddhq_gdrive_election_results
         description: raw data load from ddhq google drive for election results
+        columns:
+          - name: race_name
+            data_tests:
+              - dbt_expectations.expect_column_values_to_match_regex:
+                  arguments:
+                    regex: "^[A-Z]{2} "
+                  config:
+                    where: "race_name is not null"
       - name: gp_api_db_campaign
         description: raw data load from gp_api_db postgres db from table `campaign`
       - name: gp_api_db_campaign_position

--- a/dbt/project/models/staging/airbyte_source/ddhq_gdrive/stg_airbyte_source__ddhq_gdrive.yaml
+++ b/dbt/project/models/staging/airbyte_source/ddhq_gdrive/stg_airbyte_source__ddhq_gdrive.yaml
@@ -3,6 +3,10 @@ models:
   - name: stg_airbyte_source__ddhq_gdrive_election_results
     description: Election results data load from ddhq google drive
     columns:
+      - name: state_postal_code
+        description: 2-letter state code resolved from race_name prefix via clean_states
+        data_tests:
+          - not_null
       - name: ddhq_race_id
         data_tests:
           - not_null

--- a/dbt/project/models/staging/airbyte_source/ddhq_gdrive/stg_airbyte_source__ddhq_gdrive_election_results.sql
+++ b/dbt/project/models/staging/airbyte_source/ddhq_gdrive/stg_airbyte_source__ddhq_gdrive_election_results.sql
@@ -34,13 +34,67 @@ with
         from source
     ),
 
+    clean_states as (select * from {{ ref("clean_states") }}),
+
+    us_states as (select * from {{ ref("us_states") }}),
+
+    -- Resolve state postal code from the 2-letter prefix of race_name.
+    -- A source-level test confirms all race_names match ^[A-Z]{2} .
+    with_state as (
+        select
+            r.*,
+            split(r.race_name, ' ')[0] as state_prefix,
+            cs.state_cleaned_postal_code as state_postal_code,
+            us.state_name
+        from renamed as r
+        left join
+            clean_states as cs
+            on upper(split(r.race_name, ' ')[0]) = upper(trim(cs.state_raw))
+        left join us_states as us on cs.state_cleaned_postal_code = us.state_postal_code
+    ),
+
+    with_derived_fields as (
+        select
+            * except (state_prefix),
+            trim(
+                substring(race_name, length(state_prefix) + 2)
+            ) as official_office_name,
+            {{ parse_ddhq_candidate_office("race_name") }} as candidate_office,
+            {{ map_office_type("candidate_office") }} as office_type,
+            {{ parse_ddhq_office_level("race_name") }} as office_level,
+            coalesce(
+                nullif(
+                    regexp_extract(
+                        race_name,
+                        '(?i)(?:ward|district|seat|place|position|zone) ([^ ]+)$'
+                    ),
+                    ''
+                ),
+                nullif(regexp_extract(race_name, ' ([0-9]+)$'), ''),
+                ''
+            ) as district,
+            case
+                when
+                    lower(election_type) like '%runoff%'
+                    and lower(election_type) like '%primary%'
+                then 'primary runoff'
+                when lower(election_type) like '%runoff%'
+                then 'general runoff'
+                when lower(election_type) like '%primary%'
+                then 'primary'
+                else 'general'
+            end as election_stage,
+            {{ parse_party_affiliation("candidate_party") }} as party_affiliation
+        from with_state
+    ),
+
     invalid as (
         select _airbyte_raw_id
         from {{ ref("stg_airbyte_source__ddhq_gdrive_election_results_invalid") }}
     )
 
 select *
-from renamed
+from with_derived_fields
 where
     _airbyte_raw_id
     not in (select _airbyte_raw_id from invalid where _airbyte_raw_id is not null)

--- a/dbt/project/models/write/write__people_api_db.py
+++ b/dbt/project/models/write/write__people_api_db.py
@@ -653,7 +653,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
         incremental_strategy="append",
         unique_key="id",
         on_schema_change="append_new_columns",
-        enabled=True,
         tags=["l2", "databricks", "people_api", "write", "monthly"],
     )
 

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -51,6 +51,21 @@ seeds:
         - dbt_expectations.expect_column_distinct_values_to_equal_set:
             arguments:
               value_set: "{{ get_us_states_list(include_DC=true, include_US=false, include_territories=true) }}"
+  - name: us_states
+    description: "One row per U.S. state/territory mapping postal code to human-readable name"
+    columns:
+      - name: state_postal_code
+        description: "2-letter state postal code"
+        data_tests:
+          - unique
+          - not_null
+          - is_state_abbreviation
+      - name: state_name
+        description: "Human-readable state name"
+        data_tests:
+          - unique
+          - not_null
+
   - name: nicknames
     description: >
       Mapping of given names to their common nicknames/aliases.

--- a/dbt/project/seeds/us_states.csv
+++ b/dbt/project/seeds/us_states.csv
@@ -1,0 +1,57 @@
+state_postal_code,state_name
+AK,Alaska
+AL,Alabama
+AR,Arkansas
+AZ,Arizona
+CA,California
+CO,Colorado
+CT,Connecticut
+DC,District of Columbia
+DE,Delaware
+FL,Florida
+GA,Georgia
+HI,Hawaii
+IA,Iowa
+ID,Idaho
+IL,Illinois
+IN,Indiana
+KS,Kansas
+KY,Kentucky
+LA,Louisiana
+MA,Massachusetts
+MD,Maryland
+ME,Maine
+MI,Michigan
+MN,Minnesota
+MO,Missouri
+MS,Mississippi
+MT,Montana
+NC,North Carolina
+ND,North Dakota
+NE,Nebraska
+NH,New Hampshire
+NJ,New Jersey
+NM,New Mexico
+NV,Nevada
+NY,New York
+OH,Ohio
+OK,Oklahoma
+OR,Oregon
+PA,Pennsylvania
+RI,Rhode Island
+SC,South Carolina
+SD,South Dakota
+TN,Tennessee
+TX,Texas
+UT,Utah
+VA,Virginia
+VT,Vermont
+WA,Washington
+WI,Wisconsin
+WV,West Virginia
+WY,Wyoming
+PR,Puerto Rico
+GU,Guam
+VI,U.S. Virgin Islands
+AS,American Samoa
+MP,Northern Mariana Islands


### PR DESCRIPTION
## Summary

- Add five new intermediate DDHQ models (`int__civics_candidacy_stage_ddhq`, `int__civics_candidacy_ddhq`, `int__civics_candidate_ddhq`, `int__civics_election_ddhq`, `int__civics_election_stage_ddhq`) that transform DDHQ election results into the civics mart schema
- Expand `parse_ddhq_candidate_office` macro with broader office type coverage (village president, county sheriff/clerk/treasurer, township offices, judicial, constable, library/fire/parks/water boards, etc.)
- Enhance DDHQ staging model with name parsing, state lookups via new `us_states` seed, and `election_stage`/`candidate_office` derivation
- Simplify `int__er_prematch_candidacy_stages` by removing inline DDHQ transformations now handled upstream
- Add `us_states` seed for state name/postal code lookups
- Disable `write__people_api_db` model due to timeout issues

## Test plan
- [ ] `dbt build --select "int__civics_candidacy_stage_ddhq int__civics_candidacy_ddhq int__civics_candidate_ddhq int__civics_election_ddhq int__civics_election_stage_ddhq"`
- [ ] Verify YAML tests pass (unique, not_null, relationships, accepted_values)
- [ ] Spot-check `candidate_office` mapping coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DDHQ→civics intermediate tables and moves key parsing/ID-derivation into DDHQ staging, which can change downstream row shapes/IDs and entity-resolution matching behavior. Also disables a production write model due to timeouts, which may impact scheduled loads until re-enabled.
> 
> **Overview**
> Adds a new DDHQ pipeline into the civics intermediate layer by introducing `int__civics_candidacy_stage_ddhq` (base) plus rollups for `candidate`, `candidacy`, `election`, and `election_stage`, with associated schema docs and data tests in `int__civics.yaml`.
> 
> Enhances DDHQ staging (`stg_airbyte_source__ddhq_gdrive_election_results`) to resolve `state_postal_code`/`state_name` via a new `us_states` seed, and to derive `candidate_office`, `office_type`, `office_level`, `district`, `election_stage`, and `party_affiliation`; updates ER prematch (`int__er_prematch_candidacy_stages`) to consume these derived fields instead of recomputing them.
> 
> Expands `parse_ddhq_candidate_office` keyword coverage for more local office types, adds a source-level regex test on `ddhq_gdrive_election_results.race_name`, and disables `write__people_api_db` via project config (and removes the inline `enabled` flag) due to performance timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4599e9d33321902e875aaa8419a282165f91d152. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->