### PR TITLE
Bump apache-airflow from 3.1.7 to 3.2.0 in requirements_test.txt

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-apache-airflow==3.1.7
+apache-airflow==3.2.0
 databricks-sql-connector>=3.0.0,<5.0.0
 databricks-sdk>=0.30.0,<1.0.0
 pandas>=2.0.0,<4.0.0


### PR DESCRIPTION
## Summary
- Updates `apache-airflow` from 3.1.7 → 3.2.0 in `requirements_test.txt` to patch [CVE-2025-54550](https://nvd.nist.gov/vuln/detail/CVE-2025-54550) / [GHSA-q2hg-643c-gw8h](https://github.com/advisories/GHSA-q2hg-643c-gw8h).
- Matches the bump already applied to `/airflow` in #315.
- Resolves Dependabot alert [#107](https://github.com/thegoodparty/gp-data-platform/security/dependabot/107).

## Context
The advisory concerns an unsafe `example_xcom` DAG pattern in Airflow docs that could allow RCE if copied into user DAGs. Airflow core is not affected — this is a defense-in-depth bump so the test-environment pin matches the runtime pin.


🤖 Generated with [Claude Code](https://claude.com/claude-code)