### PR TITLE
[DATA-1718] Mark archive_2025 mart rows as ddhq-sourced when DDHQ contributed

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_2025.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_2025.sql
@@ -25,6 +25,16 @@ with
             = 1
     ),
 
+    -- Per-candidacy DDHQ match flag from the legacy LLM matcher. A candidacy
+    -- can have multiple match rows (one per stage); collapse to a single
+    -- boolean before joining so we don't fan out the candidacies grain.
+    ddhq_match_by_candidacy as (
+        select gp_candidacy_id, bool_or(coalesce(has_match, false)) as has_ddhq_match
+        from {{ ref("int__gp_ai_election_match") }}
+        where gp_candidacy_id is not null
+        group by gp_candidacy_id
+    ),
+
     candidacies as (
         select
             -- Identifiers
@@ -78,6 +88,11 @@ with
             cast(cast(tbl_companies.win_number as float) as int) as win_number,
             tbl_companies.win_number_model,
 
+            -- DDHQ provenance: true when the legacy LLM matcher linked this
+            -- candidacy to a DDHQ race. Drives 'ddhq' membership in the
+            -- mart's source_systems array for archive_2025 rows.
+            coalesce(tbl_ddhq_match.has_ddhq_match, false) as has_ddhq_match,
+
             -- loading data
             tbl_companies.created_at,
             tbl_companies.updated_at
@@ -95,6 +110,9 @@ with
         left join
             {{ ref("stg_model_predictions__viability_scores") }} as viability_scores
             on tbl_companies.company_id = viability_scores.id
+        left join
+            ddhq_match_by_candidacy as tbl_ddhq_match
+            on tbl_companies.gp_candidacy_id = tbl_ddhq_match.gp_candidacy_id
     ),
 
     -- Filter to elections on or before 2025-12-31
@@ -162,6 +180,7 @@ select
     viability_score,
     win_number,
     win_number_model,
+    has_ddhq_match,
     created_at,
     updated_at
 

--- a/dbt/project/models/intermediate/civics/int__civics_candidate_2025.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidate_2025.sql
@@ -4,6 +4,18 @@
 -- Uses archived HubSpot data from 2026-01-22 snapshot
 -- Uses companies-based model for better coverage (joins via companies.contacts field)
 with
