### PR TITLE
[DATA-1865] Add OfficePicker zip-to-position lookup model

### DIFF
--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -121,24 +121,19 @@ def model(dbt, session: SparkSession) -> DataFrame:
             ).otherwise(col("zip_code")),
         )
 
-        # On full refresh, count voters per (zip, district_name) and filter out
-        # districts where fewer than MIN_VOTER_PCT of the zip's voters are
-        # assigned there. On incremental runs, skip the threshold since the
-        # percentage is unreliable on partial batches.
-        if not dbt.is_incremental:
-            district_df = district_df.groupBy(
-                "state_postal_code", "zip_code", "district_name"
-            ).agg(count("*").alias("voter_count"))
+        # Count voters per (zip, district_name) and filter out districts where
+        # fewer than MIN_VOTER_PCT of the zip's voters are assigned there.
+        district_df = district_df.groupBy(
+            "state_postal_code", "zip_code", "district_name"
+        ).agg(count("*").alias("voter_count"))
 
-            district_df = (
-                district_df.withColumn(
-                    "total_voters", spark_sum("voter_count").over(zip_window)
-                )
-                .filter(col("voter_count") / col("total_voters") >= MIN_VOTER_PCT)
-                .drop("voter_count", "total_voters")
+        district_df = (
+            district_df.withColumn(
+                "total_voters", spark_sum("voter_count").over(zip_window)
             )
-        else:
-            district_df = district_df.distinct()
+            .filter(col("voter_count") / col("total_voters") >= MIN_VOTER_PCT)
+            .drop("voter_count", "total_voters")
+        )
 
         district_df = district_df.withColumn("district_type", lit(district_type))
 

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -121,19 +121,24 @@ def model(dbt, session: SparkSession) -> DataFrame:
             ).otherwise(col("zip_code")),
         )
 
-        # Count voters per (zip, district_name) and filter out districts where
-        # fewer than MIN_VOTER_PCT of the zip's voters are assigned there.
-        district_df = district_df.groupBy(
-            "state_postal_code", "zip_code", "district_name"
-        ).agg(count("*").alias("voter_count"))
+        # On full refresh, count voters per (zip, district_name) and filter out
+        # districts where fewer than MIN_VOTER_PCT of the zip's voters are
+        # assigned there. On incremental runs, skip the threshold since the
+        # percentage is unreliable on partial batches.
+        if not dbt.is_incremental:
+            district_df = district_df.groupBy(
+                "state_postal_code", "zip_code", "district_name"
+            ).agg(count("*").alias("voter_count"))
 
