### PR TITLE
[DATA-1631] Add active candidate windows and election date to users_win_base

### DIFF
--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -5,14 +5,15 @@ models:
     description: >
       Unified user-grain view for Win and Serve product OKR metrics tracking.
       Built incrementally as new metrics are added, including Active Candidates
-      (dashboard views in trailing 30 days).
+      (dashboard views in trailing 7, 30, and 90 days).
 
       File is named users_win_base to avoid dbt model name collision with
       mart_civics.users.
 
       Grain: One row per user.
 
-      Source: mart_civics.users + Amplitude milestones.
+      Source: mart_civics.users + mart_civics.campaigns
+      + Amplitude milestones.
 
     columns:
       - name: user_id
@@ -148,10 +149,24 @@ models:
           Total number of Candidate Dashboard view events for this user.
           From int__amplitude_user_milestones.
 
+      - name: is_active_candidate_7d
+        description: >
+          TRUE if user has viewed their Candidate Dashboard at least once
+          in the last 7 days. Uses last_dashboard_viewed_at from Amplitude milestones.
+        data_tests:
+          - not_null
+
       - name: is_active_candidate
         description: >
           TRUE if user has viewed their Candidate Dashboard at least once
           in the last 30 days. Uses last_dashboard_viewed_at from Amplitude milestones.
+        data_tests:
+          - not_null
+
+      - name: is_active_candidate_90d
+        description: >
+          TRUE if user has viewed their Candidate Dashboard at least once
+          in the last 90 days. Uses last_dashboard_viewed_at from Amplitude milestones.
         data_tests:
           - not_null
 
@@ -197,6 +212,22 @@ models:
           REQUIRED filter for Amplitude-based CVR metrics.
         data_tests:
           - not_null
+
+      - name: next_election_date
+        description: >
+          Earliest future election date across the user's non-demo campaigns
+          (latest version only). NULL if no upcoming election.
+
+      - name: last_election_date
+        description: >
+          Most recent election date (past or future) across the user's non-demo
+          campaigns (latest version only). NULL if no campaign has an election date.
+
+      - name: election_date
+        description: >
+          Best available election date for dashboard filtering: next_election_date
+          if the user has an upcoming election, otherwise last_election_date.
+          Use this column for the Active Candidates election date cohort filter.
 
       - name: first_campaign_sent_at
         description: >
@@ -284,6 +315,18 @@ models:
           config:
             where: "first_campaign_sent_at is not null"
       - dbt_utils.expression_is_true:
+          name: active_candidate_7d_has_dashboard_view
+          arguments:
+            expression: "last_dashboard_viewed_at is not null"
+          config:
+            where: "is_active_candidate_7d = true"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_active_candidate_7d = true"
+          config:
+            where: "last_dashboard_viewed_at >= current_date - interval 7 days"
+      - dbt_utils.expression_is_true:
+          name: active_candidate_30d_has_dashboard_view
           arguments:
             expression: "last_dashboard_viewed_at is not null"
           config:
@@ -293,6 +336,29 @@ models:
             expression: "is_active_candidate = true"
           config:
             where: "last_dashboard_viewed_at >= current_date - interval 30 days"
+      - dbt_utils.expression_is_true:
+          name: active_candidate_90d_has_dashboard_view
+          arguments:
+            expression: "last_dashboard_viewed_at is not null"
+          config:
+            where: "is_active_candidate_90d = true"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_active_candidate_90d = true"
+          config:
+            where: "last_dashboard_viewed_at >= current_date - interval 90 days"
+      - dbt_utils.expression_is_true:
+          name: active_candidate_7d_implies_30d
+          arguments:
+            expression: "is_active_candidate = true"
+          config:
+            where: "is_active_candidate_7d = true"
+      - dbt_utils.expression_is_true:
+          name: active_candidate_30d_implies_90d
+          arguments:
+            expression: "is_active_candidate_90d = true"
+          config:
+            where: "is_active_candidate = true"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "non_demo_campaign_count <= campaign_count"

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -160,6 +160,8 @@ models:
         description: >
           TRUE if user has viewed their Candidate Dashboard at least once
           in the last 30 days. Uses last_dashboard_viewed_at from Amplitude milestones.
+          Canonical Active Candidates OKR metric; is_active_candidate_7d and
+          is_active_candidate_90d are supplemental windows.
         data_tests:
           - not_null
 
@@ -220,8 +222,11 @@ models:
 
       - name: last_election_date
         description: >
-          Most recent election date (past or future) across the user's non-demo
-          campaigns (latest version only). NULL if no campaign has an election date.
+          Latest election date (chronologically largest, past or future) across
+          the user's non-demo campaigns (latest version only). For users with only
+          past elections this is the most recent past election; for users with
+          future elections this is the furthest future election.
+          NULL if no campaign has an election date.
 
       - name: election_date
         description: >
