### PR TITLE
Add ICP flags to PMF survey via int__hubspot_contacts

### DIFF
--- a/dbt/project/models/intermediate/int__hubspot.yaml
+++ b/dbt/project/models/intermediate/int__hubspot.yaml
@@ -18,6 +18,58 @@ models:
         description: "Last name of the contact"
         tests:
           - not_null
+      - name: br_position_id
+        description: >
+          BallotReady position database ID stored on the HubSpot contact.
+          Sourced from the HubSpot `br_position_id` property — a denormalized
+          snapshot that may lag the authoritative BallotReady data. Joins to
+          `int__icp_offices.br_database_position_id`.
+      - name: br_candidacy_id
+        description: >
+          BallotReady candidacy database ID stored on the HubSpot contact.
+          Sourced from the HubSpot `br_candidacy_id` property.
+      - name: br_race_id
+        description: >
+          BallotReady race database ID stored on the HubSpot contact. Sourced
+          from the HubSpot `br_race_id` property.
+      - name: effective_br_position_id
+        description: >
+          Resolved BallotReady position database ID for the contact, used to
+          join `int__icp_offices`. Coalesces (in order): the contact's
+          `br_position_id`, lookup via `br_race_id` against
+          `stg_airbyte_source__ballotready_api_race`, lookup via
+          `br_candidacy_id` against `int__ballotready_candidacy`, and finally
+          a lookup through the contact's HubSpot company associations to a
+          gp_api `campaigns` row carrying a `ballotready_position_id`.
+      - name: icp_win
+        description: >
+          Whether the contact's position qualifies for the Win ICP (Ideal
+          Customer Profile). Joined from `int__icp_offices` via
+          `br_position_id`. The Win effective-date guard is applied: positions
+          with a `win_effective_date` only return true when the contact's
+          general election date is on or after that date.
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: icp_serve
+        description: >
+          Whether the contact's position qualifies for the Serve ICP. Joined
+          from `int__icp_offices` via `br_position_id`. Pass-through of
+          `icp_office_serve` (no effective-date guard).
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: icp_win_supersize
+        description: >
+          Whether the contact's position is a Win-Supersize office (>100K
+          voters meeting all other ICP criteria). Joined from `int__icp_offices`
+          via `br_position_id`. Same effective-date guard as `icp_win`.
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
 
   - name: int__hubspot_contacts_w_companies
     description: >

--- a/dbt/project/models/intermediate/int__hubspot_contacts.sql
+++ b/dbt/project/models/intermediate/int__hubspot_contacts.sql
@@ -5,74 +5,189 @@
     )
 }}
 
