### PR TITLE
Fix Genie Slack bot responding to every thread message in channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ logs/
 !.claude/skills/l2-uniform-drift-remediator/dbt_logs/.gitkeep
 !.claude/skills/l2-uniform-drift-remediator/dbt_logs/README.md
 .pre-commit-cache/
+.worktrees/
+.playwright-cli/
 test_data/
 .databricks/
 

--- a/apps/genie-slack-bot/slack_bot.py
+++ b/apps/genie-slack-bot/slack_bot.py
@@ -421,23 +421,11 @@ class SlackGenieBot:
             return False
         if event.get("channel_type") == "im":
             return True
-        channel = event.get("channel")
-        thread_ts = event.get("thread_ts")
-        if not isinstance(channel, str) or not isinstance(thread_ts, str):
-            return False
-        conversation_scope = self._get_conversation_key(channel, thread_ts)
-        has_mapping = self._has_mapping(self.conversation_map, conversation_scope)
-        if not has_mapping:
-            logger.debug(
-                "Ignoring threaded Slack reply without known Genie conversation: "
-                "channel=%s channel_type=%s thread_ts=%s ts=%s conversation_key=%s",
-                channel,
-                event.get("channel_type"),
-                thread_ts,
-                event.get("ts"),
-                conversation_scope,
-            )
-        return has_mapping
+        # Non-DM messages (channels, groups, MPIMs) are handled exclusively
+        # by the app_mention handler.  Returning False here prevents the bot
+        # from replying to every message in a channel thread after a single
+        # @mention creates a conversation mapping.
+        return False
 
     @staticmethod
     def _get_conversation_key(channel: str, thread_ts: str) -> str:

--- a/tests/apps/genie_slack_bot/test_slack_bot.py
+++ b/tests/apps/genie_slack_bot/test_slack_bot.py
@@ -777,3 +777,67 @@ def test_channel_thread_reply_without_mention_ignored_even_if_mapped():
         "text": "How many by year?",
     }
     assert bot._should_handle_message_event(reply_without_mention) is False
+
+
+def test_channel_mention_in_thread_continues_conversation():
+    """An @mention reply in a channel thread reuses the existing conversation
+    when routed through app_mention -> _handle_message.
+    """
+    bot, genie_client = build_bot()
+    client = FakeSlackClient()
+
+    mention_event = {
+        "channel": "C123",
+        "channel_type": "channel",
+        "ts": "810.100",
+        "text": "<@U123BOT> How many elections?",
+    }
+    bot._handle_message(mention_event, None, client)
+
+    mention_reply = {
+        "channel": "C123",
+        "channel_type": "channel",
+        "ts": "810.200",
+        "thread_ts": "810.100",
+        "text": "<@U123BOT> How many by year?",
+    }
+    bot._handle_message(mention_reply, None, client)
+
+    assert genie_client.calls == [
+        ("How many elections?", None),
+        ("How many by year?", "conv-1"),
+    ]
+
+
+def test_top_level_channel_message_without_mention_ignored():
+    """A top-level channel message with no @mention is not handled."""
+    bot, _ = build_bot()
+
+    event = {
+        "channel": "C123",
+        "channel_type": "channel",
+        "ts": "820.100",
+        "text": "Hello everyone",
+    }
+    assert bot._should_handle_message_event(event) is False
+
+
+def test_group_and_mpim_messages_not_handled_by_message_handler():
+    """Private channels (group) and multi-person DMs (mpim) require @mention."""
+    bot, _ = build_bot()
+
+    group_event = {
+        "channel": "G123",
+        "channel_type": "group",
+        "ts": "830.100",
+        "text": "How many elections?",
+    }
+    mpim_event = {
+        "channel": "G456",
+        "channel_type": "mpim",
+        "ts": "840.100",
+        "text": "How many elections?",
+    }
+
+    assert bot._should_handle_message_event(group_event) is False
+    assert bot._should_handle_message_event(mpim_event) is False

--- a/tests/apps/genie_slack_bot/test_slack_bot.py
+++ b/tests/apps/genie_slack_bot/test_slack_bot.py
@@ -745,3 +745,29 @@ def test_no_truncation_warning_when_10_rows_or_fewer():
     updated_text = client.updates[0]["text"]
     assert "Showing 10 of" not in updated_text
     assert "Open Genie Console" in updated_text
