### PR TITLE
[DATA-1718] Merge 2026+ DDHQ data into civics marts via ER crosswalk

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
@@ -196,7 +196,9 @@ with
                 then 'Lost'
                 else null
             end as election_result,
-            'ddhq' as election_result_source
+            case
+                when s.is_winner is not null then 'ddhq' else null
+            end as election_result_source
 
         from source as s
         inner join

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
@@ -83,41 +83,74 @@ with
             year(election_date)
     ),
 
+    -- ER crosswalk: when Splink clustered this DDHQ row with a BR row, adopt
+    -- BR's canonical gp_* IDs so the mart's full outer join collapses
+    -- matched DDHQ + BR/TS pairs onto the same key. Pre-restricted to DDHQ
+    -- rows so we keep this lookup small.
+    canonical_ids as (
+        select
+            ddhq_candidate_id,
+            ddhq_race_id,
+            canonical_gp_candidacy_stage_id,
+            canonical_gp_election_stage_id,
+            canonical_gp_candidacy_id,
+            canonical_gp_candidate_id,
+            canonical_gp_election_id
+        from {{ ref("int__civics_er_canonical_ids") }}
+        where ddhq_candidate_id is not null and ddhq_race_id is not null
+    ),
+
     with_ids as (
         select
-            -- === Computed IDs ===
-            {{
-                generate_salted_uuid(
-                    fields=[
-                        "s.candidate_first_name",
-                        "s.candidate_last_name",
-                        "s.state_postal_code",
-                        "cast(null as string)",
-                        "cast(null as string)",
-                        "cast(null as string)",
-                    ]
-                )
-            }} as gp_candidate_id,
+            -- === Computed IDs (canonical from BR if Splink-matched, else hashed) ===
+            coalesce(
+                xw.canonical_gp_candidate_id,
+                {{
+                    generate_salted_uuid(
+                        fields=[
+                            "s.candidate_first_name",
+                            "s.candidate_last_name",
+                            "s.state_postal_code",
+                            "cast(null as string)",
+                            "cast(null as string)",
+                            "cast(null as string)",
+                        ]
+                    )
+                }}
+            ) as gp_candidate_id,
 
-            {{
-                generate_salted_uuid(
-                    fields=[
-                        "s.candidate_first_name",
-                        "s.candidate_last_name",
-                        "s.state_postal_code",
-                        "s.party_affiliation",
-                        "s.candidate_office",
-                        "cast(coalesce(cd.general_date, cd.primary_date, cd.general_runoff_date, cd.primary_runoff_date) as string)",
-                        "s.district",
-                    ]
-                )
-            }}
-            as gp_candidacy_id,
+            coalesce(
+                xw.canonical_gp_candidacy_id,
+                {{
+                    generate_salted_uuid(
+                        fields=[
+                            "s.candidate_first_name",
+                            "s.candidate_last_name",
+                            "s.state_postal_code",
+                            "s.party_affiliation",
+                            "s.candidate_office",
+                            "cast(coalesce(cd.general_date, cd.primary_date, cd.general_runoff_date, cd.primary_runoff_date) as string)",
+                            "s.district",
+                        ]
+                    )
+                }}
+            ) as gp_candidacy_id,
 
-            {{ generate_salted_uuid(fields=["cast(s.ddhq_race_id as string)"]) }}
-            as gp_election_stage_id,
+            coalesce(
+                xw.canonical_gp_election_stage_id,
+                {{ generate_salted_uuid(fields=["cast(s.ddhq_race_id as string)"]) }}
+            ) as gp_election_stage_id,
 
-            {{ generate_gp_election_id("elec_lookup") }} as gp_election_id,
+            coalesce(
+                xw.canonical_gp_election_id,
+                {{ generate_gp_election_id("elec_lookup") }}
+            ) as gp_election_id,
+
+            -- Carry the canonical candidacy_stage id forward so the next CTE
+            -- can coalesce it against the (gp_candidacy_id, gp_election_stage_id)
+            -- hash. Necessary because BR's gp_candidacy_stage_id is generated
+            -- by BR's int model, not from the same hash inputs we use here.
+            xw.canonical_gp_candidacy_stage_id,
 
             -- === Staging passthrough ===
             s.candidate as candidate_full_name,
@@ -126,7 +159,7 @@ with
             cast(s.candidate_id as string) as source_candidate_id,
             cast(s.ddhq_race_id as string) as source_race_id,
             s.ddhq_race_id,
-            s.state_name,
+            s.state,
             s.state_postal_code,
             s.party_affiliation,
             s.candidate_office,
@@ -199,15 +232,23 @@ with
                         ged.general_seats, s.number_of_seats_in_election
                     ) as seats_available
             ) as elec_lookup
+        left join
+            canonical_ids as xw
+            on cast(s.candidate_id as bigint) = xw.ddhq_candidate_id
+            and cast(s.ddhq_race_id as bigint) = xw.ddhq_race_id
     ),
 
     candidacy_stages as (
         select
-            {{
-                generate_salted_uuid(
-                    fields=["gp_candidacy_id", "gp_election_stage_id"]
-                )
-            }} as gp_candidacy_stage_id, *
+            coalesce(
+                canonical_gp_candidacy_stage_id,
+                {{
+                    generate_salted_uuid(
+                        fields=["gp_candidacy_id", "gp_election_stage_id"]
+                    )
+                }}
+            ) as gp_candidacy_stage_id,
+            * except (canonical_gp_candidacy_stage_id)
         from with_ids
     ),
 
@@ -238,7 +279,7 @@ select
     -- Race / election fields
     source_race_id,
     ddhq_race_id,
