### PR TITLE
chore: harden election-api swap against missing target indexes

### DIFF
--- a/airflow/astro/include/custom_functions/election_api_utils.py
+++ b/airflow/astro/include/custom_functions/election_api_utils.py
@@ -169,6 +169,33 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
 
         statements: List[str] = []
         if target_exists:
+            # Filter spec.indexes to those that actually exist on the target.
+            # The spec is the post-swap source of truth, but the target may
+            # legitimately lag — e.g. a new index was just declared in the
+            # spec and the corresponding Prisma migration hasn't reached this
+            # DB yet, or a prior swap with a narrower spec carried the index
+            # into _old and drop_old removed it. Renaming a non-existent
+            # index is a hard error that rolls back the whole swap; skipping
+            # it is safe because anything still on the target gets dropped
+            # with _old regardless of whether it's archive-renamed first.
+            cur.execute(
+                "SELECT indexname FROM pg_indexes "
+                "WHERE schemaname = %s AND tablename = %s",
+                (spec.target_schema, spec.target_table),
+            )
+            target_indexes = {row[0] for row in cur.fetchall()}
+            indexes_to_archive = [idx for idx in spec.indexes if idx in target_indexes]
+            missing_indexes = [idx for idx in spec.indexes if idx not in target_indexes]
+            if missing_indexes:
+                logger.warning(
+                    "Swap skipping archive-rename of %d index(es) absent from "
+                    "%s.%s: %s",
+                    len(missing_indexes),
+                    spec.target_schema,
+                    spec.target_table,
+                    missing_indexes,
+                )
+
             statements.append(
                 f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" '
                 f'RENAME TO "{spec.old_table}"'
@@ -177,7 +204,7 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
                 f'ALTER INDEX "{spec.target_schema}"."{spec.pk_name}" '
                 f'RENAME TO "{spec.archive_name(spec.pk_name)}"'
             )