+
+
+def test_channel_thread_reply_without_mention_ignored_even_if_mapped():
+    """After an @mention creates a conversation, thread replies without
+    @mention must NOT be handled by the message handler.
+    """
+    bot, genie_client = build_bot()
+    client = FakeSlackClient()
+
+    mention_event = {
+        "channel": "C123",
+        "channel_type": "channel",
+        "ts": "800.100",
+        "text": "<@U123BOT> How many elections?",
+    }
+    bot._handle_message(mention_event, None, client)
+    assert len(genie_client.calls) == 1
+
+    reply_without_mention = {
+        "channel": "C123",
+        "channel_type": "channel",
+        "ts": "800.200",
+        "thread_ts": "800.100",
+        "text": "How many by year?",
+    }
+    assert bot._should_handle_message_event(reply_without_mention) is False

--- a/tests/apps/genie_slack_bot/test_slack_bot.py
+++ b/tests/apps/genie_slack_bot/test_slack_bot.py
@@ -155,7 +155,8 @@ def test_duplicate_thread_reply_event_is_processed_once():
     }
 
     bot._handle_message(root_event, None, client)
-    assert bot._should_handle_message_event(reply_event) is True
+    # Channel thread replies are routed via app_mention, not the message handler.
+    assert bot._should_handle_message_event(reply_event) is False
 
     bot._handle_message(reply_event, None, client)
     bot._handle_message(reply_event, None, client)
@@ -286,7 +287,8 @@ def test_channel_follow_up_reuses_parent_thread_conversation():
 
     bot._handle_message(mention_event, None, client)
 
-    assert bot._should_handle_message_event(reply_event) is True
+    # Channel thread replies are routed via app_mention, not the message handler.
+    assert bot._should_handle_message_event(reply_event) is False
 
     bot._handle_message(reply_event, None, client)
 
@@ -525,7 +527,11 @@ def test_fast_thread_follow_up_reuses_existing_conversation_scope():
     root_thread.start()
 
     assert genie_client.first_message_sent.wait(timeout=2)
-    assert bot._should_handle_message_event(reply_event) is True
+    # Channel thread replies are routed via app_mention, not the message handler.
+    assert bot._should_handle_message_event(reply_event) is False
+    # The conversation mapping IS eagerly available for the app_mention handler:
+    conversation_key = bot._get_conversation_key("C123", "400.100")
+    assert bot._has_mapping(bot.conversation_map, conversation_key) is True
 
     bot._handle_message(reply_event, None, client)
 


### PR DESCRIPTION
## Summary

- **Bug:** GP Data Bot responded to every message in a Slack channel thread after being @mentioned once, instead of only responding to messages that @mention it
- **Root cause:** `_should_handle_message_event()` returned `True` for any channel thread reply where a conversation mapping existed 
- **Fix:** Simplified `_should_handle_message_event()` to return `False` for all non-DM messages, making the `app_mention` handler the sole entry point for channel messages. DM behavior unchanged.

## Changes

| File | Change |
|------|--------|
| `apps/genie-slack-bot/slack_bot.py` | Simplified `_should_handle_message_event` (net -12 lines) |
| `tests/apps/genie_slack_bot/test_slack_bot.py` | Flipped 3 assertions + added 4 new tests (22 total, all passing) |

## Behavior After Fix

| Scenario | Behavior |
|----------|----------|
| DM (top-level or thread) | Bot responds (unchanged) |
| Channel @mention | Bot responds via `app_mention` handler |
| Channel thread reply WITH @mention | Bot responds, reuses conversation |
| Channel thread reply WITHOUT @mention | Bot does NOT respond (was the bug) |
| "show sql" in channel | Requires @mention now (consistent) |
| Group/MPIM | Same as channels — requires @mention |

## Test plan

- [x] 22/22 unit tests passing
- [ ] Manual Slack verification: @mention in channel -> reply without @mention -> bot silent -> reply with @mention -> bot responds
- [ ] Manual Slack verification: DM conversation still works without @mention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Slack event routing so non-DM messages are no longer processed by the generic `message` handler, which could alter behavior for channel/group/MPIM conversations if any flows relied on non-mention messages. Mitigated by focused unit test updates/additions covering thread and mention scenarios.
> 
> **Overview**
> Fixes a Slack bot behavior where a single `@mention` could cause the `message` event handler to respond to subsequent non-mention replies in the same channel thread by making `_should_handle_message_event()` return `False` for all non-DM (`im`) messages.
> 
> Updates and expands tests to reflect the new routing (channel thread replies now require `app_mention`) and adds coverage for mapped thread replies without mentions, mention replies continuing a conversation, and ignoring top-level/group/MPIM non-mention messages. Also extends `.gitignore` to exclude local `.worktrees/` and `.playwright-cli/` artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d879ebc2a4633e58d927349866a59d7b5af71d20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->