### PR TITLE
[DATA-1817] Add PMF survey and Win satisfaction responses to analytics mart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ logs/
 !.claude/skills/l2-uniform-drift-remediator/dbt_logs/.gitkeep
 !.claude/skills/l2-uniform-drift-remediator/dbt_logs/README.md
 .pre-commit-cache/
+.worktrees/
+.playwright-cli/
 test_data/
 .databricks/
 

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1154,6 +1154,10 @@ models:
         description: HubSpot contact ID of the respondent
         data_tests:
           - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_airbyte_source__hubspot_api_contacts')
+                field: id
       - name: contact_email
         description: Email address of the respondent
         data_tests:
@@ -1185,3 +1189,7 @@ models:
         description: HubSpot contact ID of the respondent
         data_tests:
           - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_airbyte_source__hubspot_api_contacts')
+                field: id

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1115,3 +1115,73 @@ models:
           - accepted_values:
               arguments:
                 values: ['Won', 'Lost', 'Runoff', 'Withdrew', 'Not on Ballot']
+
+  - name: pmf_survey_responses
+    description: >
+      PMF (Product-Market Fit) web survey responses. Filtered to survey_id 8
+      ("PMF - Web survey"). One row per survey submission, joined to HubSpot
+      contacts for respondent context. PMF Score = (Very Disappointed / total) * 100.
+    columns:
+      - name: submission_id
+        description: Unique identifier for the feedback submission
+        data_tests:
+          - not_null
+          - unique
+      - name: submitted_at
+        description: Timestamp when the survey response was submitted
+        data_tests:
+          - not_null
+      - name: pmf_response
+        description: >
+          Decoded PMF answer: Very Disappointed, Somewhat Disappointed,
+          Not Disappointed, or N/A.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - "Very Disappointed"
+                  - "Somewhat Disappointed"
+                  - "Not Disappointed"
+                  - "N/A"
+      - name: is_very_disappointed
+        description: >
+          Boolean flag for PMF score calculation.
+          PMF Score = SUM(is_very_disappointed) / COUNT(*) * 100.
+        data_tests:
+          - not_null
+      - name: hs_contact_id
+        description: HubSpot contact ID of the respondent
+        data_tests:
+          - not_null
+      - name: contact_email
+        description: Email address of the respondent
+        data_tests:
+          - not_null
+
+  - name: win_user_satisfaction_responses
+    description: >
+      Win User satisfaction survey (5 stars) responses. Combines survey_id 9
+      and 10 (same survey, relaunched for ICP filtering). One row per response.
+    columns:
+      - name: submission_id
+        description: Unique identifier for the feedback submission
+        data_tests:
+          - not_null
+          - unique
+      - name: submitted_at
+        description: Timestamp when the survey response was submitted
+        data_tests:
+          - not_null
+      - name: satisfaction_stars
+        description: User satisfaction rating on a 1-5 star scale
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                max_value: 5
+      - name: hs_contact_id
+        description: HubSpot contact ID of the respondent
+        data_tests:
+          - not_null

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -11,7 +11,7 @@ with
 
     submissions as (
         select *
-        from {{ ref("stg_airbyte_source__feedback_submissions") }}
+        from {{ ref("stg_airbyte_source__hubspot_api_feedback_submissions") }}
         where hs_survey_id = '8'
     ),
 

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -49,9 +49,9 @@ with
                 then 'Not Disappointed'
                 when 'N/A - I no longer use GoodParty'
                 then 'N/A'
-                else s.pmf_response
+                else coalesce(s.pmf_response, 'N/A')
             end as pmf_response,
