### PR TITLE
DATA-1880: expand gp-api candidacy office_level to BR's 7-bucket taxonomy

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -1842,6 +1842,30 @@ models:
                   - Primary Special Runoff
                   - General Special Runoff
 
+      - name: office_level
+        description: >
+          Normalized office level matching BallotReady's 7-bucket PositionLevel
+          taxonomy (City/Local/County/Township/State/Regional/Federal). BR and
+          TS sources emit initcap(level) directly. The gp-api source prefers
+          initcap(br_position_level) when available (gp-api candidacy rows
+          inner-join to BR race via ballotready_position_id, so coverage is
+          near-100%); otherwise falls back to campaigns.election_level which
+          collapses to a 4-bucket subset (Local/County/State/Federal —
+          City/Town/Township are not distinguishable at gp-api granularity).
+          DDHQ emits a 3-value subset (Local/County/State) from race_name
+          parsing. Null is permitted for sources that cannot resolve a level.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - City
+                  - Local
+                  - County
+                  - Township
+                  - State
+                  - Regional
+                  - Federal
+
   - name: int__er_prematch_elected_officials
     description: >
       Entity resolution prematch table: BallotReady x TechSpeed elected

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -163,7 +163,11 @@ with
             ts.state_code as state,
             ts.party,
             ts.candidate_office,
-            ts.office_level,
+            -- TS staging emits mixed-case values (e.g. 'COUNTY', 'LOCAL', 'local')
+            -- alongside the dominant initcap form. Normalize here to mirror
+            -- initcap(br.level) on ballotready_stages above and keep the unioned
+            -- prematch column on a single canonical vocabulary.
+            initcap(ts.office_level) as office_level,
             ts.office_type,
             ts.district as district_raw,
             try_cast(

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -341,8 +341,17 @@ with
             upper(trim(g.campaign_state)) as state,
             {{ parse_party_affiliation("g.campaign_party") }} as party,
             g.candidate_office,
-            -- Prefer campaign election_level; fall back to BR position level
+            -- Prefer BR's 7-bucket PositionLevel taxonomy when br_position_level
+            -- is available. Mirrors initcap(br.level) on ballotready_stages
+            -- above (and int__civics_elected_official_gp_api), so cross-source
+            -- ExactMatch("office_level") works against BR/TS records that emit
+            -- City/Township/Regional. For rows without a BR position FK, fall
+            -- back to gp-api's native election_level (4-bucket: City/Local
+            -- collapse to Local; cannot distinguish City/Town/Township at this
+            -- granularity).
             case
+                when g.br_position_level is not null
+                then initcap(g.br_position_level)
                 when lower(g.election_level) in ('city', 'local')
                 then 'Local'
                 when lower(g.election_level) = 'county'
@@ -350,14 +359,6 @@ with
                 when lower(g.election_level) = 'state'
                 then 'State'
                 when lower(g.election_level) = 'federal'
-                then 'Federal'
-                when lower(g.br_position_level) in ('city', 'local', 'township')
-                then 'Local'
-                when lower(g.br_position_level) in ('county', 'regional')
-                then 'County'
-                when lower(g.br_position_level) = 'state'
-                then 'State'
-                when lower(g.br_position_level) = 'federal'
                 then 'Federal'
                 else null
             end as office_level,


### PR DESCRIPTION
## Summary

