### PR TITLE
chore: accept 'canceled' status in stripe_api_charges

### DIFF
--- a/dbt/project/models/staging/airbyte_source/stripe_api/stg_airbyte_source__stripe_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/stripe_api/stg_airbyte_source__stripe_api.yaml
@@ -138,7 +138,7 @@ models:
         tests:
           - accepted_values:
               arguments:
-                values: ['succeeded', 'pending', 'failed']
+                values: ['succeeded', 'pending', 'failed', 'canceled']
               config:
                 where: "status is not null"
       - name: livemode


### PR DESCRIPTION
## Summary

The daily `dbt build` is failing on `accepted_values_stg_airbyte_source__stripe_api_charges_status__succeeded__pending__failed` because Stripe surfaces `canceled` on charges tied to canceled PaymentIntents — a status Stripe's docs don't list for the Charge object but does occur in our data.

This adds `'canceled'` to the accepted values.

## Reproduction

Current distribution of `status` in `stripe_api_charges`:

| status    | n    |
|-----------|------|
| succeeded | 9944 |
| failed    | 4444 |
| canceled  | 1    |

Single `canceled` charge was breaking the test.

## Test plan

- [x] `dbt test --select stg_airbyte_source__stripe_api_charges` — 12/12 PASS on dev schema
- [ ] Next prod build's accepted_values test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)