### PR TITLE
[DATA-1878] Civics mart docs updates for EO models

### DIFF
--- a/dbt/project/models/marts/civics/README.md
+++ b/dbt/project/models/marts/civics/README.md
@@ -16,6 +16,8 @@ All models materialize as tables in the `mart_civics` schema.
 | `candidacy_stage` | gp_candidacy_stage_id | Per-stage election results (primary, general, runoff) |
 | `election` | gp_election_id | Full election cycles with pivoted stage dates |
 | `election_stage` | gp_election_stage_id | Individual election stages with vendor IDs |
+| `elected_officials` | gp_elected_official_id | Person-grain merge of BR + TS + gp-api elected officials |
+| `elected_official_terms` | gp_elected_official_term_id | Term-grain BR fact table with TS provenance and gp-api bridge |
 
 ## Key Concepts
 
@@ -23,6 +25,8 @@ All models materialize as tables in the `mart_civics` schema.
 - A candidate can have many candidacies. A candidacy belongs to exactly one election.
 - **Candidacy Stage** = results for one candidacy in one election phase (primary, general, etc.)
 - **Election** vs **Election Stage**: an election encompasses all stages; election_stage is one phase.
+- **Elected Official** vs **Candidate**: an EO holds office (sourced from BR's OfficeHolder feed); a Candidate ran for office (sourced from BR + HubSpot). They have different IDs and may not 1:1 correspond.
+- **Elected Official** = a person; **Elected Official Term** = one term they served. A person can have many terms.
 
 ## Which Table Do I Need?
 
@@ -32,9 +36,11 @@ What are you looking for?
 +-- What office they ran for, election dates     --> candidacy
 +-- Did they win or lose? Vote counts?           --> candidacy_stage
 +-- Election details (office, district, dates)   --> election / election_stage
++-- Officeholder (current/past)                  --> elected_officials
++-- A specific term served                       --> elected_official_terms
 +-- GP app user data (signup, Win/Serve status)  --> users
 +-- GP campaign data (verified, pledged, pro)    --> campaigns
-+-- Is the office in our target market (ICP)?    --> candidacy.is_win_icp
++-- Is the office in our target market (ICP)?    --> candidacy.is_win_icp / elected_official_terms.is_win_icp
 +-- Win/Serve product linkage                    --> organizations
 ```
 
@@ -74,4 +80,20 @@ from mart_civics.candidacy cy
 inner join mart_civics.campaigns cam
     on cy.product_campaign_id = cam.campaign_id
     and cam.is_latest_version
+```
+
+### Officeholder with terms (current and past)
+
+```sql
+select
+    eo.full_name,
+    eo.gp_api_user_id,
+    t.candidate_office,
+    t.term_start_date,
+    t.term_end_date
+from mart_civics.elected_officials eo
+inner join mart_civics.elected_official_terms t
+    on eo.gp_elected_official_id = t.gp_elected_official_id
+where (t.term_start_date is null or t.term_start_date <= current_date)
+  and (t.term_end_date is null or t.term_end_date >= current_date)
 ```

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -604,6 +604,16 @@ models:
           int__icp_offices. Derived via br_position_database_id.
           NULL for records without BallotReady position match.
 
+      - name: source_systems
+        description: |
+          Array of source systems contributing to this row, join-based per the
+          mart convention. Membership is presence-based, not value-survivorship —
+          'techspeed' in source_systems means TS contributed a row that joined
+          into this canonical record, NOT that any column took its value from TS.
+          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+        data_tests:
+          - not_null
+
       - name: created_at
         description: Timestamp when the record was created
         data_tests:
@@ -700,6 +710,16 @@ models:
 
       - name: instagram_handle
         description: Candidate's Instagram handle
+
+      - name: source_systems
+        description: |
+          Array of source systems contributing to this row, join-based per the
+          mart convention. Membership is presence-based, not value-survivorship —
+          'techspeed' in source_systems means TS contributed a row that joined
+          into this canonical record, NOT that any column took its value from TS.
+          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+        data_tests:
+          - not_null
 
       - name: created_at
         description: Timestamp when the record was created
@@ -934,6 +954,16 @@ models:
         description: >
           DDHQ's native ddhq_race_id (string-cast). Populated only when
           'ddhq' is in source_systems. Pairs with ddhq_candidate_id.
+
+      - name: source_systems
+        description: |
+          Array of source systems contributing to this row, join-based per the
+          mart convention. Membership is presence-based, not value-survivorship —
+          'techspeed' in source_systems means TS contributed a row that joined
+          into this canonical record, NOT that any column took its value from TS.
+          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+        data_tests:
+          - not_null
 
     tests:
       - dbt_utils.expression_is_true:
@@ -1175,6 +1205,16 @@ models:
                 min_value: "'1900-01-01'"
                 max_value: "'2050-12-31'"
 
+      - name: source_systems
+        description: |
+          Array of source systems contributing to this row, join-based per the
+          mart convention. Membership is presence-based, not value-survivorship —
+          'techspeed' in source_systems means TS contributed a row that joined
+          into this canonical record, NOT that any column took its value from TS.
+          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+        data_tests:
+          - not_null
+
       - name: created_at
         description: Timestamp when the record was created
         data_tests:
@@ -1375,6 +1415,16 @@ models:
           Thresholds defined in int__icp_offices. Derived via br_position_id.
           NULL for 2025 archive records without BallotReady position match.
 
+      - name: source_systems
+        description: |
+          Array of source systems contributing to this row, join-based per the
+          mart convention. Membership is presence-based, not value-survivorship —
+          'techspeed' in source_systems means TS contributed a row that joined
+          into this canonical record, NOT that any column took its value from TS.
+          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+        data_tests:
+          - not_null
+
       - name: created_at
         description: Timestamp when the record was created (from Airbyte extraction)
         data_tests:
@@ -1442,10 +1492,19 @@ models:
         description: BallotReady seat/office ID (Position.databaseId)
 
       - name: br_candidacy_id
-        description: BallotReady candidacy ID associated with this term
+        description: >
+          BallotReady candidacy ID (Candidacy.databaseId) linking this
+          office-holder term to the BallotReady candidacy record for the
+          election that placed this official in office. NULL for vacancy
+          rows and terms where BR did not provide a candidacy association.
 
       - name: br_geo_id
-        description: BallotReady geographic identifier
+        description: >
+          BallotReady geographic region identifier (Geo.databaseId) for the
+          jurisdiction this position represents (e.g. a city, county, or
+          district polygon). Can be used to join with BallotReady geography
+          data for spatial filtering or population lookups. NULL when BR has
+          no geo record for this position.
 
       - name: ts_officeholder_id
         description: |
@@ -1551,7 +1610,12 @@ models:
         description: Whether this is a vacancy placeholder (BR)
 
       - name: is_off_cycle
-        description: Whether the term is out of normal schedule (BR)
+        description: >
+          Whether this term's election fell outside the jurisdiction's
+          normal election cycle, as flagged by BallotReady. Off-cycle
+          elections (special elections, odd-year primaries, etc.) typically
+          have lower turnout and different filing timelines. NULL when BR
+          does not provide this flag for the position.
 
       - name: party_affiliation
         description: Political party affiliation
@@ -1697,6 +1761,13 @@ models:
           name: term_mart_source_systems_known_values
           config:
             severity: error
+      # Vacancy invariant: is_vacant = true iff gp_elected_official_id is null
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "(is_vacant and gp_elected_official_id is null) or (not is_vacant and gp_elected_official_id is not null)"
+          name: elected_official_terms_vacancy_implies_null_person
+          config:
+            severity: error
 
   - name: elected_officials
     description: |
@@ -1787,10 +1858,17 @@ models:
         description: BR-wins coalesce. BR's latest-term email; falls back to TS-side per-field rollup if BR has none.
 
       - name: office_phone
-        description: Office phone number
+        description: >
+          Direct phone number for the official's office. Sourced from
+          BallotReady; NULL when BR has no office phone on record. Distinct
+          from `phone` (personal/mobile, TS-wins coalesce) and `central_phone`
+          (switchboard number).
 
       - name: central_phone
-        description: Central office phone number
+        description: >
+          Switchboard or main government phone number for the office, as
+          opposed to the official's direct line. Sourced from BallotReady;
+          NULL when BR has no central phone on record.
 
       - name: candidate_office
         description: Office name from latest term
@@ -1865,22 +1943,41 @@ models:
         description: Official's Twitter profile
 
       - name: mailing_address_line_1
-        description: Mailing address line 1
+        description: >
+          Street address line 1 of the official's government mailing address,
+          as provided by BallotReady. NULL when BR has no mailing address on
+          record.
 
       - name: mailing_address_line_2
-        description: Mailing address line 2
+        description: >
+          Street address line 2 (suite, unit, etc.) of the official's
+          government mailing address. NULL when not provided by BallotReady.
 
       - name: mailing_city
-        description: Mailing city
+        description: >
+          City component of the official's government mailing address.
+          NULL when BR has no mailing address on record.
 
       - name: mailing_state
-        description: Mailing state
+        description: >
+          State abbreviation component of the official's government mailing
+          address. NULL when BR has no mailing address on record. May differ
+          from `state` (the official's office state) for federal officials
+          whose mailing address is in DC.
 
       - name: mailing_zip
-        description: Mailing ZIP code
+        description: >
+          ZIP code component of the official's government mailing address.
+          NULL when BR has no mailing address on record.
 
       - name: tier
-        description: BallotReady tier classification
+        description: >
+          BallotReady's 1–5 priority tier for this official's position.
+          Lower numbers indicate higher-priority offices (larger, more
+          prominent, or higher public interest). Tier 1 = top-tier offices
+          (federal, statewide); Tier 5 = smallest local offices. Derived
+          from the latest term via the BR person rollup; NULL for gp_api-only
+          rows.
 
       - name: selected_gp_elected_official_term_id
         description: |

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -607,7 +607,7 @@ models:
       - name: source_systems
         description: |
           Array of source systems contributing to this row. Possible values:
-          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq', 'gp_api'.
           See the model-level description for merge mechanics.
         data_tests:
           - not_null
@@ -712,7 +712,7 @@ models:
       - name: source_systems
         description: |
           Array of source systems contributing to this row. Possible values:
-          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq', 'gp_api'.
           See the model-level description for merge mechanics.
         data_tests:
           - not_null
@@ -954,7 +954,7 @@ models:
       - name: source_systems
         description: |
           Array of source systems contributing to this row. Possible values:
-          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq', 'gp_api'.
           See the model-level description for merge mechanics.
         data_tests:
           - not_null

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -606,11 +606,9 @@ models:
 
       - name: source_systems
         description: |
-          Array of source systems contributing to this row, join-based per the
-          mart convention. Membership is presence-based, not value-survivorship —
-          'techspeed' in source_systems means TS contributed a row that joined
-          into this canonical record, NOT that any column took its value from TS.
-          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          Array of source systems contributing to this row. Possible values:
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          See the model-level description for merge mechanics.
         data_tests:
           - not_null
 
@@ -713,11 +711,9 @@ models:
 
       - name: source_systems
         description: |
-          Array of source systems contributing to this row, join-based per the
-          mart convention. Membership is presence-based, not value-survivorship —
-          'techspeed' in source_systems means TS contributed a row that joined
-          into this canonical record, NOT that any column took its value from TS.
-          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          Array of source systems contributing to this row. Possible values:
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          See the model-level description for merge mechanics.
         data_tests:
           - not_null
 
@@ -957,11 +953,9 @@ models:
 
       - name: source_systems
         description: |
-          Array of source systems contributing to this row, join-based per the
-          mart convention. Membership is presence-based, not value-survivorship —
-          'techspeed' in source_systems means TS contributed a row that joined
-          into this canonical record, NOT that any column took its value from TS.
-          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          Array of source systems contributing to this row. Possible values:
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          See the model-level description for merge mechanics.
         data_tests:
           - not_null
 
@@ -1207,11 +1201,9 @@ models:
 
       - name: source_systems
         description: |
-          Array of source systems contributing to this row, join-based per the
-          mart convention. Membership is presence-based, not value-survivorship —
-          'techspeed' in source_systems means TS contributed a row that joined
-          into this canonical record, NOT that any column took its value from TS.
-          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          Array of source systems contributing to this row. Possible values:
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          See the model-level description for merge mechanics.
         data_tests:
           - not_null
 
@@ -1417,11 +1409,9 @@ models:
 
       - name: source_systems
         description: |
-          Array of source systems contributing to this row, join-based per the
-          mart convention. Membership is presence-based, not value-survivorship —
-          'techspeed' in source_systems means TS contributed a row that joined
-          into this canonical record, NOT that any column took its value from TS.
-          Possible values: 'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          Array of source systems contributing to this row. Possible values:
+          'hubspot' (2025 archive only), 'ballotready', 'techspeed', 'ddhq'.
+          See the model-level description for merge mechanics.
         data_tests:
           - not_null
 
@@ -1858,17 +1848,10 @@ models:
         description: BR-wins coalesce. BR's latest-term email; falls back to TS-side per-field rollup if BR has none.
 
       - name: office_phone
-        description: >
-          Direct phone number for the official's office. Sourced from
-          BallotReady; NULL when BR has no office phone on record. Distinct
-          from `phone` (personal/mobile, TS-wins coalesce) and `central_phone`
-          (switchboard number).
+        description: Office phone number
 
       - name: central_phone
-        description: >
-          Switchboard or main government phone number for the office, as
-          opposed to the official's direct line. Sourced from BallotReady;
-          NULL when BR has no central phone on record.
+        description: Central office phone number
 
       - name: candidate_office
         description: Office name from latest term
@@ -1943,32 +1926,19 @@ models:
         description: Official's Twitter profile
 
       - name: mailing_address_line_1
-        description: >
-          Street address line 1 of the official's government mailing address,
-          as provided by BallotReady. NULL when BR has no mailing address on
-          record.
+        description: Mailing address line 1
 
       - name: mailing_address_line_2
-        description: >
-          Street address line 2 (suite, unit, etc.) of the official's
-          government mailing address. NULL when not provided by BallotReady.
+        description: Mailing address line 2
 
       - name: mailing_city
-        description: >
-          City component of the official's government mailing address.
-          NULL when BR has no mailing address on record.
+        description: Mailing city
 
       - name: mailing_state
-        description: >
-          State abbreviation component of the official's government mailing
-          address. NULL when BR has no mailing address on record. May differ
-          from `state` (the official's office state) for federal officials
-          whose mailing address is in DC.
+        description: Mailing state
 
       - name: mailing_zip
-        description: >
-          ZIP code component of the official's government mailing address.
-          NULL when BR has no mailing address on record.
+        description: Mailing ZIP code
 
       - name: tier
         description: >

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -1598,6 +1598,8 @@ models:
 
       - name: is_vacant
         description: Whether this is a vacancy placeholder (BR)
+        data_tests:
+          - not_null
 
       - name: is_off_cycle
         description: >


### PR DESCRIPTION
## Summary
- Add `elected_officials` and `elected_official_terms` to the civics mart README (model inventory, decision tree, join examples)
- Polish thin YAML column descriptions for Genie consumption (~10 descriptions across the two new EO models)
- Add `source_systems` YAML column entries for `candidate`, `candidacy`, `candidacy_stage`, `election`, `election_stage` (column existed in SQL but was undocumented)
- Add one new dbt test on `elected_official_terms`: vacancy invariant (`is_vacant <-> gp_elected_official_id IS NULL`)
- Reference: companion ClickUp walkthrough doc was updated in DATA-1878 (sections 1-7) and the working markdown is at `.tickets/data-1878/CIVICS_MART_WALKTHROUGH_v2.md`

## No code or schema changes
This PR is documentation only. No model SQL changed. The one new dbt test (`elected_official_terms_vacancy_implies_null_person`) tests an existing invariant that current data already satisfies.

## CI test plan
- [x] dbt parse passes
- [x] vacancy invariant test passes against current `elected_official_terms` data
- [ ] CI `dbt build` materializes the 5 candidacy-side models with their existing `source_systems` columns; the new `not_null` tests on those columns should pass against the freshly-built tables

### Note on local test results
When running `dbt test` locally with deferred artifacts, 4 of the 5 new `not_null_*_source_systems` tests fail because the production deferred tables don't yet have the `source_systems` column rebuilt for those 4 models (only `candidate`'s prod table currently has it). CI runs a fresh `dbt build` which will materialize all 5 models with the column populated, and the tests will pass there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/schema YAML metadata plus one new dbt invariant test, with no model SQL or data transformation logic modified.
> 
> **Overview**
> Adds `elected_officials` and `elected_official_terms` to the civics mart README, including updated decision guidance and a new join example for officeholders and their terms.
> 
> Extends `m_civics.yaml` to document the existing `source_systems` column on `candidacy`, `candidate`, `candidacy_stage`, `election`, and `election_stage` (with `not_null` tests), and polishes several column descriptions on the elected-official models for clearer downstream consumption.
> 
> Introduces a new dbt test on `elected_official_terms` enforcing the vacancy invariant: `is_vacant` must imply `gp_elected_official_id` is NULL (and vice versa).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4883e64c447750dee4e0f67676aad1fe8dc7302f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->