### PR TITLE
[DATA-1582] Add DDHQ coverage gaps model for pre-matching

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
@@ -81,13 +81,13 @@ with
     ts_only_races as (
         select
             md5(
-                er.state
+                coalesce(er.state, '')
                 || '|'
-                || er.candidate_office
+                || coalesce(er.candidate_office, '')
                 || '|'
-                || cast(er.election_date as string)
+                || coalesce(cast(er.election_date as string), '')
                 || '|'
-                || er.election_stage
+                || coalesce(er.election_stage, '')
                 || '|'
                 || coalesce(er.official_office_name, '')
             ) as race_key,
@@ -98,7 +98,7 @@ with
             max(er.office_type) as office_type,
             er.election_date,
             er.election_stage,
-            er.official_office_name,
+            coalesce(er.official_office_name, '') as official_office_name,
             max(er.partisan_type) as partisan_type,
             max(er.seat_name) as seat_name,
             0 as br_candidate_count,
@@ -112,7 +112,7 @@ with
             er.candidate_office,
             er.election_date,
             er.election_stage,
-            er.official_office_name
+            coalesce(er.official_office_name, '')
     ),
 
     all_races as (

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
@@ -16,13 +16,6 @@ with
     -- Clusters containing at least one DDHQ record
     ddhq_clusters as (select distinct cluster_id from er where source_name = 'ddhq'),
 
-    -- Clusters that matched to DDHQ
-    matched_clusters as (
-        select distinct er.cluster_id
-        from er
-        inner join ddhq_clusters dc on er.cluster_id = dc.cluster_id
-    ),
-
     -- Races with a br_race_id, preferring BallotReady over TechSpeed.
     -- max() is used instead of any_value() because the CASE expression
     -- produces NULLs for non-matching source rows; max() skips those NULLs
@@ -77,9 +70,9 @@ with
                 distinct case when source_name = 'techspeed' then er.cluster_id end
             ) as ts_candidate_count,
             -- A race has DDHQ coverage if any candidate's cluster matched DDHQ
-            count(distinct mc.cluster_id) > 0 as has_ddhq_match
+            count(distinct dc.cluster_id) > 0 as has_ddhq_match
         from er
-        left join matched_clusters mc on er.cluster_id = mc.cluster_id
+        left join ddhq_clusters dc on er.cluster_id = dc.cluster_id
         where source_name in ('ballotready', 'techspeed') and br_race_id is not null
         group by br_race_id
     ),
@@ -100,7 +93,7 @@ with
             ) as race_key,
             cast(null as int) as br_race_id,
             er.state,
-            max(er.candidate_office) as candidate_office,
+            er.candidate_office,
             max(er.office_level) as office_level,
             max(er.office_type) as office_type,
             er.election_date,
@@ -110,9 +103,9 @@ with
             max(er.seat_name) as seat_name,
             0 as br_candidate_count,
             count(distinct er.cluster_id) as ts_candidate_count,
-            count(distinct mc.cluster_id) > 0 as has_ddhq_match
+            count(distinct dc.cluster_id) > 0 as has_ddhq_match
         from er
-        left join matched_clusters mc on er.cluster_id = mc.cluster_id
+        left join ddhq_clusters dc on er.cluster_id = dc.cluster_id
         where er.source_name = 'techspeed' and er.br_race_id is null
         group by
             er.state,

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
@@ -1,28 +1,32 @@
 -- Election stages from BallotReady / TechSpeed without DDHQ coverage.
 --
 -- Uses the Splink ER clustered candidacy-stage data to identify races
--- (by br_race_id) where no candidate was matched to a DDHQ record.
+-- where no candidate was matched to a DDHQ record.
 -- Race-level attributes prefer BallotReady values, falling back to TechSpeed.
 -- Enriched with ICP flags from the election_stage mart.
 --
--- Grain: one row per br_race_id (election stage) without DDHQ coverage.
+-- Includes both:
+-- 1. Races with a br_race_id (from BallotReady, or TechSpeed with BR linkage)
+-- 2. TechSpeed-only races without a br_race_id
+--
+-- Grain: one row per election stage without DDHQ coverage (keyed by race_key).
 with
     er as (select * from {{ ref("stg_er_source__clustered_candidacy_stages") }}),
 
     -- Clusters containing at least one DDHQ record
     ddhq_clusters as (select distinct cluster_id from er where source_name = 'ddhq'),
 
