### PR TITLE
feat: expand hubspot contacts staging with parsed property columns

### DIFF
--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
@@ -37,7 +37,21 @@ models:
               arguments:
                 values: [true, false]
   - name: stg_airbyte_source__hubspot_api_contacts
-    description: Contacts data load from HubSpot API
+    description: >
+      Contacts data loaded from the HubSpot API. Most columns are native HubSpot
+      Contact properties. A few columns are denormalized snapshots of data that
+      is authoritative elsewhere in this dbt project — they are kept here for
+      convenience/auditing but downstream models should prefer the authoritative
+      source:
+
+        - `br_candidacy_id`, `br_position_id`, `br_race_id`: BallotReady IDs.
+          Authoritative source is the BallotReady staging/intermediate models.
+        - `goodparty_user_id`: mirrors `gp_api_db_user.id`. Authoritative source
+          is the users staging model from the gp_api database.
+        - `win_icp`, `serve_icp`: HubSpot holds a snapshot of our ICP model
+          output. Authoritative ICP comes from the ICP dbt model.
+        - `win_activated_user`, `serve_activated_user`: mirror activation state
+          from the product users table.
     columns:
       - name: id
         data_tests:
@@ -73,6 +87,211 @@ models:
           - accepted_values:
               arguments:
                 values: [true, false]