+    -- Per-candidacy DDHQ match flag from the legacy LLM matcher. Joined on
+    -- the company-row's gp_candidacy_id; propagated to candidate grain via
+    -- a bool_or window once gp_candidate_id is known. We don't reuse
+    -- int__civics_candidacy_2025 here to avoid a circular dependency
+    -- (candidacy_2025 already imports candidate_2025).
+    ddhq_match_by_candidacy as (
+        select gp_candidacy_id, bool_or(coalesce(has_match, false)) as has_ddhq_match
+        from {{ ref("int__gp_ai_election_match") }}
+        where gp_candidacy_id is not null
+        group by gp_candidacy_id
+    ),
+
     ranked_candidates as (
         select
             tbl_hs_companies.contact_id as hubspot_contact_id,
@@ -33,6 +45,9 @@ with
             tbl_hs_companies.created_at,
             tbl_hs_companies.updated_at,
 
+            -- Per-row DDHQ flag; rolled up to candidate grain in candidates_with_id.
+            coalesce(tbl_ddhq_match.has_ddhq_match, false) as company_has_ddhq_match,
+
             -- Rank records by updated_at when prod_db_user_id is not null
             case
                 when tbl_gp_user.id is not null
@@ -51,6 +66,9 @@ with
         left join
             {{ ref("stg_airbyte_source__gp_api_db_user") }} as tbl_gp_user
             on tbl_hs_companies.contact_id = tbl_gp_user.meta_data:hubspotid::string
+        left join
+            ddhq_match_by_candidacy as tbl_ddhq_match
+            on tbl_hs_companies.gp_candidacy_id = tbl_ddhq_match.gp_candidacy_id
         qualify
             row_number() over (
                 partition by tbl_hs_companies.gp_candidacy_id
@@ -89,6 +107,24 @@ with
             twitter_handle,
             facebook_url,
             instagram_handle,
+            -- Candidate-grain DDHQ flag: true if any of the candidate's
+            -- candidacies had a DDHQ match. Computed before the final
+            -- gp_candidate_id dedup so all surviving rows agree.
+            bool_or(company_has_ddhq_match) over (
+                partition by
+                    {{
+                        generate_salted_uuid(
+                            fields=[
+                                "first_name",
+                                "last_name",
+                                "state",
+                                "birth_date",
+                                "email",
+                                "phone_number",
+                            ]
+                        )
+                    }}
+            ) as has_ddhq_match,
             created_at,
             updated_at
         from ranked_candidates
@@ -121,6 +157,7 @@ select
     archived_candidates.twitter_handle,
     archived_candidates.facebook_url,
     archived_candidates.instagram_handle,
+    archived_candidates.has_ddhq_match,
     archived_candidates.created_at,
     archived_candidates.updated_at
 

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -60,7 +60,9 @@ with
             is_incumbent,
             office_type,
             br_position_database_id,
-            array('hubspot') as source_systems
+            array_compact(
+                array('hubspot', case when has_ddhq_match then 'ddhq' end)
+            ) as source_systems
         from {{ ref("int__civics_candidacy_2025") }}
     ),
 

--- a/dbt/project/models/marts/civics/candidacy_stage.sql
+++ b/dbt/project/models/marts/civics/candidacy_stage.sql
@@ -42,7 +42,9 @@ with
             election_stage_date,
             created_at,
             updated_at,
-            array('hubspot') as source_systems
+            array_compact(
+                array('hubspot', case when has_match then 'ddhq' end)
+            ) as source_systems
         from {{ ref("int__civics_candidacy_stage_2025") }}
     ),
 

--- a/dbt/project/models/marts/civics/candidate.sql
+++ b/dbt/project/models/marts/civics/candidate.sql
@@ -48,7 +48,9 @@ with
             ) as birth_date,
             phone_number,
             facebook_url,
-            array('hubspot') as source_systems
+            array_compact(
+                array('hubspot', case when has_ddhq_match then 'ddhq' end)
+            ) as source_systems
         from {{ ref("int__civics_candidate_2025") }}
     ),
 

--- a/dbt/project/models/marts/civics/election.sql
+++ b/dbt/project/models/marts/civics/election.sql
@@ -43,7 +43,9 @@ with
             is_judicial,
             is_appointed,
             br_normalized_position_type,
-            array('hubspot') as source_systems
+            array_compact(
+                array('hubspot', case when has_ddhq_match then 'ddhq' end)
+            ) as source_systems
         from {{ ref("int__civics_election_2025") }}
     ),
 

--- a/dbt/project/models/marts/civics/election_stage.sql
+++ b/dbt/project/models/marts/civics/election_stage.sql
@@ -49,7 +49,9 @@ with
             cast(null as string) as filing_requirements,
             cast(null as string) as filing_address,
             cast(null as string) as filing_phone,
-            array('hubspot') as source_systems
+            array_compact(
+                array('hubspot', case when ddhq_race_id is not null then 'ddhq' end)
+            ) as source_systems
         from {{ ref("int__civics_election_stage_2025") }}
     ),
 


### PR DESCRIPTION
## Summary

The five civics mart tables (candidate, candidacy, candidacy_stage, election, election_stage) have an `archive_2025` CTE that already pulls DDHQ-derived columns — `votes_received`, `is_winner` (from `ddhq_is_winner`), `election_result_source = 'ddhq'`, `has_ddhq_match`, `ddhq_race_id`, `total_votes_cast` — onto rows the legacy LLM matcher linked to a DDHQ race. But every mart was hardcoding `source_systems` to `array('hubspot')` for those rows, so downstream consumers had no way to tell from the source_systems column that DDHQ shaped the row.

This PR closes that consistency gap. It does not change any other column values or grains, and does not touch the 2026+ live-data path.

## Changes