-    -- BR race IDs where at least one candidate matched to DDHQ
-    br_races_with_ddhq as (
-        select distinct er.br_race_id
+    -- Clusters that matched to DDHQ
+    matched_clusters as (
+        select distinct er.cluster_id
         from er
         inner join ddhq_clusters dc on er.cluster_id = dc.cluster_id
-        where er.br_race_id is not null
     ),
 
-    -- Aggregate to race level, preferring BallotReady over TechSpeed
-    races as (
+    -- Races with a br_race_id, preferring BallotReady over TechSpeed
+    br_races as (
         select
+            cast(br_race_id as string) as race_key,
             br_race_id,
             coalesce(
                 max(case when source_name = 'ballotready' then state end),
@@ -63,35 +67,87 @@ with
                 max(case when source_name = 'techspeed' then seat_name end)
             ) as seat_name,
             count(
-                distinct case when source_name = 'ballotready' then cluster_id end
+                distinct case when source_name = 'ballotready' then er.cluster_id end
             ) as br_candidate_count,
             count(
-                distinct case when source_name = 'techspeed' then cluster_id end
-            ) as ts_candidate_count
+                distinct case when source_name = 'techspeed' then er.cluster_id end
+            ) as ts_candidate_count,
+            -- A race has DDHQ coverage if any candidate's cluster matched DDHQ
+            count(distinct mc.cluster_id) > 0 as has_ddhq_match
         from er
+        left join matched_clusters mc on er.cluster_id = mc.cluster_id
         where source_name in ('ballotready', 'techspeed') and br_race_id is not null
         group by br_race_id
+    ),
+
+    -- TechSpeed-only races without a br_race_id
+    ts_only_races as (
+        select
+            md5(
+                er.state
+                || '|'
+                || er.candidate_office
+                || '|'
+                || cast(er.election_date as string)
+                || '|'
+                || er.election_stage
+                || '|'
+                || coalesce(er.official_office_name, '')
+            ) as race_key,
+            cast(null as int) as br_race_id,
+            er.state,
+            max(er.candidate_office) as candidate_office,
+            max(er.office_level) as office_level,
+            max(er.office_type) as office_type,
+            er.election_date,
+            er.election_stage,
+            er.official_office_name,
+            max(er.partisan_type) as partisan_type,
+            max(er.seat_name) as seat_name,
+            0 as br_candidate_count,
+            count(distinct er.cluster_id) as ts_candidate_count,
+            count(distinct mc.cluster_id) > 0 as has_ddhq_match
+        from er
+        left join matched_clusters mc on er.cluster_id = mc.cluster_id
+        where er.source_name = 'techspeed' and er.br_race_id is null
+        group by
+            er.state,
+            er.candidate_office,
+            er.election_date,
+            er.election_stage,
+            er.official_office_name
+    ),
+
+    all_races as (
+        select *
+        from br_races
+        where not has_ddhq_match
+
+        union all
+
+        select *
+        from ts_only_races
+        where not has_ddhq_match
     )
 
 select
-    races.br_race_id,
-    races.state,
-    races.candidate_office,
-    races.office_level,
-    races.office_type,
-    races.election_date,
-    races.election_stage,
-    races.official_office_name,
-    races.partisan_type,
-    races.seat_name,
-    races.br_candidate_count,
-    races.ts_candidate_count,
+    all_races.race_key,
+    all_races.br_race_id,
+    all_races.state,
+    all_races.candidate_office,
+    all_races.office_level,
+    all_races.office_type,
+    all_races.election_date,
+    all_races.election_stage,
+    all_races.official_office_name,
+    all_races.partisan_type,
+    all_races.seat_name,
+    all_races.br_candidate_count,
+    all_races.ts_candidate_count,
     coalesce(es.is_win_icp, false) as is_win_icp,
     coalesce(es.is_serve_icp, false) as is_serve_icp,
     coalesce(es.is_win_supersize_icp, false) as is_win_supersize_icp
-from races
-left join br_races_with_ddhq as matched on races.br_race_id = matched.br_race_id
+from all_races
 left join
     {{ ref("election_stage") }} as es
-    on cast(races.br_race_id as string) = es.br_race_id
-where matched.br_race_id is null
+    on cast(all_races.br_race_id as string) = es.br_race_id

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
@@ -148,9 +148,9 @@ select
     all_races.seat_name,
     all_races.br_candidate_count,
     all_races.ts_candidate_count,
-    coalesce(es.is_win_icp, false) as is_win_icp,
-    coalesce(es.is_serve_icp, false) as is_serve_icp,
-    coalesce(es.is_win_supersize_icp, false) as is_win_supersize_icp
+    es.is_win_icp,
+    es.is_serve_icp,
+    es.is_win_supersize_icp
 from all_races
 left join
     {{ ref("election_stage") }} as es

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
@@ -23,7 +23,11 @@ with
         inner join ddhq_clusters dc on er.cluster_id = dc.cluster_id
     ),
 
