### PR TITLE
DDHQ matcha integration: cluster-based candidacy_stage merge

### DIFF
--- a/dbt/project/macros/office_name_tokens.sql
+++ b/dbt/project/macros/office_name_tokens.sql
@@ -1,25 +1,15 @@
 {% macro office_name_tokens(col) %}
-    -- Build a normalized array of meaningful tokens from an office-name string,
-    -- for use with Splink's ArrayIntersectLevel as a fallback office-overlap
-    -- match level (mirrors how first_name_aliases drives nickname matching).
+    -- Normalized token array for Splink ArrayIntersectLevel office-overlap.
     --
-    -- Punctuation is preserved on tokens (matches the existing locality-token
-    -- check in scripts/constants.py): "(juneau" stays distinct from "juneau"
-    -- so a WI town-of-X (county) ↔ X-county-supervisor pair correctly fails
-    -- to overlap, even though both contain a "juneau"-ish substring.
+    -- Punctuation is intentionally preserved so e.g. "(juneau" stays distinct
+    -- from "juneau" — a WI town-of-X (county) row must not overlap with an
+    -- X-county-supervisor row even though both contain a "juneau"-ish token.
     --
-    -- Steps:
-    -- 1. Lowercase
-    -- 2. Collapse "r- iii" (DDHQ form with internal space) → "r-iii"
-    -- 3. Inject "r-N" after "no. N" so DDHQ's MO "Reorganized School
-    -- District No. 4" emits an "r-4" token that overlaps with BR's
-    -- "Blue Springs R-4 School Board"
-    -- 4. Split on whitespace
-    -- 5. Per-token CASE: normalize roman-numeral school district codes
-    -- (r-i ↔ r-1, r-ii ↔ r-2, …) so DDHQ's "<county> County R-IV" shares
-    -- an "r-4" token with BR's "<city> R-4 School Board"
-    -- 6. Drop length≤1, pure-digit, and stop-word tokens (stop-word list
-    -- mirrors OFFICE_STOP_WORDS in scripts/constants.py)
+    -- Roman-numeral and "No. N" → "r-N" rewrites let DDHQ "Lincoln County
+    -- R-IV School District" intersect with BR "Winfield R-4 School Board".
+    --
+    -- Stop-word list mirrors OFFICE_STOP_WORDS in the matcha repo's
+    -- scripts/constants.py — keep both in sync when editing.
     filter(
         transform(
             split(

--- a/dbt/project/macros/office_name_tokens.sql
+++ b/dbt/project/macros/office_name_tokens.sql
@@ -1,9 +1,11 @@
 {% macro office_name_tokens(col) %}
     -- Normalized token array for Splink ArrayIntersectLevel office-overlap.
     --
-    -- Punctuation is intentionally preserved so e.g. "(juneau" stays distinct
-    -- from "juneau" — a WI town-of-X (county) row must not overlap with an
-    -- X-county-supervisor row even though both contain a "juneau"-ish token.
+    -- Trailing punctuation is stripped so "county," matches the "county" stop
+    -- word and "r-iv," normalizes to "r-4". Leading punctuation is preserved:
+    -- "(juneau" (parenthetical-county marker on a WI town-of-X row) must stay
+    -- distinct from "juneau" (substantive locality on a county-supervisor row)
+    -- to avoid a false-positive office overlap.
     --
     -- Roman-numeral and "No. N" → "r-N" rewrites let DDHQ "Lincoln County
     -- R-IV School District" intersect with BR "Winfield R-4 School Board".
@@ -12,13 +14,16 @@
     -- scripts/constants.py — keep both in sync when editing.
     filter(
         transform(
-            split(
-                regexp_replace(
-                    regexp_replace(lower({{ col }}), 'r-\\s+', 'r-'),
-                    'no\\.\\s+(\\d+)',
-                    'no. $1 r-$1'
+            transform(
+                split(
+                    regexp_replace(
+                        regexp_replace(lower({{ col }}), 'r-\\s+', 'r-'),
+                        'no\\.\\s+(\\d+)',
+                        'no. $1 r-$1'
+                    ),
+                    ' '
                 ),
-                ' '
+                t -> regexp_replace(t, '\\p{Punct}+$', '')
             ),
             t -> case
                 when t = 'r-i'
@@ -105,7 +110,7 @@
             'metro',
             'and',
             'for',
-            'no.',
+            'no',
             'odd',
             'unexpired'
         )

--- a/dbt/project/macros/office_name_tokens.sql
+++ b/dbt/project/macros/office_name_tokens.sql
@@ -1,0 +1,123 @@
+{% macro office_name_tokens(col) %}
+    -- Build a normalized array of meaningful tokens from an office-name string,
+    -- for use with Splink's ArrayIntersectLevel as a fallback office-overlap
+    -- match level (mirrors how first_name_aliases drives nickname matching).
+    --
+    -- Punctuation is preserved on tokens (matches the existing locality-token
+    -- check in scripts/constants.py): "(juneau" stays distinct from "juneau"
+    -- so a WI town-of-X (county) ↔ X-county-supervisor pair correctly fails
+    -- to overlap, even though both contain a "juneau"-ish substring.
+    --
+    -- Steps:
+    -- 1. Lowercase
+    -- 2. Collapse "r- iii" (DDHQ form with internal space) → "r-iii"
+    -- 3. Inject "r-N" after "no. N" so DDHQ's MO "Reorganized School
+    -- District No. 4" emits an "r-4" token that overlaps with BR's
+    -- "Blue Springs R-4 School Board"
+    -- 4. Split on whitespace
+    -- 5. Per-token CASE: normalize roman-numeral school district codes
+    -- (r-i ↔ r-1, r-ii ↔ r-2, …) so DDHQ's "<county> County R-IV" shares
+    -- an "r-4" token with BR's "<city> R-4 School Board"
+    -- 6. Drop length≤1, pure-digit, and stop-word tokens (stop-word list
+    -- mirrors OFFICE_STOP_WORDS in scripts/constants.py)
+    filter(
+        transform(
+            split(
+                regexp_replace(
+                    regexp_replace(lower({{ col }}), 'r-\\s+', 'r-'),
+                    'no\\.\\s+(\\d+)',
+                    'no. $1 r-$1'
+                ),
+                ' '
+            ),
+            t -> case
+                when t = 'r-i'
+                then 'r-1'
+                when t = 'r-ii'
+                then 'r-2'
+                when t = 'r-iii'
+                then 'r-3'
+                when t = 'r-iv'
+                then 'r-4'
+                when t = 'r-v'
+                then 'r-5'
+                when t = 'r-vi'
+                then 'r-6'
+                when t = 'r-vii'
+                then 'r-7'
+                when t = 'r-viii'
+                then 'r-8'
+                when t = 'r-ix'
+                then 'r-9'
+                when t = 'r-x'
+                then 'r-10'
+                else t
+            end
+        ),
+        t -> length(t) > 1
+        and not regexp_like(t, '^[0-9]+$')
+        and t not in (
+            'city',
+            'of',
+            'the',
+            'county',
+            'board',
+            'council',
+            'school',
+            'district',
+            'mayor',
+            'alderperson',
+            'trustee',
+            'at',
+            'large',
+            'zone',
+            'ward',
+            'seat',
+            'position',
+            'commission',
+            'precinct',
+            'town',
+            'village',
+            'member',
+            'councilmember',
+            'supervisor',
+            'supervisors',
+            'commissioner',
+            'judge',
+            'branch',
+            'education',
+            'unified',
+            'public',
+            'elementary',
+            'consolidated',
+            'central',
+            'special',
+            'independent',
+            'office',
+            'clerk',
+            'treasurer',
+            'coroner',
+            'sheriff',
+            'magistrate',
+            'property',
+            'value',
+            'administrator',
+            'emergency',
+            'services',
+            'director',
+            'justice',
+            'peace',
+            'representative',
+            'house',
+            'representatives',
+            'legislature',
+            'legislative',
+            'metro',
+            'and',
+            'for',
+            'no.',
+            'odd',
+            'unexpired'
+        )
+    )
+{% endmacro %}

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -639,6 +639,18 @@ models:
                 to: ref('int__civics_election_stage_techspeed')
                 field: gp_election_stage_id
 
+      - name: source_candidate_id
+        description: >
+          TechSpeed's native candidate code (generated from name + state +
+          office_type + city). Asserts every raw TS record surfaces in the
+          candidacy_stage mart with 'techspeed' in source_systems. The mart
+          populates ts_source_candidate_id only when TS is in the cluster.
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('candidacy_stage')
+                field: ts_source_candidate_id
+
       - name: election_result
         description: Result of the election stage (Won or null, general stages only)
         data_tests:
@@ -934,6 +946,38 @@ models:
         description: Election ID (position + year)
         data_tests:
           - not_null
+
+      - name: source_candidate_id
+        description: >
+          DDHQ's native candidate_id (string-cast). Asserts every raw DDHQ
+          record surfaces in the candidacy_stage mart with 'ddhq' in
+          source_systems. The mart populates ddhq_candidate_id only when
+          DDHQ is in the cluster. Configured to warn on small failure
+          counts: if Splink over-clusters two DDHQ rows with different
+          candidate_ids into the same cluster, the mart's dedup keeps one
+          and drops the other's natural keys. Investigate when count grows.
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('candidacy_stage')
+                field: ddhq_candidate_id
+              config:
+                warn_if: ">0"
+                error_if: ">100"
+
+      - name: source_race_id
+        description: >
+          DDHQ's native ddhq_race_id (string-cast). Same propagation guarantee
+          as source_candidate_id, paired with it as DDHQ's compound natural
+          key. Same warn-vs-error thresholds for the same reason.
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('candidacy_stage')
+                field: ddhq_race_id
+              config:
+                warn_if: ">0"
+                error_if: ">100"
 
       - name: election_result
         description: Result of the election stage (Won or Lost)
@@ -2129,6 +2173,18 @@ models:
                 field: gp_election_stage_id
               config:
                 error_if: ">=100"
+
+      - name: br_candidacy_id
+        description: >
+          BallotReady's native candidacy stage ID. Asserts every raw BR record
+          surfaces in the candidacy_stage mart with 'ballotready' in
+          source_systems (the mart populates this column only when BR is in
+          the cluster, so a value's presence implies the source tag).
+        data_tests:
+          - relationships:
+              arguments:
+                to: ref('candidacy_stage')
+                field: br_candidacy_id
 
       - name: election_result
         description: Result of the election stage (Won, Lost, Runoff, or null)

--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -419,6 +419,11 @@ select
     nullif(phone, '') as phone,
     try_cast(br_race_id as int) as br_race_id,
     nullif(lower(trim(official_office_name)), '') as official_office_name,
+    -- Normalized token array for Splink ArrayIntersectLevel office-overlap
+    -- match. Captures locality + r-N school-district codes (e.g. DDHQ
+    -- "lincoln county r-iv" → ["lincoln","r-4"], BR "winfield r-4 school
+    -- board" → ["winfield","r-4"]) so cross-source naming variants intersect.
+    {{ office_name_tokens("official_office_name") }} as official_office_name_tokens,
     nullif(br_candidacy_id, '') as br_candidacy_id,
     nullif(seat_name, '') as seat_name,
     partisan_type

--- a/dbt/project/models/marts/civics/candidacy_stage.sql
+++ b/dbt/project/models/marts/civics/candidacy_stage.sql
@@ -134,10 +134,6 @@ with
             and cw.source_id = ddhq.source_candidate_id || '_' || ddhq.source_race_id
     ),
 
-    -- Three-way merge for 2026+ data, joined on Splink cluster_id (with a
-    -- self-key fallback for un-clustered records). All cluster members —
-    -- regardless of provider mix — share a merge_key and collapse into one
-    -- row with the full source_systems array.
     merged_since_2026 as (
         select
             coalesce(
@@ -176,10 +172,8 @@ with
                 )
             ) as source_systems,
             coalesce(br.cluster_id, ts.cluster_id, ddhq.cluster_id) as er_cluster_id,
-            -- Per-provider native primary keys, NULL when that provider isn't
-            -- in the cluster. Drives `relationships` tests on each int model
-            -- to confirm every raw record reaches a mart row tagged with its
-            -- provider in source_systems.
+            -- Per-provider natural keys, NULL when that provider isn't in
+            -- the cluster.
             br.br_candidacy_id,
             ts.source_candidate_id as ts_source_candidate_id,
             ddhq.source_candidate_id as ddhq_candidate_id,

--- a/dbt/project/models/marts/civics/candidacy_stage.sql
+++ b/dbt/project/models/marts/civics/candidacy_stage.sql
@@ -61,8 +61,15 @@ with
             cast(null as string) as er_cluster_id,
             cast(null as string) as br_candidacy_id,
             cast(null as string) as ts_source_candidate_id,
-            cast(null as string) as ddhq_candidate_id,
-            cast(null as string) as ddhq_race_id
+            -- Archive's source_candidate_id / source_race_id ARE the DDHQ
+            -- keys when has_match=true (see int__civics_candidacy_stage_2025
+            -- aliasing ddhq_candidate_id/ddhq_race_id). Forward them so the
+            -- "ddhq keys populated when 'ddhq' in source_systems" invariant
+            -- holds for the 2025 archive path too.
+            case
+                when has_match then cast(source_candidate_id as string)
+            end as ddhq_candidate_id,
+            case when has_match then cast(source_race_id as string) end as ddhq_race_id
         from {{ ref("int__civics_candidacy_stage_2025") }}
     ),
 

--- a/dbt/project/models/marts/civics/candidacy_stage.sql
+++ b/dbt/project/models/marts/civics/candidacy_stage.sql
@@ -1,8 +1,12 @@
 -- Civics mart candidacy_stage table
 -- Union of 2025 HubSpot archive and 2026+ merged BallotReady + TechSpeed + DDHQ.
--- TS and DDHQ int models remap clustered IDs to BR canonicals via
--- int__civics_er_canonical_ids, so merging collapses to a full outer join on
--- shared gp_candidacy_stage_id.
+-- The 2026+ merge wraps each provider with its Splink cluster_id and joins
+-- on coalesce(cluster_id, 'self_' || gp_candidacy_stage_id), so any provider
+-- combination (BR+TS+DDHQ, BR+DDHQ, TS+DDHQ-only, DDHQ-only, singletons)
+-- collapses to one row with the full source_systems array. Pre-cluster
+-- canonical adoption via int__civics_er_canonical_ids is no longer load-
+-- bearing for this mart — it's still used by the higher-grain civics marts
+-- (see DATA-1888 for tracking the full canonical_ids removal).
 --
 -- Provider precedence:
 -- DDHQ wins for election outcome columns (is_winner, election_result,
@@ -53,7 +57,12 @@ with
             cast(null as boolean) as is_uncontested,
             array_compact(
                 array('hubspot', case when has_match then 'ddhq' end)
-            ) as source_systems
+            ) as source_systems,
+            cast(null as string) as er_cluster_id,
+            cast(null as string) as br_candidacy_id,
+            cast(null as string) as ts_source_candidate_id,
+            cast(null as string) as ddhq_candidate_id,
+            cast(null as string) as ddhq_race_id
         from {{ ref("int__civics_candidacy_stage_2025") }}
     ),
 
@@ -79,12 +88,56 @@ with
         from {{ ref("int__civics_candidacy_stage_ddhq") }}
     ),
 
-    -- Three-way merge for 2026+ data. BR, TS, and DDHQ int models all expose
-    -- shared canonical gp_* IDs via int__civics_er_canonical_ids when Splink
-    -- clustered the row, so a full outer join on gp_candidacy_stage_id
-    -- merges matched triples; unmatched rows pass through as new rows with
-    -- NULLs on the absent providers (e.g. DDHQ-only races where Splink
-    -- found no BR/TS counterpart).
+    -- Each provider is wrapped with its Splink cluster_id (looked up from
+    -- stg_er_source__clustered_candidacy_stages on the provider's raw key).
+    -- The FOJ below joins on cluster_id with a self-prefixed
+    -- gp_candidacy_stage_id fallback, which means cluster members merge into
+    -- one mart row regardless of which providers are present — including
+    -- TS+DDHQ-only and DDHQ-only clusters where canonical_ids' BR-anchored
+    -- crosswalk doesn't fire. Records that didn't go through Splink fall
+    -- back to a self-key that's unique per provider record.
+    br_with_cluster as (
+        select
+            br.*,
+            cw.cluster_id,
+            coalesce(cw.cluster_id, 'self_' || br.gp_candidacy_stage_id) as merge_key
+        from {{ ref("int__civics_candidacy_stage_ballotready") }} as br
+        left join
+            {{ ref("stg_er_source__clustered_candidacy_stages") }} as cw
+            on cw.source_name = 'ballotready'
+            and cw.br_candidacy_id = br.br_candidacy_id
+    ),
+
+    ts_with_cluster as (
+        select
+            ts.*,
+            cw.cluster_id,
+            coalesce(cw.cluster_id, 'self_' || ts.gp_candidacy_stage_id) as merge_key
+        from {{ ref("int__civics_candidacy_stage_techspeed") }} as ts
+        left join
+            {{ ref("stg_er_source__clustered_candidacy_stages") }} as cw
+            on cw.source_name = 'techspeed'
+            and regexp_replace(cw.source_id, '__(primary|general|runoff)$', '')
+            = ts.source_candidate_id
+            and cw.election_date = ts.election_stage_date
+    ),
+
+    ddhq_with_cluster as (
+        select
+            ddhq.*,
+            cw.cluster_id,
+            coalesce(cw.cluster_id, 'self_' || ddhq.gp_candidacy_stage_id) as merge_key
+        from ddhq
+        left join
+            {{ ref("stg_er_source__clustered_candidacy_stages") }} as cw
+            on cw.source_name = 'ddhq'
+            and cw.source_id = ddhq.source_candidate_id || '_' || ddhq.source_race_id
+    ),
+
+    -- Three-way merge for 2026+ data, joined on Splink cluster_id (with a
+    -- self-key fallback for un-clustered records). All cluster members —
+    -- regardless of provider mix — share a merge_key and collapse into one
+    -- row with the full source_systems array.
     merged_since_2026 as (
         select
             coalesce(
@@ -117,21 +170,25 @@ with
             ddhq.is_uncontested,
             array_compact(
                 array(
-                    case
-                        when br.gp_candidacy_stage_id is not null then 'ballotready'
-                    end,
-                    case when ts.gp_candidacy_stage_id is not null then 'techspeed' end,
-                    case when ddhq.gp_candidacy_stage_id is not null then 'ddhq' end
+                    case when br.merge_key is not null then 'ballotready' end,
+                    case when ts.merge_key is not null then 'techspeed' end,
+                    case when ddhq.merge_key is not null then 'ddhq' end
                 )
-            ) as source_systems
-        from {{ ref("int__civics_candidacy_stage_ballotready") }} as br
+            ) as source_systems,
+            coalesce(br.cluster_id, ts.cluster_id, ddhq.cluster_id) as er_cluster_id,
+            -- Per-provider native primary keys, NULL when that provider isn't
+            -- in the cluster. Drives `relationships` tests on each int model
+            -- to confirm every raw record reaches a mart row tagged with its
+            -- provider in source_systems.
+            br.br_candidacy_id,
+            ts.source_candidate_id as ts_source_candidate_id,
+            ddhq.source_candidate_id as ddhq_candidate_id,
+            ddhq.source_race_id as ddhq_race_id
+        from br_with_cluster as br
+        full outer join ts_with_cluster as ts on br.merge_key = ts.merge_key
         full outer join
-            {{ ref("int__civics_candidacy_stage_techspeed") }} as ts
-            on br.gp_candidacy_stage_id = ts.gp_candidacy_stage_id
-        full outer join
-            ddhq
-            on coalesce(br.gp_candidacy_stage_id, ts.gp_candidacy_stage_id)
-            = ddhq.gp_candidacy_stage_id
+            ddhq_with_cluster as ddhq
+            on coalesce(br.merge_key, ts.merge_key) = ddhq.merge_key
     ),
 
     combined as (
@@ -174,6 +231,11 @@ select
     es.is_serve_icp,
     es.is_win_supersize_icp,
     deduplicated.source_systems,
+    deduplicated.er_cluster_id,
+    deduplicated.br_candidacy_id,
+    deduplicated.ts_source_candidate_id,
+    deduplicated.ddhq_candidate_id,
+    deduplicated.ddhq_race_id,
     deduplicated.created_at,
     deduplicated.updated_at
 

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -909,6 +909,38 @@ models:
         data_tests:
           - not_null
 
+      - name: er_cluster_id
+        description: >
+          Splink cluster_id when this row went through entity resolution,
+          else NULL. Internal — used as the merge key in the mart's FOJ and
+          for diagnostic joins. Note that Splink cluster_ids are NOT
+          guaranteed stable across reruns; do not use as a foreign key.
+
+      - name: br_candidacy_id
+        description: >
+          BallotReady's native candidacy ID. Populated only when 'ballotready'
+          is in source_systems. Drives the relationships test on
+          int__civics_candidacy_stage_ballotready.br_candidacy_id, which
+          asserts every raw BR record reaches the mart.
+
+      - name: ts_source_candidate_id
+        description: >
+          TechSpeed's native candidate code. Populated only when 'techspeed'
+          is in source_systems. Drives the relationships test on
+          int__civics_candidacy_stage_techspeed.source_candidate_id.
+
+      - name: ddhq_candidate_id
+        description: >
+          DDHQ's native candidate_id (string-cast). Populated only when
+          'ddhq' is in source_systems. Half of DDHQ's compound natural key
+          (paired with ddhq_race_id) and drives the relationships test on
+          int__civics_candidacy_stage_ddhq.source_candidate_id.
+
+      - name: ddhq_race_id
+        description: >
+          DDHQ's native ddhq_race_id (string-cast). Populated only when
+          'ddhq' is in source_systems. Pairs with ddhq_candidate_id.
+
     tests:
       - dbt_utils.expression_is_true:
           arguments:

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -912,29 +912,23 @@ models:
       - name: er_cluster_id
         description: >
           Splink cluster_id when this row went through entity resolution,
-          else NULL. Internal — used as the merge key in the mart's FOJ and
-          for diagnostic joins. Note that Splink cluster_ids are NOT
-          guaranteed stable across reruns; do not use as a foreign key.
+          else NULL. NOT stable across reruns; do not use as a foreign key.
 
       - name: br_candidacy_id
         description: >
           BallotReady's native candidacy ID. Populated only when 'ballotready'
-          is in source_systems. Drives the relationships test on
-          int__civics_candidacy_stage_ballotready.br_candidacy_id, which
-          asserts every raw BR record reaches the mart.
+          is in source_systems.
 
       - name: ts_source_candidate_id
         description: >
           TechSpeed's native candidate code. Populated only when 'techspeed'
-          is in source_systems. Drives the relationships test on
-          int__civics_candidacy_stage_techspeed.source_candidate_id.
+          is in source_systems.
 
       - name: ddhq_candidate_id
         description: >
           DDHQ's native candidate_id (string-cast). Populated only when
-          'ddhq' is in source_systems. Half of DDHQ's compound natural key
-          (paired with ddhq_race_id) and drives the relationships test on
-          int__civics_candidacy_stage_ddhq.source_candidate_id.
+          'ddhq' is in source_systems. Pairs with ddhq_race_id as DDHQ's
+          compound natural key.
 
       - name: ddhq_race_id
         description: >

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -1512,6 +1512,10 @@ sources:
 
     tables:
       - name: clustered_candidacy_stages
+        # Date-suffixed snapshot from the 2026-04-30 matcha run (er-audit/
+        # prematch-candidacy-stages-2026-04-30 branch). Update the identifier
+        # when promoting a new run; staging models stay unchanged.
+        identifier: clustered_candidacy_stages20260430
         description: >
           Cluster assignments produced by Splink's connected-components clustering
           (threshold: 0.95 match probability). Each row is a single candidacy-stage record
@@ -1521,6 +1525,7 @@ sources:
           unmatched records.
 
       - name: pairwise_candidacy_stages
+        identifier: pairwise_candidacy_stages20260430
         description: >
           Scored candidate pairs from Splink prediction (threshold: 0.01 match probability),
           after post-prediction filters for person identity, race-level agreement, and

--- a/dbt/project/tests/assert_er_clusters_share_election_date.sql
+++ b/dbt/project/tests/assert_er_clusters_share_election_date.sql
@@ -1,0 +1,16 @@
+-- Cluster integrity at candidacy_stage grain.
+--
+-- Each cluster from the candidacy-stage entity resolution pipeline must
+-- represent a single (candidate, race, stage) triple, and the stage is keyed
+-- by election_date. If a cluster contains records from multiple election
+-- dates, the matcher transitively merged a candidate's primary, runoff, or
+-- general candidacies into one cluster — a false positive that the dbt code
+-- relies on never happening (the marts use the cluster_id-derived
+-- gp_candidacy_stage_id as a stage-unique key when joining BR/TS/DDHQ).
+--
+-- Each row this test returns is a cluster_id that violates the invariant.
+select cluster_id, count(distinct election_date) as n_distinct_dates
+from {{ source("er_source", "clustered_candidacy_stages") }}
+where election_date is not null
+group by cluster_id
+having count(distinct election_date) > 1


### PR DESCRIPTION
## Summary

Closes the TS+DDHQ-only-cluster gap in the candidacy_stage mart and a same-stage cluster integrity gap in the ER pipeline. Both came out of the 2026-04-30 matcha audit (companion PR in the matcha repo).

### Cluster-based merge in candidacy_stage

Until now `int__civics_er_canonical_ids` was the only mechanism that gave clustered records a shared join key, and it only handles BR-anchored pairs. Clusters with TS+DDHQ but no BR (1,435 in April 2026 alone) ended up as two separate mart rows because TS and DDHQ each fell back to their self-hashed `gp_candidacy_stage_id`.

The mart now wraps each provider's int model with a left join to `stg_er_source__clustered_candidacy_stages` to expose `cluster_id`, and the FOJ joins on `coalesce(cluster_id, 'self_' || gp_candidacy_stage_id)`. All cluster shapes merge correctly:

| Cluster shape | Before | After |
| --- | --- | --- |
| BR + TS + DDHQ | 1 row, source_systems = `[ballotready, techspeed, ddhq]` | unchanged |
| BR + DDHQ / BR + TS | 1 row | unchanged |
| **TS + DDHQ (no BR)** | 2 rows, `[techspeed]` + `[ddhq]` | **1 row, `[techspeed, ddhq]`** |
| DDHQ only | 1 row, `[ddhq]` | unchanged |

`canonical_ids` is no longer load-bearing for this mart but is still used by the candidacy / candidate / election_stage / election marts. Tracking full removal in DATA-1888.

### Per-provider native keys + relationships tests

The mart exposes:

- `br_candidacy_id`, `ts_source_candidate_id`, `ddhq_candidate_id`, `ddhq_race_id` — populated only when that provider is in the cluster
- `er_cluster_id` — Splink cluster_id when in ER, NULL otherwise (diagnostic only; not stable across reruns)

These drive `relationships` tests declared on each int model's natural key column pointing back to `candidacy_stage`. The DDHQ tests are configured `warn_if: ">0"` / `error_if: ">100"` because Splink occasionally over-clusters DDHQ rows with different `(candidate_id, race_id)` tuples and the mart's dedup keeps one row's natural keys (currently 5 + 20 records — small surface, useful signal).

### Office-name token comparison

Adds the `office_name_tokens` macro and a corresponding column on `int__er_prematch_candidacy_stages` so Splink can use `ArrayIntersectLevel` as a fallback office-overlap match level. Catches cross-source naming variants like DDHQ "Lincoln County R-IV School District" vs BR "Winfield R-4 School Board" — both yield an "r-4" token even though their JW similarity is below 0.88. Token normalization (parens preserved, roman→arabic, "no. N" → "r-N") lives in dbt so the inline string-split fallback that used to live in matcha's `BASE_POST_PREDICTION_FILTER` is gone.

### Same-stage cluster integrity test

`tests/assert_er_clusters_share_election_date.sql` is a singular test that fails if any cluster contains records from multiple `election_date`s. The candidacy_stage grain treats primary / runoff / general as distinct entities, so cross-date clusters are false positives that the mart relies on never happening (cluster_id-derived identifiers would conflate stages).

### Source identifier strategy

`__sources.yaml` now uses `identifier:` to point at the date-suffixed snapshot tables `clustered_candidacy_stages20260430` / `pairwise_candidacy_stages20260430`. Promoting a new matcha run is a single-line change (`identifier:`) without touching the staging models.

## Test plan

- [x] `dbt build -s candidacy_stage int__civics_candidacy_stage_ballotready int__civics_candidacy_stage_techspeed int__civics_candidacy_stage_ddhq` passes locally in `dbt_dball` (38 PASS / 2 WARN — DDHQ relationships tests under threshold / 0 ERROR)
- [x] `assert_er_clusters_share_election_date` passes (0 cross-date clusters)
- [x] Manual diff dbt_dball vs mart_civics: prod-only rows are accountable (DDHQ rows merged into 2-way clusters, plus normal staging-snapshot drift); no phantom missing rows
- [x] Spot-checked April 2026: `[techspeed, ddhq]` count went from 0 → 1,435 rows
- [ ] CI green
- [ ] dbt Cloud deploy build green after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the join key and merge logic for the `candidacy_stage` mart (cluster-based FOJ across BR/TS/DDHQ), which can alter row counts/dedup behavior and downstream dependencies; it also updates ER source snapshot identifiers and adds new relationship/integrity tests that may affect builds.
> 
> **Overview**
> Updates the `candidacy_stage` mart to merge 2026+ BallotReady, TechSpeed, and DDHQ rows by Splink `cluster_id` (falling back to a per-row `self_` key) instead of relying on BR-anchored `canonical_ids`, fixing previously unmerged TS+DDHQ-only clusters. The mart now also surfaces diagnostic/provenance columns (`er_cluster_id` and each provider’s native keys) and adds `relationships` tests from each provider’s intermediate model to ensure those natural keys propagate into `candidacy_stage`.
> 
> Enhances entity-resolution prematch inputs by adding an `office_name_tokens` macro and a new `official_office_name_tokens` column for Splink `ArrayIntersectLevel` office-overlap matching. Points ER source tables at date-suffixed snapshot identifiers and adds a singular test (`assert_er_clusters_share_election_date`) to catch clusters that incorrectly span multiple `election_date`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50f05f710bf1d1f556380043ddb54aa51097aead. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->