### PR TITLE
Remove accepted_range test on district_top_issues issue_rank

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -374,10 +374,6 @@ models:
         description: "Rank of the issue within the district (1 = highest score)"
         tests:
           - not_null
-          - dbt_utils.accepted_range:
-              arguments:
-                min_value: 1
-                max_value: 5
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:


### PR DESCRIPTION
## Summary
- Drop the `dbt_utils.accepted_range` test (`min_value: 1, max_value: 5`) on `m_election_api__district_top_issues.issue_rank`.
- The model was just updated to return the top 10 issues per district instead of the top 5, and capping the rank in the test couples test config to whatever N the SQL happens to use today.
- `not_null` is retained on `issue_rank`.

## Test plan
- [ ] `dbt build --select m_election_api__district_top_issues` passes in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only relaxes a dbt schema test (no model logic changes) and should only affect CI/test enforcement for `m_election_api__district_top_issues`.
> 
> **Overview**
> Removes the `dbt_utils.accepted_range` schema test that capped `m_election_api__district_top_issues.issue_rank` to `1..5`, while keeping the `not_null` constraint.
> 
> This decouples validation from the current “top N issues per district” limit so the model can return more than 5 ranked issues without failing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c40aea366e2a8b5211ed2d83761baef6e883b7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->