@@ -321,6 +326,7 @@ models:
           config:
             where: "is_active_candidate_7d = true"
       - dbt_utils.expression_is_true:
+          name: active_candidate_7d_window_correctness
           arguments:
             expression: "is_active_candidate_7d = true"
           config:
@@ -332,6 +338,7 @@ models:
           config:
             where: "is_active_candidate = true"
       - dbt_utils.expression_is_true:
+          name: active_candidate_30d_window_correctness
           arguments:
             expression: "is_active_candidate = true"
           config:
@@ -343,6 +350,7 @@ models:
           config:
             where: "is_active_candidate_90d = true"
       - dbt_utils.expression_is_true:
+          name: active_candidate_90d_window_correctness
           arguments:
             expression: "is_active_candidate_90d = true"
           config:
@@ -359,6 +367,18 @@ models:
             expression: "is_active_candidate_90d = true"
           config:
             where: "is_active_candidate = true"
+      - dbt_utils.expression_is_true:
+          name: next_election_date_is_future
+          arguments:
+            expression: "next_election_date >= current_date"
+          config:
+            where: "next_election_date is not null"
+      - dbt_utils.expression_is_true:
+          name: last_election_date_geq_next
+          arguments:
+            expression: "last_election_date >= next_election_date"
+          config:
+            where: "next_election_date is not null"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "non_demo_campaign_count <= campaign_count"

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -222,11 +222,9 @@ models:
 
       - name: last_election_date
         description: >
-          Latest election date (chronologically largest, past or future) across
-          the user's non-demo campaigns (latest version only). For users with only
-          past elections this is the most recent past election; for users with
-          future elections this is the furthest future election.
-          NULL if no campaign has an election date.
+          Most recent past election date across the user's non-demo campaigns
+          (latest version only). NULL if the user has no campaign whose election
+          date is before today.
 
       - name: election_date
         description: >
@@ -367,18 +365,6 @@ models:
             expression: "is_active_candidate_90d = true"
           config:
             where: "is_active_candidate = true"
-      - dbt_utils.expression_is_true:
-          name: next_election_date_is_future
-          arguments:
-            expression: "next_election_date >= current_date"
-          config:
-            where: "next_election_date is not null"
-      - dbt_utils.expression_is_true:
-          name: last_election_date_geq_next
-          arguments:
-            expression: "last_election_date >= next_election_date"
-          config:
-            where: "next_election_date is not null"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "non_demo_campaign_count <= campaign_count"

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -156,7 +156,7 @@ models:
         data_tests:
           - not_null
 
-      - name: is_active_candidate
+      - name: is_active_candidate_30d
         description: >
           TRUE if user has viewed their Candidate Dashboard at least once
           in the last 30 days. Uses last_dashboard_viewed_at from Amplitude milestones.
@@ -334,11 +334,11 @@ models:
           arguments:
             expression: "last_dashboard_viewed_at is not null"
           config:
-            where: "is_active_candidate = true"
+            where: "is_active_candidate_30d = true"
       - dbt_utils.expression_is_true:
           name: active_candidate_30d_window_correctness
           arguments:
-            expression: "is_active_candidate = true"
+            expression: "is_active_candidate_30d = true"
           config:
             where: "last_dashboard_viewed_at >= current_date - interval 30 days"
       - dbt_utils.expression_is_true:
@@ -356,7 +356,7 @@ models:
       - dbt_utils.expression_is_true:
           name: active_candidate_7d_implies_30d
           arguments:
-            expression: "is_active_candidate = true"
+            expression: "is_active_candidate_30d = true"
           config:
             where: "is_active_candidate_7d = true"
       - dbt_utils.expression_is_true:
@@ -364,7 +364,7 @@ models:
           arguments:
             expression: "is_active_candidate_90d = true"
           config:
-            where: "is_active_candidate = true"
+            where: "is_active_candidate_30d = true"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "non_demo_campaign_count <= campaign_count"

--- a/dbt/project/models/marts/analytics/users_win_base.sql
+++ b/dbt/project/models/marts/analytics/users_win_base.sql
@@ -4,7 +4,8 @@
     mart_analytics.users_win_base
 
     Unified user-grain view for product metrics.
-    Source: mart_civics.users + int__amplitude_user_milestones.
+    Source: mart_civics.users + mart_civics.campaigns
+           + int__amplitude_user_milestones.
 
     Metric definitions in this model:
     - is_pro: user has at least one pro campaign.
