### PR TITLE
[DATA-1920] Fix NULL NOT IN bug in m_techspeed__candidate_to_hubspot

### DIFF
--- a/dbt/project/models/marts/techspeed/m_techspeed__candidate_to_hubspot.sql
+++ b/dbt/project/models/marts/techspeed/m_techspeed__candidate_to_hubspot.sql
@@ -211,8 +211,10 @@ with
             on f.techspeed_candidate_code = v.techspeed_candidate_code
         left join br_race r on try_cast(f.br_race_id as int) = r.database_id
         left join icp_offices icp on r.position.databaseid = icp.br_database_position_id
-        left join br_sent_codes s
-            on f.fuzzy_matched_hubspot_candidate_code = s.fuzzy_matched_hubspot_candidate_code
+        left join
+            br_sent_codes s
+            on f.fuzzy_matched_hubspot_candidate_code
+            = s.fuzzy_matched_hubspot_candidate_code
         -- anti-join: keep candidates whose fuzzy match isn't in the BR-sent
         -- list. NULL fuzzy matches (no HubSpot match found) are kept because
         -- the LEFT JOIN preserves them, avoiding the NULL NOT IN pitfall.

--- a/dbt/project/models/marts/techspeed/m_techspeed__candidate_to_hubspot.sql
+++ b/dbt/project/models/marts/techspeed/m_techspeed__candidate_to_hubspot.sql
@@ -81,6 +81,11 @@ with
     ),
     br_race as (select * from {{ ref("stg_airbyte_source__ballotready_api_race") }}),
     icp_offices as (select * from {{ ref("int__icp_offices") }}),
+    br_sent_codes as (
+        select distinct fuzzy_matched_hubspot_candidate_code
+        from {{ ref("m_ballotready_internal__records_sent_to_hubspot") }}
+        where fuzzy_matched_hubspot_candidate_code is not null
+    ),
     techspeed_candidates_w_hubspot as (
         select
             -- We don't want to hand values over to hubspot with string
@@ -206,13 +211,12 @@ with
             on f.techspeed_candidate_code = v.techspeed_candidate_code
         left join br_race r on try_cast(f.br_race_id as int) = r.database_id
         left join icp_offices icp on r.position.databaseid = icp.br_database_position_id
-        -- remove candidates that have already been found in ballotready
-        where
-            f.fuzzy_matched_hubspot_candidate_code not in (
-                select fuzzy_matched_hubspot_candidate_code
-                from {{ ref("m_ballotready_internal__records_sent_to_hubspot") }}
-                where fuzzy_matched_hubspot_candidate_code is not null
-            )
+        left join br_sent_codes s
+            on f.fuzzy_matched_hubspot_candidate_code = s.fuzzy_matched_hubspot_candidate_code
+        -- anti-join: keep candidates whose fuzzy match isn't in the BR-sent
+        -- list. NULL fuzzy matches (no HubSpot match found) are kept because
+        -- the LEFT JOIN preserves them, avoiding the NULL NOT IN pitfall.
+        where s.fuzzy_matched_hubspot_candidate_code is null
     )
 
 select


### PR DESCRIPTION
## Summary
- The mart filtered candidates with `f.fuzzy_matched_hubspot_candidate_code NOT IN (...)`. That column is NULL whenever the upstream fuzzy matcher finds no HubSpot match (below the 85 score threshold), and `NULL NOT IN (...)` evaluates to NULL, so the WHERE clause silently dropped every truly net-new TechSpeed candidate.
- Replaced the NOT IN subquery with a `br_sent_codes` anti-join CTE and `LEFT JOIN ... WHERE s.col IS NULL`, which preserves NULL fuzzy matches structurally and matches the repo's "avoid subqueries in favor of CTEs" convention.

## Row-count impact (verified against prod tables)

| Window | Before fix | After fix |
|---|---|---|
| All-time | 14,541 | 61,519 |
| Last 30 days | 183 | 5,265 |

The 46,978-row gap is TechSpeed candidates with NULL fuzzy match that the broken WHERE dropped over the data window. The fuzzy_deduped table covers `_airbyte_extracted_at` from 2025-11-12 onward, so this is the full bug-window count.

## Operational context — read before merging

**This row-count change is at the mart level, not at the HubSpot-contacts level.** Cross-checking against `int__hubspot_contacts` shows TS data has been reaching HubSpot through other paths throughout the bug window:

| `candidate_id_source` | Total | Since 2025-11-12 | Last 30 days | Last created |
|---|---|---|---|---|
| `TS + BR` | 88,937 | 16,862 | 190 | 2026-05-13 |
| `TS Net New` | 10,850 | 2,522 | 80 | 2026-05-13 |
| `TechSpeed` | 34,293 | 0 | 0 | 2025-07-30 (pre-bug) |
| `TechSpeed Incumbents` | 11,349 | 0 | 0 | 2025-06-12 (pre-bug) |

So the 46,978 mart-suppressed rows are **not** a 1:1 estimate of lost HubSpot contacts. The legacy `TechSpeed` source stopped flowing well before the bug went live, and the parallel `TS + BR` / `TS Net New` pipelines have continued adding TS contacts to HubSpot throughout — 19,384 since 2025-11-12.

Additionally, no in-repo job references `m_techspeed__candidate_to_hubspot` (not in airflow/, apps/, scripts/, or genie/). The mart appears to be consumed externally (Hightouch / Census / equivalent). Coordinate with the sync owner before merge — once this lands, the mart's visible row count roughly 4x's, and downstream impact depends on whether/how the external sync filters.

See DATA-1921 for the full investigation.

## Known pre-existing issues (not introduced here)
- `relationships` test on `Candidate ID Source` returns 46 violations because it targets `int__techspeed_candidates_w_hubspot` instead of `int__techspeed_candidates_fuzzy_deduped` (the model the mart actually selects from). Pre-existing, surfaced because more rows pass the WHERE.
- Two `accepted_values` tests on `icp_win` / `icp_win_supersize` error with `CAST_INVALID_INPUT` on empty-string-to-date casts in the icp date-gate macro. Pre-existing, unrelated to this change.

## Tickets
- DATA-1920 (this fix)
- DATA-1919 (parent: Investigate Techspeed lost leads count)
- DATA-1921 (sibling: investigation — see latest comment for corrected analysis)

## Test plan
- [x] `dbt build` passes on `m_techspeed__candidate_to_hubspot`
- [x] Post-fix counts verified by emulating the fix against prod tables (`5,265` last-30d, `61,519` all-time)
- [ ] Sync owner confirms downstream impact before merge
- [ ] Spot-check rows with NULL fuzzy match now appear in the post-fix mart
- [ ] Spot-check rows whose fuzzy match is in `m_ballotready_internal__records_sent_to_hubspot` are still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
