### PR TITLE
Drop relationships test on int__zip_code_to_br_office.br_database_id

### DIFF
--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -130,11 +130,6 @@ models:
         description: "LLM confidence"
       - name: br_database_id
         description: "BallotReady/CivicEngine database ID"
-        tests:
-          - relationships:
-              arguments:
-                to: ref("stg_airbyte_source__ballotready_api_position")
-                field: database_id
       - name: br_position_id
         description: "BallotReady/CivicEngine position ID"
         tests:


### PR DESCRIPTION
## Summary

- Removes the `relationships` test on `int__zip_code_to_br_office.br_database_id` → `stg_airbyte_source__ballotready_api_position.database_id`.
- Unblocks the nightly dbt build, which was failing today with 12,687 results on this single test.
- Mirrors the call Dan made in #363 for the sibling test
  `stg_model_predictions__llm_l2_br_match_20260126.br_database_id → int__enhanced_position`.

## Root cause

The test compares a column sourced from a **frozen** LLM match snapshot
(`stg_model_predictions__llm_l2_br_match_20260126`, cut on 2026-01-26) against
a **live** BR API table that Airbyte resyncs daily. BR has deprecated
positions in the API since the snapshot was cut; the snapshot still references
them. This is a structural mismatch — the test cannot stay green over time
because BR controls deletions on the FK target side.

Verified in Databricks (queries + CSVs in `.tickets/nightly-build-2026-05-07/`):

| Metric | Value |
|---|---:|
| Rows in `int__zip_code_to_br_office` with non-null `br_database_id` | 2,043,264 |
| Distinct `br_database_id` values in the model | 268,570 |
| Distinct `database_id` values in the live BR API position table | 285,178 |
| Distinct `br_database_id` values in the LLM match snapshot | 287,622 |
| **Rows failing the relationships test** | **12,687** |
| Distinct missing IDs (driver of the 12,687) | 2,897 |
| Of those 2,897 — present in the LLM snapshot | 2,897 (100%) |

State concentration of the 2,897 missing IDs: NH=697, VT=687, MA=631, IL=104, PA=89 — consistent with BR consolidating town/village positions in New England.

## Why it surfaced now (and not weeks ago)

The model is `materialized=incremental, strategy=merge` keyed on `loaded_at`. Historically it accumulated rows. PR #277 (DATA-1806, 2026-03-25) put the L2 family on a monthly refresh cadence; the first monthly full refresh ran ~2026-05-05 and rebuilt the table from current upstream. The rebuild joined the Jan-26 snapshot against the May-7 BR API in one shot, exposing the full population of drift rows. The test isn't broken-as-of-today — it's been silently incorrect since BR began deleting those positions; the full refresh just made the symptom visible.

## Alternatives considered

| Option | Why not |
|---|---|
| Keep the test (do nothing) | Nightly stays red indefinitely; drift grows monotonically as BR continues to deprecate positions |
| `severity: warn` | Preserves visibility into drift count, but adds a perpetual warning that gets tuned out. Reasonable middle ground; can be revisited if we want a drift signal |
| Restructure to compare snapshot ↔ snapshot | Requires re-cutting the LLM match on a schedule. Larger change, separate ticket |
| Replace target with `int__enhanced_position` | Dan dropped that very test in #363 — same root cause |

Going with **delete** for consistency with #363 and to keep CI signal clean.

## Test plan

- [x] `dbt parse` — clean (no errors, only pre-existing deprecation warnings)
- [x] Confirmed via Databricks query: 12,687 failures, 2,897 distinct IDs, all present in the LLM snapshot
- [ ] Tonight's scheduled nightly build runs green on this slice

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single dbt `relationships` test to avoid false failures caused by upstream BallotReady position deletions; no model SQL or data transformations change.
> 
> **Overview**
> Removes the dbt `relationships` test enforcing `int__zip_code_to_br_office.br_database_id` references `stg_airbyte_source__ballotready_api_position.database_id`, preventing nightly builds from failing due to drift between a frozen snapshot and the continuously resynced BR API table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc15c21a6b06282be26564aef95c8a36069b71d5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->