### PR TITLE
[DATA-1869] Add Win PMF survey to pmf_survey_responses mart

### DIFF
--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1144,9 +1144,10 @@ models:
                 values: ['8', '12']
       - name: pmf_variant
         description: >
-          Audience variant of the PMF survey:
-          'Serve' (survey_id 8, 'Serve PMF - Web survey') or
-          'Win' (survey_id 12, 'Win PMF - Web survey').
+          Audience variant of the PMF survey, derived from the survey_name
+          prefix: 'Serve' (any 'Serve PMF%' survey) or 'Win' (any 'Win PMF%'
+          survey). Pattern-matched on prefix so date-stamped relaunches keep
+          mapping correctly without a code change.
         data_tests:
           - not_null
           - accepted_values:

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1116,13 +1116,13 @@ models:
 
   - name: pmf_survey_responses
     description: >
-      PMF (Product-Market Fit) web survey responses. Combines two HubSpot
-      surveys that share identical fields but target different audiences:
-      'Serve PMF - Web survey' (survey_id 8) and 'Win PMF - Web survey'
-      (survey_id 12). Use `pmf_variant` to split or compare cohorts.
-      One row per survey submission, joined to HubSpot contacts for
-      respondent context.
-      PMF Score = (Very Disappointed / total) * 100.
+      PMF (Product-Market Fit) web survey responses. Combines all HubSpot
+      surveys whose name starts with 'Serve PMF' or 'Win PMF' — these share
+      identical fields but target different audiences. Filtering by name
+      prefix means any future date-stamped relaunch is automatically
+      included. Use `pmf_variant` to split or compare cohorts. One row
+      per survey submission, joined to HubSpot contacts for respondent
+      context. PMF Score = (Very Disappointed / total) * 100.
     columns:
       - name: submission_id
         description: Unique identifier for the feedback submission
@@ -1135,13 +1135,12 @@ models:
           - not_null
       - name: hs_survey_id
         description: >
-          HubSpot survey ID. 8 = 'Serve PMF - Web survey',
-          12 = 'Win PMF - Web survey'.
+          HubSpot survey ID. As of 2026-04: 8 = 'Serve PMF - Web survey',
+          12 = 'Win PMF - Web survey'. New ids may appear if HubSpot
+          relaunches either survey — the model filter is name-based, not
+          id-based, so relaunches are picked up automatically.
         data_tests:
           - not_null
-          - accepted_values:
-              arguments:
-                values: ['8', '12']
       - name: pmf_variant
         description: >
           Audience variant of the PMF survey, derived from the survey_name

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1116,11 +1116,12 @@ models:
 
   - name: pmf_survey_responses
     description: >
-      PMF (Product-Market Fit) web survey responses. Combines the Serve PMF
-      (survey_id 8) and Win PMF (survey_id 12) surveys, which use identical
-      fields but target different audiences. Use `pmf_variant` to split or
-      compare cohorts. One row per survey submission, joined to HubSpot
-      contacts for respondent context.
+      PMF (Product-Market Fit) web survey responses. Combines two HubSpot
+      surveys that share identical fields but target different audiences:
+      'Serve PMF - Web survey' (survey_id 8) and 'Win PMF - Web survey'
+      (survey_id 12). Use `pmf_variant` to split or compare cohorts.
+      One row per survey submission, joined to HubSpot contacts for
+      respondent context.
       PMF Score = (Very Disappointed / total) * 100.
     columns:
       - name: submission_id
@@ -1133,7 +1134,9 @@ models:
         data_tests:
           - not_null
       - name: hs_survey_id
-        description: HubSpot survey ID (8 = Serve PMF, 12 = Win PMF).
+        description: >
+          HubSpot survey ID. 8 = 'Serve PMF - Web survey',
+          12 = 'Win PMF - Web survey'.
         data_tests:
           - not_null
           - accepted_values:
@@ -1141,8 +1144,9 @@ models:
                 values: ['8', '12']
       - name: pmf_variant
         description: >