@@ -12,6 +13,8 @@
       time through 14 days. Use with is_post_amplitude_registration and
       registration_country = 'United States' for Amplitude-era denominators.
     - is_active_candidate: user viewed candidate dashboard in trailing 30 days.
+    - is_active_candidate_7d: same as above but 7-day window.
+    - is_active_candidate_90d: same as above but 90-day window.
     - is_activated: user has at least one voter outreach campaign event.
     - has_completed_onboarding_flow: supplemental onboarding_complete flag.
 */
@@ -21,6 +24,18 @@ with
         select * from {{ ref("goodparty_data_catalog", "users") }} where is_win_user
     ),
     milestones as (select * from {{ ref("int__amplitude_user_milestones") }}),
+
+    campaign_elections as (
+        select
+            user_id,
+            min(
+                case when election_date >= current_date then election_date end
+            ) as next_election_date,
+            max(election_date) as last_election_date
+        from {{ ref("goodparty_data_catalog", "campaigns") }}
+        where not is_demo and election_date is not null and is_latest_version
+        group by user_id
+    ),
 
     final as (
         select
@@ -70,8 +85,14 @@ with
             m.last_dashboard_viewed_at,
             m.dashboard_view_count,
             coalesce(
+                m.last_dashboard_viewed_at >= current_date - interval 7 days, false
+            ) as is_active_candidate_7d,
+            coalesce(
                 m.last_dashboard_viewed_at >= current_date - interval 30 days, false
             ) as is_active_candidate,
+            coalesce(
+                m.last_dashboard_viewed_at >= current_date - interval 90 days, false
+            ) as is_active_candidate_90d,
             m.registration_country,
             coalesce(
                 m.registration_country = 'United States'
@@ -95,6 +116,11 @@ with
             ) as has_amplitude_data,
             (u.created_at >= '2023-12-10') as is_post_amplitude_registration,
 
+            -- Election date (from non-demo campaigns, latest version only)
+            ce.next_election_date,
+            ce.last_election_date,
+            coalesce(ce.next_election_date, ce.last_election_date) as election_date,
+
             -- Activated metric
             m.first_campaign_sent_at,
             (m.first_campaign_sent_at is not null) as is_activated,
@@ -102,6 +128,7 @@ with
             m.total_recipient_count
         from users u
         left join milestones m on u.user_id = m.user_id
+        left join campaign_elections ce on u.user_id = ce.user_id
     )
 
 select *

--- a/dbt/project/models/marts/analytics/users_win_base.sql
+++ b/dbt/project/models/marts/analytics/users_win_base.sql
@@ -13,7 +13,7 @@
       time through 14 days. Use with is_post_amplitude_registration and
       registration_country = 'United States' for Amplitude-era denominators.
     - is_active_candidate_7d: user viewed candidate dashboard in trailing 7 days.
-    - is_active_candidate: trailing-30-day window (canonical Active Candidates OKR).
+    - is_active_candidate_30d: trailing-30-day window (canonical Active Candidates OKR).
     - is_active_candidate_90d: trailing-90-day window.
     - is_activated: user has at least one voter outreach campaign event.
     - has_completed_onboarding_flow: supplemental onboarding_complete flag.
@@ -96,7 +96,7 @@ with
             ) as is_active_candidate_7d,
             coalesce(
                 m.last_dashboard_viewed_at >= current_date - interval 30 days, false
-            ) as is_active_candidate,
+            ) as is_active_candidate_30d,
             coalesce(
                 m.last_dashboard_viewed_at >= current_date - interval 90 days, false
             ) as is_active_candidate_90d,

--- a/dbt/project/models/marts/analytics/users_win_base.sql
+++ b/dbt/project/models/marts/analytics/users_win_base.sql
@@ -26,14 +26,21 @@ with
     milestones as (select * from {{ ref("int__amplitude_user_milestones") }}),
 
     campaign_elections as (
+        -- Filters out-of-range election_date sentinels (e.g. year 19999) from
+        -- source data so downstream consumers never see garbage.
         select
             user_id,
             min(
                 case when election_date >= current_date then election_date end
             ) as next_election_date,
-            max(election_date) as last_election_date
+            max(
+                case when election_date < current_date then election_date end
+            ) as last_election_date
         from {{ ref("goodparty_data_catalog", "campaigns") }}
-        where not is_demo and election_date is not null and is_latest_version
+        where
+            not is_demo
+            and is_latest_version
+            and election_date between '2000-01-01' and '2050-12-31'
         group by user_id
     ),
 

--- a/dbt/project/models/marts/analytics/users_win_base.sql
+++ b/dbt/project/models/marts/analytics/users_win_base.sql
@@ -12,9 +12,9 @@
     - is_onboarded: US registration with first dashboard view from registration
       time through 14 days. Use with is_post_amplitude_registration and
       registration_country = 'United States' for Amplitude-era denominators.
