### PR TITLE
Fix er_source accepted_values test failures

### DIFF
--- a/dbt/project/models/staging/er_source/__er_source.yaml
+++ b/dbt/project/models/staging/er_source/__er_source.yaml
@@ -41,7 +41,7 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready", "techspeed", "ddhq"]
+              values: ["ballotready", "techspeed", "ddhq", "gp_api"]
       - name: first_name
         description: Candidate first name (lowercased, trimmed in prematch).
       - name: last_name
@@ -68,10 +68,18 @@ models:
       - name: election_date
         description: Date of the election stage.
       - name: election_stage
-        description: Election stage (Primary, General, or Runoff).
+        description: Election stage (Primary, General, Runoff, or Special variants).
         data_tests:
           - accepted_values:
-              values: ["Primary", "General", "Runoff"]
+              values:
+                - "Primary"
+                - "General"
+                - "Primary Runoff"
+                - "General Runoff"
+                - "Primary Special"
+                - "General Special"
+                - "Primary Special Runoff"
+                - "General Special Runoff"
       - name: email
         description: Candidate email address (sparse — used as a high-signal comparison in matching).
       - name: phone
@@ -130,13 +138,13 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready", "techspeed", "ddhq"]
+              values: ["ballotready", "techspeed", "ddhq", "gp_api"]
       - name: source_name_r
         description: Origin source for the right record.
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready", "techspeed", "ddhq"]
+              values: ["ballotready", "techspeed", "ddhq", "gp_api"]
       - name: source_id_l
         description: Left record's source-specific identifier.
       - name: source_id_r


### PR DESCRIPTION
## Summary
- Add `gp_api` to the `source_name` / `source_name_l` / `source_name_r` accepted_values tests on `stg_er_source__clustered_candidacy_stages` and `stg_er_source__pairwise_candidacy_stages`. The entity-resolution pipeline now emits a fourth source alongside ballotready/techspeed/ddhq.
- Expand the `election_stage` accepted_values test to cover the full stage domain: Primary, General, Primary/General Runoff, and the Primary/General Special (Runoff) variants. The prior list of Primary/General/Runoff did not match the upstream data.

## Test plan
- [x] dbt test --select "stg_er_source__clustered_candidacy_stages stg_er_source__pairwise_candidacy_stages" -> 15/15 PASS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates dbt schema `accepted_values` tests to match newly observed upstream values and does not change model SQL or transformations.
> 
> **Overview**
> Updates dbt schema tests for the ER-source staging models to accept a new `source_name` value (`gp_api`) in both clustered and pairwise candidacy-stage outputs.
> 
> Expands the `election_stage` `accepted_values` domain from just Primary/General/Runoff to include runoff and special-election variants (e.g. `Primary Runoff`, `General Special Runoff`), aligning tests with upstream data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f34d66f83aea45e46f2f57753d1ed06ef8dbad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->