-          Audience variant of the PMF survey: 'Serve' (survey_id 8) or
-          'Win' (survey_id 12).
+          Audience variant of the PMF survey:
+          'Serve' (survey_id 8, 'Serve PMF - Web survey') or
+          'Win' (survey_id 12, 'Win PMF - Web survey').
         data_tests:
           - not_null
           - accepted_values:

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1116,9 +1116,12 @@ models:
 
   - name: pmf_survey_responses
     description: >
-      PMF (Product-Market Fit) web survey responses. Filtered to survey_id 8
-      ("PMF - Web survey"). One row per survey submission, joined to HubSpot
-      contacts for respondent context. PMF Score = (Very Disappointed / total) * 100.
+      PMF (Product-Market Fit) web survey responses. Combines the Serve PMF
+      (survey_id 8) and Win PMF (survey_id 12) surveys, which use identical
+      fields but target different audiences. Use `pmf_variant` to split or
+      compare cohorts. One row per survey submission, joined to HubSpot
+      contacts for respondent context.
+      PMF Score = (Very Disappointed / total) * 100.
     columns:
       - name: submission_id
         description: Unique identifier for the feedback submission
@@ -1129,6 +1132,22 @@ models:
         description: Timestamp when the survey response was submitted
         data_tests:
           - not_null
+      - name: hs_survey_id
+        description: HubSpot survey ID (8 = Serve PMF, 12 = Win PMF).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['8', '12']
+      - name: pmf_variant
+        description: >
+          Audience variant of the PMF survey: 'Serve' (survey_id 8) or
+          'Win' (survey_id 12).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['Serve', 'Win']
       - name: pmf_response
         description: >
           Decoded PMF answer: Very Disappointed, Somewhat Disappointed,

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -42,8 +42,14 @@ with
             s.hs_survey_id,
             s.survey_name,
             s.survey_channel,
+            -- Pattern-match on survey_name prefix so future date-stamped
+            -- relaunches (e.g. 'Serve PMF - Web survey (...)') keep mapping
+            -- to the right variant without a code change.
             case