+with
+    -- Many races map to one position (primary + general for the same office),
+    -- so this is many-to-one and will not fan out the contacts.
+    br_race as (
+        select
+            database_id as race_database_id,
+            position.`databaseId` as position_database_id
+        from {{ ref("stg_airbyte_source__ballotready_api_race") }}
+    ),
+
+    br_candidacy as (
+        select database_id as candidacy_database_id, position_database_id
+        from {{ ref("int__ballotready_candidacy") }}
+    ),
+
+    -- gp_api stores HubSpot's COMPANY id on the campaign (not the contact id),
+    -- and HubSpot contacts carry an array of associated companies. This lookup
+    -- recovers a BR position for HubSpot contacts whose own br_*_id properties
+    -- are unset — common for product users (e.g. PMF respondents).
+    campaigns_by_company as (
+        select hubspot_id as company_id, ballotready_position_id
+        from {{ ref("campaigns") }}
+        where
+            is_latest_version
+            and hubspot_id is not null
+            and ballotready_position_id is not null
+        qualify row_number() over (partition by hubspot_id order by updated_at desc) = 1
+    ),
+
+    contact_company_pairs as (
+        select
+            contacts.id as contact_id,
+            explode(from_json(contacts.companies, 'array<string>')) as company_id
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }} as contacts
+        where
+            contacts.companies is not null
+            and trim(contacts.companies) not in ('', '[]')
+    ),
+
+    -- Pick one resolved position per contact so downstream joins stay 1:1.
+    contact_position_via_campaign as (
+        select contact_id, ballotready_position_id
+        from contact_company_pairs
+        inner join
+            campaigns_by_company
+            on contact_company_pairs.company_id = campaigns_by_company.company_id
+        qualify
+            row_number() over (partition by contact_id order by ballotready_position_id)
+            = 1
+    ),
+
+    -- Resolve an effective BR position ID. Prefer the directly-stored
+    -- br_position_id, then race ID (highest HubSpot-side coverage), candidacy
+    -- ID, and finally a linked gp_api campaign via the HubSpot company array.
+    tbl_hs_contacts as (
+        select
+            contacts.*,
+            coalesce(
+                contacts.br_position_id,
+                br_race.position_database_id,
+                br_candidacy.position_database_id,
+                contact_position_via_campaign.ballotready_position_id
+            ) as effective_br_position_id
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }} as contacts
+        left join br_race on contacts.br_race_id = br_race.race_database_id
+        left join
+            br_candidacy
+            on contacts.br_candidacy_id = br_candidacy.candidacy_database_id
+        left join
+            contact_position_via_campaign
+            on contacts.id = contact_position_via_campaign.contact_id
+    ),
+
+    -- Join ICP and pre-compute the effective-date guard once so icp_win and
+    -- icp_win_supersize stay DRY in the final SELECT. The guard mirrors
+    -- m_ballotready_internal__records_sent_to_hubspot: positions with a
+    -- win_effective_date only count for elections on/after that date.
+    contacts_with_icp as (
+        select
+            tbl_hs_contacts.*,
+            tbl_states.state_cleaned_postal_code,
+            tbl_icp_offices.icp_office_win,
+            tbl_icp_offices.icp_office_serve,
+            tbl_icp_offices.icp_win_supersize,
+            tbl_icp_offices.icp_win_effective_date is not null
+            and (
+                cast(
+                    coalesce(
+                        tbl_hs_contacts.election_date,
+                        tbl_hs_contacts.general_election_date,
+                        tbl_hs_contacts.primary_election_date
+                    ) as date
+                )
+                is null
+                or cast(
+                    coalesce(
+                        tbl_hs_contacts.election_date,
+                        tbl_hs_contacts.general_election_date,
+                        tbl_hs_contacts.primary_election_date
+                    ) as date
+                )
+                < tbl_icp_offices.icp_win_effective_date
+            ) as is_before_icp_win_effective_date
+        from tbl_hs_contacts
+        left join
+            {{ ref("clean_states") }} as tbl_states
+            on trim(upper(tbl_hs_contacts.state)) = tbl_states.state_raw
+        left join
+            {{ ref("int__icp_offices") }} as tbl_icp_offices
+            on tbl_hs_contacts.effective_br_position_id
+            = tbl_icp_offices.br_database_position_id
+    )
+
 select
     -- identifiers and relations
-    tbl_hs_contacts.id,
+    id,
+    br_position_id,
+    br_candidacy_id,
+    br_race_id,
+    effective_br_position_id,
     case
-        when
-            tbl_hs_contacts.companies is null
-            or trim(tbl_hs_contacts.companies) = ''
-            or trim(tbl_hs_contacts.companies) = '[]'
+        when companies is null or trim(companies) = '' or trim(companies) = '[]'
         then null
-        else from_json(tbl_hs_contacts.companies, 'array<string>')
+        else from_json(companies, 'array<string>')
     end as companies,  -- type is array<string>
 
     -- Personal information
-    tbl_hs_contacts.full_name,
-    tbl_hs_contacts.first_name,
-    tbl_hs_contacts.last_name,
-    tbl_hs_contacts.birth_date,
-    tbl_hs_contacts.email,
-    tbl_hs_contacts.email as email_contacts,
-    tbl_hs_contacts.phone as phone_number,
-    tbl_hs_contacts.website as website_url,
-    tbl_hs_contacts.instagram_handle,
-    tbl_hs_contacts.linkedin_url,
-    tbl_hs_contacts.twitter_handle,
-    tbl_hs_contacts.facebook_url,
-    tbl_hs_contacts.address as street_address,
-    tbl_hs_contacts.candidate_id_source,
-    tbl_hs_contacts.candidate_id_tier,
-    tbl_hs_contacts.is_pledged,
-    tbl_hs_contacts.verified_candidate_status,
+    full_name,
+    first_name,
+    last_name,
+    birth_date,
+    email,
+    email as email_contacts,
+    phone as phone_number,
+    website as website_url,
+    instagram_handle,
+    linkedin_url,
+    twitter_handle,
+    facebook_url,
+    address as street_address,
+    candidate_id_source,
+    candidate_id_tier,
+    is_pledged,
+    verified_candidate_status,
 
     -- Office information
