### PR TITLE
[DATA-1903] Phase (c): Airflow sync flag columns + shape-aware quality checks

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -162,8 +162,8 @@ DTI = TableSyncSpec(
     fkeys=("DistrictTopIssue_district_id_fkey",),
 )
 
-# Postgres dropped the denormalized l2_* columns; we read only the seven
-# columns that map 1:1 onto the live shape.
+# Eleven columns: seven from the pre-DATA-1903 shape plus the four
+# jurisdictional flags added by election-api PR #164.
 DTI_COLUMNS = [
     "id",
     "updated_at",
@@ -171,48 +171,12 @@ DTI_COLUMNS = [
     "issue",
     "issue_label",
     "score",
+    "is_local",
+    "is_regional",
+    "is_state",
+    "is_federal",
     "issue_rank",
 ]
-
-# DATA-1903 phase (a) only: the v3 mart now scores 68 issues per district
-# (up from 27), so taking the mart's top-10 by overall issue_rank would
-# surface the 41 newly-introduced issues (Aliens, Border Wall, federal-only
-# noise) ahead of the locally-actionable issues the API serves today. To
-# preserve pre-DATA-1903 API behavior while the election-api team's Prisma
-# migration is in flight, the load_staging query filters the mart to this
-# legacy 27-issue universe, recomputes issue_rank within the filtered set,
-# and takes top-10. Drop V2_LEGACY_ISSUES and the legacy_top_10 CTE in
-# phase (c) once the four jurisdictional flag columns are live in Postgres
-# and the API can do its own filter-then-rerank by flag.
-V2_LEGACY_ISSUES = (
-    "hs_abortion_pro_choice",
-    "hs_affordable_housing_gov_has_role",
-    "hs_casino_support",
-    "hs_charter_schools_support",
-    "hs_civil_liberties_support",
-    "hs_climate_change_believer",
-    "hs_death_penalty_support",
-    "hs_dei_support",
-    "hs_econ_anxiety_very_worried",
-    "hs_gun_control_support",
-    "hs_immigration_undesirable",
-    "hs_income_inequality_serious",
-    "hs_marijuana_legal_support",
-    "hs_medicaid_expansion_support",
-    "hs_medicare_for_all_support",
-    "hs_min_wage_15_increase_support",
-    "hs_pipeline_fracking_support",
-    "hs_police_trust_yes",
-    "hs_public_transit_support",
-    "hs_regulations_too_harsh",
-    "hs_same_sex_marriage_support",
-    "hs_school_choice_support",
-    "hs_school_funding_more",
-    "hs_tax_cuts_support",
-    "hs_trump_tariffs_support",
-    "hs_unions_beneficial",
-    "hs_violent_crime_very_worried",
-)
 
 
 def _dti_constraint_ddl() -> list[str]:
@@ -386,40 +350,11 @@ def sync_election_api():
         @task
         def load_staging() -> int:
             catalog = Variable.get("databricks_catalog")
-            # TEMP (DATA-1903 phase a): the v3 mart ranks all 68 issues per
-            # district. Postgres still has the pre-DATA-1903 7-column shape
-            # and the API has no jurisdictional-flag filter yet. To preserve
-            # current API behavior, filter the mart to the 27 legacy issues,
-            # recompute issue_rank within that subset, and take top-10. The
-            # entire legacy_top_10 CTE and V2_LEGACY_ISSUES are removed in
-            # phase (c) once Patrick's Prisma migration adds the four
-            # jurisdictional flag columns to DistrictTopIssue and DTI_COLUMNS
-            # is extended to sync them.
-            legacy_in_clause = ", ".join(f"'{i}'" for i in V2_LEGACY_ISSUES)
-            # `new_rank` (not `issue_rank`) inside the CTE — the source mart
-            # has its own `issue_rank` column, and Databricks resolves a
-            # QUALIFY clause against the source column instead of the SELECT
-            # alias when they share a name, which would silently filter to
-            # the mart's 1..68 ranks (~3 legacy issues per district), not
-            # the recomputed 1..N within the filtered subset. Outer SELECT
-            # renames `new_rank` back to `issue_rank` to match DTI_COLUMNS.
+            col_list = ", ".join(DTI_COLUMNS)
             query = (
-                f"WITH legacy_top_10 AS ("
-                f"  SELECT"
-                f"    id, updated_at, district_id, issue, issue_label, score,"
-                f"    row_number() OVER ("
-                f"      PARTITION BY district_id "
-                f"      ORDER BY score DESC, issue ASC"
-                f"    ) AS new_rank"
-                f"  FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
+                f"SELECT {col_list} "
+                f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
                 f"`m_election_api__district_top_issues`"
-                f"  WHERE issue IN ({legacy_in_clause})"
-                f"  QUALIFY new_rank <= 10"
-                f") "
-                f"SELECT"
-                f"  id, updated_at, district_id, issue, issue_label, score,"
-                f"  new_rank AS issue_rank "
-                f"FROM legacy_top_10"
             )
             with _open_pg() as conn:
                 return bulk_insert_from_databricks(
@@ -436,33 +371,82 @@ def sync_election_api():
 
         @task
         def quality_checks(loaded_count: int) -> None:
-            if loaded_count < 1_000:
-                raise ValueError(
-                    f"Only {loaded_count} rows loaded (<1000) — refusing to swap"
-                )
+            # Shape-aware: compare staging to the prior live table so the
+            # thresholds auto-track the table's natural size as it grows.
+            # Catches catastrophic regressions (e.g., a partial Databricks
+            # load that drops most rows) without hardcoding numbers that
+            # will drift as the seed grows or shrinks.
             with _open_pg() as conn:
                 cur = conn.cursor()
                 try:
                     cur.execute(
-                        f"SELECT COUNT(DISTINCT issue) "
+                        f"SELECT "
+                        f"COUNT(DISTINCT issue), "
+                        f"MIN(issue_rank), MAX(issue_rank), "
+                        f"COUNT(*) FILTER ("
+                        f"  WHERE is_local IS NULL OR is_regional IS NULL"
+                        f"  OR is_state IS NULL OR is_federal IS NULL) "
                         f'FROM "{DTI.staging_schema}"."{DTI.new_table}"'
                     )
-                    distinct_issues = cur.fetchone()[0]
-                    if distinct_issues < 10:
-                        raise ValueError(
-                            f"Only {distinct_issues} distinct issues "
-                            f"(<10) — refusing to swap"
-                        )
+                    distinct_issues, min_rank, max_rank, null_flag_rows = cur.fetchone()
+
+                    # Prior live state (may be absent on a true cold start)
                     cur.execute(
-                        f"SELECT MIN(issue_rank), MAX(issue_rank) "
-                        f'FROM "{DTI.staging_schema}"."{DTI.new_table}"'
+                        "SELECT to_regclass(%s)",
+                        (f"{DTI.target_schema}.{DTI.target_table}",),
                     )
-                    min_rank, max_rank = cur.fetchone()
+                    prior_exists = cur.fetchone()[0] is not None
+                    if prior_exists:
+                        cur.execute(
+                            f"SELECT COUNT(*), COUNT(DISTINCT issue) "
+                            f'FROM "{DTI.target_schema}"."{DTI.target_table}"'
+                        )
+                        prior_count, prior_issues = cur.fetchone()
+                    else:
+                        prior_count, prior_issues = 0, 0
+
+                    # Row count: refuse on a >50% drop vs prior live;
+                    # absolute floor only used on cold start.
+                    if prior_count > 0:
+                        ratio = loaded_count / prior_count
+                        if ratio < 0.5:
+                            raise ValueError(
+                                f"Loaded {loaded_count} rows, prior live had "
+                                f"{prior_count} (ratio {ratio:.2f}) "
+                                f"— refusing to swap"
+                            )
+                    elif loaded_count < 100_000:
+                        raise ValueError(
+                            f"Cold-start load of {loaded_count} rows is "
+                            f"implausibly small — refusing to swap"
+                        )
+
+                    # Distinct issues: stay at-or-above prior. Allows growth
+                    # (e.g., seed adds new issues) and catches regression.
+                    if distinct_issues < prior_issues:
+                        raise ValueError(
+                            f"Staging has {distinct_issues} distinct issues, "
+                            f"prior live had {prior_issues} — refusing to swap"
+                        )
+
+                    # Flag integrity: every row should have all four flags
+                    # populated. The mart's LEFT JOIN to haystaq_issue_tags
+                    # only emits NULLs on drift, which the dbt-side tests
+                    # catch — this check is a belt-and-suspenders gate.
+                    if null_flag_rows > 0:
+                        raise ValueError(
+                            f"{null_flag_rows} staging rows have a NULL "
+                            f"jurisdictional flag — refusing to swap"
+                        )
+
                     t_log.info(
-                        "Quality checks passed: %d rows, %d distinct issues, "
-                        "issue_rank range %s..%s",
+                        "Quality checks passed: %d rows (prior %d), "
+                        "%d distinct issues (prior %d), "
+                        "issue_rank %s..%s, all flags populated",
                         loaded_count,
+                        prior_count,
                         distinct_issues,
+                        prior_issues,
                         min_rank,
                         max_rank,
                     )

--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -410,7 +410,13 @@ def sync_election_api():
                         prior_count, prior_issues = 0, 0
 
                     # Row count: refuse on a >50% drop vs prior live;
-                    # absolute floor only used on cold start.
+                    # absolute floor only used on cold start. High-ratio
+                    # syncs (>3x prior) log a warning but do not refuse —
+                    # the DATA-1903 phase-c cutover is intentionally ~6.8x
+                    # (970K legacy top-10 rows -> 6.6M full-mart rows), so
+                    # blocking on growth would self-DOS the cutover. After
+                    # cutover the ratio stabilizes near 1.0; future >3x
+                    # excursions are worth on-call attention.
                     if prior_count > 0:
                         ratio = loaded_count / prior_count
                         if ratio < 0.5:
@@ -418,6 +424,17 @@ def sync_election_api():
                                 f"Loaded {loaded_count} rows, prior live had "
                                 f"{prior_count} (ratio {ratio:.2f}) "
                                 f"— refusing to swap"
+                            )
+                        if ratio > 3:
+                            t_log.warning(
+                                "High-ratio sync: loaded %d rows, prior live "
+                                "had %d (ratio %.2f). Sometimes intentional "
+                                "(e.g., DATA-1903 phase-c cutover) — sometimes "
+                                "a JOIN fan-out or duplication bug. Verify "
+                                "the source mart's grain before trusting.",
+                                loaded_count,
+                                prior_count,
+                                ratio,
                             )
                     elif loaded_count < 100_000:
                         raise ValueError(

--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -390,10 +390,14 @@ def sync_election_api():
                     )
                     distinct_issues, min_rank, max_rank, null_flag_rows = cur.fetchone()
 
-                    # Prior live state (may be absent on a true cold start)
+                    # Prior live state (may be absent on a true cold start).
+                    # Both identifiers must be double-quoted in the regclass
+                    # argument — Postgres folds unquoted mixed-case to lowercase,
+                    # so `public.DistrictTopIssue` would resolve to
+                    # `public.districttopissue` and always return NULL.
                     cur.execute(
                         "SELECT to_regclass(%s)",
-                        (f"{DTI.target_schema}.{DTI.target_table}",),
+                        (f'"{DTI.target_schema}"."{DTI.target_table}"',),
                     )
                     prior_exists = cur.fetchone()[0] is not None
                     if prior_exists:

--- a/airflow/astro/tests/test_sync_election_api.py
+++ b/airflow/astro/tests/test_sync_election_api.py
@@ -35,6 +35,7 @@ for _mod in _STUBS:
     sys.modules[_mod] = MagicMock()
 
 from dags.sync_election_api import (  # noqa: E402
+    DTI_COLUMNS,
     ZTP_SOURCE_COLUMNS,
     ZTP_TARGET_COLUMNS,
     _ztp_transform_row,
@@ -107,3 +108,27 @@ def test_ztp_source_columns_match_transform_arity():
     row = tuple(range(len(ZTP_SOURCE_COLUMNS)))
     out = _ztp_transform_row(row)
     assert len(out) == len(ZTP_TARGET_COLUMNS)
+
+
+def test_dti_columns_pinned():
+    """Pin DTI_COLUMNS to catch silent column reorderings.
+
+    The DistrictTopIssue bulk-insert path passes values to
+    psycopg2.extras.execute_values positionally, so swapping or dropping a
+    DTI_COLUMNS entry would land the wrong value into Postgres without any
+    error at insert time. Pin the list so reorderings show up as a failing
+    test instead of a corrupted DistrictTopIssue table.
+    """
+    assert DTI_COLUMNS == [
+        "id",
+        "updated_at",
+        "district_id",
+        "issue",
+        "issue_label",
+        "score",
+        "is_local",
+        "is_regional",
+        "is_state",
+        "is_federal",
+        "issue_rank",
+    ]


### PR DESCRIPTION
## Merge gate

Do **not** merge until both of these are deployed to prod:

1. **election-api PR #164** (Prisma migration adding the four boolean columns).
2. **The election-api filter-behavior change** — `voterIssues.service.ts` must filter by the new flag columns and re-rank within the filtered subset before this PR's first prod sync.

Without (2), this PR's first sync exposes the full 68-issue mart to Postgres, and the API's current top-10-by-overall-rank query would surface federal-only issues (Aliens, Border Wall, Ukraine policy, etc.) to school-board candidates — the exact regression this ticket exists to fix. The Win team's filter change is the load-bearing piece, not just the schema migration.

Verified by a review pass against prod Databricks: `issue_rank <= 10` on the v3 mart contains 641,674 rows from the 41 newly-introduced issues, and every district has at least one new issue in its top-10. So merging this PR ahead of the API filter change would deliver the noise straight to the candidate onboarding flow.

Coordination is on the Win team side: they decide whether to fold the filter change into #164 or open a separate quick follow-up. Either is fine.

---

## Summary
Phase (c) of the DATA-1903 local-issue-filter rollout. Drops the temporary phase-(a) Airflow scaffolding now that election-api#164 adds the four jurisdictional flag columns to `DistrictTopIssue` in Postgres. After this lands, the next `sync_election_api` Airflow run delivers `is_local`, `is_regional`, `is_state`, `is_federal` data to Postgres, and the API can serve filtered top-issues queries.

## Why
Phase (a) (gp-data-platform#390, merged) shipped the v3 dbt mart with 68 issues + 4 flags, but kept Postgres on its pre-DATA-1903 shape via a temporary Airflow `WHERE issue_rank <= 10` filter on the 27 legacy issues. That filter exists because (1) Postgres didn't have the flag columns yet and (2) without the filter, the unfiltered v3 mart would have surfaced federal-only issues (Aliens, Border Wall, etc.) in candidates' top-issues lists with no way to filter them out on the API side. With election-api#164 adding the columns and the data platform side coordinated, this PR removes the scaffolding.

## Files changed
Just `airflow/astro/dags/sync_election_api.py`. Three substantive changes:

1. **Drop `V2_LEGACY_ISSUES` and `legacy_top_10` CTE in `load_staging`.** The mart's overall `issue_rank` (1..68) is what flows to Postgres now. No in-flight re-ranking, no legacy filter.
2. **Extend `DTI_COLUMNS` from 7 to 11 entries**, adding `is_local`, `is_regional`, `is_state`, `is_federal` between `score` and `issue_rank`. `bulk_insert_from_databricks` picks them up automatically since it reads from `DTI_COLUMNS`.
3. **Replace hardcoded quality-check thresholds with shape-aware comparisons** against the prior live table:
   - Row-count: refuse to swap if loaded rows are <50% of prior live's row count (catches catastrophic partial loads regardless of absolute size, no hardcoded `1_000`).
   - Distinct issues: refuse to swap if staging has fewer distinct issues than prior live (allows growth as the seed evolves, catches regression, no hardcoded `10` or `60`).
   - Flag integrity: refuse to swap if any staging row has a NULL flag (belt-and-suspenders on top of the dbt-side LEFT JOIN drift tests).
   - Cold-start absolute floor of 100K only when no prior live table exists.

## Dependency on election-api#164
**Do not merge this until election-api#164 is in prod.** Sequence:

1. election-api#164 merges and the Prisma migration deploys to prod Postgres. The four new columns exist as `BOOLEAN NULL` (all NULL until this PR's first sync).
2. This PR gets reviewed and merged. Astro deploys the new DAG code to dev + prod.
3. Manually trigger the dev `sync_election_api` DAG. Watch the run end-to-end: `load_staging`, `build_indexes_and_fk`, `quality_checks`, `swap`. Confirm dev Postgres has ~6.6M rows × 11 columns and 0 NULL flag rows.
4. Manually trigger the prod DAG (or wait for the next scheduled run). Watch the wall-clock for `load_staging` — 14× row growth vs phase (a)'s ~970K, so we'll get a real-world measurement here. If it's significantly slow, the fallback is the `COPY`-based loader path noted in `.tickets/data-1903/04-design.md` §13.

## Test plan
- [ ] CI passes (pre-commit, pytest).
- [ ] Manual: after election-api#164 deploys and this PR merges, trigger dev DAG, confirm staging→swap succeeds end-to-end and Postgres reflects the new shape.
- [ ] Manual: after dev validation, trigger prod DAG, watch wall-clock + spot-check Postgres + API behavior with the Win team.
- [ ] Manual: after prod sync completes, hit the API for a sample district query and confirm `is_local` etc. come back populated.

## Design reference
`.tickets/data-1903/04-design.md` in this repo. Phase (c) corresponds to design §11 step 14-17 and §12 (risks/mitigations).

## Note on shape-aware quality checks
The reviewer feedback on phase (a) ([06-plan-review-findings.md](.tickets/data-1903/06-plan-review-findings.md) S5) flagged the original hardcoded thresholds as "too weak for the new shape" — a severe partial load could pass `< 60` distinct issues + `< 1_000` rows. Comparing to prior live makes the gate auto-track the table's natural size as the seed grows or shrinks, with no values to hardcode and update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `DistrictTopIssue` sync shape and removes legacy filtering/reranking, which can materially alter row volumes and the data served by election-api if the upstream mart or schema assumptions are off. New QC gates reduce swap risk but could also block deployments if counts/flags don’t match expectations (especially on cold start).
> 
> **Overview**
> Updates the `DistrictTopIssue` Airflow sync to pull the full mart output, **dropping the temporary legacy-issues filter and re-ranking logic**, and expanding `DTI_COLUMNS` to also load the new jurisdictional flags (`is_local`, `is_regional`, `is_state`, `is_federal`).
> 
> Reworks `district_top_issues.quality_checks` to be **shape-aware** by comparing staging vs the prior live table (row-count ratio and distinct-issue regression checks), adds a cold-start minimum row floor, and hard-fails if any jurisdictional flag is NULL before allowing the atomic swap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89be44586924d77796bc759e4539720212a1116. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