-            s.pmf_response = 'Option 1' as is_very_disappointed,
+            coalesce(s.pmf_response = 'Option 1', false) as is_very_disappointed,
 
             -- respondent info (from submission)
             s.hs_contact_id,

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -1,0 +1,79 @@
+/*
+    PMF (Product-Market Fit) web survey responses from HubSpot Feedback Surveys.
+    Filtered to survey_id = '8' (PMF - Web survey).
+    Joined to HubSpot contacts for additional user context.
+
+    Grain: One row per survey response.
+
+    PMF Score = (count of 'Very Disappointed' / total responses) * 100
+*/
+with
+
+    submissions as (
+        select *
+        from {{ ref("stg_airbyte_source__feedback_submissions") }}
+        where hs_survey_id = '8'
+    ),
+
+    contacts as (
+        select
+            id as hs_contact_id,
+            email,
+            first_name,
+            last_name,
+            state,
+            type,
+            verified_candidate_status,
+            office_level
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
+    ),
+
+    final as (
+        select
+            -- identifiers
+            s.submission_id,
+
+            -- survey metadata
+            s.survey_name,
+            s.survey_channel,
+
+            -- PMF response (decoded from internal option names)
+            s.pmf_response as pmf_response_raw,
+            case
+                s.pmf_response
+                when 'Option 1'
+                then 'Very Disappointed'
+                when 'Option 2'
+                then 'Somewhat Disappointed'
+                when 'Not disappointed'
+                then 'Not Disappointed'
+                when 'N/A - I no longer use GoodParty'
+                then 'N/A'
+                else s.pmf_response
+            end as pmf_response,
+            s.pmf_response = 'Option 1' as is_very_disappointed,
+
+            -- respondent info (from submission)
+            s.hs_contact_id,
+            s.contact_email,
+            s.contact_first_name,
+            s.contact_last_name,
+
+            -- respondent context (from contacts)
+            c.state,
+            c.type as contact_type,
+            c.verified_candidate_status,
+            c.office_level,
+
+            -- submission context
+            s.submission_url,
+            s.submitted_at,
+            s.created_at,
+            s.updated_at
+
+        from submissions s
+        left join contacts c on s.hs_contact_id = c.hs_contact_id
+    )
+
+select *
+from final

--- a/dbt/project/models/marts/analytics/win_user_satisfaction_responses.sql
+++ b/dbt/project/models/marts/analytics/win_user_satisfaction_responses.sql
@@ -8,7 +8,7 @@ with
 
     submissions as (
         select *
-        from {{ ref("stg_airbyte_source__feedback_submissions") }}
+        from {{ ref("stg_airbyte_source__hubspot_api_feedback_submissions") }}
         where hs_survey_id in ('9', '10')
     ),
 

--- a/dbt/project/models/marts/analytics/win_user_satisfaction_responses.sql
+++ b/dbt/project/models/marts/analytics/win_user_satisfaction_responses.sql
@@ -1,0 +1,66 @@
+/*
+    Win User satisfaction survey (5 stars) responses from HubSpot Feedback
+    Surveys. Combines survey_id 9 and 10 (same survey, relaunched for ICP).
+
+    Grain: One row per survey response.
+*/
+with
+
+    submissions as (
+        select *
+        from {{ ref("stg_airbyte_source__feedback_submissions") }}
+        where hs_survey_id in ('9', '10')
+    ),
+
+    contacts as (
+        select
+            id as hs_contact_id,
+            email,
+            first_name,
+            last_name,
+            state,
+            type,
+            verified_candidate_status,
+            office_level
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
+    ),
+
+    final as (
+        select
+            -- identifiers
+            s.submission_id,
+
+            -- survey metadata
+            s.survey_name,
+            s.hs_survey_id,
+            s.survey_channel,
+
+            -- satisfaction response
+            s.satisfaction_stars,
+            s.satisfaction_rating,
+            s.survey_additional_notes,
+
+            -- respondent info
+            s.hs_contact_id,
+            s.contact_email,
+            s.contact_first_name,
+            s.contact_last_name,
+
+            -- respondent context (from contacts)
+            c.state,
+            c.type as contact_type,
+            c.verified_candidate_status,
+            c.office_level,
+
+            -- submission context
+            s.submission_url,
+            s.submitted_at,
+            s.created_at,
+            s.updated_at
+
+        from submissions s
+        left join contacts c on s.hs_contact_id = c.hs_contact_id
+    )
+
+select *
+from final

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -138,6 +138,11 @@ sources:
         description: raw data load from HubSpot data model
       - name: hubspot_api_tickets
         description: raw data load from HubSpot data model
+      - name: feedback_submissions
+        description: >
+          HubSpot Feedback Survey submissions ingested via custom Airbyte
+          Connector Builder source. Contains responses from all feedback
+          surveys (PMF, user satisfaction, research compensation, etc.).
       - name: stripe_api_accounts
         description: Stripe account information and settings
         config:

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -138,7 +138,7 @@ sources:
         description: raw data load from HubSpot data model
       - name: hubspot_api_tickets
         description: raw data load from HubSpot data model