+      - name: br_candidacy_id
+        description: >
+          BallotReady candidacy ID stored on the HubSpot contact. Not
+          authoritative — prefer BallotReady staging/intermediate models.
+      - name: br_position_id
+        description: >
+          BallotReady position ID stored on the HubSpot contact. Not
+          authoritative — prefer BallotReady staging/intermediate models.
+      - name: br_race_id
+        description: >
+          BallotReady race ID stored on the HubSpot contact. Not authoritative —
+          prefer BallotReady staging/intermediate models.
+      - name: goodparty_user_id
+        description: >
+          Denormalized copy of `gp_api_db_user.id` stored on the HubSpot
+          contact. Authoritative source is the users staging model from the
+          gp_api database.
+      - name: candidate_id_result
+        description: HubSpot-tracked outcome of the candidate-ID research process.
+      - name: candidate_type
+        description: HubSpot classification of the candidate (e.g. Pro, Lead, etc.).
+      - name: is_confirmed_candidate
+        description: Whether HubSpot has confirmed this contact as a running candidate.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: is_filed_candidate
+        description: Whether the candidate has filed for office per HubSpot.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: is_pro_candidate
+        description: Whether the contact is flagged as a Pro candidate in HubSpot.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: has_ever_been_pro
+        description: Whether the contact has ever held Pro status in HubSpot.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: pledge_status
+        description: Raw HubSpot pledge status string (see `is_pledged` for boolean).
+      - name: has_email_pledge
+        description: Whether the contact has submitted an email-based pledge.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: has_verbal_pledge
+        description: Whether the contact has given a verbal pledge.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: has_verbal_pro
+        description: Whether the contact has given a verbal Pro commitment.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: has_verbal_serve
+        description: Whether the contact has given a verbal Serve commitment.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: product_line
+        description: HubSpot product line classification for the contact.
+      - name: product_stage
+        description: HubSpot product stage classification for the contact.
+      - name: hubspot_owner_id
+        description: HubSpot user ID of the contact owner.
+      - name: marketing_contact_status
+        description: HubSpot `hs_marketable_status` — whether the contact is marketable.
+      - name: is_contact_unworked
+        description: HubSpot `hs_is_unworked` — whether the contact has no logged outreach.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: lifecycle_stage
+        description: HubSpot lifecycle stage for the contact.
+      - name: journey_stage
+        description: HubSpot journey stage (`hs_journey_stage`) for the contact.
+      - name: lead_status
+        description: HubSpot lead status.
+      - name: lead_source
+        description: HubSpot lead source.
+      - name: conversion_type
+        description: HubSpot conversion type.
+      - name: lifecycle_current_stage_entered_at
+        description: Timestamp the contact entered its current lifecycle stage.
+      - name: lifecycle_customer_entered_at
+        description: Timestamp the contact first entered the Customer lifecycle stage.
+      - name: lifecycle_evangelist_entered_at
+        description: Timestamp the contact first entered the Evangelist lifecycle stage.
+      - name: lifecycle_lead_entered_at
+        description: Timestamp the contact first entered the Lead lifecycle stage.
+      - name: lifecycle_mql_entered_at
+        description: Timestamp the contact first entered the MQL lifecycle stage.
+      - name: lifecycle_opportunity_entered_at
+        description: Timestamp the contact first entered the Opportunity lifecycle stage.
+      - name: lifecycle_other_entered_at
+        description: Timestamp the contact first entered the Other lifecycle stage.
+      - name: lifecycle_sql_entered_at
+        description: Timestamp the contact first entered the SQL lifecycle stage.
+      - name: lifecycle_subscriber_entered_at
+        description: Timestamp the contact first entered the Subscriber lifecycle stage.
+      - name: win_stage
+        description: Current Win pipeline stage for the contact.
+      - name: win_stage_0_intake_entered_at
+        description: Timestamp the contact entered Win Stage 0 (Intake).
+      - name: win_stage_1_new_assigned_entered_at
+        description: Timestamp the contact entered Win Stage 1 (New/Assigned).
+      - name: win_stage_2_discovery_complete_entered_at
+        description: Timestamp the contact entered Win Stage 2 (Discovery Complete).
+      - name: win_stage_3_pro_presented_entered_at
+        description: Timestamp the contact entered Win Stage 3 (Pro Presented).
+      - name: win_stage_4_pro_consideration_entered_at
+        description: Timestamp the contact entered Win Stage 4 (Pro Consideration).
+      - name: win_stage_5_closed_won_pro_entered_at
+        description: Timestamp the contact entered Win Stage 5 (Closed Won — Pro).
+      - name: win_stage_6_activated_pro_user_entered_at
+        description: Timestamp the contact entered Win Stage 6 (Activated Pro User).
+      - name: win_stage_closed_too_early_entered_at
+        description: Timestamp the contact entered Win Stage Closed (Too Early).
+      - name: win_icp
+        description: >
+          HubSpot snapshot of the Win ICP classification. Not authoritative —
+          authoritative ICP comes from the ICP dbt model.
+      - name: serve_icp
+        description: >
+          HubSpot snapshot of the Serve ICP classification. Not authoritative —
+          authoritative ICP comes from the ICP dbt model.
+      - name: win_activated_user
+        description: >
+          HubSpot snapshot of Win activation status. Not authoritative —
+          sourced from the product users table.
+      - name: serve_activated_user
+        description: >
+          HubSpot snapshot of Serve activation status. Not authoritative —
+          sourced from the product users table.
+      - name: serve_stage
+        description: Current Serve pipeline stage.
+      - name: serve_onboarding_stage
+        description: Serve onboarding stage label.
+      - name: is_serve_opted_in
+        description: Whether the contact has opted into the Serve program.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: has_serve_results_viewed
+        description: Whether the contact has viewed their Serve results.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: serve_opt_in_at
+        description: Timestamp the contact opted into Serve.
+      - name: serve_activated_at
+        description: Timestamp the contact became a Serve activated user.
+      - name: serve_results_received_at
+        description: Timestamp Serve results were received for the contact.
+      - name: serve_results_viewed_at
+        description: Timestamp the contact viewed their Serve results.
+      - name: serve_lifecycle_lead_entered_at
+        description: Timestamp the contact became a Serve lifecycle Lead.
+      - name: serve_lifecycle_converted_entered_at
+        description: Timestamp the contact became a Serve lifecycle Converted.
+      - name: serve_lifecycle_activated_entered_at
+        description: Timestamp the contact became a Serve lifecycle Activated.
+      - name: serve_lifecycle_noshow_sql_entered_at
+        description: Timestamp the contact became a Serve lifecycle No-Show SQL.
+      - name: serve_lifecycle_opportunity_entered_at
+        description: Timestamp the contact became a Serve lifecycle Opportunity.
+      - name: serve_lifecycle_sal_entered_at
+        description: Timestamp the contact became a Serve lifecycle SAL.
+      - name: serve_lifecycle_sql_entered_at
+        description: Timestamp the contact became a Serve lifecycle SQL.
+      - name: serve_lifecycle_churned_entered_at
+        description: Timestamp the contact became Serve lifecycle Churned.
+      - name: serve_lifecycle_not_qualified_entered_at
+        description: Timestamp the contact became Serve lifecycle Not Qualified.
+      - name: serve_lifecycle_scheduled_sql_entered_at
+        description: Timestamp the contact became a Serve lifecycle Scheduled SQL.
+      - name: serve_lifecycle_retained_entered_at
+        description: Timestamp the contact became Serve lifecycle Retained.
+      - name: last_call_at
+        description: Date of the last recorded sales call.
+      - name: last_call_outcome
+        description: Outcome label from the last recorded sales call.
+      - name: last_contacted_at
+        description: HubSpot `notes_last_contacted` — timestamp of last contact activity.
+      - name: number_of_serve_calls
+        description: Count of Serve calls logged for this contact.
+      - name: pro_update_at
+        description: HubSpot `pro_upgrade_date` — timestamp of the Pro upgrade.
+      - name: contact_created_at
+        description: HubSpot `createdate` — when the contact was created in HubSpot.
   - name: stg_airbyte_source__hubspot_api_deals
     description: Deals data load from HubSpot API
     columns:

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
@@ -103,7 +103,9 @@ models:
         description: >
           Denormalized copy of `gp_api_db_user.id` stored on the HubSpot
           contact. Authoritative source is the users staging model from the