- `int__civics_candidacy_2025.sql`: aggregate `int__gp_ai_election_match` by `gp_candidacy_id` (collapse multiple stage-level match rows into a single boolean) and expose a new `has_ddhq_match` column.
- `int__civics_candidate_2025.sql`: same aggregation joined via the company row's `gp_candidacy_id`, then rolled up to candidate grain with a `bool_or() over (partition by gp_candidate_id)` window before final dedup. Avoids depending on `int__civics_candidacy_2025` to prevent a circular ref.
- 5 mart files: replace `array('hubspot') as source_systems` with `array_compact(array('hubspot', case when <signal> then 'ddhq' end))`.

Per-mart signal:

| Mart | Signal |
|------|--------|
| `candidacy_stage` | `has_match` (already on `int__civics_candidacy_stage_2025`) |
| `candidacy` | `has_ddhq_match` (new on `int__civics_candidacy_2025`) |
| `candidate` | `has_ddhq_match` (new on `int__civics_candidate_2025`) |
| `election` | `has_ddhq_match` (already on `int__civics_election_2025`) |
| `election_stage` | `ddhq_race_id is not null` (already on `int__civics_election_stage_2025`) |

## Verification

`dbt build --select int__civics_candidacy_2025+ int__civics_candidate_2025+`: 179 PASS / 2 WARN (pre-existing) / 0 ERROR. All existing relationships, uniqueness, not-null, and accepted-values tests on the affected marts still pass.

After build, `'ddhq'` appears in `source_systems` on:

| Mart | Total rows | Rows with 'ddhq' |
|------|-----------:|------------------:|
| candidacy_stage | 275,051 | 2,256 |
| candidacy       | 242,188 | 2,234 |
| candidate       | 326,176 | 2,244 |
| election        | 474,666 | 1,121 |
| election_stage  | 770,210 | 1,705 |

100% of ddhq-tagged rows also carry `'hubspot'`, as expected — this path only changes archive_2025 rows.

For candidacy_stage, the 5-row gap between `election_result_source = 'ddhq'` (2,251) and `'ddhq' in source_systems` (2,256) is intentional: the 5 extra rows are 2025-archive cases where the LLM matcher linked a DDHQ candidate (`has_match = true`) but the matched DDHQ row had `ddhq_is_winner = null`, so `election_result_source` stayed null/hubspot. We still want `'ddhq'` in `source_systems` for those rows because DDHQ contributed to the row even if it didn't determine the result.

## Scope

This is the first of three planned PRs for DATA-1718. Out of scope here:
- Joining 2026+ DDHQ intermediates into the marts via the ER crosswalk (next PR — adds 'ddhq' to merged_since_2026 source_systems too).
- Mart-level documentation for DDHQ provenance and domain-expert tests (third PR).

## Test plan

- [x] `dbt parse` — clean
- [x] `dbt build --select int__civics_candidacy_2025+ int__civics_candidate_2025+` — 179 PASS / 0 ERROR
- [x] Spot-check `source_systems` row counts in all 5 marts post-build
- [ ] Reviewer to confirm the 5-row gap explanation is acceptable, or request a tighter signal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to archive_2025 provenance tagging and a new boolean column; main risk is downstream consumers reacting to the expanded `source_systems` values rather than data correctness.
> 
> **Overview**
> Updates the 2025 archive intermediates to compute a per-entity DDHQ match indicator from `int__gp_ai_election_match` (collapsing stage-level rows with `bool_or`), exposing `has_ddhq_match` on `int__civics_candidacy_2025` and rolling it up to candidate-grain in `int__civics_candidate_2025`.
> 
> Adjusts the `archive_2025` CTEs in the five civics marts (`candidate`, `candidacy`, `candidacy_stage`, `election`, `election_stage`) so `source_systems` is no longer hardcoded to `['hubspot']` and instead conditionally includes `'ddhq'` when DDHQ contributed (via `has_ddhq_match`/`has_match`/`ddhq_race_id`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36cf7d5f440c94fdd2a1aab084dd4d901376eef8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->