-      - name: feedback_submissions
+      - name: hubspot_api_feedback_submissions
         description: >
           HubSpot Feedback Survey submissions ingested via custom Airbyte
           Connector Builder source. Contains responses from all feedback

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__feedback_submissions.sql
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__feedback_submissions.sql
@@ -1,0 +1,42 @@
+select
+    -- identifiers
+    id as submission_id,
+
+    -- survey metadata
+    properties:hs_survey_id::string as hs_survey_id,
+    properties:hs_survey_name::string as survey_name,
+    properties:hs_survey_type::string as survey_type,
+    properties:hs_survey_channel::string as survey_channel,
+
+    -- submission details
+    cast(properties:hs_submission_timestamp::string as timestamp) as submitted_at,
+    properties:hs_response_group::string as response_group,
+    properties:hs_content::string as response_content,
+    properties:hs_submission_url::string as submission_url,
+
+    -- contact details (denormalized from HubSpot)
+    properties:hs_contact_id::string as hs_contact_id,
+    properties:hs_contact_email_rollup::string as contact_email,
+    properties:hs_contact_firstname::string as contact_first_name,
+    properties:hs_contact_lastname::string as contact_last_name,
+
+    -- PMF-specific fields
+    properties:pmf_survey_4_options::string as pmf_response,
+    properties:pmf_additional_feedback::string as pmf_additional_feedback,
+
+    -- satisfaction survey fields
+    properties:user_satisfaction_rating::string as satisfaction_rating,
+    cast(properties:user_satisfaction_stars::string as int) as satisfaction_stars,
+    properties:survey_additional_notes::string as survey_additional_notes,
+
+    -- research fields
+    properties:user_research_opt_in::string as user_research_opt_in,
+    properties:win_user_research_opt_in::string as win_user_research_opt_in,
+    properties:feature_request::string as feature_request,
+
+    -- timestamps
+    cast(createdat as timestamp) as created_at,
+    cast(updatedat as timestamp) as updated_at,
+    _airbyte_extracted_at
+
+from {{ source("airbyte_source", "feedback_submissions") }}

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
@@ -108,7 +108,7 @@ models:
         data_tests:
           - not_null
           - unique
-  - name: stg_airbyte_source__feedback_submissions
+  - name: stg_airbyte_source__hubspot_api_feedback_submissions
     description: >
       Staged HubSpot Feedback Survey submissions. Contains responses from all
       feedback surveys including PMF, user satisfaction, and research
@@ -120,9 +120,19 @@ models:
           - not_null
           - unique
       - name: hs_survey_id
-        description: HubSpot survey identifier
+        description: >
+          HubSpot survey identifier. Known surveys:
+          2 = User research compensation,
+          3 = Win - User research compensation,
+          8 = PMF - Web survey (March18,2026),
+          9 = Win User satisfaction survey (5 stars) (Web),
+          10 = Win User satisfaction survey (5 stars) (Web) (3+ Sessions + ICP),
+          5058880 = Knowledge base feedback.
         data_tests:
           - not_null
+          - accepted_values:
+              arguments:
+                values: ["2", "3", "8", "9", "10", "5058880"]
       - name: submitted_at
         description: Timestamp when the survey response was submitted
         data_tests:
@@ -141,3 +151,16 @@ models:
           - accepted_values:
               arguments:
                 values: ["WEB"]
+      - name: pmf_response
+        description: >
+          Raw PMF survey option value. Only populated for survey_id 8.
+          Values: Option 1 (Very Disappointed), Option 2 (Somewhat Disappointed),
+          Not disappointed, N/A - I no longer use GoodParty.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - "Option 1"
+                  - "Option 2"
+                  - "Not disappointed"
+                  - "N/A - I no longer use GoodParty"

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
@@ -108,3 +108,36 @@ models:
         data_tests:
           - not_null
           - unique