-          gp_api database.
+          gp_api database. Parsed from the HubSpot property
+          `goodparty_org_user_id` (named after the goodparty.org domain, not
+          an "org user" concept — this is the only user-ID key on the contact).
       - name: candidate_id_result
         description: HubSpot-tracked outcome of the candidate-ID research process.
       - name: candidate_type
@@ -288,7 +290,7 @@ models:
         description: HubSpot `notes_last_contacted` — timestamp of last contact activity.
       - name: number_of_serve_calls
         description: Count of Serve calls logged for this contact.
-      - name: pro_update_at
+      - name: pro_upgrade_at
         description: HubSpot `pro_upgrade_date` — timestamp of the Pro upgrade.
       - name: contact_created_at
         description: HubSpot `createdate` — when the contact was created in HubSpot.

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
@@ -52,7 +52,11 @@ select
     -- cross-system identifiers (sourced from HubSpot snapshot)
     -- NOTE: `goodparty_user_id` mirrors gp_api_db_user.id — the authoritative
     -- source is the users staging model from the gp_api database, not HubSpot.
-    get_json_object(properties, '$.goodparty_org_user_id') as goodparty_user_id,
+    -- The HubSpot property is named after the goodparty.org domain (not an
+    -- "org user" concept); it is the only user-ID key on the contact.
+    cast(
+        get_json_object(properties, '$.goodparty_org_user_id') as int
+    ) as goodparty_user_id,
 
     -- office information
     properties_official_office_name as official_office_name,
