### PR TITLE
Candidacy ER: gamma_office_level + bf_office_level in pairwise staging

### DIFF
--- a/dbt/project/models/staging/er_source/__er_source.yaml
+++ b/dbt/project/models/staging/er_source/__er_source.yaml
@@ -277,6 +277,16 @@ models:
         description: >
           Bayes factor for the district_identifier comparison. Values >1 indicate
           evidence of match; <1 indicate evidence of non-match.
+      - name: office_level_l
+        description: Left record's office level classification.
+      - name: office_level_r
+        description: Right record's office level classification.
+      - name: gamma_office_level
+        description: "Comparison level for office_level: 1=exact match, -1=one or both null, 0=else."
+      - name: bf_office_level
+        description: >
+          Bayes factor for the office_level comparison. Values >1 indicate
+          evidence of match; <1 indicate evidence of non-match.
       - name: br_race_id_l
         description: Left record's BallotReady race ID.
       - name: br_race_id_r
@@ -285,10 +295,6 @@ models:
         description: Left record's candidate office name.
       - name: candidate_office_r
         description: Right record's candidate office name.
-      - name: office_level_l
-        description: Left record's office level classification.
-      - name: office_level_r
-        description: Right record's office level classification.
       - name: office_type_l
         description: Left record's office type classification.
       - name: office_type_r
@@ -420,7 +426,9 @@ models:
       bypass). No race ID filter (elected officials have no br_race_id).
 
       Compared to candidacy stages, this entity type adds office_type and
-      office_level as Splink comparisons and drops election_date.
+      ballotready_position_id as Splink comparisons and drops election_date
+      and br_race_id. (office_level is a Splink comparison in both entity
+      types.)
     columns:
       - name: match_weight
         description: >

--- a/dbt/project/models/staging/er_source/stg_er_source__pairwise_candidacy_stages.sql
+++ b/dbt/project/models/staging/er_source/stg_er_source__pairwise_candidacy_stages.sql
@@ -81,13 +81,17 @@ with
             cast(gamma_district_identifier as int) as gamma_district_identifier,
             cast(bf_district_identifier as double) as bf_district_identifier,
 
+            -- office_level comparison
+            office_level_l,
+            office_level_r,
+            cast(gamma_office_level as int) as gamma_office_level,
+            cast(bf_office_level as double) as bf_office_level,
+
             -- race-level context
             cast(br_race_id_l as int) as br_race_id_l,
             cast(br_race_id_r as int) as br_race_id_r,
             candidate_office_l,
             candidate_office_r,
-            office_level_l,
-            office_level_r,
             office_type_l,
             office_type_r,
             district_raw_l,


### PR DESCRIPTION
## Summary

Companion to [gp-data-matcha PR #10](https://github.com/thegoodparty/gp-data-matcha/pull/10), which adds `cl.ExactMatch("office_level")` as the 10th candidacy Splink comparison. Splink's pairwise output now contains `gamma_office_level` (1=match, 0=mismatch, -1=null) and `bf_office_level` (Bayes factor) columns; this PR projects them in the candidacy pairwise staging model and documents them in `__er_source.yaml`.

Builds on [DATA-1880 / PR #352](https://github.com/thegoodparty/gp-data-platform/pull/352) — the taxonomy alignment was the prerequisite. Spec at `.tickets/data-1880/follow-up-office-level-comparison.md`.

## Changes

- **`stg_er_source__pairwise_candidacy_stages.sql`:** moves `office_level_l` and `office_level_r` out of the "race-level context" passthrough block into a dedicated "office_level comparison" block, and adds `cast(gamma_office_level as int)` and `cast(bf_office_level as double)`. Mirrors the EO pairwise staging pattern.
- **`__er_source.yaml`:** adds column descriptions for `gamma_office_level` and `bf_office_level` on the candidacy pairwise model. Updates the EO clustered description (now correctly notes that `office_level` is a comparison in BOTH entity types — the EO differentiator is `office_type` and `ballotready_position_id`, not `office_level`).

## Verification

Built against live `er_source.pairwise_candidacy_stages` after the matcha rerun overwrote the table with the new schema:

```
$ dbt build -s stg_er_source__pairwise_candidacy_stages
Done. PASS=9 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=9
```

```sql
select count(*) as n_rows,
       count(gamma_office_level) as has_gamma,
       count(bf_office_level) as has_bf
from goodparty_data_catalog.er_source.pairwise_candidacy_stages
-- → 15741 / 15741 / 15741
```

Regression check on clustered candidacy staging:
```
$ dbt build -s stg_er_source__clustered_candidacy_stages
Done. PASS=8 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=8
```

## Coordination

- **Companion gp-data-matcha PR:** thegoodparty/gp-data-matcha#10
- Matcha was re-run against `goodparty_data_catalog.dbt.int__er_prematch_candidacy_stages` with `--output-cluster-table` and `--output-pairwise-table` flags before this PR was opened, so the new schema is already live in `goodparty_data_catalog.er_source.*`.

## Match-rate impact

Cluster output is bit-for-bit identical pre/post the comparison feature on current data — see the matcha PR for the empirical analysis. The value is defensive coverage as gp-api volume scales, not a current-data recall lift.

## Test plan

- [x] `dbt build -s stg_er_source__pairwise_candidacy_stages` passes (9/9)
- [x] `dbt build -s stg_er_source__clustered_candidacy_stages` passes (8/8) — no regression
- [x] `gamma_office_level` and `bf_office_level` populated on all 15,741 pairwise rows in live `er_source`
- [ ] dbt Cloud CI green

## Refs

- Spec: `.tickets/data-1880/follow-up-office-level-comparison.md`
- Empirical findings: `.tickets/data-1880/comparison-feature-empirical-findings.md`
- Companion PR: thegoodparty/gp-data-matcha#10
- Prereq: DATA-1880 / PR #352
- Pattern source: PR #346 (DATA-1731 EO prematch + staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `gamma_office_level`/`bf_office_level` fields to the `stg_er_source__pairwise_candidacy_stages` model, which is a schema change that could affect downstream consumers expecting a fixed column set.
> 
> **Overview**
> Exposes Splink’s `office_level` comparison outputs in candidacy-stage pairwise staging by selecting `gamma_office_level` and `bf_office_level` (and grouping `office_level_l/r` alongside those comparison fields) in `stg_er_source__pairwise_candidacy_stages`.
> 
> Updates `__er_source.yaml` to document the new candidacy pairwise columns and corrects the elected-officials pairwise model description to clarify which comparison features differ between entity types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d6c22ac41597df85b74cb869c71e00d651c7d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->