-        district_df = (
-            district_df.withColumn(
-                "total_voters", spark_sum("voter_count").over(zip_window)
+            district_df = (
+                district_df.withColumn(
+                    "total_voters", spark_sum("voter_count").over(zip_window)
+                )
+                .filter(col("voter_count") / col("total_voters") >= MIN_VOTER_PCT)
+                .drop("voter_count", "total_voters")
             )
-            .filter(col("voter_count") / col("total_voters") >= MIN_VOTER_PCT)
-            .drop("voter_count", "total_voters")
-        )
+        else:
+            district_df = district_df.distinct()
 
         district_df = district_df.withColumn("district_type", lit(district_type))
 

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -42,7 +42,7 @@ THIS_TABLE_SCHEMA = StructType(
 # Minimum percentage of voters in a zip code that must be assigned to a district
 # for that district to be included. Filters out noise from tiny geographic overlaps.
 # See: https://goodpartyorg.slack.com/archives/C090662DLRM/p1776185747062729
-MIN_VOTER_PCT = 0.001  # 0.1%
+MIN_VOTER_PCT = 0.005  # 0.5%
 
 
 def model(dbt, session: SparkSession) -> DataFrame:

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -41,7 +41,6 @@ THIS_TABLE_SCHEMA = StructType(
 
 # Minimum percentage of voters in a zip code that must be assigned to a district
 # for that district to be included. Filters out noise from tiny geographic overlaps.
-# See: https://goodpartyorg.slack.com/archives/C090662DLRM/p1776185747062729
 MIN_VOTER_PCT = 0.005  # 0.5%
 
 

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -3,8 +3,6 @@ from datetime import datetime
 from pyspark.sql import SparkSession
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import (
-    array_distinct,
-    array_union,
     col,
     collect_list,
     concat,
@@ -64,21 +62,34 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     l2_uniform_data: DataFrame = dbt.ref("int__l2_nationwide_uniform")
 
-    # get the max loaded for this table and compare against latest changes to l2 uniform data
-    existing_table = None
+    # On incremental runs, identify zip codes with new voter records, then
+    # recompute those zips against the full source population so the voter
+    # percentage threshold is accurate (not skewed by batch size).
     if dbt.is_incremental:
         existing_table = session.table(f"{dbt.this}")
         max_loaded_at = existing_table.agg({"loaded_at": "max"}).collect()[0][0]
 
-        # Handle case where table is empty (max_loaded_at is None)
         if max_loaded_at is not None:
-            l2_uniform_data = l2_uniform_data.filter(col("loaded_at") > max_loaded_at)
+            new_records = l2_uniform_data.filter(col("loaded_at") > max_loaded_at)
+        else:
+            new_records = l2_uniform_data
 
-        if l2_uniform_data.count() == 0:
+        if new_records.count() == 0:
             return session.createDataFrame(
                 data=[],
                 schema=THIS_TABLE_SCHEMA,
             )
+
+        affected_zips = (
+            new_records.select("Residence_Addresses_Zip", "state_postal_code")
+            .filter(col("Residence_Addresses_Zip").isNotNull())
+            .distinct()
+        )
+        l2_uniform_data = l2_uniform_data.join(
+            affected_zips,
+            on=["Residence_Addresses_Zip", "state_postal_code"],
+            how="inner",
+        )
 
     # Create a list of DataFrames for each district type
     district_dataframes = []
@@ -170,34 +181,5 @@ def model(dbt, session: SparkSession) -> DataFrame:
     # drop rows which have no district names or the size of the array is 0
     final_result = final_result.filter(col("district_names").isNotNull())
     final_result = final_result.filter(size(col("district_names")) > 0)
-
-    # On incremental runs, merge new district_names with existing ones so that
-    # the upsert doesn't overwrite previously captured districts.
-    if existing_table is not None:
-        final_result = (
-            final_result.alias("new")
-            .join(
-                existing_table.select(
-                    "zip_code",
-                    "state_postal_code",
-                    "district_type",
-                    col("district_names").alias("existing_district_names"),
-                ),
-                on=["zip_code", "state_postal_code", "district_type"],
-                how="left",
-            )
-            .withColumn(
-                "district_names",
-                when(
-                    col("existing_district_names").isNotNull(),
-                    array_distinct(
-                        array_union(
-                            col("district_names"), col("existing_district_names")
-                        )
-                    ),
-                ).otherwise(col("district_names")),
-            )
-            .drop("existing_district_names")
-        )
 
     return final_result

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -8,9 +8,13 @@ from pyspark.sql.functions import (
     col,
     collect_list,
     concat,
+    count,
     length,
     lit,
     size,
+)
+from pyspark.sql.functions import sum as spark_sum
+from pyspark.sql.functions import (
     when,
 )
 from pyspark.sql.types import (
@@ -20,6 +24,7 @@ from pyspark.sql.types import (
     StructType,
     TimestampType,
 )
+from pyspark.sql.window import Window
 
 THIS_TABLE_SCHEMA = StructType(
     [
@@ -32,6 +37,12 @@ THIS_TABLE_SCHEMA = StructType(
         StructField(name="loaded_at", dataType=TimestampType(), nullable=False),
     ]
 )
+
+
+# Minimum percentage of voters in a zip code that must be assigned to a district
+# for that district to be included. Filters out noise from tiny geographic overlaps.
+# See: https://goodpartyorg.slack.com/archives/C090662DLRM/p1776185747062729
+MIN_VOTER_PCT = 0.001  # 0.1%
 
 
 def model(dbt, session: SparkSession) -> DataFrame:
@@ -99,8 +110,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
             )
             .filter(col("Residence_Addresses_Zip").isNotNull())
             .filter(col("district_name").isNotNull())
-            .distinct()
-            .withColumn("district_type", lit(district_type))
         )
 
         # if zipcode is 4 characters, pad with a 0
@@ -110,6 +119,23 @@ def model(dbt, session: SparkSession) -> DataFrame:
                 length(col("zip_code")) == 4, concat(lit("0"), col("zip_code"))
             ).otherwise(col("zip_code")),
         )
+
+        # Count voters per (zip, district_name) and filter out districts where
+        # fewer than MIN_VOTER_PCT of the zip's voters are assigned there.
+        district_df = district_df.groupBy(
+            "state_postal_code", "zip_code", "district_name"
+        ).agg(count("*").alias("voter_count"))
+
+        zip_window = Window.partitionBy("zip_code", "state_postal_code")
+        district_df = (
+            district_df.withColumn(
+                "total_voters", spark_sum("voter_count").over(zip_window)
+            )
+            .filter(col("voter_count") / col("total_voters") >= MIN_VOTER_PCT)
+            .drop("voter_count", "total_voters")
+        )
+
+        district_df = district_df.withColumn("district_type", lit(district_type))
 
         district_dataframes.append(district_df)
 

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -99,6 +99,8 @@ def model(dbt, session: SparkSession) -> DataFrame:
         if district_type not in ["Country", "State"]
     ]
 
+    zip_window = Window.partitionBy("zip_code", "state_postal_code")
+
     for district_type in district_type_from_columns:
         # Get data for this district type from residence
         district_df = (
@@ -125,7 +127,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
             "state_postal_code", "zip_code", "district_name"
         ).agg(count("*").alias("voter_count"))
 
-        zip_window = Window.partitionBy("zip_code", "state_postal_code")
         district_df = (
             district_df.withColumn(
                 "total_voters", spark_sum("voter_count").over(zip_window)

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -204,11 +204,11 @@ models:
 
   - name: m_election_api__zip_to_position
     description: >
-      Maps zip codes to future election offices for the OfficePicker product.
+      Maps zip codes to future election positions for the OfficePicker product.
       Joins the civics election mart with the zip-to-BallotReady-office
       intermediate model, filtered to upcoming elections (before 2029).
 
-      Grain: One row per (zip_code, gp_election_id) pair. Elections without
+      Grain: One row per (zip_code, position_id) pair. Positions without
       zip coverage will have a null zip_code.
     columns:
       - name: position_id

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -206,10 +206,11 @@ models:
     description: >
       Maps zip codes to future election positions for the OfficePicker product.
       Joins the civics election mart with the zip-to-BallotReady-office
-      intermediate model, filtered to upcoming elections (before 2029).
+      intermediate model, filtered to elections within two years of the
+      current date.
 
-      Grain: One row per (zip_code, position_id) pair. Positions without
-      zip coverage will have a null zip_code.
+      Grain: One row per (zip_code, position_id, election_date). Positions
+      without zip coverage will have a null zip_code.
     columns:
       - name: position_id
         description: >
@@ -261,6 +262,13 @@ models:
         description: "Database ID of the `position` from BallotReady"
         tests:
           - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - zip_code
+              - position_id
+              - election_date
 
   - name: m_election_api__stance
     description: "Mart model that serves the Election API"

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -202,6 +202,63 @@ models:
                 to: ref('int__enhanced_race')
                 field: br_database_id
 
+  - name: m_election_api__zip_to_office
+    description: >
+      Maps zip codes to future election offices for the OfficePicker product.
+      Joins the civics election mart with the zip-to-BallotReady-office
+      intermediate model, filtered to upcoming elections (before 2029).
+
+      Grain: One row per (zip_code, gp_election_id) pair. Elections without
+      zip coverage will have a null zip_code.
+    columns:
+      - name: gp_election_id
+        description: >
+          GoodParty election identifier (position + year). Foreign key to the
+          election mart.
+        tests:
+          - not_null
+      - name: display_name
+        description: "Official office name for display in the OfficePicker UI"
+      - name: zip_code
+        description: "5-digit zip code mapped to this office via L2 district matching"
+      - name: election_year
+        description: "Year of the election"
+        tests:
+          - not_null
+      - name: display_office_level
+        description: >
+          Office level for display. Maps judicial positions to 'Judicial',
+          otherwise uses the standard office_level value.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - City
+                  - County
+                  - Federal
+                  - Judicial
+                  - Local
+                  - Regional
+                  - State
+                  - Township
+      - name: office_type
+        description: "Type of office (e.g. City Council, Mayor, Judge)"
+      - name: state
+        description: "Two-letter state postal code"
+      - name: city
+        description: "City associated with the office"
+      - name: district
+        description: "District identifier for the office"
+      - name: election_date
+        description: "Date of the election"
+        tests:
+          - not_null
+      - name: br_position_database_id
+        description: "BallotReady numeric position identifier, used for upstream joins"
+        tests:
+          - not_null
+
   - name: m_election_api__stance
     description: "Mart model that serves the Election API"
     columns:

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -211,6 +211,14 @@ models:
       Grain: One row per (zip_code, gp_election_id) pair. Elections without
       zip coverage will have a null zip_code.
     columns:
+      - name: position_id
+        description: >
+          Election API position UUID. Foreign key to m_election_api__position.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('m_election_api__position')
+                field: id
       - name: gp_election_id
         description: >
           GoodParty election identifier (position + year). Foreign key to the

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -215,12 +215,13 @@ models:
         description: >
           Election API position UUID. Foreign key to m_election_api__position.
         tests:
+          - not_null
           - relationships:
               arguments:
                 to: ref('m_election_api__position')
                 field: id
-      - name: display_name
-        description: "Official office name for display in the OfficePicker UI"
+      - name: name
+        description: "BallotReady position name"
       - name: zip_code
         description: "5-digit zip code mapped to this office via L2 district matching"
       - name: election_year
@@ -256,8 +257,8 @@ models:
         description: "Date of the election"
         tests:
           - not_null
-      - name: br_position_database_id
-        description: "BallotReady numeric position identifier, used for upstream joins"
+      - name: br_database_id
+        description: "Database ID of the `position` from BallotReady"
         tests:
           - not_null
 

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -202,7 +202,7 @@ models:
                 to: ref('int__enhanced_race')
                 field: br_database_id
 
-  - name: m_election_api__zip_to_office
+  - name: m_election_api__zip_to_position
     description: >
       Maps zip codes to future election offices for the OfficePicker product.
       Joins the civics election mart with the zip-to-BallotReady-office
@@ -219,12 +219,6 @@ models:
               arguments:
                 to: ref('m_election_api__position')
                 field: id
-      - name: gp_election_id
-        description: >
-          GoodParty election identifier (position + year). Foreign key to the
-          election mart.
-        tests:
-          - not_null
       - name: display_name
         description: "Official office name for display in the OfficePicker UI"
       - name: zip_code

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_office.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_office.sql
@@ -1,0 +1,52 @@
+{{
+    config(
+        materialized="table",
+        tags=["mart", "election_api", "officepicker"],
+    )
+}}
+
+with
+    future_elections as (
+        select
+            gp_election_id,
+            election_date,
+            election_year,
+            state,
+            official_office_name,
+            office_level,
+            office_type,
+            city,
+            district,
+            is_judicial,
+            br_position_database_id
+        from {{ ref("election") }}
+        where election_date > current_date() and election_year < 2029
+    ),
+
+    zip_to_office as (
+        select zip_code, district_name, br_database_id
+        from {{ ref("int__zip_code_to_br_office") }}
+    ),
+
+    officepicker as (
+        select
+            elec.gp_election_id,
+            elec.official_office_name as display_name,
+            zips.zip_code,
+            elec.election_year,
+            case
+                when elec.is_judicial then 'Judicial' else elec.office_level
+            end as display_office_level,
+            elec.office_type,
+            elec.state,
+            elec.city,
+            elec.district,
+            elec.election_date,
+            elec.br_position_database_id
+        from future_elections as elec
+        left join
+            zip_to_office as zips on zips.br_database_id = elec.br_position_database_id
+    )
+
+select *
+from officepicker

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_office.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_office.sql
@@ -28,8 +28,14 @@ with
         from {{ ref("int__zip_code_to_br_office") }}
     ),
 
+    positions as (
+        select id as position_id, br_database_id
+        from {{ ref("m_election_api__position") }}
+    ),
+
     officepicker as (
         select
+            pos.position_id,
             elec.gp_election_id,
             elec.official_office_name as display_name,
             zips.zip_code,
@@ -46,6 +52,7 @@ with
         from future_elections as elec
         left join
             zip_to_office as zips on zips.br_database_id = elec.br_position_database_id
+        left join positions as pos on pos.br_database_id = elec.br_position_database_id
     )
 
 select *

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -8,7 +8,6 @@
 with
     future_elections as (
         select
-            gp_election_id,
             election_date,
             election_year,
             state,
@@ -36,7 +35,6 @@ with
     officepicker as (
         select
             pos.position_id,
-            elec.gp_election_id,
             elec.official_office_name as display_name,
             zips.zip_code,
             elec.election_year,

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -31,6 +31,7 @@ with
     positions as (
         select id as position_id, br_database_id
         from {{ ref("m_election_api__position") }}
+        where district_id is not null
     ),
 
     officepicker as (

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -11,7 +11,6 @@ with
             election_date,
             election_year,
             state,
-            official_office_name,
             office_level,
             office_type,
             city,
@@ -29,7 +28,7 @@ with
     ),
 
     positions as (
-        select id as position_id, br_database_id
+        select id as position_id, name, br_database_id
         from {{ ref("m_election_api__position") }}
         where district_id is not null
     ),
@@ -37,7 +36,7 @@ with
     officepicker as (
         select
             pos.position_id,
-            elec.official_office_name as name,
+            pos.name,
             zips.zip_code,
             elec.election_year,
             case

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -25,8 +25,7 @@ with
     ),
 
     zip_to_position as (
-        select zip_code, district_name, br_database_id
-        from {{ ref("int__zip_code_to_br_office") }}
+        select zip_code, br_database_id from {{ ref("int__zip_code_to_br_office") }}
     ),
 
     positions as (

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -19,7 +19,9 @@ with
             is_judicial,
             br_position_database_id
         from {{ ref("election") }}
-        where election_date > current_date() and election_year < 2029
+        where
+            election_date > current_date()
+            and election_date <= current_date() + interval 2 years
     ),
 
     zip_to_position as (

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -37,7 +37,7 @@ with
     officepicker as (
         select
             pos.position_id,
-            elec.official_office_name as display_name,
+            elec.official_office_name as name,
             zips.zip_code,
             elec.election_year,
             case
@@ -48,12 +48,12 @@ with
             elec.city,
             elec.district,
             elec.election_date,
-            elec.br_position_database_id
+            elec.br_position_database_id as br_database_id
         from future_elections as elec
         left join
             zip_to_position as zips
             on zips.br_database_id = elec.br_position_database_id
-        left join positions as pos on pos.br_database_id = elec.br_position_database_id
+        inner join positions as pos on pos.br_database_id = elec.br_position_database_id
     )
 
 select *

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -22,7 +22,7 @@ with
         where election_date > current_date() and election_year < 2029
     ),
 
-    zip_to_office as (
+    zip_to_position as (
         select zip_code, district_name, br_database_id
         from {{ ref("int__zip_code_to_br_office") }}
     ),
@@ -49,7 +49,8 @@ with
             elec.br_position_database_id
         from future_elections as elec
         left join
-            zip_to_office as zips on zips.br_database_id = elec.br_position_database_id
+            zip_to_position as zips
+            on zips.br_database_id = elec.br_position_database_id
         left join positions as pos on pos.br_database_id = elec.br_position_database_id
     )
 


### PR DESCRIPTION
## Summary

- Adds `m_election_api__zip_to_position` mart model that maps zip codes to future election positions for the OfficePicker product
- Joins the civics `election` mart with `int__zip_code_to_br_office` and `m_election_api__position`, filtered to elections within a rolling 2-year window
- Uses `position_id` (election API UUID) as the primary identifier, with column names aligned to `m_election_api__position`
- Adds a 0.5% voter percentage threshold to `int__zip_code_to_l2_district` to filter out noisy zip-to-district mappings from tiny geographic overlaps
- Keyword validation join deferred to a future iteration (will use `model_predictions` schema)

## Deployment notes

- `int__zip_code_to_l2_district` needs a `--full-refresh` after merge to apply the voter threshold to historical data. Incremental runs will only apply the threshold to new records.

## Test plan

- [x] `dbt build --select m_election_api__zip_to_position` passes (1 table + 8 tests)
- [x] Inspected data: ~1.1M rows, 34.6K zip codes
- [x] `position_id` is 100% populated with valid FK to `m_election_api__position`
- [x] Grain verified: unique on `(zip_code, position_id, election_date)`
- [ ] Verify Serve team can query the table for OfficePicker integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)