-    state_name,
+    state,
     state_postal_code,
     party_affiliation,
     candidate_office,

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_ddhq.sql
@@ -103,6 +103,8 @@ with
     with_ids as (
         select
             -- === Computed IDs (canonical from BR if Splink-matched, else hashed) ===
+            -- Lateral column refs let us derive gp_candidacy_stage_id from the
+            -- same-row gp_candidacy_id / gp_election_stage_id without a chained CTE.
             coalesce(
                 xw.canonical_gp_candidate_id,
                 {{
@@ -146,11 +148,14 @@ with
                 {{ generate_gp_election_id("elec_lookup") }}
             ) as gp_election_id,
 
-            -- Carry the canonical candidacy_stage id forward so the next CTE
-            -- can coalesce it against the (gp_candidacy_id, gp_election_stage_id)
-            -- hash. Necessary because BR's gp_candidacy_stage_id is generated
-            -- by BR's int model, not from the same hash inputs we use here.
-            xw.canonical_gp_candidacy_stage_id,
+            coalesce(
+                xw.canonical_gp_candidacy_stage_id,
+                {{
+                    generate_salted_uuid(
+                        fields=["gp_candidacy_id", "gp_election_stage_id"]
+                    )
+                }}
+            ) as gp_candidacy_stage_id,
 
             -- === Staging passthrough ===
             s.candidate as candidate_full_name,
@@ -238,23 +243,9 @@ with
             and cast(s.ddhq_race_id as bigint) = xw.ddhq_race_id
     ),
 
-    candidacy_stages as (
-        select
-            coalesce(
-                canonical_gp_candidacy_stage_id,
-                {{
-                    generate_salted_uuid(
-                        fields=["gp_candidacy_id", "gp_election_stage_id"]
-                    )
-                }}
-            ) as gp_candidacy_stage_id,
-            * except (canonical_gp_candidacy_stage_id)
-        from with_ids
-    ),
-
     deduplicated as (
         select *
-        from candidacy_stages
+        from with_ids
         qualify
             row_number() over (
                 partition by gp_candidacy_stage_id order by _airbyte_extracted_at desc

--- a/dbt/project/models/intermediate/civics/int__civics_candidate_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidate_ddhq.sql
@@ -23,7 +23,7 @@ select
     candidate_last_name as last_name,
     candidate_full_name as full_name,
     cast(null as date) as birth_date,
-    state_name as state,
+    state,
     state_postal_code,
     cast(null as string) as email,
     cast(null as string) as phone_number,

--- a/dbt/project/models/intermediate/civics/int__civics_election_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_ddhq.sql
@@ -28,7 +28,7 @@ select
     candidate_office,
     office_level,
     office_type,
-    state_name as state,
+    state,
     state_postal_code,
     cast(null as string) as city,
     district,

--- a/dbt/project/models/intermediate/civics/int__civics_election_stage_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_stage_ddhq.sql
@@ -20,7 +20,7 @@ with
             any_value(election_stage) as stage_type,
             any_value(election_date) as election_date,
 
-            any_value(state_name) as state,
+            any_value(state) as state,
             any_value(state_postal_code) as state_postal_code,
 
             any_value(state_postal_code)

--- a/dbt/project/models/intermediate/civics/int__civics_er_canonical_ids.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_er_canonical_ids.sql
@@ -5,8 +5,10 @@
 -- BR's IDs. Keyed on raw provider fields (not provider-computed hashes) to
 -- avoid a cycle with the consuming provider models.
 --
--- Providers: TechSpeed (ts_source_candidate_id + ts_stage_election_date) and
--- Product DB / gp_api (gp_api_campaign_id + gp_api_stage_election_date).
+-- Providers:
+-- TechSpeed (ts_source_candidate_id + ts_stage_election_date)
+-- Product DB / gp_api (gp_api_campaign_id + gp_api_stage_election_date)
+-- DDHQ (ddhq_candidate_id + ddhq_race_id)
 with
     ts_stage_matches as (
         select
@@ -16,6 +18,8 @@ with
             cast(ts_cw.election_date as date) as ts_stage_election_date,
             cast(null as bigint) as gp_api_campaign_id,
             cast(null as date) as gp_api_stage_election_date,
+            cast(null as bigint) as ddhq_candidate_id,
+            cast(null as bigint) as ddhq_race_id,
             br_cs.gp_candidacy_stage_id as canonical_gp_candidacy_stage_id,
             br_cs.gp_election_stage_id as canonical_gp_election_stage_id,
             br_cs.gp_candidacy_id as canonical_gp_candidacy_id,
@@ -53,6 +57,8 @@ with
             -- variant (general_runoff, primary_special_runoff, …), so split.
             cast(split(gp_cw.source_id, '__')[0] as bigint) as gp_api_campaign_id,
             cast(gp_cw.election_date as date) as gp_api_stage_election_date,
+            cast(null as bigint) as ddhq_candidate_id,
+            cast(null as bigint) as ddhq_race_id,
             br_cs.gp_candidacy_stage_id as canonical_gp_candidacy_stage_id,
             br_cs.gp_election_stage_id as canonical_gp_election_stage_id,
             br_cs.gp_candidacy_id as canonical_gp_candidacy_id,
@@ -80,6 +86,44 @@ with
                 order by br_updated_at desc
             )
             = 1
+    ),
+
+    ddhq_stage_matches as (
+        select
+            cast(null as string) as ts_source_candidate_id,
+            cast(null as date) as ts_stage_election_date,
+            cast(null as bigint) as gp_api_campaign_id,
+            cast(null as date) as gp_api_stage_election_date,
+            -- DDHQ source_id is '{candidate_id}_{race_id}' (both integers cast
+            -- to string in int__er_prematch_candidacy_stages), so split on '_'.
+            cast(split(ddhq_cw.source_id, '_')[0] as bigint) as ddhq_candidate_id,
+            cast(split(ddhq_cw.source_id, '_')[1] as bigint) as ddhq_race_id,
+            br_cs.gp_candidacy_stage_id as canonical_gp_candidacy_stage_id,
+            br_cs.gp_election_stage_id as canonical_gp_election_stage_id,
+            br_cs.gp_candidacy_id as canonical_gp_candidacy_id,
+            br_c.gp_candidate_id as canonical_gp_candidate_id,
+            br_es.gp_election_id as canonical_gp_election_id,
+            br_cs.updated_at as br_updated_at
+        from {{ ref("stg_er_source__clustered_candidacy_stages") }} as br_cw
+        inner join
+            {{ ref("stg_er_source__clustered_candidacy_stages") }} as ddhq_cw using (
+                cluster_id
+            )
+        inner join
+            {{ ref("int__civics_candidacy_stage_ballotready") }} as br_cs
+            on br_cw.br_candidacy_id = br_cs.br_candidacy_id
+        inner join
+            {{ ref("int__civics_candidacy_ballotready") }} as br_c
+            on br_cs.gp_candidacy_id = br_c.gp_candidacy_id
+        inner join
+            {{ ref("int__civics_election_stage_ballotready") }} as br_es
+            on br_cs.gp_election_stage_id = br_es.gp_election_stage_id
+        where br_cw.source_name = 'ballotready' and ddhq_cw.source_name = 'ddhq'
+        qualify
+            row_number() over (
+                partition by ddhq_candidate_id, ddhq_race_id order by br_updated_at desc
+            )
+            = 1
     )
 
 select
@@ -87,6 +131,8 @@ select
     ts_stage_election_date,
     gp_api_campaign_id,
     gp_api_stage_election_date,
+    ddhq_candidate_id,
+    ddhq_race_id,
     canonical_gp_candidacy_stage_id,
     canonical_gp_election_stage_id,
     canonical_gp_candidacy_id,
@@ -99,9 +145,25 @@ select
     ts_stage_election_date,
     gp_api_campaign_id,
     gp_api_stage_election_date,
+    ddhq_candidate_id,
+    ddhq_race_id,
     canonical_gp_candidacy_stage_id,
     canonical_gp_election_stage_id,
     canonical_gp_candidacy_id,
     canonical_gp_candidate_id,
     canonical_gp_election_id
 from gp_api_stage_matches
+union all
+select
+    ts_source_candidate_id,
+    ts_stage_election_date,
+    gp_api_campaign_id,
+    gp_api_stage_election_date,
+    ddhq_candidate_id,
+    ddhq_race_id,
+    canonical_gp_candidacy_stage_id,
+    canonical_gp_election_stage_id,
+    canonical_gp_candidacy_id,
+    canonical_gp_candidate_id,
+    canonical_gp_election_id
+from ddhq_stage_matches

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -1,5 +1,11 @@
 -- Civics mart candidacy table
--- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed data
+-- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed + DDHQ.
+--
+-- Provider precedence: BR > TS > DDHQ for every column. DDHQ contributes a
+-- subset of fields (party_affiliation, candidate_office, official_office_name,
+-- office_level, office_type, candidacy_result, *_election_date) and acts only
+-- as a fallback when neither BR nor TS has a value. DDHQ-only candidacies
+-- (no Splink match) appear as new rows with their own gp_candidacy_id.
 {%- set br_wins_cols = [
     "product_campaign_id",
     "hubspot_contact_id",
@@ -32,8 +38,9 @@ with
             gp_candidacy_id,
             gp_candidate_id,
             gp_election_id,
-            -- Column order must match merged_2026 (br_wins_cols loop order,
-            -- then TS-wins, then BR-only, then source_systems)
+            -- Column order must match merged_since_2026 (br_wins_cols loop
+            -- order, then TS-wins is_incumbent, BR-only office_type +
+            -- br_position_database_id, then source_systems)
             product_campaign_id,
             hubspot_contact_id,
             hubspot_company_ids,
@@ -66,32 +73,46 @@ with
         from {{ ref("int__civics_candidacy_2025") }}
     ),
 
-    -- TS int models remap clustered rows to BR's gp_* IDs (via
+    -- TS and DDHQ int models remap clustered rows to BR's gp_* IDs (via
     -- int__civics_er_canonical_ids), so a full outer join on gp_candidacy_id
-    -- merges matched pairs automatically. Unmatched rows on either side pass
-    -- through with NULLs on the opposite side.
-    merged_2026 as (
+    -- merges matched triples automatically. Unmatched rows on any side pass
+    -- through with NULLs on the absent providers (e.g. DDHQ-only candidacies
+    -- where Splink found no BR/TS match).
+    merged_since_2026 as (
         select
-            coalesce(br.gp_candidacy_id, ts.gp_candidacy_id) as gp_candidacy_id,
-            coalesce(br.gp_candidate_id, ts.gp_candidate_id) as gp_candidate_id,
-            coalesce(br.gp_election_id, ts.gp_election_id) as gp_election_id,
+            coalesce(
+                br.gp_candidacy_id, ts.gp_candidacy_id, ddhq.gp_candidacy_id
+            ) as gp_candidacy_id,
+            coalesce(
+                br.gp_candidate_id, ts.gp_candidate_id, ddhq.gp_candidate_id
+            ) as gp_candidate_id,
+            coalesce(
+                br.gp_election_id, ts.gp_election_id, ddhq.gp_election_id
+            ) as gp_election_id,
             {% for col in br_wins_cols %}
-                coalesce(br.{{ col }}, ts.{{ col }}) as {{ col }},
+                coalesce(br.{{ col }}, ts.{{ col }}, ddhq.{{ col }}) as {{ col }},
             {% endfor %}
-            -- TS wins for is_incumbent (TS: 51k populated, BR: 0)
+            -- TS wins for is_incumbent (TS: 51k populated, BR: 0). DDHQ never
+            -- provides this so it stays out of the chain.
             coalesce(ts.is_incumbent, br.is_incumbent) as is_incumbent,
-            br.office_type,
+            -- office_type is BR-authoritative; DDHQ supplies as fallback (TS
+            -- doesn't carry office_type at this grain).
+            coalesce(br.office_type, ddhq.office_type) as office_type,
             br.br_position_database_id,
             array_compact(
                 array(
                     case when br.gp_candidacy_id is not null then 'ballotready' end,
-                    case when ts.gp_candidacy_id is not null then 'techspeed' end
+                    case when ts.gp_candidacy_id is not null then 'techspeed' end,
+                    case when ddhq.gp_candidacy_id is not null then 'ddhq' end
                 )
             ) as source_systems
         from {{ ref("int__civics_candidacy_ballotready") }} as br
         full outer join
             {{ ref("int__civics_candidacy_techspeed") }} as ts
             on br.gp_candidacy_id = ts.gp_candidacy_id
+        full outer join
+            {{ ref("int__civics_candidacy_ddhq") }} as ddhq
+            on coalesce(br.gp_candidacy_id, ts.gp_candidacy_id) = ddhq.gp_candidacy_id
     ),
 
     combined as (
@@ -99,7 +120,7 @@ with
         from archive_2025
         union all
         select *
-        from merged_2026
+        from merged_since_2026
     ),
 
     deduplicated as (

--- a/dbt/project/models/marts/civics/candidacy_stage.sql
+++ b/dbt/project/models/marts/civics/candidacy_stage.sql
@@ -1,23 +1,30 @@
 -- Civics mart candidacy_stage table
--- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed data.
--- TS int models remap clustered IDs to BR canonicals via int__civics_er_canonical_ids,
--- so merging collapses to a full outer join on shared gp_candidacy_stage_id.
+-- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed + DDHQ.
+-- TS and DDHQ int models remap clustered IDs to BR canonicals via
+-- int__civics_er_canonical_ids, so merging collapses to a full outer join on
+-- shared gp_candidacy_stage_id.
+--
+-- Provider precedence:
+-- DDHQ wins for election outcome columns (is_winner, election_result,
+-- election_result_source, votes_received, is_uncontested) — DDHQ is the
+-- authoritative source for past-race results.
+-- BR > TS > DDHQ for descriptive columns (candidate_name, source_*,
+-- candidate_party, election_stage_date, timestamps).
+-- match_* and has_match come from BR/TS only (DDHQ has no LLM-match metadata).
 {%- set br_wins_cols = [
     "candidate_name",
     "source_candidate_id",
     "source_race_id",
     "candidate_party",
-    "is_winner",
-    "election_result",
-    "election_result_source",
-    "match_confidence",
-    "match_reasoning",
-    "match_top_candidates",
-    "has_match",
-    "votes_received",
     "election_stage_date",
     "created_at",
     "updated_at",
+] %}
+{%- set ddhq_wins_cols = [
+    "is_winner",
+    "election_result",
+    "election_result_source",
+    "votes_received",
 ] %}
 
 with
@@ -26,55 +33,105 @@ with
             gp_candidacy_stage_id,
             gp_candidacy_id,
             gp_election_stage_id,
-            -- Column order must match merged_2026 (br_wins_cols loop order)
+            -- Column order must match merged_since_2026 (br_wins, ddhq_wins,
+            -- BR/TS-only match_*, is_uncontested, source_systems)
             candidate_name,
             cast(source_candidate_id as string) as source_candidate_id,
             cast(source_race_id as string) as source_race_id,
             candidate_party,
+            election_stage_date,
+            created_at,
+            updated_at,
             is_winner,
             election_result,
             election_result_source,
+            votes_received,
             cast(match_confidence as float) as match_confidence,
             match_reasoning,
             match_top_candidates,
             has_match,
-            votes_received,
-            election_stage_date,
-            created_at,
-            updated_at,
+            cast(null as boolean) as is_uncontested,
             array_compact(
                 array('hubspot', case when has_match then 'ddhq' end)
             ) as source_systems
         from {{ ref("int__civics_candidacy_stage_2025") }}
     ),
 
-    -- TS int model remaps clustered rows to BR's gp_* IDs (via
-    -- int__civics_er_canonical_ids), so a full outer join on gp_candidacy_stage_id
-    -- merges matched pairs automatically.
-    merged_2026 as (
+    -- DDHQ projected into the BR/TS merge-row schema (column rename only).
+    -- Done up front so the coalesce loops below stay symmetric across providers.
+    ddhq as (
+        select
+            gp_candidacy_stage_id,
+            gp_candidacy_id,
+            gp_election_stage_id,
+            candidate_full_name as candidate_name,
+            source_candidate_id,
+            source_race_id,
+            party_affiliation as candidate_party,
+            election_date as election_stage_date,
+            created_at,
+            updated_at,
+            is_winner,
+            election_result,
+            election_result_source,
+            cast(votes as string) as votes_received,
+            is_uncontested
+        from {{ ref("int__civics_candidacy_stage_ddhq") }}
+    ),
+
+    -- Three-way merge for 2026+ data. BR, TS, and DDHQ int models all expose
+    -- shared canonical gp_* IDs via int__civics_er_canonical_ids when Splink
+    -- clustered the row, so a full outer join on gp_candidacy_stage_id
+    -- merges matched triples; unmatched rows pass through as new rows with
+    -- NULLs on the absent providers (e.g. DDHQ-only races where Splink
+    -- found no BR/TS counterpart).
+    merged_since_2026 as (
         select
             coalesce(
-                br.gp_candidacy_stage_id, ts.gp_candidacy_stage_id
+                br.gp_candidacy_stage_id,
+                ts.gp_candidacy_stage_id,
+                ddhq.gp_candidacy_stage_id
             ) as gp_candidacy_stage_id,
-            coalesce(br.gp_candidacy_id, ts.gp_candidacy_id) as gp_candidacy_id,
             coalesce(
-                br.gp_election_stage_id, ts.gp_election_stage_id
+                br.gp_candidacy_id, ts.gp_candidacy_id, ddhq.gp_candidacy_id
+            ) as gp_candidacy_id,
+            coalesce(
+                br.gp_election_stage_id,
+                ts.gp_election_stage_id,
+                ddhq.gp_election_stage_id
             ) as gp_election_stage_id,
             {% for col in br_wins_cols %}
-                coalesce(br.{{ col }}, ts.{{ col }}) as {{ col }},
+                coalesce(br.{{ col }}, ts.{{ col }}, ddhq.{{ col }}) as {{ col }},
             {% endfor %}
+            {% for col in ddhq_wins_cols %}
+                coalesce(ddhq.{{ col }}, br.{{ col }}, ts.{{ col }}) as {{ col }},
+            {% endfor %}
+            -- LLM-match metadata only exists on BR/TS legacy paths.
+            coalesce(br.match_confidence, ts.match_confidence) as match_confidence,
+            coalesce(br.match_reasoning, ts.match_reasoning) as match_reasoning,
+            coalesce(
+                br.match_top_candidates, ts.match_top_candidates
+            ) as match_top_candidates,
+            coalesce(br.has_match, ts.has_match) as has_match,
+            -- is_uncontested only exists on DDHQ at this grain.
+            ddhq.is_uncontested,
             array_compact(
                 array(
                     case
                         when br.gp_candidacy_stage_id is not null then 'ballotready'
                     end,
-                    case when ts.gp_candidacy_stage_id is not null then 'techspeed' end
+                    case when ts.gp_candidacy_stage_id is not null then 'techspeed' end,
+                    case when ddhq.gp_candidacy_stage_id is not null then 'ddhq' end
                 )
             ) as source_systems
         from {{ ref("int__civics_candidacy_stage_ballotready") }} as br
         full outer join
             {{ ref("int__civics_candidacy_stage_techspeed") }} as ts
             on br.gp_candidacy_stage_id = ts.gp_candidacy_stage_id
+        full outer join
+            ddhq
+            on coalesce(br.gp_candidacy_stage_id, ts.gp_candidacy_stage_id)
+            = ddhq.gp_candidacy_stage_id
     ),
 
     combined as (
@@ -82,7 +139,7 @@ with
         from archive_2025
         union all
         select *
-        from merged_2026
+        from merged_since_2026
     ),
 
     deduplicated as (
@@ -111,6 +168,7 @@ select
     deduplicated.match_top_candidates,
     deduplicated.has_match,
     deduplicated.votes_received,
+    deduplicated.is_uncontested,
     deduplicated.election_stage_date,
     es.is_win_icp,
     es.is_serve_icp,

--- a/dbt/project/models/marts/civics/candidate.sql
+++ b/dbt/project/models/marts/civics/candidate.sql
@@ -1,6 +1,11 @@
 -- Civics mart candidate table
--- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed data
--- Deduplicates on gp_candidate_id (a person may appear in both sources)
+-- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed + DDHQ.
+-- Deduplicates on gp_candidate_id (a person may appear in multiple sources)
+--
+-- DDHQ contributes only first_name / last_name / full_name / state at the
+-- candidate grain — every other column (HubSpot, contact, social) is
+-- BR/TS-only. DDHQ-only candidates (no Splink match to BR/TS) appear as new
+-- rows with source_systems = ['ddhq'] and BR/TS-only columns null.
 {%- set br_wins_cols = [
     "hubspot_contact_id",
     "prod_db_user_id",
@@ -20,13 +25,24 @@
 ] -%}
 {# TS wins: birth_date (TS: 2885, BR: 0), phone_number (TS: 48k, BR: 8k), facebook_url (TS: 9279 real) #}
 {%- set ts_wins_cols = ["birth_date", "phone_number", "facebook_url"] %}
+{# DDHQ-fallback columns. state is sourced as state_postal_code (2-letter)
+   to match BR/TS convention; the DDHQ int model exposes state as the full
+   name. #}
+{%- set ddhq_fallback_cols = [
+    "first_name",
+    "last_name",
+    "full_name",
+    "state",
+    "created_at",
+    "updated_at",
+] %}
 
 with
     archive_2025 as (
         select
             gp_candidate_id,
-            -- Column order must match merged_2026 (br_wins_cols, ts_wins_cols,
-            -- source_systems)
+            -- Column order must match merged_since_2026 (br_wins_cols,
+            -- ts_wins_cols, source_systems)
             hubspot_contact_id,
             prod_db_user_id,
             candidate_id_tier,
@@ -54,13 +70,36 @@ with
         from {{ ref("int__civics_candidate_2025") }}
     ),
 
-    -- TS int model remaps clustered rows to BR's gp_candidate_id, so a full
-    -- outer join auto-merges matched pairs.
-    merged_2026 as (
+    -- DDHQ projected into the mart-row schema. The mart's `state` column
+    -- carries 2-letter postal codes (BR/TS convention) — pull DDHQ's
+    -- state_postal_code through, not its `state` (which is the human-readable
+    -- name per the int_model convention).
+    ddhq as (
         select
-            coalesce(br.gp_candidate_id, ts.gp_candidate_id) as gp_candidate_id,
+            gp_candidate_id,
+            first_name,
+            last_name,
+            full_name,
+            state_postal_code as state,
+            created_at,
+            updated_at
+        from {{ ref("int__civics_candidate_ddhq") }}
+    ),
+
+    -- TS and DDHQ int models remap clustered rows to BR's gp_candidate_id, so
+    -- a full outer join auto-merges matched triples. ddhq_fallback_cols above
+    -- enumerates the subset of BR-wins columns DDHQ supplies; all other
+    -- columns get null on DDHQ-only rows.
+    merged_since_2026 as (
+        select
+            coalesce(
+                br.gp_candidate_id, ts.gp_candidate_id, ddhq.gp_candidate_id
+            ) as gp_candidate_id,
             {% for col in br_wins_cols %}
-                coalesce(br.{{ col }}, ts.{{ col }}) as {{ col }},
+                {% if col in ddhq_fallback_cols %}
+                    coalesce(br.{{ col }}, ts.{{ col }}, ddhq.{{ col }}) as {{ col }},
+                {% else %} coalesce(br.{{ col }}, ts.{{ col }}) as {{ col }},
+                {% endif %}
             {% endfor %}
             {% for col in ts_wins_cols %}
                 coalesce(ts.{{ col }}, br.{{ col }}) as {{ col }},
@@ -68,13 +107,17 @@ with
             array_compact(
                 array(
                     case when br.gp_candidate_id is not null then 'ballotready' end,
-                    case when ts.gp_candidate_id is not null then 'techspeed' end
+                    case when ts.gp_candidate_id is not null then 'techspeed' end,
+                    case when ddhq.gp_candidate_id is not null then 'ddhq' end
                 )
             ) as source_systems
         from {{ ref("int__civics_candidate_ballotready") }} as br
         full outer join
             {{ ref("int__civics_candidate_techspeed") }} as ts
             on br.gp_candidate_id = ts.gp_candidate_id
+        full outer join
+            ddhq
+            on coalesce(br.gp_candidate_id, ts.gp_candidate_id) = ddhq.gp_candidate_id
     ),
 
     combined as (
@@ -82,7 +125,7 @@ with
         from archive_2025
         union all
         select *
-        from merged_2026
+        from merged_since_2026
     ),
 
     deduplicated as (

--- a/dbt/project/models/marts/civics/candidate.sql
+++ b/dbt/project/models/marts/civics/candidate.sql
@@ -25,9 +25,12 @@
 ] -%}
 {# TS wins: birth_date (TS: 2885, BR: 0), phone_number (TS: 48k, BR: 8k), facebook_url (TS: 9279 real) #}
 {%- set ts_wins_cols = ["birth_date", "phone_number", "facebook_url"] %}
-{# DDHQ-fallback columns. state is sourced as state_postal_code (2-letter)
-   to match BR/TS convention; the DDHQ int model exposes state as the full
-   name. #}
+{# DDHQ-fallback columns. Must be a subset of br_wins_cols — the merge loop
+   below tests `col in ddhq_fallback_cols` to decide whether to coalesce
+   DDHQ in. Adding a BR-wins column that DDHQ also supplies requires
+   adding it here too. state is sourced as state_postal_code (2-letter)
+   to match BR/TS convention; the DDHQ int model exposes state as the
+   full name. #}
 {%- set ddhq_fallback_cols = [
     "first_name",
     "last_name",

--- a/dbt/project/models/marts/civics/election.sql
+++ b/dbt/project/models/marts/civics/election.sql
@@ -23,7 +23,6 @@
     "seats_available",
     "term_start_date",
     "number_of_opponents",
-    "has_ddhq_match",
     "created_at",
     "updated_at",
 ] %}
@@ -40,8 +39,9 @@ with
         select
             gp_election_id,
             -- Column order must match merged_since_2026 (br_wins_cols loop order,
-            -- then ts_wins_cols, then BR-only, then source_systems)
+            -- has_ddhq_match, ts_wins_cols, BR-only, source_systems)
             {% for col in br_wins_cols %} {{ col }}, {% endfor %}
+            has_ddhq_match,
             {% for col in ts_wins_cols %} {{ col }}, {% endfor %}
             br_position_database_id,
             is_judicial,
@@ -70,6 +70,11 @@ with
             {% for col in br_wins_cols %}
                 coalesce(br.{{ col }}, ts.{{ col }}, ddhq.{{ col }}) as {{ col }},
             {% endfor %}
+            -- has_ddhq_match must be handled outside the coalesce loop: BR
+            -- and TS hardcode it to false (non-null), so a coalesce would
+            -- always pick BR's false on Splink-matched BR+DDHQ rows. Derive
+            -- directly from join presence instead.
+            ddhq.gp_election_id is not null as has_ddhq_match,
             -- TS wins for these (BR always NULL on 2026+ for population/
             -- filing_deadline; TS populated from techspeed source). DDHQ
             -- supplies is_uncontested as a fallback.

--- a/dbt/project/models/marts/civics/election.sql
+++ b/dbt/project/models/marts/civics/election.sql
@@ -1,10 +1,14 @@
 -- Civics mart election table
--- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed data
+-- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed + DDHQ.
 --
--- BallotReady is the authoritative spine for elections (positions). TS int
--- models remap clustered rows to BR's gp_election_id via
+-- BallotReady is the authoritative spine for elections (positions). TS and
+-- DDHQ int models remap clustered rows to BR's gp_election_id via
 -- int__civics_er_canonical_ids, so a full outer join on gp_election_id merges
--- matched pairs automatically. Unmatched TS elections pass through as net-new.
+-- matched triples. Unmatched DDHQ-only elections pass through as new rows
+-- (DDHQ's hashed gp_election_id) with source_systems = ['ddhq'].
+--
+-- has_ddhq_match: true when either the 2025 archive linked a DDHQ race or a
+-- 2026+ DDHQ row clustered into this election via Splink. NULL otherwise.
 {%- set br_wins_cols = [
     "official_office_name",
     "candidate_office",
@@ -49,15 +53,28 @@ with
         from {{ ref("int__civics_election_2025") }}
     ),
 
+    -- DDHQ projected into the mart-row schema. The mart's `state` column
+    -- holds 2-letter codes (BR/TS-staging convention) — pull DDHQ's
+    -- state_postal_code through, not its `state` column (which is the
+    -- human-readable name per int_model convention).
+    ddhq as (
+        select * except (state), state_postal_code as state
+        from {{ ref("int__civics_election_ddhq") }}
+    ),
+
     merged_since_2026 as (
         select
-            coalesce(br.gp_election_id, ts.gp_election_id) as gp_election_id,
+            coalesce(
+                br.gp_election_id, ts.gp_election_id, ddhq.gp_election_id
+            ) as gp_election_id,
             {% for col in br_wins_cols %}
-                coalesce(br.{{ col }}, ts.{{ col }}) as {{ col }},
+                coalesce(br.{{ col }}, ts.{{ col }}, ddhq.{{ col }}) as {{ col }},
             {% endfor %}
-            -- TS wins: BR always NULL, TS populated from techspeed source
+            -- TS wins for these (BR always NULL on 2026+ for population/
+            -- filing_deadline; TS populated from techspeed source). DDHQ
+            -- supplies is_uncontested as a fallback.
             {% for col in ts_wins_cols %}
-                coalesce(ts.{{ col }}, br.{{ col }}) as {{ col }},
+                coalesce(ts.{{ col }}, br.{{ col }}, ddhq.{{ col }}) as {{ col }},
             {% endfor %}
             br.br_position_database_id,
             br.is_judicial,
@@ -66,13 +83,16 @@ with
             array_compact(
                 array(
                     case when br.gp_election_id is not null then 'ballotready' end,
-                    case when ts.gp_election_id is not null then 'techspeed' end
+                    case when ts.gp_election_id is not null then 'techspeed' end,
+                    case when ddhq.gp_election_id is not null then 'ddhq' end
                 )
             ) as source_systems
         from {{ ref("int__civics_election_ballotready") }} as br
         full outer join
             {{ ref("int__civics_election_techspeed") }} as ts
             on br.gp_election_id = ts.gp_election_id
+        full outer join
+            ddhq on coalesce(br.gp_election_id, ts.gp_election_id) = ddhq.gp_election_id
     ),
 
     combined as (

--- a/dbt/project/models/marts/civics/election_stage.sql
+++ b/dbt/project/models/marts/civics/election_stage.sql
@@ -1,11 +1,16 @@
 -- Civics mart election_stage table
--- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed data
+-- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed + DDHQ.
 --
--- BallotReady is the authoritative spine for election_stages (races). TS int
--- models remap clustered stages to BR's gp_election_stage_id via
+-- BallotReady is the authoritative spine for election_stages (races). TS and
+-- DDHQ int models remap clustered stages to BR's gp_election_stage_id via
 -- int__civics_er_canonical_ids, so a full outer join on gp_election_stage_id
--- merges matched pairs automatically. Unmatched TS stages pass through as
--- net-new.
+-- merges matched triples. Unmatched DDHQ stages (no BR/TS Splink counterpart)
+-- pass through as net-new rows with source_systems = ['ddhq'].
+--
+-- Precedence: BR > TS > DDHQ for descriptive columns. total_votes_cast is
+-- BR-first only when BR has a numeric count; BR's 'uncontested' literal
+-- yields to DDHQ's actual count when present. ddhq_race_id falls back to
+-- DDHQ when BR's null.
 {%- set br_wins_cols = [
     "gp_election_id",
     "br_race_id",
@@ -58,15 +63,25 @@ with
     merged_since_2026 as (
         select
             coalesce(
-                br.gp_election_stage_id, ts.gp_election_stage_id
+                br.gp_election_stage_id,
+                ts.gp_election_stage_id,
+                ddhq.gp_election_stage_id
             ) as gp_election_stage_id,
             {% for col in br_wins_cols %}
-                coalesce(br.{{ col }}, ts.{{ col }}) as {{ col }},
+                coalesce(br.{{ col }}, ts.{{ col }}, ddhq.{{ col }}) as {{ col }},
             {% endfor %}
             br.br_election_id,
             br.br_position_id,
-            br.ddhq_race_id,
-            br.total_votes_cast,
+            -- ddhq_race_id: DDHQ's own ID is more reliable than BR's
+            -- (which is sometimes null for 2026+ rows even when DDHQ has data).
+            coalesce(br.ddhq_race_id, ddhq.ddhq_race_id) as ddhq_race_id,
+            -- total_votes_cast: BR can carry the literal 'uncontested' as a
+            -- sentinel; treat that as missing and prefer DDHQ's numeric count.
+            coalesce(
+                nullif(br.total_votes_cast, 'uncontested'),
+                ddhq.total_votes_cast,
+                br.total_votes_cast
+            ) as total_votes_cast,
             br.partisan_type,
             br.filing_period_start_on,
             br.filing_period_end_on,
@@ -78,13 +93,18 @@ with
                     case
                         when br.gp_election_stage_id is not null then 'ballotready'
                     end,
-                    case when ts.gp_election_stage_id is not null then 'techspeed' end
+                    case when ts.gp_election_stage_id is not null then 'techspeed' end,
+                    case when ddhq.gp_election_stage_id is not null then 'ddhq' end
                 )
             ) as source_systems
         from {{ ref("int__civics_election_stage_ballotready") }} as br
         full outer join
             {{ ref("int__civics_election_stage_techspeed") }} as ts
             on br.gp_election_stage_id = ts.gp_election_stage_id
+        full outer join
+            {{ ref("int__civics_election_stage_ddhq") }} as ddhq
+            on coalesce(br.gp_election_stage_id, ts.gp_election_stage_id)
+            = ddhq.gp_election_stage_id
     ),
 
     combined as (

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -1023,9 +1023,15 @@ models:
 
       - name: has_ddhq_match
         description: >
-          Whether DDHQ election results data is available for this election.
-          Only applicable to 2025 elections, as DDHQ was the results source
-          for that cycle. Always NULL for 2026+ BallotReady-sourced elections.
+          True when DDHQ election results data is available for this
+          election: either the 2025 archive linked a DDHQ race or a 2026+
+          DDHQ row clustered into this election via Splink. False otherwise.
+          Should agree with `'ddhq' in source_systems`.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
 
       - name: br_position_database_id
         description: >
@@ -1157,6 +1163,9 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "updated_at >= created_at"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "has_ddhq_match = array_contains(source_systems, 'ddhq')"
 
   - name: election_stage
     description: >

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -369,9 +369,25 @@ models:
 
   - name: candidacy
     description: >
-      Candidacies combining 2025 HubSpot archive and 2026+ BallotReady data.
+      Candidacies combining 2025 HubSpot archive and 2026+ BallotReady,
+      TechSpeed, and DDHQ data.
 
       Grain: One row per candidacy.
+
+      Provider precedence: BR > TS > DDHQ for every column. DDHQ contributes
+      only as a fallback (and only for fields it carries: party_affiliation,
+      candidate_office, official_office_name, office_level, office_type,
+      candidacy_result, *_election_date). DDHQ supplies Won/Lost as
+      candidacy_result — it never carries Runoff/Withdrew/Not on Ballot/
+      Cannot Determine.
+
+      DDHQ-only candidacies (DDHQ races with no Splink match to BR/TS/gp_api)
+      appear as new rows with source_systems = ['ddhq'] and BR/TS-only fields
+      (product_campaign_id, hubspot_*, viability_score, win_number,
+      verification status, br_position_database_id) all NULL. Pre-2026
+      DDHQ-derived candidacies still flow through the 2025 HubSpot archive
+      path (limited to GP-product candidates the LLM matcher linked to a
+      DDHQ race); the new live path covers 2026+.
 
     columns:
       - name: gp_candidacy_id
@@ -391,7 +407,15 @@ models:
                 field: gp_candidate_id
 
       - name: gp_election_id
-        description: Foreign key to election table (no relationship test - matches m_general behavior)
+        description: Foreign key to election table.
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('election')
+                field: gp_election_id
+              config:
+                where: "gp_election_id is not null"
+                severity: warn
 
       - name: product_campaign_id
         description: >
@@ -597,9 +621,18 @@ models:
 
   - name: candidate
     description: >
-      Candidates combining 2025 HubSpot archive and 2026+ BallotReady data.
+      Candidates combining 2025 HubSpot archive and 2026+ BallotReady,
+      TechSpeed, and DDHQ data.
 
       Grain: One row per candidate.
+
+      Provider precedence: BR > TS > DDHQ. DDHQ contributes only first_name,
+      last_name, full_name, and state at this grain — every other column
+      (HubSpot, contact, social, prod_db_user_id) is BR/TS-only.
+      DDHQ-only candidates (DDHQ candidacies with no Splink match) appear
+      as new rows with source_systems = ['ddhq']; the mart's `state` column
+      receives DDHQ's state_postal_code (2-letter code) to match BR/TS
+      convention at this layer.
 
     columns:
       - name: gp_candidate_id
@@ -692,10 +725,25 @@ models:
 
   - name: candidacy_stage
     description: >
-      Candidacy stages (primary, general, primary runoff, general runoff results) combining 2025 HubSpot/DDHQ archive
-      and 2026+ BallotReady data.
+      Candidacy stages (primary, general, primary runoff, general runoff
+      results) combining 2025 HubSpot/DDHQ archive and 2026+ BallotReady,
+      TechSpeed, and DDHQ data.
 
       Grain: One row per candidacy stage (candidacy + election stage combination).
+
+      Provider precedence: DDHQ wins for election outcome columns
+      (is_winner, election_result, election_result_source, votes_received,
+      is_uncontested) — DDHQ is the authoritative source for past-race
+      results where it has coverage. BR > TS > DDHQ for descriptive columns
+      (candidate_name, source_*, candidate_party, election_stage_date,
+      timestamps). LLM-match metadata (match_confidence, match_reasoning,
+      match_top_candidates, has_match) only exists on the BR/TS legacy
+      paths; DDHQ has no equivalent.
+
+      DDHQ-only candidacy_stages (no Splink match to BR/TS) appear as new
+      rows with source_systems = ['ddhq']. election_result_source identifies
+      which provider supplied the result for each row (ddhq, ballotready,
+      techspeed, or hubspot for legacy archive rows).
 
     columns:
       - name: gp_candidacy_stage_id
@@ -767,8 +815,16 @@ models:
 
       - name: election_result_source
         description: >
-          Source of the election_result value.
-          Values: 'hubspot', 'ddhq', 'ballotready', or null if no result available.
+          Source of the election_result / is_winner / votes_received values.
+          Values: 'ddhq' (preferred when DDHQ covers the race), 'ballotready'
+          (BR-supplied results), 'techspeed' (TS-supplied results),
+          'hubspot' (2025-archive HubSpot stage results), or null if no
+          result is available. DDHQ wins precedence for past-race outcomes
+          where it has coverage.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["ddhq", "ballotready", "techspeed", "hubspot"]
 
       - name: match_confidence
         description: >
@@ -797,7 +853,21 @@ models:
           available. When true, vote counts and election results are populated.
 
       - name: votes_received
-        description: Number of votes received in this election stage
+        description: >
+          Number of votes received in this election stage. Stored as a
+          string because BallotReady occasionally carries the literal
+          "uncontested" alongside numeric counts. DDHQ wins for this column
+          when DDHQ has data; BR/TS otherwise.
+
+      - name: is_uncontested
+        description: >
+          Whether the race for this candidacy stage was uncontested,
+          sourced from DDHQ. NULL for BR/TS-only rows (those providers
+          don't carry uncontested status at the candidacy_stage grain).
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
 
       - name: election_stage_date
         description: Date of the election stage
@@ -846,9 +916,18 @@ models:
 
   - name: election
     description: >
-      Elections combining 2025 HubSpot archive and 2026+ BallotReady data.
+      Elections combining 2025 HubSpot archive and 2026+ BallotReady,
+      TechSpeed, and DDHQ data.
 
       Grain: One row per election.
+
+      Provider precedence: BR > TS > DDHQ for descriptive columns; TS wins
+      for filing_deadline / population / is_uncontested / is_open_seat (BR
+      doesn't carry those at this grain), with DDHQ supplying is_uncontested
+      as a fallback. has_ddhq_match is true when either the 2025 archive
+      linked a DDHQ race to this election OR a 2026+ DDHQ row clustered
+      into this election via Splink. The mart's `state` column receives
+      DDHQ's state_postal_code (2-letter code) to match BR/TS convention.
 
     columns:
       - name: gp_election_id
@@ -1081,10 +1160,22 @@ models:
 
   - name: election_stage
     description: >
-      Election stages (primary, general, primary runoff, general runoff) combining 2025 DDHQ archive
-      and 2026+ BallotReady data.
+      Election stages (primary, general, primary runoff, general runoff)
+      combining 2025 DDHQ archive and 2026+ BallotReady, TechSpeed, and
+      DDHQ data.
 
       Grain: One row per election stage.
+
+      Provider precedence: BR > TS > DDHQ for descriptive columns
+      (stage_type, election_date, race_name, is_primary, is_runoff,
+      is_retention, number_of_seats). total_votes_cast carries the literal
+      'uncontested' from BR as a sentinel — when present, DDHQ's numeric
+      count overrides. ddhq_race_id falls back to DDHQ's own ID when BR
+      has no value.
+
+      DDHQ-only stages (no Splink match) appear as new rows with
+      source_systems = ['ddhq']; BR-only fields (br_election_id,
+      br_position_id, partisan_type, filing_*) are NULL.
 
     columns:
       - name: gp_election_stage_id

--- a/dbt/project/models/staging/airbyte_source/ddhq_gdrive/stg_airbyte_source__ddhq_gdrive_election_results.sql
+++ b/dbt/project/models/staging/airbyte_source/ddhq_gdrive/stg_airbyte_source__ddhq_gdrive_election_results.sql
@@ -45,7 +45,7 @@ with
             r.*,
             split(r.race_name, ' ')[0] as state_prefix,
             cs.state_cleaned_postal_code as state_postal_code,
-            us.state_name
+            us.state_name as state
         from renamed as r
         left join
             clean_states as cs

--- a/dbt/project/tests/assert_ddhq_votes_sum_within_total.sql
+++ b/dbt/project/tests/assert_ddhq_votes_sum_within_total.sql
@@ -1,0 +1,42 @@
+{{
+    config(
+        severity="warn",
+        warn_if=">100",
+        error_if=">500",
+    )
+}}
+
+-- For past DDHQ-covered election stages, the sum of votes_received across
+-- candidacy_stage rows should be within ±5% of election_stage.total_votes_cast.
+-- Real-world tolerance: write-ins, late certifications, and DDHQ partial
+-- coverage produce legitimate gaps, so we warn rather than fail. A discrepancy
+-- larger than 5% is a domain-expert flag (something is meaningfully off).
+with
+    stage_totals as (
+        select
+            gp_election_stage_id,
+            try_cast(total_votes_cast as bigint) as total_votes_cast
+        from {{ ref("election_stage") }}
+        where
+            array_contains(source_systems, 'ddhq')
+            and election_date < current_date()
+            and try_cast(total_votes_cast as bigint) is not null
+            and try_cast(total_votes_cast as bigint) > 0
+    ),
+
+    candidate_sums as (
+        select
+            gp_election_stage_id, sum(try_cast(votes_received as bigint)) as votes_sum
+        from {{ ref("candidacy_stage") }}
+        where gp_election_stage_id in (select gp_election_stage_id from stage_totals)
+        group by gp_election_stage_id
+    )
+
+select
+    s.gp_election_stage_id,
+    s.total_votes_cast,
+    c.votes_sum,
+    abs(s.total_votes_cast - coalesce(c.votes_sum, 0)) / s.total_votes_cast as pct_diff
+from stage_totals as s
+left join candidate_sums as c on s.gp_election_stage_id = c.gp_election_stage_id
+where abs(s.total_votes_cast - coalesce(c.votes_sum, 0)) / s.total_votes_cast > 0.05

--- a/dbt/project/tests/assert_ddhq_votes_sum_within_total.sql
+++ b/dbt/project/tests/assert_ddhq_votes_sum_within_total.sql
@@ -26,10 +26,12 @@ with
 
     candidate_sums as (
         select
-            gp_election_stage_id, sum(try_cast(votes_received as bigint)) as votes_sum
-        from {{ ref("candidacy_stage") }}
-        where gp_election_stage_id in (select gp_election_stage_id from stage_totals)
-        group by gp_election_stage_id
+            cs.gp_election_stage_id,
+            sum(try_cast(cs.votes_received as bigint)) as votes_sum
+        from {{ ref("candidacy_stage") }} as cs
+        inner join
+            stage_totals as st on cs.gp_election_stage_id = st.gp_election_stage_id
+        group by cs.gp_election_stage_id
     )
 
 select

--- a/dbt/project/tests/assert_ddhq_winner_count_matches_seats.sql
+++ b/dbt/project/tests/assert_ddhq_winner_count_matches_seats.sql
@@ -24,7 +24,7 @@ with
     winner_counts as (
         select cs.gp_election_stage_id, count_if(cs.is_winner) as winners
         from {{ ref("candidacy_stage") }} as cs
-        where cs.gp_election_stage_id in (select gp_election_stage_id from stages)
+        inner join stages as s on cs.gp_election_stage_id = s.gp_election_stage_id
         group by cs.gp_election_stage_id
     )
 

--- a/dbt/project/tests/assert_ddhq_winner_count_matches_seats.sql
+++ b/dbt/project/tests/assert_ddhq_winner_count_matches_seats.sql
@@ -1,0 +1,34 @@
+{{
+    config(
+        severity="warn",
+        warn_if=">100",
+        error_if=">500",
+    )
+}}
+
+-- For past election_stages where DDHQ contributed results, the count of
+-- candidacy_stage rows with is_winner = true should equal number_of_seats.
+-- Soft threshold: real-world exceptions exist (write-ins, certifications,
+-- DDHQ coverage gaps), so we warn rather than fail.
+with
+    stages as (
+        select es.gp_election_stage_id, es.number_of_seats, es.election_date
+        from {{ ref("election_stage") }} as es
+        where
+            array_contains(es.source_systems, 'ddhq')
+            and es.election_date < current_date()
+            and es.number_of_seats is not null
+            and es.number_of_seats > 0
+    ),
+
+    winner_counts as (
+        select cs.gp_election_stage_id, count_if(cs.is_winner) as winners
+        from {{ ref("candidacy_stage") }} as cs
+        where cs.gp_election_stage_id in (select gp_election_stage_id from stages)
+        group by cs.gp_election_stage_id
+    )
+
+select s.gp_election_stage_id, s.number_of_seats, coalesce(w.winners, 0) as winners
+from stages as s
+left join winner_counts as w on s.gp_election_stage_id = w.gp_election_stage_id
+where coalesce(w.winners, 0) != s.number_of_seats

--- a/dbt/project/tests/assert_no_election_result_before_election_date.sql
+++ b/dbt/project/tests/assert_no_election_result_before_election_date.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        severity="warn",
+        warn_if=">200",
+        error_if=">1000",
+    )
+}}
+
+-- A candidacy_stage row should not have a populated election_result before
+-- the election_stage_date. If we're seeing winners declared before the race
+-- happens, the upstream provider has a data freshness or stage-attribution
+-- bug. Warn-only because BR/TS sometimes attribute candidate-level results
+-- to future stages; the threshold is set to surface trends without blocking.
+select gp_candidacy_stage_id, election_stage_date, election_result, is_winner
+from {{ ref("candidacy_stage") }}
+where
+    election_stage_date > current_date()
+    and (election_result is not null or is_winner is not null)

--- a/dbt/project/tests/assert_uncontested_implies_single_candidate.sql
+++ b/dbt/project/tests/assert_uncontested_implies_single_candidate.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        severity="warn",
+        warn_if=">10",
+        error_if=">100",
+    )
+}}
+
+-- A race flagged as uncontested should have exactly one candidate. Multiple
+-- candidates on an "uncontested" race is something a campaign operative
+-- would immediately spot as wrong. Soft warn — DDHQ occasionally reports
+-- a race as uncontested even when 2+ candidates appear (write-ins, etc).
+select gp_election_stage_id, count(*) as candidate_count
+from {{ ref("candidacy_stage") }}
+where is_uncontested
+group by gp_election_stage_id
+having count(*) > 1

--- a/dbt/project/tests/assert_winner_count_le_seats.sql
+++ b/dbt/project/tests/assert_winner_count_le_seats.sql
@@ -22,7 +22,7 @@ with
     winner_counts as (
         select cs.gp_election_stage_id, count_if(cs.is_winner) as winners
         from {{ ref("candidacy_stage") }} as cs
-        where cs.gp_election_stage_id in (select gp_election_stage_id from stages)
+        inner join stages as s on cs.gp_election_stage_id = s.gp_election_stage_id
         group by cs.gp_election_stage_id
     )
 

--- a/dbt/project/tests/assert_winner_count_le_seats.sql
+++ b/dbt/project/tests/assert_winner_count_le_seats.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        severity="warn",
+        warn_if=">50",
+        error_if=">200",
+    )
+}}
+
+-- The number of winners declared in any election stage cannot exceed the
+-- number of seats on the ballot. This catches duplicate joining, bad
+-- crosswalk matches, or upstream data corruption that would inflate the
+-- winner count. Stricter than winner_count_matches_seats — that test
+-- expects equality (which has many real-world exceptions); this one only
+-- catches strictly-too-many.
+with
+    stages as (
+        select gp_election_stage_id, number_of_seats
+        from {{ ref("election_stage") }}
+        where number_of_seats is not null and number_of_seats > 0
+    ),
+
+    winner_counts as (
+        select cs.gp_election_stage_id, count_if(cs.is_winner) as winners
+        from {{ ref("candidacy_stage") }} as cs
+        where cs.gp_election_stage_id in (select gp_election_stage_id from stages)
+        group by cs.gp_election_stage_id
+    )
+
+select s.gp_election_stage_id, s.number_of_seats, w.winners
+from stages as s
+inner join winner_counts as w on s.gp_election_stage_id = w.gp_election_stage_id
+where w.winners > s.number_of_seats


### PR DESCRIPTION
Wires the existing DDHQ intermediate models into the five civics marts so DDHQ-supplied election results join cleanly to BR/TS-anchored rows where Splink clustered them, and DDHQ-only rows pass through as new entries with `source_systems = ['ddhq']`. Adds 5 domain-expert tests and updates mart-level docs with provider precedence and DDHQ caveats.

`int__civics_er_canonical_ids`: add a `ddhq_stage_matches` branch keyed on `(ddhq_candidate_id, ddhq_race_id)` extracted from the cluster source_id (`'{candidate_id}_{race_id}'`). Two new keys added to the union output schema; TS/gp_api branches null them.

`int__civics_candidacy_stage_ddhq`: left-join the canonical_ids xwalk and coalesce computed `gp_*` IDs against canonical IDs so Splink-matched DDHQ rows adopt BR's IDs. The four downstream DDHQ intermediates (`_candidacy_ddhq`, `_candidate_ddhq`, `_election_ddhq`, `_election_stage_ddhq`) all derive from this model so they inherit canonical IDs automatically.

5 mart files: extend `merged_since_2026` from `BR FOJ TS` to `BR FOJ TS FOJ DDHQ` on the shared canonical id. Provider precedence:

| Mart | DDHQ wins | DDHQ fallback (BR > TS > DDHQ) | DDHQ excluded |
|---|---|---|---|
| `candidacy_stage` | `is_winner`, `election_result`, `election_result_source`, `votes_received`, plus new `is_uncontested` column | `candidate_name`, `source_*`, `candidate_party`, `election_stage_date`, timestamps | `match_*`, `has_match` |
| `candidacy` | none | every column DDHQ carries | every column DDHQ doesn't |
| `election_stage` | `total_votes_cast` (over BR's `'uncontested'` literal), `ddhq_race_id` (when BR null) | descriptive cols | `br_*`, `partisan_type`, `filing_*` |
| `election` | none | descriptive cols + `is_uncontested` | `br_*`, `is_judicial`, `is_appointed` |
| `candidate` | none | first/last/full_name, state | every other column |

`election.has_ddhq_match` is now true when either the 2025 archive linked a DDHQ race OR a 2026+ DDHQ row clustered into this election via Splink.

## Naming convention fix

Per project guidance (rename at staging only, no downstream renames):
- DDHQ staging: rename `us_states.state_name` → `state` (human-readable). `state_postal_code` stays as the 2-letter code.
- DDHQ int models drop their downstream `state_name as state` renames and reference the staging columns directly.
- Mart `state` column receives DDHQ's `state_postal_code` (BR/TS staging publishes the 2-letter code under `state` today; the mart matches that convention. Bringing BR/TS staging into convention is left for a follow-up).

## tests + docs

`m_civics.yaml`:
- Enforced `candidacy.gp_election_id → election` relationship test (severity `warn`) — was previously not enforced.
- Updated model-level descriptions for all 5 marts to document provider precedence and DDHQ caveats.
- Added `is_uncontested` column doc on `candidacy_stage`.
- Tightened `election_result_source` enum to `[ddhq, ballotready, techspeed, hubspot]` with `accepted_values` test.

5 new singular tests under `tests/` (all `severity = warn`, set to surface trends without blocking):
- `assert_ddhq_winner_count_matches_seats`
- `assert_ddhq_votes_sum_within_total` (±5%)
- `assert_no_election_result_before_election_date`
- `assert_uncontested_implies_single_candidate`
- `assert_winner_count_le_seats`

## Verification

`dbt build` over all touched models + new tests:

```
PASS=146  WARN=6  ERROR=0
```

The 6 warnings:
- 1 pre-existing (156 rows, threshold 150) — unrelated to DDHQ.
- 5 from the new domain-expert tests, configured warn-only because real political data has legitimate exceptions (write-ins, late certifications, multi-source disagreements).

Splink matching yield: of 2,515 DDHQ candidacy stages, **946 adopted BR canonical IDs** (37.6% match rate). The remaining 1,569 pass through as DDHQ-only rows with `source_systems = ['ddhq']`. All existing relationship tests on the 5 marts pass.

## Test plan

- [x] `dbt parse` — clean
- [x] `dbt build --select` over the changed lineage — PASS=146 / WARN=6 / ERROR=0
- [x] Confirmed Splink-matched DDHQ rows share `gp_candidacy_stage_id` with BR rows (946 of 2,515)
- [x] Confirmed `'ddhq'` appears in `source_systems` across all 5 marts post-build
- [x] Confirmed candidacy_stage's new `is_uncontested` column populates from DDHQ
- [ ] Reviewer to spot-check a known 2026 race that has both BR and DDHQ coverage (single `gp_election_stage_id`, `votes_received` sum ≈ `total_votes_cast`, `source_systems` includes both providers)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes ID generation/canonicalization and three-way merge logic across core civics marts, which can affect row collapsing/duplication and downstream relationships; added warn-only tests help catch data integrity regressions but won’t block builds.
> 
> **Overview**
> Integrates 2026+ DDHQ election results into the civics marts by extending entity-resolution crosswalks and updating the mart merges to **three-way full-outer-join** `ballotready` + `techspeed` + `ddhq`, allowing Splink-matched DDHQ rows to collapse onto BR canonical `gp_*` IDs while DDHQ-only rows flow through with `source_systems = ['ddhq']`.
> 
> Updates DDHQ intermediates to coalesce computed IDs against `int__civics_er_canonical_ids` (now keyed for DDHQ by `(candidate_id, race_id)`), standardizes DDHQ `state` naming in staging, and adjusts mart-level precedence rules (notably: DDHQ wins for `candidacy_stage` outcome fields and adds `is_uncontested`; `election_stage` prefers DDHQ totals over BR’s `'uncontested'` sentinel; `election.has_ddhq_match` is derived from DDHQ join presence).
> 
> Adds/updates civics docs and tests in `m_civics.yaml` (including a warn-severity `candidacy.gp_election_id` relationship and stricter `election_result_source` enum), plus 5 new warn-only domain sanity tests around vote totals, winner counts vs seats, uncontested semantics, and results appearing before election dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486a6a44ae1aab72bd54ac70b3dc3657601b5b5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->