-    tbl_hs_contacts.official_office_name,
-    tbl_hs_contacts.candidate_office,
-    tbl_hs_contacts.office_level,
-    tbl_hs_contacts.office_type,
-    tbl_hs_contacts.party_affiliation,
-    tbl_hs_contacts.is_partisan,
+    official_office_name,
+    candidate_office,
+    office_level,
+    office_type,
+    party_affiliation,
+    is_partisan,
 
     -- Geographic information
-    coalesce(tbl_states.state_cleaned_postal_code, tbl_hs_contacts.state) as state,
-    tbl_hs_contacts.city,
-    tbl_hs_contacts.candidate_district as district,
+    coalesce(state_cleaned_postal_code, state) as state,
+    city,
+    candidate_district as district,
     cast(null as string) as seat,
-    tbl_hs_contacts.is_open_seat,
-    tbl_hs_contacts.population,
+    is_open_seat,
+    population,
 
     -- Election dates
-    tbl_hs_contacts.filing_deadline,
-    tbl_hs_contacts.primary_election_date,
-    coalesce(
-        tbl_hs_contacts.election_date, tbl_hs_contacts.general_election_date
-    ) as general_election_date,
+    filing_deadline,
+    primary_election_date,
+    coalesce(election_date, general_election_date) as general_election_date,
     cast(null as date) as runoff_election_date,
 
     -- Election context
-    tbl_hs_contacts.is_incumbent,
-    tbl_hs_contacts.is_uncontested,
-    tbl_hs_contacts.number_opponents as number_of_opponents,
+    is_incumbent,
+    is_uncontested,
+    number_opponents as number_of_opponents,
+
+    -- ICP flags
+    case
+        when is_before_icp_win_effective_date then false else icp_office_win
+    end as icp_win,
+    icp_office_serve as icp_serve,
+    case
+        when is_before_icp_win_effective_date then false else icp_win_supersize
+    end as icp_win_supersize,
 
     -- Metadata
-    tbl_hs_contacts.created_at,
-    tbl_hs_contacts.updated_at
-from {{ ref("stg_airbyte_source__hubspot_api_contacts") }} tbl_hs_contacts
-left join
-    {{ ref("clean_states") }} as tbl_states
-    on trim(upper(tbl_hs_contacts.state)) = tbl_states.state_raw
-where
-    1 = 1
-    and tbl_hs_contacts.first_name is not null
-    and tbl_hs_contacts.last_name is not null
+    created_at,
+    updated_at
+from contacts_with_icp
+where first_name is not null and last_name is not null

--- a/dbt/project/models/intermediate/int__hubspot_contacts.sql
+++ b/dbt/project/models/intermediate/int__hubspot_contacts.sql
@@ -25,7 +25,7 @@ with
     -- recovers a BR position for HubSpot contacts whose own br_*_id properties
     -- are unset — common for product users (e.g. PMF respondents).
     campaigns_by_company as (
-        select hubspot_id as company_id, ballotready_position_id
+        select hubspot_id as company_id, ballotready_position_id, election_date
         from {{ ref("campaigns") }}
         where
             is_latest_version
@@ -45,6 +45,8 @@ with
     ),
 
     -- Pick one resolved position per contact so downstream joins stay 1:1.