-            for idx in spec.indexes:
+            for idx in indexes_to_archive:
                 statements.append(
                     f'ALTER INDEX "{spec.target_schema}"."{idx}" '
                     f'RENAME TO "{spec.archive_name(idx)}"'

--- a/tests/airflow/test_election_api_utils.py
+++ b/tests/airflow/test_election_api_utils.py
@@ -1,0 +1,149 @@
+"""Tests for swap_staging_into_target's resilience to target/spec drift.
+
+The swap's archive-rename loop used to fail hard if a `spec.indexes` entry
+didn't exist on the target table. That's how the DATA-1896 sync first broke
+in prod: a prior swap with a narrower spec carried the new composite index
+into `_old` and `drop_old` removed it, so the next swap with the wider spec
+couldn't find the index to archive-rename. These tests pin the resilient
+behavior so the same shape of failure can't return silently.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# Stub airflow / databricks / psycopg2 so the module collects without the
+# Astro runtime installed. Same pattern as airflow/astro/tests/test_sync_election_api.py.
+for _mod in (
+    "airflow",
+    "airflow.sdk",
+    "databricks",
+    "databricks.sql",
+    "databricks.sql.client",
+    "databricks.sdk",
+    "databricks.sdk.core",
+    "paramiko",
+    "pendulum",
+    "sshtunnel",
+    "psycopg2",
+    "psycopg2.extras",
+):
+    sys.modules.setdefault(_mod, MagicMock())
+
+import pytest  # noqa: E402
+from include.custom_functions.election_api_utils import (  # noqa: E402
+    TableSyncSpec,
+    swap_staging_into_target,
+)
+
+
+@pytest.fixture
+def mock_conn():
+    """psycopg2-style conn/cursor whose `fetchone`/`fetchall` are scriptable."""
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def _executed_ddl(cur) -> list:
+    """Return only the DDL statements (single-arg execute calls), in order."""
+    return [call.args[0] for call in cur.execute.call_args_list if len(call.args) == 1]
+
+
+SPEC = TableSyncSpec(
+    target_table="ZipToPosition",
+    indexes=(
+        "ZipToPosition_zip_code_idx",
+        "ZipToPosition_position_id_idx",
+        "ZipToPosition_zip_code_pct_districtzip_to_zip_idx",
+    ),
+)
+
+
+def test_swap_skips_archive_rename_for_missing_target_index(mock_conn):
+    """If a spec.indexes entry is absent from the target, skip its archive
+    rename instead of failing the whole swap.
+    """
+    conn, cur = mock_conn
+    # First execute: pg_tables existence check → target exists.
+    cur.fetchone.return_value = (1,)
+    # Second execute: pg_indexes → only two of three spec indexes present.
+    cur.fetchall.return_value = [
+        ("ZipToPosition_zip_code_idx",),
+        ("ZipToPosition_position_id_idx",),
+    ]
+
+    swap_staging_into_target(conn, SPEC)
+
+    ddl = _executed_ddl(cur)
+    # The missing index must not be archive-renamed.
+    assert not any(
+        '"ZipToPosition_zip_code_pct_districtzip_to_zip_idx"' in s
+        and "RENAME TO" in s
+        and '"ZipToPosition_old_zip_code_pct_districtzip_to_zip_idx"' in s
+        for s in ddl
+    ), "Should not emit archive-rename for a missing target index"
+    # Present indexes are archive-renamed.
+    assert any(
+        'ALTER INDEX "public"."ZipToPosition_zip_code_idx" '
+        'RENAME TO "ZipToPosition_old_zip_code_idx"' == s
+        for s in ddl
+    )
+    assert any(
+        'ALTER INDEX "public"."ZipToPosition_position_id_idx" '
+        'RENAME TO "ZipToPosition_old_position_id_idx"' == s
+        for s in ddl
+    )
+    # Staging-side restore loop still names every spec index canonically,
+    # including the one that was missing from the target.
+    assert any(
+        'ALTER INDEX "public"."ZipToPosition_new_zip_code_pct_districtzip_to_zip_idx" '
+        'RENAME TO "ZipToPosition_zip_code_pct_districtzip_to_zip_idx"' == s
+        for s in ddl
+    )
+    conn.commit.assert_called_once()
+    conn.rollback.assert_not_called()
+
+
+def test_swap_archive_renames_all_present_indexes(mock_conn):
+    """When every spec.indexes entry exists on the target, every one is
+    archive-renamed (regression guard so the filter doesn't accidentally
+    skip valid indexes).
+    """
+    conn, cur = mock_conn
+    cur.fetchone.return_value = (1,)
+    cur.fetchall.return_value = [(idx,) for idx in SPEC.indexes]
+
+    swap_staging_into_target(conn, SPEC)
+
+    ddl = _executed_ddl(cur)
+    for idx in SPEC.indexes:
+        assert any(
+            f'ALTER INDEX "public"."{idx}" RENAME TO "{SPEC.archive_name(idx)}"' == s
+            for s in ddl
+        ), f"Expected archive-rename for {idx}"
+
+
+def test_swap_skips_index_lookup_when_target_absent(mock_conn):
+    """First-run path: no target table → no pg_indexes lookup, no archive
+    renames. Staging table still gets promoted.
+    """
+    conn, cur = mock_conn
+    # Target does not exist.
+    cur.fetchone.return_value = None
+
+    swap_staging_into_target(conn, SPEC)
+
+    ddl = _executed_ddl(cur)
+    assert not any(
+        "RENAME TO" in s and "_old" in s for s in ddl
+    ), "First-run swap must not attempt any _old renames"
+    # Staging promotion still happens.
+    assert any(
+        'ALTER TABLE "staging"."ZipToPosition_new" SET SCHEMA "public"' == s
+        for s in ddl
+    )
+    assert any(
+        'ALTER TABLE "public"."ZipToPosition_new" RENAME TO "ZipToPosition"' == s
+        for s in ddl
+    )


### PR DESCRIPTION
## Summary

The atomic rename-swap in `election_api_utils.swap_staging_into_target` emits `ALTER INDEX ... RENAME TO ...` for every entry in `spec.indexes` on the target table. If the spec declares an index that the target doesn't actually have, the rename throws `UndefinedTable` and the whole swap rolls back.

This is how the DATA-1896 zip-to-position sync first broke in prod earlier today:
1. The Prisma migration added a new composite index `ZipToPosition_zip_code_pct_districtzip_to_zip_idx` to `public.ZipToPosition`.
2. A prior `sync_election_api` run with the **old** airflow code (which didn't list the composite in `spec.indexes`) renamed `public.ZipToPosition` → `_old`, carrying the composite index along. The old swap's archive-rename loop didn't touch it, so the index stayed on `_old` with its canonical name.
3. `drop_old` then dropped `_old` and the composite index with it.
4. Today's swap with the **new** airflow code (composite in `spec.indexes`) tried to archive-rename the index that no longer existed on `public.ZipToPosition`. Hard error, four retries failed in a row.

## The fix

Filter `spec.indexes` against `pg_indexes` for the target table before emitting the archive-rename loop. Missing indexes get a warning log and are skipped — anything still on the target is dropped with `_old` regardless of whether it's archive-renamed first, so skipping is safe. The staging-side restore loop is unchanged and keeps naming every spec index canonically.

```python
cur.execute(
    \"SELECT indexname FROM pg_indexes \"
    \"WHERE schemaname = %s AND tablename = %s\",
    (spec.target_schema, spec.target_table),
)
target_indexes = {row[0] for row in cur.fetchall()}
indexes_to_archive = [idx for idx in spec.indexes if idx in target_indexes]
```

## Scope notes

- **Indexes only.** `spec.fkeys` has the same theoretical hole but no FKs are currently spec'd, so it's not fixed here — easy to extend symmetrically when a FK first gets added.
- **No behavior change when the target matches the spec.** Verified by `test_swap_archive_renames_all_present_indexes`.
- **No behavior change on first-run (target absent).** Verified by `test_swap_skips_index_lookup_when_target_absent`.

## Test plan

- [x] `pytest tests/airflow/test_election_api_utils.py` — 3/3 pass locally
- [x] Red/green verified: test 1 (missing index) fails against the pre-fix code, passes after the fix
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)