### PR TITLE
[DATA-1903] Local issue filter for district top issues

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -174,6 +174,46 @@ DTI_COLUMNS = [
     "issue_rank",
 ]
 
+# DATA-1903 phase (a) only: the v3 mart now scores 68 issues per district
+# (up from 27), so taking the mart's top-10 by overall issue_rank would
+# surface the 41 newly-introduced issues (Aliens, Border Wall, federal-only
+# noise) ahead of the locally-actionable issues the API serves today. To
+# preserve pre-DATA-1903 API behavior while the election-api team's Prisma
+# migration is in flight, the load_staging query filters the mart to this
+# legacy 27-issue universe, recomputes issue_rank within the filtered set,
+# and takes top-10. Drop V2_LEGACY_ISSUES and the legacy_top_10 CTE in
+# phase (c) once the four jurisdictional flag columns are live in Postgres
+# and the API can do its own filter-then-rerank by flag.
+V2_LEGACY_ISSUES = (
+    "hs_abortion_pro_choice",
+    "hs_affordable_housing_gov_has_role",
+    "hs_casino_support",
+    "hs_charter_schools_support",
+    "hs_civil_liberties_support",
+    "hs_climate_change_believer",
+    "hs_death_penalty_support",
+    "hs_dei_support",
+    "hs_econ_anxiety_very_worried",
+    "hs_gun_control_support",
+    "hs_immigration_undesirable",
+    "hs_income_inequality_serious",
+    "hs_marijuana_legal_support",
+    "hs_medicaid_expansion_support",
+    "hs_medicare_for_all_support",
+    "hs_min_wage_15_increase_support",
+    "hs_pipeline_fracking_support",
+    "hs_police_trust_yes",
+    "hs_public_transit_support",
+    "hs_regulations_too_harsh",
+    "hs_same_sex_marriage_support",
+    "hs_school_choice_support",
+    "hs_school_funding_more",
+    "hs_tax_cuts_support",
+    "hs_trump_tariffs_support",
+    "hs_unions_beneficial",
+    "hs_violent_crime_very_worried",
+)
+
 
 def _dti_constraint_ddl() -> list[str]:
     sn, nt = DTI.staging_schema, DTI.new_table
@@ -346,19 +386,40 @@ def sync_election_api():
         @task
         def load_staging() -> int:
             catalog = Variable.get("databricks_catalog")