-                s.hs_survey_id when '8' then 'Serve' when '12' then 'Win'
+                when s.survey_name ilike 'Serve PMF%'
+                then 'Serve'
+                when s.survey_name ilike 'Win PMF%'
+                then 'Win'
             end as pmf_variant,
 
             -- PMF response (decoded from internal option names)

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -1,8 +1,10 @@
 /*
     PMF (Product-Market Fit) web survey responses from HubSpot Feedback Surveys.
-    Combines the Serve PMF (survey_id '8') and Win PMF (survey_id '12') surveys,
-    which use identical fields but target different audiences. Use the
-    `pmf_variant` column to split or compare cohorts.
+    Combines two HubSpot surveys that share identical fields but target
+    different audiences:
+      - 'Serve PMF - Web survey' (survey_id '8')
+      - 'Win PMF - Web survey'   (survey_id '12')
+    Use the `pmf_variant` column to split or compare cohorts.
 
     Joined to HubSpot contacts for additional user context.
 

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -1,10 +1,11 @@
 /*
     PMF (Product-Market Fit) web survey responses from HubSpot Feedback Surveys.
-    Combines two HubSpot surveys that share identical fields but target
-    different audiences:
-      - 'Serve PMF - Web survey' (survey_id '8')
-      - 'Win PMF - Web survey'   (survey_id '12')
-    Use the `pmf_variant` column to split or compare cohorts.
+    Combines all surveys whose name starts with 'Serve PMF' or 'Win PMF' —
+    these share identical fields but target different audiences. Filtering by
+    name prefix (rather than hs_survey_id) means any future date-stamped
+    relaunch is automatically included. As of 2026-04: id 8 = 'Serve PMF -
+    Web survey', id 12 = 'Win PMF - Web survey'. Use the `pmf_variant`
+    column to split or compare cohorts.
 
     Joined to HubSpot contacts for additional user context.
 
@@ -17,7 +18,7 @@ with
     submissions as (
         select *
         from {{ ref("stg_airbyte_source__hubspot_api_feedback_submissions") }}
-        where hs_survey_id in ('8', '12')
+        where survey_name ilike 'Serve PMF%' or survey_name ilike 'Win PMF%'
     ),
 
     contacts as (

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -1,6 +1,9 @@
 /*
     PMF (Product-Market Fit) web survey responses from HubSpot Feedback Surveys.
-    Filtered to survey_id = '8' (PMF - Web survey).
+    Combines the Serve PMF (survey_id '8') and Win PMF (survey_id '12') surveys,
+    which use identical fields but target different audiences. Use the
+    `pmf_variant` column to split or compare cohorts.
+
     Joined to HubSpot contacts for additional user context.
 
     Grain: One row per survey response.
@@ -12,7 +15,7 @@ with
     submissions as (
         select *
         from {{ ref("stg_airbyte_source__hubspot_api_feedback_submissions") }}
-        where hs_survey_id = '8'
+        where hs_survey_id in ('8', '12')
     ),
 
     contacts as (
@@ -34,8 +37,12 @@ with
             s.submission_id,
 
             -- survey metadata
+            s.hs_survey_id,
             s.survey_name,
             s.survey_channel,
+            case
+                s.hs_survey_id when '8' then 'Serve' when '12' then 'Win'
+            end as pmf_variant,
 
             -- PMF response (decoded from internal option names)
             s.pmf_response as pmf_response_raw,
@@ -52,6 +59,7 @@ with
                 else coalesce(s.pmf_response, 'N/A')
             end as pmf_response,
             coalesce(s.pmf_response = 'Option 1', false) as is_very_disappointed,
+            s.pmf_additional_feedback,
 
             -- respondent info (from submission)
             s.hs_contact_id,


### PR DESCRIPTION
## Summary
- Surface the new Win PMF HubSpot survey to `mart_analytics.pmf_survey_responses`. Dan confirmed Win PMF uses identical fields to Serve PMF, so one mart with a variant column beats forking a parallel model.
- Filter by `survey_name` prefix (`'Serve PMF%'` or `'Win PMF%'`) rather than hard-coding `hs_survey_id` — date-stamped HubSpot relaunches will flow in automatically with no code change.
- Surface `hs_survey_id`, a derived `pmf_variant` (`'Serve'` / `'Win'`), and the previously-dropped `pmf_additional_feedback` so analysts can split or compare cohorts.
- Refresh the model docstring + `m_analytics.yaml` description; add `not_null` on `hs_survey_id` and `not_null` + `accepted_values: ['Serve', 'Win']` on `pmf_variant`.

ClickUp: [DATA-1869](https://goodparty.clickup.com/t/90132012119/DATA-1869)

## Validation: which surveys are now flowing into the mart?

Run this against my dev schema (or swap `dbt_hugh` → `mart_analytics` once merged) to confirm exactly what's being included by the new name-based filter:

```sql
select
    hs_survey_id,
    survey_name,
    pmf_variant,
    count(*) as n_responses,
    min(submitted_at) as first_submission,
    max(submitted_at) as latest_submission
from goodparty_data_catalog.dbt_hugh.pmf_survey_responses
group by 1, 2, 3
order by pmf_variant, hs_survey_id
;
```

**Current results in `dbt_hugh`:**

| hs_survey_id | survey_name | pmf_variant | n_responses | first_submission | latest_submission |
|---|---|---|---|---|---|
| 8 | Serve PMF - Web survey (March18,2026) | Serve | 9 | 2026-03-20 16:02 | 2026-04-11 19:53 |
| 12 | Win PMF - Web survey (4/13/26) | Win | 1 | 2026-04-14 17:11 | 2026-04-14 17:11 |

Two surveys, two variants, no surprise rows — exactly the cohort we expect.

## Test plan
- [x] `dbt build --select +pmf_survey_responses` — passes (10 rows: 9 Serve + 1 Win)
- [x] `dbt test --select pmf_survey_responses` — 12/12 pass, including new tests on `hs_survey_id` and `pmf_variant`
- [x] `inspect_data` — confirmed `pmf_variant` correctly maps Serve/Win and `pmf_additional_feedback` populates as expected (sparse, optional free-text)
- [x] Validation query above — confirms only the two intended surveys flow in

## Note for reviewers
The Win PMF survey only has one submission so far (from 2026-04-14). PMF Score by variant won't be meaningful for the Win cohort until volume builds — the mart is wired up and ready to receive them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)