+  - name: stg_airbyte_source__feedback_submissions
+    description: >
+      Staged HubSpot Feedback Survey submissions. Contains responses from all
+      feedback surveys including PMF, user satisfaction, and research
+      compensation surveys. One row per submission.
+    columns:
+      - name: submission_id
+        description: Unique identifier for the feedback submission
+        data_tests:
+          - not_null
+          - unique
+      - name: hs_survey_id
+        description: HubSpot survey identifier
+        data_tests:
+          - not_null
+      - name: submitted_at
+        description: Timestamp when the survey response was submitted
+        data_tests:
+          - not_null
+      - name: survey_type
+        description: Type of survey (CUSTOM, KNOWLEDGE, etc.)
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["CUSTOM", "KNOWLEDGE"]
+      - name: survey_channel
+        description: Channel through which the survey was delivered
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["WEB"]

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_feedback_submissions.sql
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_feedback_submissions.sql
@@ -39,4 +39,4 @@ select
     cast(updatedat as timestamp) as updated_at,
     _airbyte_extracted_at
 
-from {{ source("airbyte_source", "feedback_submissions") }}
+from {{ source("airbyte_source", "hubspot_api_feedback_submissions") }}


### PR DESCRIPTION
## Summary

- Adds `stg_airbyte_source__feedback_submissions` staging model — extracts HubSpot feedback survey properties from Airbyte JSON column using Databricks variant access syntax
- Adds `pmf_survey_responses` mart model — PMF survey (survey_id=8) with decoded option labels and `is_very_disappointed` flag for PMF score calculation
- Adds `win_user_satisfaction_responses` mart model — combines Win satisfaction surveys (survey_id 9+10, same survey relaunched for ICP) with 1-5 star ratings
- Both marts join to HubSpot contacts for respondent context (state, contact type, verified status, office level)

## Validation

| Model | Rows | Tests |
|---|---|---|
| `stg_airbyte_source__feedback_submissions` | 226 | 8 pass |
| `pmf_survey_responses` | 6 | 8 pass |
| `win_user_satisfaction_responses` | 12 | 6 pass |

**PMF Score: 66.7%** (4/6 Very Disappointed)
**Win Satisfaction: avg 4.17 stars** (12 responses, range 1-5)

Full validation results: `.tickets/data-1817/07_validation_results.md`

### PMF response breakdown
```sql
SELECT pmf_response, COUNT(*) as n
FROM mart_analytics.pmf_survey_responses
GROUP BY 1 ORDER BY 2 DESC
-- Very Disappointed: 4
-- Somewhat Disappointed: 2
```

### Win satisfaction breakdown
```sql
SELECT hs_survey_id, survey_name, COUNT(*) as n, ROUND(AVG(satisfaction_stars), 1) as avg_stars
FROM mart_analytics.win_user_satisfaction_responses
GROUP BY 1, 2 ORDER BY 1
-- 9: Win User satisfaction survey (5 stars) (Web) — 2 responses, 4.0 avg
-- 10: Win User satisfaction survey (5 stars) (Web) (3+ Sessions + ICP) — 10 responses, 4.2 avg
```

## Test plan

- [x] `dbt build` passes for all 3 models (25/25 pass)
- [x] Row counts match HubSpot API validation (226 total, 6 PMF, 12 Win satisfaction)
- [x] PMF option decoding matches Chadwyck's confirmed mapping
- [x] Contact join resolves 100% for both mart models
- [ ] Reviewer: verify mart tables are accessible in `mart_analytics` schema after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new dbt source/staging and mart models plus schema tests without modifying existing transformation logic, but relies on correct JSON property extraction and option decoding.
> 
> **Overview**
> Adds a new Airbyte source table definition for HubSpot `feedback_submissions` and a staging model `stg_airbyte_source__feedback_submissions` that extracts survey submission fields from JSON properties.
> 
> Introduces two new analytics mart models: `pmf_survey_responses` (survey `hs_survey_id` = `8`, with decoded PMF labels and an `is_very_disappointed` flag) and `win_user_satisfaction_responses` (surveys `9`/`10`, 1–5 star ratings), both enriched via joins to HubSpot contacts and documented/tested in `m_analytics.yaml`.
> 
> Also updates `.gitignore` to exclude local `.worktrees/` and `.playwright-cli/` directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e09640e9ba2015b28b2be1dec86bbd863fd717. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->