### PR TITLE
[DATA-1837] Add district override for FL Circuit 9, Seat 2

### DIFF
--- a/dbt/project/CLAUDE.md
+++ b/dbt/project/CLAUDE.md
@@ -4,7 +4,10 @@ Use the `gh` cli to make pull-requests and interact with GitHub.
 
 - We use the dbt *cloud* cli, not the dbt-core cli.
 - You do not need to specify `--defer` or the location of a state file in dbt cloud.
-- Do not invoke dbt via `poetry`.dbt cloud cli is installed at the system level.
+- Do not invoke dbt via `poetry`. dbt cloud cli is installed at the system level.
+- Before committing, activate the poetry environment from `dbt/` so pre-commit
+  hooks (pytest) can find dependencies like `pyspark` and `airflow`:
+  `source $(cd dbt && poetry env info --path)/bin/activate`
 - When adding or modifying models and/or tests, run `dbt build` on the modified
 objects to ensure they build as exected.
 

--- a/dbt/project/CLAUDE.md
+++ b/dbt/project/CLAUDE.md
@@ -5,9 +5,9 @@ Use the `gh` cli to make pull-requests and interact with GitHub.
 - We use the dbt *cloud* cli, not the dbt-core cli.
 - You do not need to specify `--defer` or the location of a state file in dbt cloud.
 - Do not invoke dbt via `poetry`. dbt cloud cli is installed at the system level.
-- Before committing, activate the poetry environment from `dbt/` so pre-commit
-  hooks (pytest) can find dependencies like `pyspark` and `airflow`:
-  `source $(cd dbt && poetry env info --path)/bin/activate`
+- When running `git commit`, use `poetry run` from the `dbt/` directory so the
+  pre-commit pytest hook can find `pyspark` and `airflow`:
+  `cd dbt && poetry run git commit ...`
 - When adding or modifying models and/or tests, run `dbt build` on the modified
 objects to ensure they build as exected.
 

--- a/dbt/project/seeds/l2_br_match_overrides.csv
+++ b/dbt/project/seeds/l2_br_match_overrides.csv
@@ -10,3 +10,4 @@ br_database_id,br_position_name,state,l2_district_type,l2_district_name,reason
 167254,Georgia Public Service Commission - District 3,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 267702,Georgia Public Service Commission - District 4,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 167255,Georgia Public Service Commission - District 5,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
+289892,Circuit Court Judge - Circuit 9 Seat 2,FL,County,ORANGE,FL Circuit 9 spans Orange and Osceola counties; L2 has no Judicial_Circuit_Court_District for FL. Mapping to primary county (Orange) as workaround (DATA-1837)

--- a/dbt/project/seeds/l2_br_match_overrides.csv
+++ b/dbt/project/seeds/l2_br_match_overrides.csv
@@ -10,4 +10,4 @@ br_database_id,br_position_name,state,l2_district_type,l2_district_name,reason
 167254,Georgia Public Service Commission - District 3,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 267702,Georgia Public Service Commission - District 4,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 167255,Georgia Public Service Commission - District 5,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
-289892,Circuit Court Judge - Circuit 9 Seat 2,FL,County,ORANGE,FL Circuit 9 spans Orange and Osceola counties; L2 has no Judicial_Circuit_Court_District for FL. Mapping to primary county (Orange) as workaround (DATA-1837)
+289892,"Circuit Court Judge - Circuit 9, Seat 2",FL,County,ORANGE,FL Circuit 9 spans Orange and Osceola counties; L2 has no Judicial_Circuit_Court_District for FL. Mapping to primary county (Orange) as workaround (DATA-1837)

--- a/dbt/project/seeds/l2_br_match_overrides.csv
+++ b/dbt/project/seeds/l2_br_match_overrides.csv
@@ -10,4 +10,4 @@ br_database_id,br_position_name,state,l2_district_type,l2_district_name,reason
 167254,Georgia Public Service Commission - District 3,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 267702,Georgia Public Service Commission - District 4,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 167255,Georgia Public Service Commission - District 5,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
-289892,"Circuit Court Judge - Circuit 9, Seat 2",FL,County,ORANGE,FL Circuit 9 spans Orange and Osceola counties; L2 has no Judicial_Circuit_Court_District for FL. Mapping to primary county (Orange) as workaround (DATA-1837)
+289892,"Circuit Court Judge - Circuit 9, Seat 2",FL,County,ORANGE,FL Circuit 9 spans Orange and Osceola counties; L2 has no Judicial_Circuit_Court_District for FL. Mapping to primary county (Orange) covers ~78% of voters. Multi-county district joins not yet supported (DATA-1837)


### PR DESCRIPTION
## Summary
- FL Circuit Court Judge positions had no voter file because L2 has zero `Judicial_Circuit_Court_District` data for Florida, causing the LLM match to return `NOT_MATCHED`
- Added a manual override in `l2_br_match_overrides.csv` mapping position 289892 (Circuit Court Judge - Circuit 9, Seat 2) to `County/ORANGE`
- **Limitation:** Circuit 9 spans Orange and Osceola counties, but the position model is 1:1 position-to-district, so only Orange County (~78% of circuit population) is included. Full multi-county support would require architecture changes.

## Test plan
- [x] `dbt seed --select l2_br_match_overrides` — loads 12 rows successfully
- [x] `dbt run --select m_election_api__position` — position 289892 now has `district_id` linked to `County/ORANGE`
- [x] `dbt test --select m_election_api__position` — all 10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)