### PR TITLE
Override L2/BR match for Katy ISD Board Position 4

### DIFF
--- a/dbt/project/seeds/l2_br_match_overrides.csv
+++ b/dbt/project/seeds/l2_br_match_overrides.csv
@@ -11,3 +11,4 @@ br_database_id,br_position_name,state,l2_district_type,l2_district_name,reason
 267702,Georgia Public Service Commission - District 4,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 167255,Georgia Public Service Commission - District 5,GA,State,GA,Office holder must reside in district but election is statewide (https://ballotpedia.org/Georgia_Public_Service_Commission)
 289892,"Circuit Court Judge - Circuit 9, Seat 2",FL,County,ORANGE,FL Circuit 9 spans Orange and Osceola counties; L2 has no Judicial_Circuit_Court_District for FL. Mapping to primary county (Orange) covers ~78% of voters. Multi-county district joins not yet supported (DATA-1837)
+138417,Katy Independent School Board - Position 4,TX,School_District,KATY ISD (EST.),LLM match returned NOT_MATCHED for this seat while the six sibling Katy ISD board positions all matched to School_District / KATY ISD (EST.)


### PR DESCRIPTION
## Summary

- The LLM-based L2/BR position matcher returned `NOT_MATCHED` for `br_database_id=138417` (Katy Independent School Board - Position 4), while all six sibling Katy ISD board positions matched correctly to `School_District / KATY ISD (EST.)`.
- Without an override, `m_election_api__position.sql` drops the seat (the `tbl_district.id is not null` filter on line 42 excludes it), which means the position does not land in the election-api DB.
- Downstream impact: the seat is not selectable in the district/position picker, and the voter file cannot be resolved for candidates running for it. This is the data-side cause of a support ticket about `jimdavidsonforkaty@gmail.com`.

## Verification

Built locally:

```
dbt build --select "l2_br_match_overrides m_election_api__position"
```
22 of 23 tests passed. The single failure (`relationships_m_election_api__zip_to_position_position_id__id__ref_m_election_api__position_`) is an unrelated cross-model test that needs `m_election_api__zip_to_position` materialized in the dev schema; it will pass in prod once that model is also built.

After the build, `dbt show` on the rebuilt mart confirms the seat now resolves:

| br_database_id | name | state | district_id |
|---|---|---|---|
| 138417 | Katy Independent School Board - Position 4 | TX | 8d36abb9-d2aa-0fd8-6783-ee745cc0dd70 |

That district_id matches the six sibling Katy ISD board positions (1, 2, 3, 5, 6, 7).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single seed override row to correct one position-to-district mapping, affecting only downstream district resolution for that BR position.
> 
> **Overview**
> Forces `br_database_id=138417` (Katy ISD Board Position 4) to resolve to `TX / School_District / KATY ISD (EST.)` by adding a new row to the `l2_br_match_overrides` seed.
> 
> This ensures `m_election_api__position` can join the position to a non-null `district_id` (instead of being dropped when the LLM matcher returns `NOT_MATCHED`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957c51a4d3d40548898d064cc2fff698ab9ecaac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->