@@ -267,7 +271,7 @@ select
     ) as number_of_serve_calls,
     cast(
         get_json_object(properties, '$.pro_upgrade_date') as timestamp
-    ) as pro_update_at,
+    ) as pro_upgrade_at,
 
     -- metadata
     cast(

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
@@ -19,12 +19,40 @@ select
 
     -- candidate information
     properties_br_race_id as br_race_id,
+    get_json_object(properties, '$.br_candidacy_id') as br_candidacy_id,
+    get_json_object(properties, '$.br_position_id') as br_position_id,
     properties_candidate_id_source as candidate_id_source,
     properties_candidate_id_tier as candidate_id_tier,
+    get_json_object(properties, '$.candidate_id_result') as candidate_id_result,
+    get_json_object(properties, '$.candidate_type') as candidate_type,
+    {{ cast_to_boolean("get_json_object(properties, '$.confirmed_candidate')") }}
+    as is_confirmed_candidate,
+    {{ cast_to_boolean("get_json_object(properties, '$.filed_candidate')") }}
+    as is_filed_candidate,
+    {{ cast_to_boolean("get_json_object(properties, '$.pro_candidate')") }}
+    as is_pro_candidate,
+    {{ cast_to_boolean("get_json_object(properties, '$.has_ever_been_pro')") }}
+    as has_ever_been_pro,
     {{ cast_to_boolean("properties_pledge_status") }} as is_pledged,
+    get_json_object(properties, '$.pledge_status') as pledge_status,
+    {{ cast_to_boolean("get_json_object(properties, '$.email_pledge')") }}
+    as has_email_pledge,
+    {{ cast_to_boolean("get_json_object(properties, '$.verbal_pledge')") }}
+    as has_verbal_pledge,
+    {{ cast_to_boolean("get_json_object(properties, '$.verbal_pro')") }}
+    as has_verbal_pro,
+    {{ cast_to_boolean("get_json_object(properties, '$.verbal_serve')") }}
+    as has_verbal_serve,
     properties_verified_candidate_status as verified_candidate_status,
     properties_type as type,
     properties_product_user as product_user,
+    get_json_object(properties, '$.product_line') as product_line,
+    get_json_object(properties, '$.product_stage') as product_stage,
+
+    -- cross-system identifiers (sourced from HubSpot snapshot)
+    -- NOTE: `goodparty_user_id` mirrors gp_api_db_user.id — the authoritative
+    -- source is the users staging model from the gp_api database, not HubSpot.
+    get_json_object(properties, '$.goodparty_org_user_id') as goodparty_user_id,
 
     -- office information
     properties_official_office_name as official_office_name,
@@ -58,7 +86,193 @@ select
         cast(properties_number_of_seats_available as float) as int
     ) as number_of_seats_available,
 