-    - is_active_candidate: user viewed candidate dashboard in trailing 30 days.
-    - is_active_candidate_7d: same as above but 7-day window.
-    - is_active_candidate_90d: same as above but 90-day window.
+    - is_active_candidate_7d: user viewed candidate dashboard in trailing 7 days.
+    - is_active_candidate: trailing-30-day window (canonical Active Candidates OKR).
+    - is_active_candidate_90d: trailing-90-day window.
     - is_activated: user has at least one voter outreach campaign event.
     - has_completed_onboarding_flow: supplemental onboarding_complete flag.
 */
@@ -81,7 +81,7 @@ with
             -- Onboarding metric
             m.amplitude_registration_completed_at,
             m.first_dashboard_viewed_at,
-            -- Active Candidates metric (approved definition)
+            -- Active Candidates metric (7d/30d/90d windows)
             m.last_dashboard_viewed_at,
             m.dashboard_view_count,
             coalesce(
@@ -116,7 +116,7 @@ with
             ) as has_amplitude_data,
             (u.created_at >= '2023-12-10') as is_post_amplitude_registration,
 
-            -- Election date (from non-demo campaigns, latest version only)
+            -- Election date context (for dashboard cohort filtering)
             ce.next_election_date,
             ce.last_election_date,
             coalesce(ce.next_election_date, ce.last_election_date) as election_date,


### PR DESCRIPTION
## Summary
- Add `is_active_candidate_7d` / `is_active_candidate_30d` (renamed from `is_active_candidate`) / `is_active_candidate_90d` alongside the existing Active Candidates metric
- Add `next_election_date`, `last_election_date`, and `election_date` columns sourced from non-demo, latest-version `mart_civics.campaigns` rows — unblocks dashboard cohort filtering by election date without waiting for Global Dimensions
- `election_date` = nearest future election if available, otherwise the user's most recent past election

## Column semantics
| Column | Definition |
|--------|-----------|
| `is_active_candidate_7d` | Dashboard viewed in the last 7 days |
| `is_active_candidate_30d` | Dashboard viewed in the last 30 days (canonical OKR metric, renamed from `is_active_candidate` for suite consistency) |
| `is_active_candidate_90d` | Dashboard viewed in the last 90 days |
| `next_election_date` | Earliest future election date across the user's non-demo latest-version campaigns; NULL if none upcoming |
| `last_election_date` | Most recent past election date across the user's non-demo latest-version campaigns; NULL if none past |
| `election_date` | `coalesce(next_election_date, last_election_date)` — best available election date for dashboard filtering |

## Source data hygiene
- `campaign_elections` CTE filters `election_date BETWEEN '2000-01-01' AND '2050-12-31'` to exclude year-19999 sentinels present in source `campaigns` data. Prevents garbage from leaking to the analytics mart.

## Data validation
Election date cohort breakdown with active candidate counts (pre-rename; post-rename figures identical, column renamed):

| Cohort | Users | Active 7d | Active 30d | Active 90d |
|--------|-------|-----------|------------|------------|
| next 12 months | 9,460 | 153 | 417 | 1,489 |
| past | 30,547 | 38 | 130 | 899 |
| beyond 12 months | 866 | 10 | 39 | 159 |
| no election date | 20,451 | 28 | 56 | 80 |

- Active candidate windows nest correctly (7d ⊆ 30d ⊆ 90d) — verified by `active_candidate_7d_implies_30d` and `active_candidate_30d_implies_90d` tests.
- `next_election_date >= current_date` and `last_election_date < current_date` hold by CTE construction (no user can have `last > next`).

## Breaking change
- Renamed `is_active_candidate` → `is_active_candidate_30d`. Downstream Databricks dashboards and Metabase cards that reference the old column name will need to be updated. No in-repo SQL references this column.
- **The "Serve and Win KRs" dashboard** references the old `is_active_candidate` column and must be updated alongside this PR.

## Test plan
- [x] `dbt build --select users_win_base` — 45/45 pass (model + all data tests)
- [x] Window correctness tests (one per 7d/30d/90d): flag ⇔ `last_dashboard_viewed_at` window match
- [x] Nesting invariant tests: 7d ⇒ 30d ⇒ 90d
- [x] `not_null` tests on all three boolean flags
- [x] Inspected election-date distribution — 99% of users have exactly 1 election date; 18 year-19999 sentinel rows filtered in CTE
- [ ] Update the "Serve and Win KRs" dashboard: rename `is_active_candidate` → `is_active_candidate_30d`, add 7/30/90 window selector, add election date filter
- [ ] Audit any other external BI references to the renamed `is_active_candidate` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)