Cross-pipeline parity follow-up to [DATA-1731](https://goodparty.clickup.com/t/90131918049/DATA-1731). Expands the gp-api candidacy ER prematch's `office_level` derivation to BR's 7-bucket PositionLevel taxonomy, mirroring the EO-side fix at [PR #346 commit 44107a8](https://github.com/thegoodparty/gp-data-platform/pull/346/commits/44107a896003a3c2e70fe0a6df46883345a5015a).

While adding the new `accepted_values` test, also caught and fixed a pre-existing TS data-quality issue (mixed-case office_level values).

## Why

Previously, the gp-api candidacy `office_level` CASE in `int__er_prematch_candidacy_stages.sql` collapsed BR's `City`/`Township` into `Local` and `Regional` into `County` (4-bucket vocabulary). This loses cross-pipeline taxonomy alignment with BR/TS records — which emit the full BR `PositionLevel` enum (`City`/`Local`/`County`/`Township`/`State`/`Regional`/`Federal`).

The EO sibling pipeline was fixed in PR #346 (commit 44107a8). This PR ports the identical fix to candidacy for consistency, and as a corollary cleans up TS case normalization that the new test caught.

## Changes

- **`int__er_prematch_candidacy_stages.sql` (gp_api_stages CTE, lines 344–363):**
  - Flips priority — now prefers `initcap(g.br_position_level)` when available, mirroring `initcap(br.level)` on the BR source above (line 86) and `int__civics_elected_official_gp_api`.
  - Falls back to the existing `election_level` mapping for rows without a BR position FK. Coverage of `br_position_level` is **100%** of pre-dedup gp-api candidacy rows; the fallback is a safety net.
  - Removes the BR-specific `WHEN` clauses that did the 4-bucket collapse.

- **`int__er_prematch_candidacy_stages.sql` (techspeed_stages CTE, line 166):**
  - `ts.office_level` → `initcap(ts.office_level)`. TS staging emits mixed-case values (`COUNTY`, `LOCAL`, `local`) alongside the dominant initcap form; normalize here to mirror BR and keep the unioned prematch column on a single canonical vocabulary.

- **`int__civics.yaml`:** adds a documented `office_level` column entry to the `int__er_prematch_candidacy_stages` schema with `accepted_values` for the full BR taxonomy. The candidacy prematch had no `office_level` schema docs (asymmetric with EO post-PR #346); this PR aligns them.

## Verification — bucket distribution

**Baseline (prod, current 4-bucket logic, post-dedup, gp_api source):**

| office_level | n     | share |
| ------------ | ----- | ----- |
| State        | 5,709 | 27.9% |
| Local        | 5,622 | 27.5% |
| County       | 4,795 | 23.4% |
| Federal      | 4,326 | 21.2% |
| **Total**    | **20,452** |  |

**CI-built table (new 7-bucket logic, gp_api source, post-dedup):**

| office_level | n     | share |
| ------------ | ----- | ----- |
| State        | 5,729 | 28.1% |
| County       | 4,767 | 23.4% |
| Federal      | 4,341 | 21.3% |
| City         | 3,550 | 17.4% |
| Local        | 1,699 | 8.3%  |
| Township     | 301   | 1.5%  |
| Regional     | 65    | 0.3%  |
| **Total**    | **20,452** |  |

Pattern matches expected: old "Local" splits into new Local/City/Township; old "County" mostly stays County with "Regional" peeling off; "State"/"Federal" essentially unchanged. Total unchanged (20,452). (Working artifact: `.tickets/data-1880/distribution-validation.md`.)

## Match-rate impact

**The candidacy matcha config does NOT use `office_level` as a Splink comparison.** Verified against `gp-data-matcha/scripts/configs/candidacy.py` — `office_level` appears only in `additional_columns_to_retain` (passthrough), not in `comparisons`, `blocking_rules_for_prediction`, `em_training_blocks`, or `post_prediction_filters`.

Implication: this change has **zero impact on candidacy match rates** by construction, regardless of EM training noise. (Contrast with EO PR #346, where `cl.ExactMatch("office_level")` IS a comparison and the change drove a -0.3pp recall-neutral delta.)

The value of this PR is therefore purely:
1. Cross-pipeline taxonomy alignment (consistency principle)
2. Better-typed passthrough column for downstream consumers (e.g., the candidacy/EO marts that union office_level cross-source — see `int__civics_candidacy_gp_api.office_level` description at int__civics.yaml line 2231 referencing the cross-source enum)
3. Explicit `accepted_values` test that catches future regressions — already paid off by catching the TS case-mixed values

**No matcha PR needed; no candidacy matcha re-run is required to validate this change.**

## Test plan

- [x] Pre-commit + Python Tests CI green
- [x] dbt Cloud CI builds the model successfully (first run found the TS case bug; fix pushed)
- [ ] dbt Cloud CI green on the second run after TS fix — `accepted_values` test passes against live data
- [x] Distribution against CI-built table matches the simulation (20,452 total preserved; expected 7-bucket split)
- [x] Verified candidacy matcha config does not reference `office_level` as a comparison feature → zero match-rate impact by construction

## Out of scope

- DDHQ source still emits a 3-value subset (`Local`/`County`/`State`) from race-name parsing. That's a deeper source-specific limitation — could be filed as a separate ticket if desired.
- Adding `office_level` as a Splink comparison feature in candidacy matcha. Possible follow-up ticket: this PR's taxonomy alignment is the prerequisite for cross-source `ExactMatch("office_level")` to fire correctly. EM retraining + match-rate validation needed; non-trivial.
- Matcha config changes — not required for this PR (verified above).

## Refs

- DATA-1880 (this PR)
- DATA-1731 (parent — EO prematch rewrite)
- PR #346 (EO sibling fix; commit 44107a8 is the direct precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)