+    -- hubspot ownership & marketing status
+    get_json_object(properties, '$.hubspot_owner_id') as hubspot_owner_id,
+    get_json_object(properties, '$.hs_marketable_status') as marketing_contact_status,
+    {{ cast_to_boolean("get_json_object(properties, '$.hs_is_unworked')") }}
+    as is_contact_unworked,
+
+    -- hubspot lifecycle / journey
+    get_json_object(properties, '$.lifecyclestage') as lifecycle_stage,
+    get_json_object(properties, '$.hs_journey_stage') as journey_stage,
+    get_json_object(properties, '$.hs_lead_status') as lead_status,
+    get_json_object(properties, '$.lead_source') as lead_source,
+    get_json_object(properties, '$.conversion_type') as conversion_type,
+
+    -- hubspot lifecycle stage entry timestamps
+    cast(
+        get_json_object(properties, '$.hs_v2_date_entered_current_stage') as timestamp
+    ) as lifecycle_current_stage_entered_at,
+    cast(
+        get_json_object(properties, '$.hs_v2_date_entered_customer') as timestamp
+    ) as lifecycle_customer_entered_at,
+    cast(
+        get_json_object(properties, '$.hs_v2_date_entered_evangelist') as timestamp
+    ) as lifecycle_evangelist_entered_at,
+    cast(
+        get_json_object(properties, '$.hs_v2_date_entered_lead') as timestamp
+    ) as lifecycle_lead_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.hs_v2_date_entered_marketingqualifiedlead'
+        ) as timestamp
+    ) as lifecycle_mql_entered_at,
+    cast(
+        get_json_object(properties, '$.hs_v2_date_entered_opportunity') as timestamp
+    ) as lifecycle_opportunity_entered_at,
+    cast(
+        get_json_object(properties, '$.hs_v2_date_entered_other') as timestamp
+    ) as lifecycle_other_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.hs_v2_date_entered_salesqualifiedlead'
+        ) as timestamp
+    ) as lifecycle_sql_entered_at,
+    cast(
+        get_json_object(properties, '$.hs_v2_date_entered_subscriber') as timestamp
+    ) as lifecycle_subscriber_entered_at,
+
+    -- win pipeline stage and stage-entry timestamps
+    get_json_object(properties, '$.win_stage') as win_stage,
+    cast(
+        get_json_object(properties, '$.date_entered_win_stage_0_intake') as timestamp
+    ) as win_stage_0_intake_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.date_entered_win_stage_1_newassigned'
+        ) as timestamp
+    ) as win_stage_1_new_assigned_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.date_entered_win_stage_2_discovery_complete'
+        ) as timestamp
+    ) as win_stage_2_discovery_complete_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.date_entered_win_stage_3_pro_presented'
+        ) as timestamp
+    ) as win_stage_3_pro_presented_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.date_entered_win_stage_4_pro_consideration'
+        ) as timestamp
+    ) as win_stage_4_pro_consideration_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.date_entered_win_stage_5_closed_won__pro'
+        ) as timestamp
+    ) as win_stage_5_closed_won_pro_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.date_entered_win_stage_6_activated_pro_user'
+        ) as timestamp
+    ) as win_stage_6_activated_pro_user_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.date_entered_win_stage_closed_too_early'
+        ) as timestamp
+    ) as win_stage_closed_too_early_entered_at,
+
+    -- win / serve ICP and activation
+    -- NOTE: `win_icp` and `serve_icp` are stored in HubSpot as a snapshot of
+    -- our own ICP model. The authoritative ICP values come from the ICP dbt
+    -- model, not this staging column.
+    get_json_object(properties, '$.win_icp') as win_icp,
+    get_json_object(properties, '$.serve_icp') as serve_icp,
+    -- NOTE: `win_activated_user` / `serve_activated_user` mirror activation
+    -- status from the product `users` table; HubSpot holds a denormalized copy.
+    get_json_object(properties, '$.win_activated_user') as win_activated_user,
+    get_json_object(properties, '$.serve_activated_user') as serve_activated_user,
+
+    -- serve pipeline stage, onboarding, and activity
+    get_json_object(properties, '$.serve_stage') as serve_stage,
+    get_json_object(properties, '$.serve_onboarding_stage') as serve_onboarding_stage,
+    {{ cast_to_boolean("get_json_object(properties, '$.serve_opted_in')") }}
+    as is_serve_opted_in,
+    {{ cast_to_boolean("get_json_object(properties, '$.serve_results_viewed')") }}
+    as has_serve_results_viewed,
+    cast(
+        get_json_object(properties, '$.serve_optin_date') as timestamp
+    ) as serve_opt_in_at,
+    cast(
+        get_json_object(properties, '$.serve_activated_date') as timestamp
+    ) as serve_activated_at,
+    cast(
+        get_json_object(properties, '$.serve_results_received_date') as timestamp
+    ) as serve_results_received_at,
+    cast(
+        get_json_object(properties, '$.serve_results_viewed_date') as timestamp
+    ) as serve_results_viewed_at,
+
+    -- serve lifecycle stage entry timestamps
+    cast(
+        get_json_object(
+            properties, '$.serve_lifecycle_stage__became_a_lead_date'
+        ) as timestamp
+    ) as serve_lifecycle_lead_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.servelifecyclestagebecameaconverteddate'
+        ) as timestamp
+    ) as serve_lifecycle_converted_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.servelifecyclestagebecameanactivateddate'
+        ) as timestamp
+    ) as serve_lifecycle_activated_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.serve_lifecycle_stage__became_an_noshow_sql_date'
+        ) as timestamp
+    ) as serve_lifecycle_noshow_sql_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.servelifecyclestagebecameanopportunitydate'
+        ) as timestamp
+    ) as serve_lifecycle_opportunity_entered_at,
+    cast(
+        get_json_object(properties, '$.servelifecyclestagebecameansaldate') as timestamp
+    ) as serve_lifecycle_sal_entered_at,
+    cast(
+        get_json_object(properties, '$.servelifecyclestagebecameansqldate') as timestamp
+    ) as serve_lifecycle_sql_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.servelifecyclestagebecamechurneddate'
+        ) as timestamp
+    ) as serve_lifecycle_churned_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.serve_lifecycle_stage_became_not_qualified_date'
+        ) as timestamp
+    ) as serve_lifecycle_not_qualified_entered_at,
+    cast(
+        get_json_object(
+            properties, '$.servelifecyclestagebecamescheduledsqldate'
+        ) as timestamp
+    ) as serve_lifecycle_scheduled_sql_entered_at,
+    cast(
+        get_json_object(properties, '$.became_a_retained_date') as timestamp
+    ) as serve_lifecycle_retained_entered_at,
+    -- NOTE: "Serve Lifecycle Stages - Became an MQL date" has no matching
+    -- HubSpot property key in current source data; column omitted.
+    -- call and contact activity
+    cast(get_json_object(properties, '$.last_call_date') as date) as last_call_at,
+    get_json_object(properties, '$.last_call_outcome') as last_call_outcome,
+    cast(
+        get_json_object(properties, '$.notes_last_contacted') as timestamp
+    ) as last_contacted_at,
+    cast(
+        get_json_object(properties, '$.number_of_serve_calls') as int
+    ) as number_of_serve_calls,
+    cast(
+        get_json_object(properties, '$.pro_upgrade_date') as timestamp
+    ) as pro_update_at,
+
     -- metadata