+    -- Prefer the campaign with the latest election_date (most relevant to the
+    -- contact's current cycle); ballotready_position_id breaks ties.
     contact_position_via_campaign as (
         select contact_id, ballotready_position_id
         from contact_company_pairs
@@ -52,7 +54,10 @@ with
             campaigns_by_company
             on contact_company_pairs.company_id = campaigns_by_company.company_id
         qualify
-            row_number() over (partition by contact_id order by ballotready_position_id)
+            row_number() over (
+                partition by contact_id
+                order by election_date desc nulls last, ballotready_position_id
+            )
             = 1
     ),
 

--- a/dbt/project/models/intermediate/int__hubspot_contacts.sql
+++ b/dbt/project/models/intermediate/int__hubspot_contacts.sql
@@ -64,7 +64,7 @@ with
     -- Resolve an effective BR position ID. Prefer the directly-stored
     -- br_position_id, then race ID (highest HubSpot-side coverage), candidacy
     -- ID, and finally a linked gp_api campaign via the HubSpot company array.
-    tbl_hs_contacts as (
+    hs_contacts as (
         select
             contacts.*,
             coalesce(
@@ -89,38 +89,38 @@ with
     -- win_effective_date only count for elections on/after that date.
     contacts_with_icp as (
         select
-            tbl_hs_contacts.*,
-            tbl_states.state_cleaned_postal_code,
-            tbl_icp_offices.icp_office_win,
-            tbl_icp_offices.icp_office_serve,
-            tbl_icp_offices.icp_win_supersize,
-            tbl_icp_offices.icp_win_effective_date is not null
+            hs_contacts.*,
+            states.state_cleaned_postal_code,
+            icp_offices.icp_office_win,
+            icp_offices.icp_office_serve,
+            icp_offices.icp_win_supersize,
+            icp_offices.icp_win_effective_date is not null
             and (
                 cast(
                     coalesce(
-                        tbl_hs_contacts.election_date,
-                        tbl_hs_contacts.general_election_date,
-                        tbl_hs_contacts.primary_election_date
+                        hs_contacts.election_date,
+                        hs_contacts.general_election_date,
+                        hs_contacts.primary_election_date
                     ) as date
                 )
                 is null
                 or cast(
                     coalesce(
-                        tbl_hs_contacts.election_date,
-                        tbl_hs_contacts.general_election_date,
-                        tbl_hs_contacts.primary_election_date
+                        hs_contacts.election_date,
+                        hs_contacts.general_election_date,
+                        hs_contacts.primary_election_date
                     ) as date
                 )
-                < tbl_icp_offices.icp_win_effective_date
+                < icp_offices.icp_win_effective_date
             ) as is_before_icp_win_effective_date
-        from tbl_hs_contacts
+        from hs_contacts
         left join
-            {{ ref("clean_states") }} as tbl_states
-            on trim(upper(tbl_hs_contacts.state)) = tbl_states.state_raw
+            {{ ref("clean_states") }} as states
+            on trim(upper(hs_contacts.state)) = states.state_raw
         left join
-            {{ ref("int__icp_offices") }} as tbl_icp_offices
-            on tbl_hs_contacts.effective_br_position_id
-            = tbl_icp_offices.br_database_position_id
+            {{ ref("int__icp_offices") }} as icp_offices
+            on hs_contacts.effective_br_position_id
+            = icp_offices.br_database_position_id
     )
 
 select

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1255,6 +1255,33 @@ models:
         description: Email address of the respondent
         data_tests:
           - not_null
+      - name: icp_win
+        description: >
+          Whether the respondent's office qualifies for the Win ICP. Sourced
+          from int__hubspot_contacts which resolves a BR position via
+          br_position_id (preferred), br_race_id, or br_candidacy_id. The Win
+          effective-date guard is applied. Null when no BR position resolves.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: icp_serve
+        description: >
+          Whether the respondent's office qualifies for the Serve ICP. Sourced
+          from int__hubspot_contacts. Null when no BR position resolves.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: icp_win_supersize
+        description: >
+          Whether the respondent's office is a Win-Supersize office (>100K
+          voters meeting all other ICP criteria). Sourced from
+          int__hubspot_contacts. Null when no BR position resolves.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
 
   - name: win_user_satisfaction_responses
     description: >

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -34,6 +34,11 @@ with
         from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
     ),
 
+    contact_icp as (
+        select id as hs_contact_id, icp_win, icp_serve, icp_win_supersize
+        from {{ ref("int__hubspot_contacts") }}
+    ),
+
     final as (
         select
             -- identifiers
@@ -82,6 +87,10 @@ with
             c.verified_candidate_status,
             c.office_level,
 
+            icp.icp_win,
+            icp.icp_serve,
+            icp.icp_win_supersize,
+
             -- submission context
             s.submission_url,
             s.submitted_at,
@@ -90,6 +99,7 @@ with
 
         from submissions s
         left join contacts c on s.hs_contact_id = c.hs_contact_id
+        left join contact_icp icp on s.hs_contact_id = icp.hs_contact_id
     )
 
 select *

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
@@ -18,9 +18,11 @@ select
     properties_address as address,
 
     -- candidate information
-    properties_br_race_id as br_race_id,
-    get_json_object(properties, '$.br_candidacy_id') as br_candidacy_id,
-    get_json_object(properties, '$.br_position_id') as br_position_id,
+    try_cast(properties_br_race_id as int) as br_race_id,
+    try_cast(
+        get_json_object(properties, '$.br_candidacy_id') as int
+    ) as br_candidacy_id,
+    try_cast(get_json_object(properties, '$.br_position_id') as int) as br_position_id,
     properties_candidate_id_source as candidate_id_source,
     properties_candidate_id_tier as candidate_id_tier,
     get_json_object(properties, '$.candidate_id_result') as candidate_id_result,


### PR DESCRIPTION
## Summary

- Resolves an `effective_br_position_id` on `int__hubspot_contacts` via four fallbacks: direct `br_position_id`, lookup via `br_race_id` against `stg_airbyte_source__ballotready_api_race`, lookup via `br_candidacy_id` against `int__ballotready_candidacy`, and finally a HubSpot company association lookup against the `campaigns` mart.
- Joins `int__icp_offices` on that key and surfaces `icp_win`, `icp_serve`, `icp_win_supersize` on `int__hubspot_contacts`. Effective-date guard mirrors `m_ballotready_internal__records_sent_to_hubspot`, with the date taken as `coalesce(election_date, general_election_date, primary_election_date)`.
- Casts `br_position_id`, `br_candidacy_id`, `br_race_id` on `stg_airbyte_source__hubspot_api_contacts` to int via `try_cast` so they line up with BR `database_id` columns. The literal string `'null'` is a known value in this property — `try_cast` tolerates it.
- Adds the same three ICP flags to `pmf_survey_responses` by joining `int__hubspot_contacts` on `hs_contact_id`.

## Coverage

| metric | before | after |
| --- | --- | --- |
| HubSpot contacts with `effective_br_position_id` | 11,461 (4.4%) | 75,627 (29.0%) |
| Contacts ICP-matched | n/a | 74,979 |
| PMF Win responses with ICP | 5/27 | 24/27 (89%) |
| PMF Serve responses with ICP | 4/15 | 10/15 (67%) |

The campaign-via-company fallback is the largest contributor (~28k contacts) — most product users with a campaign carrying a `ballotready_position_id` had no BR IDs of their own on the HubSpot contact.

## Test plan

- [x] `dbt build --select "stg_airbyte_source__hubspot_api_contacts int__hubspot_contacts pmf_survey_responses"` (all tests pass — accepted_values on the three ICP flags + existing relationship/uniqueness)
- [x] Spot-checked PMF coverage by `pmf_variant`
- [x] Verified `effective_br_position_id` is 1:1 with contacts (no fanout from race/candidacy/companies lookups)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core contact enrichment logic and adds multi-source ID resolution/joins, which can affect downstream analytics coverage and correctness if key casting or 1:1 selection logic is off; no auth or write-path impact.
> 
> **Overview**
> Adds BallotReady ID normalization and a new `effective_br_position_id` on `int__hubspot_contacts`, resolving a position via direct HubSpot fields, race/candidacy lookups, or HubSpot company → latest `campaigns` association, then joins `int__icp_offices` to surface `icp_win`, `icp_serve`, and `icp_win_supersize` (with a Win effective-date guard).
> 
> Propagates these ICP flags into the `pmf_survey_responses` mart and documents/tests the new columns in `int__hubspot.yaml` and `m_analytics.yaml`; HubSpot `br_*_id` staging fields are now `try_cast` to `int` to align joins and tolerate literal `'null'` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e279f58a195239fb3d5caeeddbc6900ef0c770. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->