### PR TITLE
[DATA-1903] Document Astro git-deploy + election-api migration timing

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -38,6 +38,17 @@ tables to Postgres via JDBC from a Databricks cluster) onto Airflow.
 The source schema is hardcoded to `dbt` (not `databricks_dbt_schema`, which
 points at `dbt_staging` for in-flight dbt build artifacts). The election-api
 sync reads the production-quality version of the marts in both dev and prod.
+
+### Deploy model:
+- `main` → `astro-prod`. `astro-dev`'s branch mapping is set manually in the
+  Astro Cloud UI's Git Deploys settings. Astro's webhook fires on push events
+  to the mapped branch, so a branch-mapping change alone does not redeploy —
+  a subsequent push to the new branch (or a manual redeploy via the Astro UI)
+  is what triggers the sync.
+- The election-api Postgres schema is owned by the election-api repo. Prisma
+  migrations apply when election-api is deployed to the corresponding env,
+  not on PR merge alone. Check status via the `_prisma_migrations` table on
+  the target Postgres before kicking a sync that depends on new columns.
 """
 
 import logging


### PR DESCRIPTION
## Summary
Documents two operational notes in the `sync_election_api` DAG docstring that came out of the DATA-1903 phase-c rollout. Also serves as the trigger push for the Astro dev redeploy after switching the dev branch mapping from `DATA-1896-...` back to `main`.

## Why
Both gotchas cost real debugging time during the phase-c cutover:

1. **Astro's git-deploy webhook fires on push events to the mapped branch, not on branch-mapping changes alone.** Switching `astro-dev` from one branch to another doesn't actually trigger a redeploy until a subsequent push or a manual redeploy in the Astro UI.
2. **The election-api Postgres schema is owned by the election-api repo** (Win team's territory). Prisma migrations apply when election-api is deployed to the target env, not on PR merge alone. Worth checking `_prisma_migrations` before kicking a sync that depends on new columns.

Both are captured in the DAG docstring's existing operational-notes section so the next contributor doesn't re-discover them.

## Files changed
- `airflow/astro/dags/sync_election_api.py` — appends a "Deploy model:" section to the existing module docstring. No code changes.

## Test plan
- [x] CI passes (pre-commit + pytest, both green locally before push).
- [ ] After merge, Astro's webhook fires and the dev deployment redeploys against `main` (this is the side effect we want from this PR's merge).
- [ ] Subsequent dev `sync_election_api` DAG trigger validates the full phase-c rollout end-to-end (per the design doc's §11 rollout sequence).

## Note
This is technically a "trigger push" PR — the docstring update is genuinely useful, but the merge itself is also the mechanism for kicking Astro's git-deploy webhook now that the dev branch mapping was switched to `main`. Branch protection on `main` blocks direct pushes, hence the PR. Five-minute review, no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the `sync_election_api` DAG module docstring with operational notes and does not change runtime code or data handling.
> 
> **Overview**
> Adds a new **"Deploy model"** section to the `sync_election_api.py` DAG docstring documenting two operational gotchas: Astro Git Deploys only redeploy on a push to the mapped branch (not on branch-mapping changes), and election-api Postgres schema changes land via election-api Prisma migrations (verify via `_prisma_migrations`) rather than by merging this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7f3d4249b55e580b25c20771bedf7a8348f3d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->