+    cast(
+        get_json_object(properties, '$.createdate') as timestamp
+    ) as contact_created_at,
     createdat as created_at,
     updatedat as updated_at
 from {{ source("airbyte_source", "hubspot_api_contacts") }}


### PR DESCRIPTION
## Summary
- Parse ~65 additional HubSpot contact properties out of the raw `properties` JSON into typed staging columns in `stg_airbyte_source__hubspot_api_contacts` — candidate/pledge flags, lifecycle and Win pipeline stage-entry timestamps, Serve pipeline stage + lifecycle timestamps, ownership/marketing status, and call activity.
- Document in the yaml (table- and column-level) that a handful of these columns are *denormalized snapshots* of data that is authoritative elsewhere in the project, so downstream models prefer the real source:
  - `br_candidacy_id` / `br_position_id` / `br_race_id` → BallotReady staging/intermediate models
  - `goodparty_user_id` → gp_api users staging model
  - `win_icp` / `serve_icp` → ICP dbt model
  - `win_activated_user` / `serve_activated_user` → product users table
- Add `accepted_values [true, false]` tests for all new boolean columns.

One gap worth flagging: the requested "Serve Lifecycle Stages - Became an MQL date" has no matching HubSpot property key in current source data (checked several spelling variants across the full table), so the column is omitted with an inline comment.

## Test plan
- [x] `dbt build --select stg_airbyte_source__hubspot_api_contacts` — model builds, 20/20 tests pass
- [ ] Reviewer eyeballs the HubSpot-JSON-key → staging-column mapping for the new columns
- [ ] Confirm the naming convention for the "denormalized snapshot" columns (`win_icp`, `goodparty_user_id`, etc.) is acceptable, or request a prefix like `hs_` to make the non-authoritative source more obvious at call sites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it significantly expands the `stg_airbyte_source__hubspot_api_contacts` schema with many newly parsed columns and casts, which can affect downstream models expecting the old shape or relying on raw JSON keys/typing.
> 
> **Overview**
> `stg_airbyte_source__hubspot_api_contacts` now parses a large set of additional HubSpot contact properties from the raw `properties` JSON into explicit staging columns (candidate/pledge flags, ownership & marketing status, lifecycle and Win/Serve pipeline fields, stage-entry timestamps, and call/activity metrics), including new typed casts and boolean normalization via `cast_to_boolean`.
> 
> The HubSpot staging YAML is expanded to document these new fields and clarify which identifiers/classifications are *denormalized snapshots* that are authoritative elsewhere (e.g., BallotReady IDs, `goodparty_user_id`, ICP/activation snapshots), and adds `accepted_values` tests for the newly introduced boolean columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa01a88bed546fb446b25b1e6a06b334e6ff27b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->