### PR TITLE
Add Sigma passthrough views for amplitude + hubspot in mart_analytics

### DIFF
--- a/dbt/project/models/marts/analytics/amplitude_events.sql
+++ b/dbt/project/models/marts/analytics/amplitude_events.sql
@@ -1,0 +1,11 @@
+{{ config(materialized="view") }}
+
+/*
+    Passthrough exposure of stg_airbyte_source__amplitude_api_events into
+    mart_analytics for Sigma BI POV consumption. View materialization (not
+    table) because this is a thin alias and storage duplication isn't
+    justified. Promote to a transformed table model if Sigma usage patterns
+    warrant it post-POV. See .tickets/sigma_setup/decisions.md.
+*/
+select *
+from {{ ref("stg_airbyte_source__amplitude_api_events") }}

--- a/dbt/project/models/marts/analytics/amplitude_events.sql
+++ b/dbt/project/models/marts/analytics/amplitude_events.sql
@@ -5,7 +5,8 @@
     mart_analytics for Sigma BI POV consumption. View materialization (not
     table) because this is a thin alias and storage duplication isn't
     justified. Promote to a transformed table model if Sigma usage patterns
-    warrant it post-POV. See .tickets/sigma_setup/decisions.md.
+    warrant it post-POV. Sigma SP access to mart_analytics is provisioned
+    in thegoodparty/gp-terraform-dataplatform#29.
 */
 select *
 from {{ ref("stg_airbyte_source__amplitude_api_events") }}

--- a/dbt/project/models/marts/analytics/hubspot_contacts.sql
+++ b/dbt/project/models/marts/analytics/hubspot_contacts.sql
@@ -1,0 +1,9 @@
+{{ config(materialized="view") }}
+
+/*
+    Passthrough exposure of stg_airbyte_source__hubspot_api_contacts into
+    mart_analytics for Sigma BI POV consumption. See amplitude_events.sql
+    header for view-materialization rationale.
+*/
+select *
+from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1321,6 +1321,12 @@ models:
       transformations. Columns documented at the upstream staging model.
 
       Source: stg_airbyte_source__amplitude_api_events.
+    columns:
+      - name: uuid
+        description: Unique identifier for the event (primary key).
+        data_tests:
+          - not_null
+          - unique
 
   - name: hubspot_contacts
     description: >
@@ -1329,3 +1335,9 @@ models:
       transformations. Columns documented at the upstream staging model.
 
       Source: stg_airbyte_source__hubspot_api_contacts.
+    columns:
+      - name: id
+        description: HubSpot contact ID (primary key).
+        data_tests:
+          - not_null
+          - unique

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1313,3 +1313,19 @@ models:
               arguments:
                 to: ref('stg_airbyte_source__hubspot_api_contacts')
                 field: id
+
+  - name: amplitude_events
+    description: >
+      Passthrough exposure of stg_airbyte_source__amplitude_api_events
+      into mart_analytics for Sigma BI POV. View materialization, no
+      transformations. Columns documented at the upstream staging model.
+
+      Source: stg_airbyte_source__amplitude_api_events.
+
+  - name: hubspot_contacts
+    description: >
+      Passthrough exposure of stg_airbyte_source__hubspot_api_contacts
+      into mart_analytics for Sigma BI POV. View materialization, no
+      transformations. Columns documented at the upstream staging model.
+
+      Source: stg_airbyte_source__hubspot_api_contacts.


### PR DESCRIPTION
## TL;DR

Two new passthrough views in `mart_analytics` exposing amplitude events and hubspot contacts for the Sigma Computing BI POV. No transformations, no new tests, no schema or permission changes elsewhere.

## What

- New model `mart_analytics.amplitude_events` (view): `select *` from `stg_airbyte_source__amplitude_api_events`.
- New model `mart_analytics.hubspot_contacts` (view): `select *` from `stg_airbyte_source__hubspot_api_contacts`.
- Entries added to `dbt/project/models/marts/analytics/m_analytics.yaml` documenting both as passthroughs. No column-level docs at this layer; columns are documented at the upstream staging models.

## Why

The Sigma POV analyst needs both tables available in Sigma. Sigma's service principal already has SELECT on `mart_analytics`, so wrapping each staging table in a thin mart model is the dbt-only path to exposing them. This preserves the "marts only for external surfaces" boundary and avoids granting direct access to staging schemas, which drift more often than marts.

Sigma's SP access to `mart_analytics` was provisioned in [thegoodparty/gp-terraform-dataplatform#29](https://github.com/thegoodparty/gp-terraform-dataplatform/pull/29) and is already applied to prod. See `.tickets/sigma_setup/decisions.md` for the full decision record (POV scope, MNDA/DPA cover, deferred deal-close gates).

## Verification (against dev target)

- `dbt parse` clean.
- `dbt run --select "amplitude_events hubspot_contacts"` PASS=2, both views created.
- `dbt show` row counts: ~11.0M rows for `amplitude_events`, ~307K rows for `hubspot_contacts`.
- `dbt test --select "amplitude_events hubspot_contacts"` no tests defined on these models (intentional, see below); nothing to run.
- `pre-commit run` clean. sqlfmt reformatted both SQL files on first pass; the formatted versions are what's committed.

## Deliberate non-choices

- `select *` over explicit column lists. Intentional for POV speed. Trade-off: an upstream column rename or drop will break Sigma dashboards on the next dbt run. Acceptable for a 3-week POV; revisit if usage persists post-POV.
- View over table. A passthrough table would duplicate storage and incur build cost for zero added value. View materialization keeps the namespace clean without paying for it.
- No tests at this layer. Upstream stg tests already cover data quality. Add invariants here only if the analyst surfaces specific ones Sigma depends on.
- No PII redaction at this layer. POV is under MNDA + DPA, documented in `decisions.md`. Column-level masking is a deal-close gate, not a POV concern.

## Out of scope

- `m_general__candidacy`. Legacy, being deprecated into `mart_civics`; handled separately.
- Other marts and any non-Sigma consumers.
- Terraform or Sigma SP permission changes. Already provisioned in PR #29 of `gp-terraform-dataplatform`.
- Promotion to `table` materialization or test coverage on the new views. Deferred until POV usage justifies it.

## Follow-ups

- After POV wrap (~3 weeks from kickoff on 2026-05-14): if Sigma usage continues, revisit `select *` vs. explicit columns, view vs. table, and whether to add invariants the analyst depends on.
- If POV converts to a paid engagement, the deal-close items in `decisions.md` (column-level masking, etc.) come into scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `mart_analytics` views that surface raw Amplitude/HubSpot staging data to downstream BI, increasing potential blast radius for schema drift and unintended PII exposure. Changes are otherwise simple `select *` passthroughs with no transformation logic.
> 
> **Overview**
> Adds two new `mart_analytics` passthrough models, `amplitude_events` and `hubspot_contacts`, materialized as **views** that `select *` from their respective Airbyte staging models for Sigma consumption.
> 
> Updates `m_analytics.yaml` to document both new mart models (no additional column-level docs/tests added at this layer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df85fac0b609ab559b80d51431b0f769ddae9d16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->