### PR TITLE
Eng 10175 claude onborading

### DIFF
--- a/.claude/agents/code-critic.md
+++ b/.claude/agents/code-critic.md
@@ -1,0 +1,51 @@
+---
+name: code-critic
+description: Reviews recent code changes in this repo against the rule files in `ai-rules/` and the repo-local style enforcement. Use after a substantive change (new DAG, new dbt model, new app endpoint, edits to pre-commit config, edits to a subproject's pyproject.toml) to catch rule violations before opening a PR.
+---
+
+You are a strict code reviewer for `gp-data-platform`. Your job is to read the recent diff and report rule violations against the rule files in `ai-rules/`, `CLAUDE.md`, the per-subproject `CLAUDE.md` files, and the active pre-commit configuration. You do not write code. You report findings.
+
+## Process
+
+1. Identify the change. Run `git status` and `git diff` (uncommitted) and/or `git diff main...HEAD` (branch since fork point), depending on what the user asks for. If the scope is unclear, ask.
+2. Read the files that changed, plus enough surrounding context that you can judge whether a violation is real.
+3. Read every rule file in `ai-rules/` — every top-level `.md` file (excluding `README.md` and the `*-template.md` files, which are scaffolding, not rules) plus everything under `ai-rules/skills/`. Discover them at runtime (`ls ai-rules/*.md` and `ls ai-rules/skills/`); don't rely on a hard-coded list — the submodule's contents change.
+4. Cross-check `CLAUDE.md` (root) — every "Never" item is a hard rule. Treat violations as Blockers.
+5. **If the diff touches `dbt/`**, also read `dbt/project/CLAUDE.md` and apply its rules — naming conventions (mart names domain-friendly, no `m_` prefix; `stg_<source>__<table>`; `int__<domain>_<object>_<year>`), no-`+`-upstream-selector, lateral column references, NULL-in-NOT-IN, accepted_values doesn't need `where: not null`, etc.
+6. Cross-check `.pre-commit-config.yaml` against the diff. If a Python file would fail black / isort / flake8 / mypy / sqlfmt as configured, that's a Blocker. Don't run the formatters yourself — predict their output from the rules in the config.
+7. Pay special attention to:
+   - **Single-venv assumptions** — don't accept code or docs that assume `gp-data-platform` has one Python env. It has several.
+   - **Wrong package manager for the subproject** — `apps/genie-slack-bot/` is pip + requirements.txt, not poetry. `dbt/`, `airflow/`, `apps/genie-tools/` are poetry.
+   - **Direct `dbt` invocation via `poetry`** — that's wrong; dbt Cloud CLI is system-installed.
+   - **Python 3.12 features in code that CI runs on 3.11** — flag if the test workflow could break.
+   - **Edits inside `ai-rules/`** — that's a submodule; changes belong in the submodule's repo, not here.
+   - **Edits inside `.claude/skills/l2-uniform-drift-remediator/`** that aren't explicitly part of the diff's scope.
+
+## Output format
+
+Group findings by severity. Use file:line references the user can click.
+
+```
+## Blockers
+- path/file.py:42 — <one-line description of the violation> (<rule source>)
+  Why: <one-sentence justification tied to the rule>
+  Fix: <concrete suggestion>
+
+## Should-fix
+- ...
+
+## Nits
+- ...
+
+## Looks good
+- <list of rules you checked that passed, so the user knows what was reviewed>
+```
+
+If the diff is clean, say so explicitly with the "Looks good" list — don't invent issues to fill space.
+
+## Never
+
+- Never edit files. You only read and report.
+- Never run `pre-commit run` with `--no-verify` style bypasses, or any other mutating command. The user runs hooks themselves after reviewing your findings.
+- Never approve changes that violate a `CLAUDE.md` "Never" item — those are blockers, not nits.
+- Never claim something passes a rule you didn't actually check. If a rule file is missing or unreadable, say so.

--- a/.claude/skills/python-developer.md
+++ b/.claude/skills/python-developer.md
@@ -1,0 +1,70 @@
+---
+name: python-developer
+description: Repo-local guidance for writing Python in gp-data-platform. Captures the multi-venv, multi-tool reality so agents don't reach for the wrong package manager or run the wrong test command. Use whenever a task involves writing or running Python code in this repo.
+---
+
+You are writing Python in `gp-data-platform`. Read this before you `cd` anywhere or run any command.
+
+## Ground truth
+
+This repo is **multi-project**, not a single Python package. There is no root `pyproject.toml`, no root venv, no `make install`. Each Python subproject manages its own deps:
+
+| Subproject | Tool | Lockfile | Python | Notes |
+|------------|------|----------|--------|-------|
+| `airflow/` | `poetry` | `airflow/poetry.lock` | 3.12 | Local DAG dev outside Astro container |
+| `airflow/astro/` | `pip` (Astronomer) | `requirements.txt` | (Astronomer-managed) | The actual deployed Airflow runtime |
+| `dbt/` | `poetry` | `dbt/poetry.lock` | 3.12 | Hosts the pre-commit pytest hook |
+| `apps/genie-tools/` | `pip install -e .` | none committed | 3.12+ | PEP 621 `[project]` metadata, setuptools build backend, no `[tool.poetry]` block. CLI: `genie-tools` |
+| `apps/genie-slack-bot/` | `pip` | `requirements.txt` | (no version pinned) | No `pyproject.toml` |
+| **root pytest (CI)** | `pip` | `requirements_test.txt` | 3.11 | What `.github/workflows/python_tests.yml` runs |
+
+Pick the row that matches what you're touching. If you're not sure, **ask the user before installing anything**.
+
+## Decision tree
+
+- **Are you adding or fixing a dbt model?** → `cd dbt && poetry install && eval "$(poetry env activate)"`. Then `cd project` and follow `dbt/project/CLAUDE.md`. **Do not** invoke dbt via `poetry`; dbt Cloud CLI is system-installed.
+- **Are you adding or fixing an Airflow DAG?** → For local DAG-code dev: `cd airflow && poetry install && eval "$(poetry env activate)"`. To run Airflow itself locally: `cd airflow/astro && astro dev start` (Docker).
+- **Are you working on `apps/genie-tools`?** → `cd apps/genie-tools && python -m venv .venv && source .venv/bin/activate && pip install -e .`. (Not poetry — `pyproject.toml` is PEP 621 + setuptools, no `[tool.poetry]` block.)
+- **Are you working on `apps/genie-slack-bot`?** → `cd apps/genie-slack-bot && python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`. **Not poetry** — different from the other apps.
+- **Are you adding a cross-subproject test?** → Test goes under `tests/<subproject>/`. CI installs `requirements_test.txt` and runs `pytest tests` from the repo root.
+
+## Style enforcement
+
+`.pre-commit-config.yaml` is the source of truth for code style. It runs:
+
+- **black** with `--line-length=88`
+- **isort** with `--profile black --line-length=88`
+- **flake8** with `--max-line-length=88` and an explicit ignore list (`D100,D103,D200,D205,D400,D401,E203,E501,F821,W503`)
+- **mypy** with type stubs declared in the hook (`types-requests`, `types-psycopg2`, `types-paramiko`, `types-tabulate`)
+- **sqlfmt** for `.sql` files (with `[jinjafmt]` for dbt Jinja)
+- a local **`pytest`** hook that runs the test suite before each commit
+
+Run them yourself with `pre-commit run --all-files`. CI runs the same; local-green = CI-green.
+
+## Testing
+
+- **Cross-subproject tests** (CI parity): from the repo root,
+  ```bash
+  pip install -r requirements_test.txt
+  pytest tests
+  ```
+- **Per-subproject tests:** `cd <subproject> && poetry run pytest` (or `pytest` if you already activated the env).
+- **dbt model tests:** `cd dbt/project && dbt test --select <model>`. **Not pytest** — these are dbt's own data tests.
+- **Pre-commit pytest hook:** runs from wherever you `git commit` from. From `dbt/`, do `poetry run git commit ...` so the hook can find pyspark and airflow.
+
+## Common pitfalls
+
+- **Running `poetry install` at the repo root.** There's no root `pyproject.toml`. You have to `cd` first.
+- **Adding deps to `requirements_test.txt` without a reason.** That file is for **CI test deps** — anything else belongs in a subproject's `pyproject.toml` (or `requirements.txt` in the case of `apps/genie-slack-bot/` or `airflow/astro/`).
+- **Writing `match` statements (Python 3.10+ structural pattern matching) in code that CI runs on 3.11.** Fine. **But** subprojects pin 3.12; don't use 3.13-only features anywhere.
+- **Disabling a pre-commit hook in a one-off commit.** If a hook is failing, fix the root cause. Bypassing locally just pushes the failure into the PR.
+- **Editing the dbt project without reading `dbt/project/CLAUDE.md` first.** The dbt-specific runbook there is non-trivial — `+` selectors, lateral column refs, NULL in `NOT IN`, naming conventions. Skipping it produces broken or wasteful code.
+- **Editing `ai-rules/` directly.** Submodule. Changes belong in the upstream `thegoodparty/ai-rules` repo.
+
+## What "good" looks like
+
+- You picked the right subproject + venv before you started.
+- You ran `pre-commit run --all-files` and it's green before you commit.
+- You added or extended tests under `tests/<subproject>/` (or dbt tests in `dbt/project/`).
+- You didn't touch `ai-rules/` or `.claude/skills/l2-uniform-drift-remediator/` unless the task explicitly involves them.
+- If you added a new package manager, lockfile, or top-level convention, you also updated `CLAUDE.md` and `docs/architecture.md` to reflect it.

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,5 @@ test_data/
 entity_resolution/data/
 entity_resolution/results/*.csv
 
-# Claude runbook
+# Claude runbook (CLAUDE.md is intentionally tracked; this ignores legacy paths only)
 .claude/RUNBOOK.md
-claude.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ai-rules"]
+	path = ai-rules
+	url = https://github.com/thegoodparty/ai-rules.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+Guidance for Claude Code and other AI agents working in `gp-data-platform`. Keep this file short — push detail into `docs/` and the per-subproject `CLAUDE.md` files.
+
+## Project
+
+Heterogeneous **multi-project** Python repo for GoodParty's data platform: Airflow DAGs (Astronomer-hosted) for orchestration, dbt models (dbt Cloud against Databricks) for transformation, plus standalone apps and ad-hoc scripts. **Each subproject manages its own Python deps** — `airflow/` and `dbt/` use `poetry`; `apps/genie-tools/` uses `pip install -e .` (PEP 621 + setuptools); `apps/genie-slack-bot/` uses `pip install -r requirements.txt`. Top-level CI uses `pip` + `requirements_test.txt` to run pytest across the repo. There is no single venv; there are several.
+
+## Commands (most-used first)
+
+```bash
+# Top-level CI parity (what GitHub Actions runs)
+pip install -r requirements_test.txt        # install root test deps
+pytest tests                                 # run the cross-subproject tests
+pre-commit run --all-files                   # black + isort + flake8 + mypy + sqlfmt + pytest
+
+# Per-subproject local dev (run from inside the subdirectory)
+cd dbt && poetry install && eval "$(poetry env activate)"
+cd airflow && poetry install && eval "$(poetry env activate)"
+cd apps/genie-tools && python -m venv .venv && source .venv/bin/activate && pip install -e .   # PEP 621 + setuptools, not poetry
+
+# After hooks are installed:
+pre-commit install                           # one-time, in the cloned repo
+```
+
+The repo's `Makefile` is intentionally minimal — its one task is `make submodule-init` for the `ai-rules` submodule init step. Per-subproject installs deliberately stay out of `Makefile` (each subproject has its own venv; see § Environment).
+
+## Pointer table — when in doubt
+
+| Doing | Read |
+|-------|------|
+| Adding or fixing an Airflow DAG | `airflow/astro/README.md` and `airflow/README.md` |
+| Adding or fixing a dbt model | `dbt/project/CLAUDE.md` (already detailed) |
+| Working on `apps/genie-tools` (Genie config CLI) | `apps/genie-tools/README.md` |
+| Working on `apps/genie-slack-bot` (Slack bot) | `apps/genie-slack-bot/README.md` |
+| Architecture overview (how the subprojects fit) | `docs/architecture.md` |
+| First-time setup | `docs/getting-started.md` |
+| AI rule-by-rule code review | `ai-rules/` (git submodule) |
+| Why a thing is the way it is | `docs/adr/` (not yet seeded) |
+
+## Code style
+
+- **Python 3.12+** in subprojects (`airflow/` and `dbt/` pin `requires-python = ">=3.12,<3.13"`; `apps/genie-tools/` is `>=3.12` with no upper bound). **CI runs Python 3.11** for the root pytest pass — see § Environment.
+- **Black**, line length **88** (`.pre-commit-config.yaml`). Don't fight it; `pre-commit run --all-files` is the source of truth.
+- **isort**, `--profile black`, line length 88.
+- **flake8** with `--max-line-length=88` and the ignore list in `.pre-commit-config.yaml`. Don't widen the ignore list without a reason.
+- **mypy** runs in pre-commit. Type stubs come from the `additional_dependencies` block in `.pre-commit-config.yaml`.
+- **sqlfmt** for `.sql` files (with `[jinjafmt]` for dbt's Jinja templating).
+- Use type hints on public APIs. Don't blanket-`# type: ignore` — narrow the ignore with a reason if absolutely needed.
+
+## Subproject map
+
+```
+gp-data-platform/
+├── airflow/                   # Airflow / Astronomer
+│   ├── astro/                 # Astronomer project (Dockerfile, dags/, requirements.txt)
+│   ├── pyproject.toml         # poetry — name: astro-goodparty (Python 3.12, Airflow 3.2.0)
+│   └── poetry.lock
+├── apps/
+│   ├── genie-tools/           # Databricks Genie config export CLI (setuptools-built, src/ layout)
+│   │   └── pyproject.toml
+│   └── genie-slack-bot/       # Slack bot wrapping Genie (requirements.txt — pip-only)
+├── dbt/                       # dbt Cloud + Databricks
+│   ├── project/               # dbt project root: models / macros / seeds / snapshots / tests
+│   │   └── CLAUDE.md          # dbt-specific guidance (pre-existing, detailed)
+│   ├── pyproject.toml         # poetry — name: dbt-goodparty
+│   ├── poetry.toml            # virtualenvs.in-project = false
+│   └── poetry.lock
+├── genie/civics/              # Genie space configs
+├── scripts/                   # shell glue (tgp_to_gp, local_to_election_db, dbt codegen)
+├── tests/                     # cross-subproject pytest suites (airflow / apps / dbt)
+├── requirements_test.txt      # what root CI installs to run the pytest suite
+├── .pre-commit-config.yaml    # the actual style enforcement
+└── .github/workflows/         # pre-commit.yml, python_tests.yml
+```
+
+`dbt/project/` is where most day-to-day data work happens — its `CLAUDE.md` has the dbt-specific runbook (model build/test workflow, naming conventions, the lateral-column-reference / NULL-in-NOT-IN gotchas).
+
+## Testing
+
+- Framework: **pytest** (root pytest + per-subproject pytest where each has a `pyproject.toml`).
+- Test layout at the root: `tests/airflow/`, `tests/apps/`, `tests/dbt/` mirror the source tree. CI runs `pytest tests` from the repo root after `pip install -r requirements_test.txt`.
+- The `pytest` hook in `.pre-commit-config.yaml` also runs locally on commit. Per `dbt/project/CLAUDE.md`, the dbt subproject requires `cd dbt && poetry run git commit ...` so the hook can find `pyspark` and `airflow`.
+- **dbt model tests** are **dbt's own tests** (`dbt test`), not pytest — see `dbt/project/CLAUDE.md`.
+
+## Never
+
+- Never add commands to the root that assume a single venv. There isn't one. If your command needs deps, document **which subproject** to `cd` into first.
+- Never invoke `dbt` via `poetry`. Per `dbt/project/CLAUDE.md`, dbt Cloud CLI is installed at the system level. `poetry run dbt ...` is wrong here.
+- Never edit a file under `ai-rules/` directly — it's a submodule. Changes belong in the `thegoodparty/ai-rules` repo. Bump the pin afterward and stage `ai-rules` in the parent.
+- Never overwrite `.claude/skills/l2-uniform-drift-remediator/`. That skill is a complete, working tool with scripts, tests, and reference runbooks.
+- Never disable a pre-commit hook in a one-off commit to "make CI green." Fix the underlying issue. CI runs `pre-commit run --all-files`; bypassing it locally pushes the failure to the PR.
+- Never check secrets into `.env`. Only `.env.example` is committed (`DBT_CLOUD_PROJECT_ID=`).
+
+## Environment
+
+- **Python 3.12** in subprojects (their `pyproject.toml`s pin it; `apps/genie-tools/` is `>=3.12` with no upper bound, the others cap at `<3.13`). **CI uses Python 3.11** (`.github/workflows/python_tests.yml` and `.github/workflows/pre-commit.yml`). This split is pre-existing — flag any new code that depends on a 3.12-only feature.
+- **Package manager varies by subproject:** `airflow/` and `dbt/` use **poetry** (≥ 2.0, installed via `pipx`, with Python pinned via `pyenv`); `apps/genie-tools/` uses **pip + setuptools** (PEP 621); `apps/genie-slack-bot/` uses **pip + requirements.txt**. The poetry virtualenvs live in poetry's cache (`dbt/poetry.toml` sets `virtualenvs.in-project = false`).
+- **No `uv` migration today.** The org-wide direction may be `uv`, but this repo isn't there yet — don't pre-write `uv` commands into new docs. Update the docs in lockstep with the actual migration.
+- The `ai-rules/` submodule isn't auto-initialized (no `package.json` postinstall available). After cloning, run `make submodule-init` (see `Makefile`) or `git submodule update --init --recursive`.
+- Required env: see `.env.example` (currently just `DBT_CLOUD_PROJECT_ID=`).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: help submodule-init
+
+help:
+	@echo "Available commands:"
+	@echo "  make submodule-init   - Initialize the ai-rules git submodule"
+	@echo ""
+	@echo "Per-subproject installs are intentionally not in this Makefile —"
+	@echo "  cd <subproject> && poetry install"
+	@echo ""
+	@echo "See docs/getting-started.md for the full setup guide."
+
+submodule-init:
+	git submodule update --init --recursive
+	@echo "ai-rules submodule initialized at: $$(cd ai-rules && git rev-parse --short HEAD)"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,126 @@
+# Architecture
+
+A pointer-heavy doc. Detailed conventions live in `CLAUDE.md`, the per-subproject READMEs, `dbt/project/CLAUDE.md`, and `ai-rules/`.
+
+## Repo shape: multi-project, not a monorepo
+
+`gp-data-platform` is **not** a single Python package. It's a collection of sibling subprojects that share a repo because they belong to the same data team:
+
+```
+gp-data-platform/
+├── airflow/   ── orchestration (Astronomer-hosted Airflow 3.2)
+├── dbt/       ── transformation (dbt Cloud + Databricks SQL)
+├── apps/      ── small standalone services and CLIs
+├── genie/     ── Genie config exports
+├── scripts/   ── shell glue between the above
+├── tests/     ── cross-subproject pytest suites
+└── .github/   ── shared CI (pre-commit + pytest)
+```
+
+Each Python subproject (`airflow/`, `dbt/`, `apps/genie-tools/`) has its **own** `pyproject.toml` + `poetry.lock`. Local development is per-subproject: you `cd <subproject>` and `poetry install` there. CI is **not** per-subproject — `.github/workflows/python_tests.yml` does a flat `pip install -r requirements_test.txt` at the root and runs `pytest tests`.
+
+## Stack
+
+- **Orchestration:** Apache Airflow 3.2 on **Astronomer** (`airflow/astro/`, Astro Runtime `3.2-2` per `airflow/astro/Dockerfile`). DAGs live in `airflow/astro/dags/`. Branch deploys: `main` auto-deploys to `astro-prod`; `astro-dev` is **manually** pointed at one feature branch at a time via the Astro UI (see `airflow/astro/README.md` § Environments).
+- **Transformation:** **dbt Cloud** running against **Databricks SQL** (`dbt/project/`). The dbt Cloud CLI is installed at the system level — **don't** invoke dbt via `poetry`.
+- **Apps:**
+  - `apps/genie-tools/` — Python CLI (`genie-tools` entry point, src/ layout, setuptools-built via PEP 621 `[project]` metadata — no `poetry.lock` here, install with `pip install -e .`). Depends only on `databricks-sdk`. Used to export-only Databricks Genie space configs.
+  - `apps/genie-slack-bot/` — Slack bot wrapping Genie. `requirements.txt`-based; no `pyproject.toml`.
+- **Lineage / config:** `genie/civics/` holds Genie space configs.
+- **Style enforcement:** `.pre-commit-config.yaml` with **black**, **isort**, **flake8**, **mypy**, **sqlfmt**, plus a local `pytest` hook. CI runs `pre-commit run --all-files` on every PR.
+- **Python versions:** `airflow/` and `dbt/` pin **3.12** (`requires-python = ">=3.12,<3.13"`); `apps/genie-tools/` is `>=3.12` with no upper bound. CI workflows (`.github/workflows/python_tests.yml`, `.github/workflows/pre-commit.yml`) run on **Python 3.11**. This split is pre-existing — flagged in `CLAUDE.md` § Environment.
+
+## Subproject details
+
+### `airflow/`
+
+- `airflow/astro/` is an [Astronomer](https://www.astronomer.io/) project (`Dockerfile`, `dags/`, `include/`, `tests/`, `requirements.txt`, `airflow_settings.yaml.example`). The Astro CLI runs Airflow locally in Docker; deploys go to Astronomer-hosted `astro-dev` / `astro-prod`.
+- `airflow/pyproject.toml` (`name: astro-goodparty`, Python 3.12, poetry-managed) is for **local development of DAG code** outside the Astro container — i.e. when you want a poetry-managed Python env to import the same packages the DAGs use (`pyspark`, `databricks-sql-connector`, `paramiko`, etc.).
+- DAG tests live at the repo root in `tests/airflow/`, not inside `airflow/`.
+
+### `dbt/`
+
+- `dbt/project/` is the dbt project root: `models/`, `macros/`, `seeds/`, `snapshots/`, `tests/`, `analyses/`, `dbt_project.yml`, `package-lock.yml`, `packages.yml`. **Read `dbt/project/CLAUDE.md`** before you touch anything here — it has the model-build/inspect/test workflow, the lateral-column-reference and NULL-in-NOT-IN gotchas, and naming conventions.
+- `dbt/pyproject.toml` (`name: dbt-goodparty`, poetry-managed) is for the **Python utilities and pre-commit hooks**, not for dbt itself. The pre-commit pytest hook runs from `dbt/`'s poetry env so it can find `pyspark` and `airflow`. That's why `dbt/project/CLAUDE.md` says to `cd dbt && poetry run git commit ...`.
+- `dbt/poetry.toml` sets `virtualenvs.in-project = false` — the venv lives in poetry's cache, not in `dbt/.venv/`.
+- dbt model tests are run with **`dbt test`**, not pytest. The pytest tests at `tests/dbt/` are about the surrounding Python utilities.
+
+### `apps/genie-tools/`
+
+- A small CLI (`genie-tools`) for exporting Databricks Genie space configurations. Uses `setuptools` (not poetry) for build, with PEP 621 `[project]` metadata in `pyproject.toml`. No `poetry.lock` is committed; the standard install is `pip install -e .`. Source under `src/genie_tools/`.
+- Depends only on `databricks-sdk`.
+- Tests live at `tests/apps/genie_tools/`.
+
+### `apps/genie-slack-bot/`
+
+- A Slack bot. `requirements.txt`-based — no `pyproject.toml`, no poetry. Just `pip install -r requirements.txt`.
+- Tests live at `tests/apps/genie_slack_bot/`.
+
+### `genie/civics/spaces/`
+
+- Genie space configs (likely YAML/JSON). Edited and exported via `apps/genie-tools/`.
+
+### `scripts/`
+
+- Shell scripts:
+  - `dbt_codegen_stg_uniform_files.sh` — codegen for dbt staging models.
+  - `tgp_to_gp/` — extract / transform / load between TGP and GP databases.
+  - `local_to_election_db/` — local-to-election-DB sync helpers.
+
+## Data flow (high-level)
+
+```
+External sources (Airbyte, files, APIs)
+        │
+        ▼  ingestion (Airbyte configs — YAML, not in this repo's Python)
+   Databricks (raw / bronze)
+        │
+        ▼  dbt models (dbt Cloud, dbt/project/models/staging → intermediate → marts)
+   Databricks (silver / gold)
+        │
+        ▼  consumed by:
+        ├── Airflow DAGs (orchestration jobs in airflow/astro/dags/)
+        ├── Genie spaces (genie/civics/spaces/, exported via apps/genie-tools)
+        └── BI / downstream services
+```
+
+The dbt staging-→ intermediate → mart layering is documented in `dbt/project/CLAUDE.md` (mart names use domain-friendly names, no `m_` prefix; staging follows `stg_<source>__<table>.sql`; intermediate follows `int__<domain>_<object>_<year>.sql`).
+
+## Cross-service edges
+
+| Direction | Service | Protocol | Notes |
+|-----------|---------|----------|-------|
+| outbound | Databricks SQL warehouse | `databricks-sql-connector` / `databricks-sdk` | Used by dbt, airflow utils, genie-tools |
+| outbound | dbt Cloud | dbt Cloud CLI (system-installed) | Triggered manually by devs and via Airflow |
+| outbound | Astronomer (Airflow) | Git deploy | `main` → `astro-prod` (auto); `astro-dev` is manually mapped to one feature branch via the Astro UI |
+| outbound | Slack | `slack-bolt` (+ `slack-sdk`) | `apps/genie-slack-bot` |
+| outbound | TGP / election databases | `psycopg2`, ssh tunnel | `scripts/tgp_to_gp/`, `scripts/local_to_election_db/` |
+
+There is no inbound HTTP API in this repo. Other services don't call into `gp-data-platform`; this repo runs scheduled or triggered jobs that read upstream sources and write to Databricks.
+
+## Testing
+
+- Root pytest is what CI runs:
+  ```bash
+  pip install -r requirements_test.txt
+  pytest tests
+  ```
+  This installs deps (Airflow, pyspark, databricks-sql-connector, pandas, pytest, ...) at the repo root and discovers tests under `tests/`.
+- The pre-commit `pytest` hook also runs on every commit — but **from the repo root** unless you `cd` somewhere else. From `dbt/`, you must run `poetry run git commit ...` so the hook finds Spark and Airflow inside the `dbt-goodparty` venv. See `dbt/project/CLAUDE.md` for the rationale.
+- dbt model tests are run separately via `dbt test --select <model>` from `dbt/project/`.
+
+## CI
+
+Two workflows:
+
+- `.github/workflows/python_tests.yml` — Python 3.11, `pip install -r requirements_test.txt`, `pytest tests`. Runs on every push.
+- `.github/workflows/pre-commit.yml` — Python 3.11, `pip install -r requirements_test.txt && pip install pre-commit && pre-commit run --all-files`. Runs on PRs and pushes to `main` / `develop`.
+
+## Skills
+
+- `.claude/skills/l2-uniform-drift-remediator/` is an existing repo-local skill: scripts that detect and remediate L2 Uniform schema drift in Databricks, plus reference runbooks and tests. Don't touch it from a Python-onboarding PR.
+- `.claude/skills/python-developer.md` (added in this onboarding) is a small skill that captures the multi-venv, multi-tool reality of this repo so agents don't reach for the wrong package manager or run the wrong test command.
+
+## ADRs
+
+`docs/adr/` is not yet seeded. Add one when a non-obvious decision lands — likely candidates are: why poetry per-subproject instead of a single monorepo lockfile, why Astronomer for Airflow, why dbt Cloud over dbt Core, why Databricks (vs Snowflake / BigQuery). Use `ai-rules/adr-template.md`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,150 @@
+# Getting Started
+
+First-time setup for `gp-data-platform`. The high-level repo description lives in `README.md` and the dbt-specific runbook in `dbt/project/CLAUDE.md`. This doc covers what you need to be productive across the whole repo.
+
+## Prerequisites
+
+- **`pyenv`** for managing Python versions ([install guide](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation)).
+- **Python 3.12** for subproject local dev (`pyenv install 3.12`). CI uses Python 3.11; if you want to reproduce CI exactly, install 3.11 too.
+- **`pipx`** for installing tool-level CLIs ([install guide](https://pipx.pypa.io/stable/installation/)).
+- **`poetry` ≥ 2.0** via `pipx install poetry` (per-subproject dep management). The `eval "$(poetry env activate)"` invocation used below is poetry-2.0-and-up syntax — older poetry installs will fail on it.
+- **Docker** if you plan to run Airflow locally via the Astro CLI.
+- **`astro` CLI** (`brew install astro` on macOS) if you'll be working on Airflow DAGs.
+- **dbt Cloud CLI** installed at the **system level** (not via poetry) if you'll be working on dbt models. See [dbt Cloud docs](https://docs.getdbt.com/docs/cloud/cloud-cli-installation).
+- **Databricks** access (creds + warehouse URL) if you'll run anything that hits the warehouse.
+
+## Clone
+
+This repo uses `ai-rules` as a git submodule. Clone with `--recursive`:
+
+```bash
+git clone --recursive git@github.com:thegoodparty/gp-data-platform.git
+cd gp-data-platform
+```
+
+If you already cloned without `--recursive`:
+
+```bash
+make submodule-init    # or: git submodule update --init --recursive
+```
+
+There is **no `package.json` postinstall** to do this for you — run it explicitly. The `Makefile` target is added in this onboarding for convenience.
+
+## Pick your subproject
+
+There's no single "install everything" step — local dev is per-subproject. Pick the one you're working on and follow that section.
+
+### Working on dbt models (most common)
+
+```bash
+cd dbt
+poetry install
+eval "$(poetry env activate)"          # shell hook to use the dbt-goodparty venv
+pre-commit install                     # one-time, in the cloned repo
+
+# Then for actual dbt work:
+cd project
+dbt build --select my_model           # see dbt/project/CLAUDE.md for the workflow
+```
+
+dbt Cloud CLI is system-installed; `dbt` is **not** invoked via `poetry`. The poetry env is needed so that the pre-commit pytest hook can find `pyspark` and `airflow`. If you skip the venv, your commit hooks fail.
+
+### Working on Airflow DAGs
+
+For DAG code outside the Astro container:
+
+```bash
+cd airflow
+poetry install
+eval "$(poetry env activate)"
+```
+
+For running Airflow locally (with the same DAGs Astronomer runs in prod):
+
+```bash
+cd airflow/astro
+astro dev start                        # Docker-based local Airflow on http://localhost:8080
+```
+
+See `airflow/astro/README.md` for the full Astro CLI flow (deploy, env vars, connections).
+
+### Working on `apps/genie-tools` (CLI)
+
+```bash
+cd apps/genie-tools
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+genie-tools --help
+```
+
+Note `apps/genie-tools` uses PEP 621 `[project]` metadata with `setuptools` as the build backend — there is no `[tool.poetry]` block and no `poetry.lock` committed. Don't reach for poetry here.
+
+### Working on `apps/genie-slack-bot`
+
+```bash
+cd apps/genie-slack-bot
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Note this is `pip` + `requirements.txt`, not poetry — different from the other apps.
+
+### Reproducing CI locally (root pytest)
+
+```bash
+# From the repo root, in a fresh venv:
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements_test.txt
+pytest tests
+```
+
+This is what `.github/workflows/python_tests.yml` runs. Same Python (3.11), same deps. Matches CI.
+
+## Pre-commit hooks
+
+```bash
+pip install pre-commit                 # if not already
+pre-commit install                     # one-time
+pre-commit run --all-files             # run all hooks against all files
+```
+
+The hooks are: `black`, `isort`, `flake8`, `mypy`, `sqlfmt` (for `.sql` files), plus a local `pytest` hook. The full set is in `.pre-commit-config.yaml`. CI runs `pre-commit run --all-files` on every PR — if it's green locally, it'll be green in CI.
+
+## Environment variables
+
+`.env.example` is the source of truth. Today it has:
+
+| Var | Notes |
+|-----|-------|
+| `DBT_CLOUD_PROJECT_ID` | dbt Cloud project ID for jobs/triggers |
+
+Subprojects may need their own envs (Databricks creds, Slack tokens, etc.) — those live in subproject-specific files; check the relevant README.
+
+## Running tests
+
+| What | Command |
+|------|---------|
+| Cross-subproject pytest (CI parity) | `pytest tests` (from repo root, after `pip install -r requirements_test.txt`) |
+| dbt model tests | `cd dbt/project && dbt test --select <model>` |
+| Per-subproject pytest | `cd <subproject> && poetry run pytest` |
+| All pre-commit hooks | `pre-commit run --all-files` |
+
+## Common gotchas
+
+- **`ai-rules/` is empty after clone** → run `make submodule-init` or `git submodule update --init --recursive`. There's no postinstall hook (no `package.json`).
+- **Pre-commit pytest fails with "no module named pyspark / airflow"** → you ran the commit from outside the `dbt/` poetry env. Per `dbt/project/CLAUDE.md`, do `cd dbt && poetry run git commit ...`.
+- **`poetry install` complains about Python version** → make sure `pyenv` has `3.12.x` installed and active in this directory (`pyenv local 3.12.x`).
+- **CI fails on a 3.12-only feature** → CI uses Python 3.11. `match` (PEP 634) is fine — it's 3.10+. Things like `type` statements / PEP 695 generics, `TypeVar`-with-defaults syntax, and 3.12-only typing additions will break CI; don't reach for them without bumping the workflow.
+- **`dbt run` complains about deferred state** → you don't need `--defer` or a state file path with dbt Cloud CLI. Per `dbt/project/CLAUDE.md`.
+- **`dbt build --select +my_model` is slow** → don't use the `+` upstream selector during development — dbt Cloud already defers to prod artifacts. List only the modified models. Per `dbt/project/CLAUDE.md`.
+- **Slack bot can't connect locally** → no `pyproject.toml` here; remember it's `pip install -r requirements.txt` inside `apps/genie-slack-bot/`.
+- **`SECRETS` in `.env`** → never commit. `.env.example` is the only env file in git.
+
+## Where to go next
+
+- `README.md` — repo overview and component map.
+- `CLAUDE.md` — agent + style guide for the whole repo.
+- `dbt/project/CLAUDE.md` — dbt-specific workflow, conventions, terminology, ID mappings.
+- `airflow/README.md` and `airflow/astro/README.md` — Airflow / Astronomer setup.
+- `docs/architecture.md` — subproject map, data flow, CI shape.
+- `ai-rules/` — org-wide review rules and skills (submodule).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation and repo-metadata changes only (new docs, Makefile target, and `ai-rules` submodule declaration). Main risk is workflow friction if the new `ai-rules` submodule/init expectations are misconfigured for existing clones/CI.
> 
> **Overview**
> Adds repo-wide Claude/agent onboarding via a new root `CLAUDE.md`, a `docs/getting-started.md` setup guide, and an `docs/architecture.md` overview that codify the repo’s *multi-venv / per-subproject* workflow and CI testing expectations.
> 
> Introduces an `ai-rules` git submodule (via `.gitmodules`) plus a minimal `Makefile` target (`make submodule-init`) to initialize it, and adds new Claude agent/skill definitions (`.claude/agents/code-critic.md`, `.claude/skills/python-developer.md`) for rule-based reviews and Python workflow guidance.
> 
> Tweaks `.gitignore` to clarify that `CLAUDE.md` is tracked while continuing to ignore legacy Claude runbook paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7515fc2ca194fdcb8488acaaf28620516b7ccbe3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->