-    -- Races with a br_race_id, preferring BallotReady over TechSpeed
+    -- Races with a br_race_id, preferring BallotReady over TechSpeed.
+    -- max() is used instead of any_value() because the CASE expression
+    -- produces NULLs for non-matching source rows; max() skips those NULLs
+    -- while any_value() could return one. Within a source, values for a
+    -- given br_race_id are identical so max() just picks the single value.
     br_races as (
         select
             cast(br_race_id as string) as race_key,

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.sql
@@ -1,0 +1,97 @@
+-- Election stages from BallotReady / TechSpeed without DDHQ coverage.
+--
+-- Uses the Splink ER clustered candidacy-stage data to identify races
+-- (by br_race_id) where no candidate was matched to a DDHQ record.
+-- Race-level attributes prefer BallotReady values, falling back to TechSpeed.
+-- Enriched with ICP flags from the election_stage mart.
+--
+-- Grain: one row per br_race_id (election stage) without DDHQ coverage.
+with
+    er as (select * from {{ ref("stg_er_source__clustered_candidacy_stages") }}),
+
+    -- Clusters containing at least one DDHQ record
+    ddhq_clusters as (select distinct cluster_id from er where source_name = 'ddhq'),
+
+    -- BR race IDs where at least one candidate matched to DDHQ
+    br_races_with_ddhq as (
+        select distinct er.br_race_id
+        from er
+        inner join ddhq_clusters dc on er.cluster_id = dc.cluster_id
+        where er.br_race_id is not null
+    ),
+
+    -- Aggregate to race level, preferring BallotReady over TechSpeed
+    races as (
+        select
+            br_race_id,
+            coalesce(
+                max(case when source_name = 'ballotready' then state end),
+                max(case when source_name = 'techspeed' then state end)
+            ) as state,
+            coalesce(
+                max(case when source_name = 'ballotready' then candidate_office end),
+                max(case when source_name = 'techspeed' then candidate_office end)
+            ) as candidate_office,
+            coalesce(
+                max(case when source_name = 'ballotready' then office_level end),
+                max(case when source_name = 'techspeed' then office_level end)
+            ) as office_level,
+            coalesce(
+                max(case when source_name = 'ballotready' then office_type end),
+                max(case when source_name = 'techspeed' then office_type end)
+            ) as office_type,
+            coalesce(
+                max(case when source_name = 'ballotready' then election_date end),
+                max(case when source_name = 'techspeed' then election_date end)
+            ) as election_date,
+            coalesce(
+                max(case when source_name = 'ballotready' then election_stage end),
+                max(case when source_name = 'techspeed' then election_stage end)
+            ) as election_stage,
+            coalesce(
+                max(
+                    case when source_name = 'ballotready' then official_office_name end
+                ),
+                max(case when source_name = 'techspeed' then official_office_name end)
+            ) as official_office_name,
+            coalesce(
+                max(case when source_name = 'ballotready' then partisan_type end),
+                max(case when source_name = 'techspeed' then partisan_type end)
+            ) as partisan_type,
+            coalesce(
+                max(case when source_name = 'ballotready' then seat_name end),
+                max(case when source_name = 'techspeed' then seat_name end)
+            ) as seat_name,
+            count(
+                distinct case when source_name = 'ballotready' then cluster_id end
+            ) as br_candidate_count,
+            count(
+                distinct case when source_name = 'techspeed' then cluster_id end
+            ) as ts_candidate_count
+        from er
+        where source_name in ('ballotready', 'techspeed') and br_race_id is not null
+        group by br_race_id
+    )
+
+select
+    races.br_race_id,
+    races.state,
+    races.candidate_office,
+    races.office_level,
+    races.office_type,
+    races.election_date,
+    races.election_stage,
+    races.official_office_name,
+    races.partisan_type,
+    races.seat_name,
+    races.br_candidate_count,
+    races.ts_candidate_count,
+    coalesce(es.is_win_icp, false) as is_win_icp,
+    coalesce(es.is_serve_icp, false) as is_serve_icp,
+    coalesce(es.is_win_supersize_icp, false) as is_win_supersize_icp
+from races
+left join br_races_with_ddhq as matched on races.br_race_id = matched.br_race_id
+left join
+    {{ ref("election_stage") }} as es
+    on cast(races.br_race_id as string) = es.br_race_id
+where matched.br_race_id is null

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
@@ -9,14 +9,25 @@ models:
       Race-level attributes prefer BallotReady values, falling back to
       TechSpeed. Enriched with ICP flags from the election_stage mart.
 
-      Grain: one row per br_race_id (election stage) without DDHQ coverage.
+      Grain: one row per election stage without DDHQ coverage (keyed by race_key).
+      Includes both races with a br_race_id (BallotReady / TechSpeed with BR
+      linkage) and TechSpeed-only races without one.
 
     columns:
-      - name: br_race_id
-        description: BallotReady race ID identifying the election stage.
+      - name: race_key
+        description: >
+          Surrogate primary key. For races with a br_race_id this is
+          cast(br_race_id as string); for TechSpeed-only races it is an
+          md5 hash of (state, candidate_office, election_date, election_stage,
+          official_office_name).
         data_tests:
           - unique
           - not_null
+
+      - name: br_race_id
+        description: >
+          BallotReady race ID. Null for TechSpeed-only races that have
+          no BallotReady linkage.
 
       - name: state
         description: Two-letter US state postal code.

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
@@ -83,16 +83,16 @@ models:
         description: Number of distinct TechSpeed candidates in this race within the ER data.
 
       - name: is_win_icp
-        description: Whether the race is a Win ICP office.
-        data_tests:
-          - not_null
+        description: >
+          Whether the race is a Win ICP office. Null for TechSpeed-only
+          races that have no BallotReady position linkage.
 
       - name: is_serve_icp
-        description: Whether the race is a Serve ICP office.
-        data_tests:
-          - not_null
+        description: >
+          Whether the race is a Serve ICP office. Null for TechSpeed-only
+          races that have no BallotReady position linkage.
 
       - name: is_win_supersize_icp
-        description: Whether the race is a Win supersize ICP office.
-        data_tests:
-          - not_null
+        description: >
+          Whether the race is a Win supersize ICP office. Null for
+          TechSpeed-only races that have no BallotReady position linkage.

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
@@ -1,0 +1,75 @@
+version: 2
+
+models:
+  - name: int__civics_ddhq_coverage_gaps
+    description: >
+      Election stages from BallotReady / TechSpeed without DDHQ coverage.
+      Uses the Splink ER clustered candidacy-stage data to identify races
+      (by br_race_id) where no candidate was matched to a DDHQ record.
+      Race-level attributes prefer BallotReady values, falling back to
+      TechSpeed. Enriched with ICP flags from the election_stage mart.
+
+      Grain: one row per br_race_id (election stage) without DDHQ coverage.
+
+    columns:
+      - name: br_race_id
+        description: BallotReady race ID identifying the election stage.
+        data_tests:
+          - unique
+          - not_null
+
+      - name: state
+        description: Two-letter US state postal code.
+        data_tests:
+          - not_null
+
+      - name: candidate_office
+        description: Normalized office name (e.g. US House, State Senate, Mayor).
+
+      - name: office_level
+        description: Office level (Federal, State, County, Local, Regional, Township).
+
+      - name: office_type
+        description: Office type (Executive, Legislative, Judicial, School Board, Other).
+
+      - name: election_date
+        description: Date of the election stage.
+        data_tests:
+          - not_null
+
+      - name: election_stage
+        description: Election stage (Primary, General, or Runoff).
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: ["Primary", "General", "Runoff"]
+
+      - name: official_office_name
+        description: Full office name from the source (lowercased, trimmed).
+
+      - name: partisan_type
+        description: Partisan classification of the race.
+
+      - name: seat_name
+        description: Seat or position name from the source.
+
+      - name: br_candidate_count
+        description: Number of distinct BallotReady candidates in this race within the ER data.
+
+      - name: ts_candidate_count
+        description: Number of distinct TechSpeed candidates in this race within the ER data.
+
+      - name: is_win_icp
+        description: Whether the race is a Win ICP office.
+        data_tests:
+          - not_null
+
+      - name: is_serve_icp
+        description: Whether the race is a Serve ICP office.
+        data_tests:
+          - not_null
+
+      - name: is_win_supersize_icp
+        description: Whether the race is a Win supersize ICP office.
+        data_tests:
+          - not_null

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
@@ -5,7 +5,7 @@ models:
     description: >
       Election stages from BallotReady / TechSpeed without DDHQ coverage.
       Uses the Splink ER clustered candidacy-stage data to identify races
-      (by br_race_id) where no candidate was matched to a DDHQ record.
+      where no candidate was matched to a DDHQ record.
       Race-level attributes prefer BallotReady values, falling back to
       TechSpeed. Enriched with ICP flags from the election_stage mart.
 

--- a/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics_ddhq_coverage_gaps.yaml
@@ -49,11 +49,23 @@ models:
           - not_null
 
       - name: election_stage
-        description: Election stage (Primary, General, or Runoff).
+        description: >
+          Election stage (Primary, General, Primary Runoff, General Runoff,
+          Primary Special, General Special, Primary Special Runoff,
+          General Special Runoff).
         data_tests:
           - not_null
           - accepted_values:
-              values: ["Primary", "General", "Runoff"]
+              values:
+                - "Primary"
+                - "General"
+                - "Runoff"
+                - "Primary Runoff"
+                - "General Runoff"
+                - "Primary Special"
+                - "General Special"
+                - "Primary Special Runoff"
+                - "General Special Runoff"
 
       - name: official_office_name
         description: Full office name from the source (lowercased, trimmed).


### PR DESCRIPTION
## Summary
- Adds `int__civics_ddhq_coverage_gaps` intermediate model that identifies BallotReady/TechSpeed election stages without DDHQ coverage
- Uses ER clustered candidacy-stage data to find races where no candidate was matched to a DDHQ record
- Race-level attributes prefer BallotReady values, falling back to TechSpeed via `coalesce(max(case when ballotready ...), max(case when techspeed ...))`
- Includes TechSpeed-only races without a `br_race_id` (keyed by md5 hash surrogate)
- Enriched with ICP flags (`is_win_icp`, `is_serve_icp`, `is_win_supersize_icp`) from the `election_stage` mart — null for TechSpeed-only races (unknown ICP status)
- Schema YAML with `unique`/`not_null` on `race_key`, `not_null` on `state`/`election_date`/`election_stage`, and `accepted_values` on `election_stage` (all 9 possible values)

## Current output (dev)

**BR/TechSpeed races without DDHQ coverage:**
| Metric | Count |
|--------|-------|
| Total gaps | 25,746 |
| — with `br_race_id` | 23,125 |
| — TechSpeed-only (no `br_race_id`) | 2,621 |
| Through May 2026 | ~24,200 |
| Win ICP (where known) | 15,555 |

**DDHQ races in ER without BR/TechSpeed match:**
| Metric | Count |
|--------|-------|
| Total DDHQ races (ER, 2026+) | 166 |
| Matched to BR/TS | 116 |
| Unmatched (DDHQ-only) | 50 |

## Caveat
The ER clustered data has DDHQ records only through 2026-02-28 (532 candidacy records across 166 races), while DDHQ staging goes to 2026-03-14 (1,199 distinct races). The gap list is conservative — some races may already have DDHQ coverage added after the last ER pipeline run.

## Test plan
- [x] `dbt run --select int__civics_ddhq_coverage_gaps` succeeds
- [x] `dbt test --select int__civics_ddhq_coverage_gaps` — 6/6 tests pass
- [x] `inspect_data` confirms 25,746 rows, all key columns 100% populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive dbt model and schema tests; main risk is incorrect gap identification or race-key hashing leading to misleading analytics.
> 
> **Overview**
> Introduces `int__civics_ddhq_coverage_gaps`, an intermediate model that aggregates ER clustered candidacy-stage data to flag election stages where *no* candidate cluster includes a DDHQ record, preferring BallotReady race attributes with TechSpeed fallbacks and generating a hashed `race_key` for TechSpeed-only races.
> 
> Enriches the output with ICP flags from `election_stage` when `br_race_id` is present, and adds a schema YAML with `unique`/`not_null` tests on `race_key`, required field tests, and an `accepted_values` constraint for `election_stage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979a13a32b6777946ee29906438a879f25c2c648. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->