-            col_list = ", ".join(DTI_COLUMNS)
-            # TEMP (DATA-1903 phase a): cap Postgres at top-10-by-overall-score
-            # per district while the v3 mart change rolls out. The mart now
-            # emits all issues per district with no QUALIFY cap; the four
-            # jurisdictional flag columns don't exist in Postgres yet. Drop
-            # this WHERE clause in DATA-1903 phase (c) once Patrick's Prisma
-            # migration has added the is_local/is_regional/is_state/is_federal
-            # columns and DTI_COLUMNS has been extended to sync them.
+            # TEMP (DATA-1903 phase a): the v3 mart ranks all 68 issues per
+            # district. Postgres still has the pre-DATA-1903 7-column shape
+            # and the API has no jurisdictional-flag filter yet. To preserve
+            # current API behavior, filter the mart to the 27 legacy issues,
+            # recompute issue_rank within that subset, and take top-10. The
+            # entire legacy_top_10 CTE and V2_LEGACY_ISSUES are removed in
+            # phase (c) once Patrick's Prisma migration adds the four
+            # jurisdictional flag columns to DistrictTopIssue and DTI_COLUMNS
+            # is extended to sync them.
+            legacy_in_clause = ", ".join(f"'{i}'" for i in V2_LEGACY_ISSUES)
+            # `new_rank` (not `issue_rank`) inside the CTE — the source mart
+            # has its own `issue_rank` column, and Databricks resolves a
+            # QUALIFY clause against the source column instead of the SELECT
+            # alias when they share a name, which would silently filter to
+            # the mart's 1..68 ranks (~3 legacy issues per district), not
+            # the recomputed 1..N within the filtered subset. Outer SELECT
+            # renames `new_rank` back to `issue_rank` to match DTI_COLUMNS.
             query = (
-                f"SELECT {col_list} "
-                f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
-                f"`m_election_api__district_top_issues` "
-                f"WHERE issue_rank <= 10"
+                f"WITH legacy_top_10 AS ("
+                f"  SELECT"
+                f"    id, updated_at, district_id, issue, issue_label, score,"
+                f"    row_number() OVER ("
+                f"      PARTITION BY district_id "
+                f"      ORDER BY score DESC, issue ASC"
+                f"    ) AS new_rank"
+                f"  FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
+                f"`m_election_api__district_top_issues`"
+                f"  WHERE issue IN ({legacy_in_clause})"
+                f"  QUALIFY new_rank <= 10"
+                f") "
+                f"SELECT"
+                f"  id, updated_at, district_id, issue, issue_label, score,"
+                f"  new_rank AS issue_rank "
+                f"FROM legacy_top_10"
             )
             with _open_pg() as conn:
                 return bulk_insert_from_databricks(

--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -347,10 +347,18 @@ def sync_election_api():
         def load_staging() -> int:
             catalog = Variable.get("databricks_catalog")
             col_list = ", ".join(DTI_COLUMNS)
+            # TEMP (DATA-1903 phase a): cap Postgres at top-10-by-overall-score
+            # per district while the v3 mart change rolls out. The mart now
+            # emits all issues per district with no QUALIFY cap; the four
+            # jurisdictional flag columns don't exist in Postgres yet. Drop
+            # this WHERE clause in DATA-1903 phase (c) once Patrick's Prisma
+            # migration has added the is_local/is_regional/is_state/is_federal
+            # columns and DTI_COLUMNS has been extended to sync them.
             query = (
                 f"SELECT {col_list} "
                 f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
-                f"`m_election_api__district_top_issues`"
+                f"`m_election_api__district_top_issues` "
+                f"WHERE issue_rank <= 10"
             )
             with _open_pg() as conn:
                 return bulk_insert_from_databricks(

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -319,14 +319,24 @@ models:
 
   - name: m_election_api__district_top_issues
     description: >
-      Top 10 Haystaq issue scores per L2 district, covering every L2 district
-      with an `is_matched = true` row in the LLM L2-to-BallotReady-district
-      match (`stg_model_predictions__llm_l2_br_match_20260126`). Not scoped to
-      a single election cycle — districts with off-cycle offices are included
-      as well.
+      District-level Haystaq issue scores per L2 district, covering every L2
+      district with an `is_matched = true` row in the LLM L2-to-BallotReady
+      district match (`stg_model_predictions__llm_l2_br_match_20260126`). Not
+      scoped to a single election cycle — districts with off-cycle offices
+      are included as well.
 
-      Grain: One row per (l2_state, l2_district_type, l2_district_name, issue)
-      for the top 10 issues by average voter score in that district.
+      Each row carries four jurisdictional flags (is_local, is_regional,
+      is_state, is_federal) indicating where the issue is actionable.
+      Downstream consumers filter by flag and re-rank within the filtered
+      set. The mart emits the overall `issue_rank` only.
+
+      Grain: up to one row per (l2_state, l2_district_type, l2_district_name,
+      issue) where the district has at least one voter with a non-null score
+      for that issue. Spark UNPIVOT defaults to EXCLUDE NULLS, so districts
+      with NULL average scores for an issue emit no row for that issue.
+
+      Issue universe, labels, and flags are sourced from the
+      `haystaq_issue_tags` seed.
     columns:
       - name: id
         description: "UUID of the district-issue row"
@@ -365,7 +375,11 @@ models:
         tests:
           - not_null
       - name: l2_voter_count
-        description: "Number of L2 voters used to compute the average issue scores for this district"
+        description: >
+          Voters in this district (the count(*) denominator behind the issue
+          averages). Voters with a NULL upstream score for a specific issue
+          are still counted here but do not contribute to that issue's avg —
+          per-issue contributing-voter counts are not pre-computed.
         tests:
           - not_null
           - dbt_utils.accepted_range:
@@ -375,38 +389,12 @@ models:
         description: "Haystaq issue score column name (e.g. hs_charter_schools_support)"
         tests:
           - not_null
-          - accepted_values:
+          - relationships:
               arguments:
-                values:
-                  - hs_charter_schools_support
-                  - hs_school_choice_support
-                  - hs_school_funding_more
-                  - hs_dei_support
-                  - hs_civil_liberties_support
-                  - hs_affordable_housing_gov_has_role
-                  - hs_public_transit_support
-                  - hs_min_wage_15_increase_support
-                  - hs_tax_cuts_support
-                  - hs_medicaid_expansion_support
-                  - hs_medicare_for_all_support
-                  - hs_abortion_pro_choice
-                  - hs_same_sex_marriage_support
-                  - hs_climate_change_believer
-                  - hs_marijuana_legal_support
-                  - hs_gun_control_support
-                  - hs_death_penalty_support
-                  - hs_police_trust_yes
-                  - hs_violent_crime_very_worried
-                  - hs_pipeline_fracking_support
-                  - hs_casino_support
-                  - hs_immigration_undesirable
-                  - hs_econ_anxiety_very_worried
-                  - hs_income_inequality_serious
-                  - hs_unions_beneficial
-                  - hs_regulations_too_harsh
-                  - hs_trump_tariffs_support
+                to: ref('haystaq_issue_tags')
+                field: issue
       - name: issue_label
-        description: "Human-readable issue label for product display"
+        description: "Human-readable issue label for product display, sourced from haystaq_issue_tags seed"
         tests:
           - not_null
       - name: score
@@ -417,10 +405,33 @@ models:
               arguments:
                 min_value: 0
                 max_value: 100
-      - name: issue_rank
-        description: "Rank of the issue within the district (1 = highest score)"
+      - name: is_local
+        description: "Issue is actionable at the local level (city, township, county). Sourced from haystaq_issue_tags seed."
         tests:
           - not_null
+      - name: is_regional
+        description: "Issue is actionable at the regional level (MPO, transit authority, etc.). Sourced from haystaq_issue_tags seed."
+        tests:
+          - not_null
+      - name: is_state
+        description: "Issue is actionable at the state level. Sourced from haystaq_issue_tags seed."
+        tests:
+          - not_null
+      - name: is_federal
+        description: "Issue is actionable at the federal level. Sourced from haystaq_issue_tags seed."
+        tests:
+          - not_null
+      - name: issue_rank
+        description: >
+          Overall rank of the issue within the district (1 = highest score),
+          with a deterministic tie-breaker on `issue asc`. Not capped — the
+          API filters by jurisdictional flag and re-ranks within the
+          filtered set.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
@@ -175,6 +175,12 @@ with
         -- Join seed metadata in a dedicated CTE so the final SELECT has only one
         -- source in scope, avoiding ambiguity when `generate_salted_uuid` passes
         -- unqualified column names into the SQL.
+        --
+        -- LEFT JOIN (not INNER) so issues in the inline `issue_columns` list
+        -- above that are missing from the seed produce rows with NULL labels
+        -- and flags, which the `not_null` and `relationships` tests on those
+        -- columns surface as loud test failures. With an INNER JOIN the same
+        -- drift would silently drop the issue's rows from the mart.
         select
             d.l2_state,
             d.l2_district_type,
@@ -188,7 +194,7 @@ with
             t.is_state,
             t.is_federal
         from district_issue_long as d
-        inner join {{ ref("haystaq_issue_tags") }} as t on t.issue = d.issue
+        left join {{ ref("haystaq_issue_tags") }} as t on t.issue = d.issue
     )
 
 select

--- a/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
@@ -17,18 +17,97 @@
     defaults to EXCLUDE NULLS, so districts with NULL average scores for an
     issue emit no row for that issue.
 
-    Issue universe, labels, and jurisdictional flags come from the
-    `haystaq_issue_tags` seed — the seed is the source of truth. Edit the
-    seed to add, remove, or re-tag issues; rebuild the seed before rebuilding
-    this model so `dbt_utils.get_column_values` reads the new column list.
+    Issue universe is the `issue_columns` list below. Issue labels and the
+    four jurisdictional flags come from the `haystaq_issue_tags` seed, joined
+    at runtime.
+
+    Why two places: dbt cloud CI compiles the mart against a fresh PR schema
+    where the seed isn't materialized yet, so a `dbt_utils.get_column_values`
+    lookup against `ref('haystaq_issue_tags')` fails at compile time. The
+    inline list is the compile-time source of truth for the column set; the
+    seed is the runtime source of truth for labels and flags. The singular
+    test `tests/assert_district_top_issues_seed_coverage.sql` asserts every
+    seed issue appears in the mart, catching drift between the two if a new
+    issue is added to one place but not the other.
+
+    To add or remove an issue: edit both this list (keep it alphabetical) and
+    `seeds/haystaq_issue_tags.csv`. The singular test will fail loudly if
+    they drift apart.
 
     Downstream consumers (election-api) filter by jurisdictional flag and
     re-rank within the filtered set. The mart emits the overall `issue_rank`
     only.
 -#}
-{%- set issue_columns = dbt_utils.get_column_values(
-    ref("haystaq_issue_tags"), "issue", order_by="issue"
-) -%}
+{%- set issue_columns = [
+    "hs_abortion_pro_choice",
+    "hs_affordable_housing_gov_has_role",
+    "hs_age_limit_support",
+    "hs_aliens_governenment_hiding_much",
+    "hs_amazon_exploitative",
+    "hs_artificial_intelligence_excited",
+    "hs_autonomous_vehicles_allow",
+    "hs_casino_support",
+    "hs_charter_schools_support",
+    "hs_china_foreign_policy_advesarial",
+    "hs_civil_liberties_support",
+    "hs_climate_change_believer",
+    "hs_college_admissions_consider_race",
+    "hs_community_college_free_support",
+    "hs_critical_race_theory_books_ban",
+    "hs_crypto_increase_restrictions",
+    "hs_death_penalty_support",
+    "hs_defense_spending_increase",
+    "hs_dei_support",
+    "hs_doge_support",
+    "hs_econ_anxiety_very_worried",
+    "hs_family_medical_leave_support",
+    "hs_felon_voting_support",
+    "hs_gas_tax_support",
+    "hs_general_anti_vax_pro_vax",
+    "hs_gentrification_oppose",
+    "hs_gig_work_make_employees",
+    "hs_green_new_deal_support",
+    "hs_gun_control_support",
+    "hs_immigration_undesirable",
+    "hs_income_inequality_serious",
+    "hs_infrastructure_funding_fund_more",
+    "hs_insurance_of_last_resort_government_should_provide",
+    "hs_israel_military_actions_support",
+    "hs_jan_6th_pardons_support",
+    "hs_jobs_guarantee_support",
+    "hs_marijuana_legal_support",
+    "hs_mass_deporations_support",
+    "hs_medicaid_expansion_support",
+    "hs_medicare_for_all_support",
+    "hs_mexican_wall_support",
+    "hs_min_wage_15_increase_support",
+    "hs_obamacare_aca_protect",
+    "hs_online_gambling_more_legal",
+    "hs_opioid_crisis_treat",
+    "hs_pipeline_fracking_support",
+    "hs_police_trust_yes",
+    "hs_public_transit_support",
+    "hs_rank_choice_voting_support",
+    "hs_redistricting_indep_com",
+    "hs_regulations_too_harsh",
+    "hs_same_sex_marriage_support",
+    "hs_school_choice_support",
+    "hs_school_funding_more",
+    "hs_sell_federal_lands_support",
+    "hs_social_media_truth_vs_speech_truth",
+    "hs_social_security_tax_increase_support",
+    "hs_stadium_public_financing_approve",
+    "hs_state_level_fema_support",
+    "hs_tax_cuts_support",
+    "hs_teachers_union_positive",
+    "hs_trans_athlete_yes",
+    "hs_trump_tariffs_support",
+    "hs_trump_ukraine_policy_support",
+    "hs_unions_beneficial",
+    "hs_united_healthcare_at_fault",
+    "hs_violent_crime_very_worried",
+    "hs_voting_fraud_concern_fraud",
+] -%}
 
 with
     target_districts as (

--- a/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
@@ -34,6 +34,14 @@
     `seeds/haystaq_issue_tags.csv`. The singular test will fail loudly if
     they drift apart.
 
+    Column-name constraint: every value in this list must be a live column on
+    int__l2_nationwide_uniform_w_haystaq; the Jinja loops below render
+    `AVG(<issue>)` against those identifiers directly. Two known L2 typos are
+    preserved verbatim (`hs_aliens_governenment_hiding_much`,
+    `hs_mass_deporations_support`) — do not "fix" the spelling here without a
+    matching upstream rename. See the haystaq_issue_tags seed description in
+    seeds_schema.yaml for the full rule.
+
     Downstream consumers (election-api) filter by jurisdictional flag and
     re-rank within the filtered set. The mart emits the overall `issue_rank`
     only.

--- a/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql
@@ -6,51 +6,29 @@
 }}
 
 {#-
-    Top 10 Haystaq issue scores per L2 district, covering every L2 district with
-    an `is_matched = true` row in the LLM L2-to-BallotReady-district match
-    (`stg_model_predictions__llm_l2_br_match_20260126`). Not scoped to a single
-    election cycle — districts with off-cycle offices are included as well.
+    District-level Haystaq issue scores per L2 district. Covers every L2
+    district with an `is_matched = true` row in the LLM L2-to-BallotReady
+    district match (`stg_model_predictions__llm_l2_br_match_20260126`). Not
+    scoped to a single election cycle — districts with off-cycle offices are
+    included as well.
 
-    One row per (district x issue) for the top 10 issues by average voter score.
+    Grain: up to one row per (district, issue) where the district has at
+    least one voter with a non-null score for that issue. Spark UNPIVOT
+    defaults to EXCLUDE NULLS, so districts with NULL average scores for an
+    issue emit no row for that issue.
 
-    The (column, label) pairs below are the single source of truth for the
-    Haystaq issue scores used by this model. The Jinja loops below expand them
-    into the AVG aggregation, the UNPIVOT, and the issue-label CASE.
+    Issue universe, labels, and jurisdictional flags come from the
+    `haystaq_issue_tags` seed — the seed is the source of truth. Edit the
+    seed to add, remove, or re-tag issues; rebuild the seed before rebuilding
+    this model so `dbt_utils.get_column_values` reads the new column list.
+
+    Downstream consumers (election-api) filter by jurisdictional flag and
+    re-rank within the filtered set. The mart emits the overall `issue_rank`
+    only.
 -#}
-{%- set issues = [
-    ("hs_charter_schools_support", "Support Charter Schools"),
-    ("hs_school_choice_support", "Support School Choice"),
-    ("hs_school_funding_more", "Increase School Funding"),
-    ("hs_dei_support", "Support Diversity & Inclusion"),
-    ("hs_civil_liberties_support", "Support Civil Liberties"),
-    (
-        "hs_affordable_housing_gov_has_role",
-        "Government Should Address Affordable Housing",
-    ),
-    ("hs_public_transit_support", "Support Public Transit"),
-    ("hs_min_wage_15_increase_support", "Support a $15 Minimum Wage"),
-    ("hs_tax_cuts_support", "Support Tax Cuts"),
-    ("hs_medicaid_expansion_support", "Support Medicaid Expansion"),
-    ("hs_medicare_for_all_support", "Support Medicare For All"),
-    ("hs_abortion_pro_choice", "Pro-Choice on Abortion"),
-    ("hs_same_sex_marriage_support", "Support Same-Sex Marriage"),
-    ("hs_climate_change_believer", "Believe in Climate Change"),
-    ("hs_marijuana_legal_support", "Support Legalizing Marijuana"),
-    ("hs_gun_control_support", "Support Gun Control"),
-    ("hs_death_penalty_support", "Support the Death Penalty"),
-    ("hs_police_trust_yes", "Trust the Police"),
-    ("hs_violent_crime_very_worried", "Worried About Violent Crime"),
-    ("hs_pipeline_fracking_support", "Support Pipelines and Fracking"),
-    ("hs_casino_support", "Support Legal Casinos"),
-    ("hs_immigration_undesirable", "View Immigration Negatively"),
-    ("hs_econ_anxiety_very_worried", "Worried About the Economy"),
-    ("hs_income_inequality_serious", "Concerned About Income Inequality"),
-    ("hs_unions_beneficial", "Support Labor Unions"),
-    ("hs_regulations_too_harsh", "Reduce Business Regulations"),
-    ("hs_trump_tariffs_support", "Support Tariffs on Imports"),
-] -%}
-
-{%- set issue_columns = issues | map(attribute=0) | list -%}
+{%- set issue_columns = dbt_utils.get_column_values(
+    ref("haystaq_issue_tags"), "issue", order_by="issue"
+) -%}
 
 with
     target_districts as (
@@ -112,6 +90,26 @@ with
         from
             district_avg_scores
             unpivot (score for issue in ({{ issue_columns | join(", ") }}))
+    ),
+
+    district_issue_tagged as (
+        -- Join seed metadata in a dedicated CTE so the final SELECT has only one
+        -- source in scope, avoiding ambiguity when `generate_salted_uuid` passes
+        -- unqualified column names into the SQL.
+        select
+            d.l2_state,
+            d.l2_district_type,
+            d.l2_district_name,
+            d.l2_voter_count,
+            d.issue,
+            d.score,
+            t.issue_label,
+            t.is_local,
+            t.is_regional,
+            t.is_state,
+            t.is_federal
+        from district_issue_long as d
+        inner join {{ ref("haystaq_issue_tags") }} as t on t.issue = d.issue
     )
 
 select
@@ -141,15 +139,14 @@ select
     l2_district_name,
     l2_voter_count,
     issue,
-    case
-        issue
-        {%- for column, label in issues %}
-            when '{{ column }}' then '{{ label }}'
-        {%- endfor %}
-    end as issue_label,
+    issue_label,
     score,
+    is_local,
+    is_regional,
+    is_state,
+    is_federal,
     row_number() over (
-        partition by l2_state, l2_district_type, l2_district_name order by score desc
+        partition by l2_state, l2_district_type, l2_district_name
+        order by score desc, issue asc
     ) as issue_rank
-from district_issue_long
-qualify issue_rank <= 10
+from district_issue_tagged

--- a/dbt/project/seeds/haystaq_issue_tags.csv
+++ b/dbt/project/seeds/haystaq_issue_tags.csv
@@ -1,0 +1,69 @@
+issue,issue_label,is_local,is_regional,is_state,is_federal
+hs_abortion_pro_choice,Pro-Choice on Abortion,True,False,True,True
+hs_affordable_housing_gov_has_role,Government Should Address Affordable Housing,True,True,True,True
+hs_age_limit_support,Support Federal Office Age Limits,False,False,False,True
+hs_aliens_governenment_hiding_much,Government Hiding Information About Aliens,False,False,False,True
+hs_amazon_exploitative,View Amazon as Exploitative,False,False,True,True
+hs_artificial_intelligence_excited,Excited About AI,False,False,True,True
+hs_autonomous_vehicles_allow,Allow Autonomous Vehicles,True,False,True,True
+hs_casino_support,Support Legal Casinos,True,False,True,False
+hs_charter_schools_support,Support Charter Schools,True,False,True,False
+hs_china_foreign_policy_advesarial,Adversarial China Policy,False,False,False,True
+hs_civil_liberties_support,Support Civil Liberties,False,False,True,True
+hs_climate_change_believer,Believe in Climate Change,True,True,True,True
+hs_college_admissions_consider_race,Consider Race in College Admissions,False,False,False,True
+hs_community_college_free_support,Support Free Community College,False,False,True,True
+hs_critical_race_theory_books_ban,Ban CRT-Related Books,True,False,True,False
+hs_crypto_increase_restrictions,Increase Crypto Restrictions,False,False,True,True
+hs_death_penalty_support,Support the Death Penalty,False,False,True,True
+hs_defense_spending_increase,Increase Defense Spending,False,False,False,True
+hs_dei_support,Support Diversity & Inclusion,True,False,True,True
+hs_doge_support,Support DOGE,False,False,False,True
+hs_econ_anxiety_very_worried,Worried About the Economy,True,False,True,True
+hs_family_medical_leave_support,Support Family Medical Leave,True,False,True,True
+hs_felon_voting_support,Support Felon Voting Rights,False,False,True,False
+hs_gas_tax_support,Support Gas Tax,False,False,True,True
+hs_general_anti_vax_pro_vax,Pro-Vaccine,True,False,True,True
+hs_gentrification_oppose,Oppose Gentrification,True,True,False,False
+hs_gig_work_make_employees,Classify Gig Workers as Employees,True,False,True,True
+hs_green_new_deal_support,Support the Green New Deal,False,False,False,True
+hs_gun_control_support,Support Gun Control,True,False,True,True
+hs_immigration_undesirable,View Immigration Negatively,True,False,True,True
+hs_income_inequality_serious,Concerned About Income Inequality,True,False,True,True
+hs_infrastructure_funding_fund_more,Fund More Infrastructure,True,True,True,True
+hs_insurance_of_last_resort_government_should_provide,Government Insurance of Last Resort,False,False,True,True
+hs_israel_military_actions_support,Support Israeli Military Actions,False,False,False,True
+hs_jan_6th_pardons_support,Support January 6th Pardons,False,False,False,True
+hs_jobs_guarantee_support,Support a Federal Jobs Guarantee,False,False,False,True
+hs_marijuana_legal_support,Support Legalizing Marijuana,True,False,True,True
+hs_mass_deporations_support,Support Mass Deportations,True,False,True,True
+hs_medicaid_expansion_support,Support Medicaid Expansion,False,False,True,True
+hs_medicare_for_all_support,Support Medicare For All,False,False,False,True
+hs_mexican_wall_support,Support the Border Wall,False,False,False,True
+hs_min_wage_15_increase_support,Support a $15 Minimum Wage,True,False,True,True
+hs_obamacare_aca_protect,Protect the Affordable Care Act,False,False,False,True
+hs_online_gambling_more_legal,Support More Legal Online Gambling,False,False,True,False
+hs_opioid_crisis_treat,Treat Opioid Crisis as Public Health,True,True,True,True
+hs_pipeline_fracking_support,Support Pipelines and Fracking,True,False,True,True
+hs_police_trust_yes,Trust the Police,True,False,True,False
+hs_public_transit_support,Support Public Transit,True,True,True,False
+hs_rank_choice_voting_support,Support Ranked Choice Voting,True,False,True,False
+hs_redistricting_indep_com,Independent Redistricting Commissions,True,False,True,False
+hs_regulations_too_harsh,Reduce Business Regulations,True,False,True,True
+hs_same_sex_marriage_support,Support Same-Sex Marriage,False,False,True,True
+hs_school_choice_support,Support School Choice,True,False,True,False
+hs_school_funding_more,Increase School Funding,True,False,True,False
+hs_sell_federal_lands_support,Sell Federal Lands,False,False,False,True
+hs_social_media_truth_vs_speech_truth,Prioritize Truth over Free Speech Online,False,False,False,True
+hs_social_security_tax_increase_support,Raise the Social Security Tax Cap,False,False,False,True
+hs_stadium_public_financing_approve,Approve of Public Stadium Financing,True,False,True,False
+hs_state_level_fema_support,Move FEMA to the States,False,False,True,True
+hs_tax_cuts_support,Support Tax Cuts,True,False,True,True
+hs_teachers_union_positive,Positive View of Teachers Unions,True,False,True,False
+hs_trans_athlete_yes,Support Trans Athlete Participation,True,False,True,True
+hs_trump_tariffs_support,Support Tariffs on Imports,False,False,False,True
+hs_trump_ukraine_policy_support,Support Trump Ukraine Policy,False,False,False,True
+hs_unions_beneficial,Support Labor Unions,True,False,True,True
+hs_united_healthcare_at_fault,View Health Insurers as At Fault,False,False,False,True
+hs_violent_crime_very_worried,Worried About Violent Crime,True,True,True,True
+hs_voting_fraud_concern_fraud,Concerned About Voting Fraud,False,False,True,True

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -183,3 +183,55 @@ seeds:
           - dbt_expectations.expect_column_values_to_match_regex:
               arguments:
                 regex: ^\\[([0-9]{5},[0-9]{5})\\]$
+
+  - name: haystaq_issue_tags
+    description: >
+      Per-issue metadata used by m_election_api__district_top_issues. One row
+      per Haystaq issue column with the user-facing label and four
+      jurisdictional flags (is_local, is_regional, is_state, is_federal)
+      indicating where the issue is actionable. Flags are not mutually
+      exclusive. Regional is tagged conservatively (only where a regional
+      body has meaningful authority). Sort rows alphabetically by `issue`
+      when editing.
+    config:
+      column_types:
+        issue: STRING
+        issue_label: STRING
+        is_local: BOOLEAN
+        is_regional: BOOLEAN
+        is_state: BOOLEAN
+        is_federal: BOOLEAN
+    columns:
+      - name: issue
+        description: >
+          Haystaq score column name on int__l2_nationwide_uniform_w_haystaq.
+        data_tests:
+          - not_null
+          - unique
+      - name: issue_label
+        description: Human-readable label for product display.
+        data_tests:
+          - not_null
+      - name: is_local
+        description: Issue is actionable at the local level (city, township, county).
+        data_tests:
+          - not_null
+      - name: is_regional
+        description: >
+          Issue is actionable at the regional level (MPO, transit authority,
+          regional planning council, air quality district, regional health
+          district).
+        data_tests:
+          - not_null
+      - name: is_state
+        description: Issue is actionable at the state level.
+        data_tests:
+          - not_null
+      - name: is_federal
+        description: Issue is actionable at the federal level.
+        data_tests:
+          - not_null
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_local or is_regional or is_state or is_federal"

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -193,6 +193,20 @@ seeds:
       exclusive. Regional is tagged conservatively (only where a regional
       body has meaningful authority). Sort rows alphabetically by `issue`
       when editing.
+
+
+      Column-name constraint: the `issue` values here must match the upstream
+      `hs_*` column names on int__l2_nationwide_uniform_w_haystaq verbatim,
+      including pre-existing L2 typos. The mart references each value as a
+      live SQL identifier in an AVG aggregation, so renaming an `issue` in
+      this seed without renaming the upstream column would break the mart
+      compile (column-not-found) and the `relationships` test on
+      m_election_api__district_top_issues.issue (mart values would no longer
+      be a subset of seed values). Two known typos currently present:
+      `hs_aliens_governenment_hiding_much` (should be `government`) and
+      `hs_mass_deporations_support` (should be `deportations`). Keep both
+      as-is; if L2 ever fixes them upstream, update the seed, the inline
+      `issue_columns` list in the mart SQL, and rebuild.
     config:
       column_types:
         issue: STRING

--- a/dbt/project/tests/assert_district_top_issues_seed_coverage.sql
+++ b/dbt/project/tests/assert_district_top_issues_seed_coverage.sql
@@ -1,0 +1,22 @@
+{#-
+    DATA-1903: assert every issue in the haystaq_issue_tags seed appears at
+    least once in m_election_api__district_top_issues.
+
+    The mart's compile-time issue column list lives inline in the model SQL
+    (a fresh-CI compile against an unmaterialized seed can't read it via
+    dbt_utils.get_column_values). The seed is the runtime source for labels +
+    flags. This test catches the silent failure mode where the seed gets a
+    new issue but the mart's inline list doesn't, which would cause that
+    issue's column to be missing from the AVG/UNPIVOT clauses and produce no
+    mart rows for it.
+
+    Returns rows iff the lists are out of sync.
+-#}
+select t.issue
+from {{ ref("haystaq_issue_tags") }} as t
+where
+    t.issue not in (
+        select distinct m.issue
+        from {{ ref("m_election_api__district_top_issues") }} as m
+        where m.issue is not null
+    )


### PR DESCRIPTION
## Summary
- Expand `m_election_api__district_top_issues` from 27 issues to 68, with four jurisdictional flags (`is_local`, `is_regional`, `is_state`, `is_federal`) per issue.
- Drop the `QUALIFY issue_rank <= 10` cap on the mart so the election-api can filter by flag then re-rank within the filtered set.
- Move the issue universe, labels, and flags into a new `haystaq_issue_tags` dbt seed so non-engineers can iterate without touching SQL.

## Why
Today the mart serves jurisdictionally-mixed top issues to candidates and elected officials. A school-board candidate sees federal-only issues (war in Iran, federal jobs guarantee) alongside locally actionable ones. The new flags let the election-api filter to office-relevant issues per persona. Žak-driven ask via Samuel; Patrick approved the issue set; research-team-tested.

## Files changed
- `dbt/project/seeds/haystaq_issue_tags.csv` (NEW) — 68 rows; source of truth for the issue universe + labels + flags.
- `dbt/project/seeds/seeds_schema.yaml` — appended `haystaq_issue_tags` schema entry with explicit `column_types` for the four booleans, plus tests including an `expression_is_true` assertion that every row has at least one flag TRUE.
- `dbt/project/models/marts/election_api/m_election_api__district_top_issues.sql` — rewritten: column list read from the seed via `dbt_utils.get_column_values` (so a seed edit is a one-file change), no `QUALIFY` cap, deterministic `issue_rank` tie-breaker on `issue asc`, seed join lifted into a CTE to avoid `generate_salted_uuid` ambiguity.
- `dbt/project/models/marts/election_api/m_election_api.yaml` — replaced the hardcoded 27-element `accepted_values` on `issue` with a `relationships` test against the seed; added `not_null` on the four flag columns; updated description to drop the "Top 10" framing and document the EXCLUDE NULLS grain.
- `airflow/astro/dags/sync_election_api.py` — temporary `WHERE issue_rank <= 10` guard on the Postgres sync (with comment pointing to the phase-(c) follow-up).

## Local commands
```bash
# From repo root:
cd dbt/project
dbt build --select "haystaq_issue_tags m_election_api__district_top_issues"
```
The quoted multi-model selector is required so the seed materializes before the model compile reads from it via `get_column_values`.

## Phase plan
- **Phase (a) — this PR**: dbt mart + seed ship; Airflow `WHERE issue_rank <= 10` keeps Postgres row volume bounded (~970K from 97K districts × top 10, up from today's ~470K). No API behavior change.
- **Phase (b) — election-api repo, owned by Patrick's team**: Prisma migration adds `is_local`, `is_regional`, `is_state`, `is_federal` as `BOOLEAN NULL` on `DistrictTopIssue` (nullable, no default — see `.tickets/data-1903/04-design.md` §14 for the column contract). Patrick will be pinged via Slack once this PR opens.
- **Phase (c) — small follow-up PR in this repo**: drop the `WHERE`, extend `DTI_COLUMNS` to 11 entries, swap hardcoded quality checks for shape-aware ones that query the seed row count from Databricks. Wait until Patrick's Prisma migration is in production.

## Validation
Full results: `.tickets/data-1903/07-validation-results.md`.

- dbt build PASS=24 ERROR=0. All 23 mart data tests pass (FK to district mart, FK to seed via `relationships`, `not_null` on every column, `unique_combination_of_columns`, `accepted_range`, `is_uuid`). Plus the seed-level `expression_is_true` flag invariant.
- Math correctness: for AK statewide, spot-checked 3 issues — mart score equals `AVG(hs_*)` over the upstream intermediate exactly (delta 0.0). Aggregation logic is right.
- Universe correctness for AK: dev mart has 92 AK districts. Samuel's prebuilt `private_samuel.district_top_issues_us_all` has 92 AK districts. Exact match at the available scope.
- Flag correctness: 0 mismatches across 6,256 shared rows with Samuel's table.
- Dev validation is AK-only because `dbt_sroberts.int__l2_nationwide_uniform_w_haystaq` was previously materialized with `l2_state_allowlist=AK`; dbt cloud's defer picks it up over prod. Prod-scale validation runs on the first prod dbt run after merge.
- Samuel-snapshot score drift (~0.02 absolute on a 0-100 scale) is normal Haystaq update churn between his build and today; not a logic concern.

## Design + history
- Design doc: `.tickets/data-1903/04-design.md`.
- Plan review findings: `.tickets/data-1903/06-plan-review-findings.md` (3 blockers + 7 strong recs all folded in or explicitly deferred).
- Brainstorming notes: `.tickets/data-1903/01-brainstorming-notes.md`.

## Test plan
- [x] CI passes (dbt build + tests in dbt cloud).
- [ ] Post-merge: prod dbt run produces ~6.6M rows in `goodparty_data_catalog.dbt.m_election_api__district_top_issues`.
- [ ] Post-merge: `sync_election_api` Airflow DAG loads ~970K rows into Postgres (bounded by the `WHERE issue_rank <= 10` guard), quality checks pass, swap succeeds, no downstream alerts.
- [ ] Post-merge: API behavior unchanged from today (top-10 issues per district, same ordering modulo any natural Haystaq drift).
- [ ] Coordinate Slack thread with Patrick for the Prisma migration; queue data-eng team on the schema-stability follow-ups in `04-design.md` §13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape and row volume of the `m_election_api__district_top_issues` mart (new columns, more issues, no top-10 cap), which can impact downstream syncs and consumers; Postgres sync is temporarily guarded but needs follow-up when schema catches up.
> 
> **Overview**
> **Expands `m_election_api__district_top_issues` to support jurisdiction-based filtering.** The mart now outputs *all* district/issue rows (removing the top-10 `QUALIFY` cap), adds `is_local`/`is_regional`/`is_state`/`is_federal` flags, and makes `issue_rank` deterministic with a tie-break on `issue`.
> 
> **Moves issue metadata into a new dbt seed.** Adds `haystaq_issue_tags` seed as the source of truth for the issue universe, labels, and flags; the model dynamically reads issue columns from the seed and joins it for metadata, and YAML tests switch from hardcoded `accepted_values` to a seed `relationships` check plus `not_null`/range assertions.
> 
> **Keeps Postgres sync stable during rollout.** The Airflow `sync_election_api` DAG temporarily adds `WHERE issue_rank <= 10` when loading `DistrictTopIssue` from Databricks to avoid increased volume until the Postgres schema is migrated to include the new flag columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a844d2b8fed82163196fa8b99f983640f368531. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->