### PR TITLE
[DATA-1496] Add prospects mart for Connect Rate / Activation Rate metrics

### DIFF
--- a/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
@@ -220,6 +220,13 @@ models:
         data_tests:
           - not_null
           - unique
+      - name: goodparty_user_id
+        description: >
+          Direct HubSpot contact-to-product-DB user link (from
+          stg_airbyte_source__hubspot_api_contacts.goodparty_user_id).
+          Nullable — most contacts without a product account have this as
+          NULL. Used as the preferred gp_user_id source in the prospects
+          mart, ahead of the candidate-mediated prod_db_user_id path.
 
   - name: int__hubspot_contact_calls
     description: |

--- a/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
@@ -220,3 +220,59 @@ models:
         data_tests:
           - not_null
           - unique
+
+  - name: int__hubspot_contact_calls
+    description: |
+      One row per HubSpot contact_id with at least one logged call.
+      Disjoint per-outcome_family subtotals sum to total_calls. The
+      connected_calls column is a convenience aggregate (pledge + reject
+      + other) and is excluded from the disjoint-sum invariant test.
+    columns:
+      - name: contact_id
+        description: HubSpot contact ID.
+        data_tests:
+          - not_null
+          - unique
+      - name: total_calls
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: connected_pledge_calls
+        data_tests:
+          - not_null
+      - name: connected_reject_calls
+        data_tests:
+          - not_null
+      - name: connected_other_calls
+        data_tests:
+          - not_null
+      - name: not_connected_calls
+        data_tests:
+          - not_null
+      - name: unmapped_calls
+        data_tests:
+          - not_null
+      - name: null_disposition_calls
+        data_tests:
+          - not_null
+      - name: ever_connected
+        data_tests:
+          - not_null
+      - name: first_call_at
+        data_tests:
+          - not_null
+      - name: last_call_at
+        data_tests:
+          - not_null
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: |
+              total_calls =
+                connected_pledge_calls + connected_reject_calls + connected_other_calls
+                + not_connected_calls + unmapped_calls + null_disposition_calls
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "last_call_at >= first_call_at"

--- a/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
@@ -257,6 +257,13 @@ models:
       - name: null_disposition_calls
         data_tests:
           - not_null
+      - name: connected_calls
+        description: |
+          Convenience aggregate = connected_pledge_calls +
+          connected_reject_calls + connected_other_calls. Overlaps with the
+          disjoint subtotals and is excluded from the disjoint-sum invariant.
+        data_tests:
+          - not_null
       - name: ever_connected
         data_tests:
           - not_null
@@ -266,6 +273,18 @@ models:
       - name: last_call_at
         data_tests:
           - not_null
+      - name: last_connected_call_at
+        description: |
+          Timestamp of the most recent connected-family call. NULL for
+          contacts who have never had a connected call (by design).
+      - name: distinct_owners
+        description: Count of distinct hubspot_owner_id values across this contact's calls.
+        data_tests:
+          - not_null
+      - name: last_owner_id
+        description: |
+          hubspot_owner_id of the most recent call for this contact.
+          Nullable when the owner field is unset on the latest call.
     data_tests:
       - dbt_utils.expression_is_true:
           arguments:
@@ -273,6 +292,9 @@ models:
               total_calls =
                 connected_pledge_calls + connected_reject_calls + connected_other_calls
                 + not_connected_calls + unmapped_calls + null_disposition_calls
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "connected_calls = connected_pledge_calls + connected_reject_calls + connected_other_calls"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "last_call_at >= first_call_at"

--- a/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
@@ -207,3 +207,16 @@ models:
         data_tests:
           - unique
           - not_null
+
+  - name: int__hubspot_prospect_contacts
+    description: |
+      One row per HubSpot contact, with lifecycle/stage/activation/pledge
+      fields and resolved position-based ICP from int__hubspot_contacts.
+      Does NOT filter by name — unlike int__hubspot_contacts — so prospects
+      with missing names are included.
+    columns:
+      - name: id
+        description: HubSpot contact ID.
+        data_tests:
+          - not_null
+          - unique

--- a/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
@@ -2,17 +2,16 @@ version: 2
 
 models:
   - name: int__hubspot_calls
-    description: >
-      HubSpot call engagements with their disposition GUID resolved to a
-      human-readable label via the `hubspot_call_dispositions` seed. Thin
-      pass-through of the staging model; adds two columns and no row-level
-      transformations.
+    description: |
+      HubSpot engagement calls, deduped to one row per call_id and enriched
+      with the disposition label and outcome_family classification from
+      the hubspot_call_dispositions seed.
     columns:
       - name: id
-        description: "HubSpot engagement ID for the call"
+        description: HubSpot call engagement ID. Unique per call after dedupe.
         data_tests:
-          - unique
           - not_null
+          - unique
       - name: hs_call_disposition
         description: "HubSpot internal GUID for the call outcome"
       - name: disposition_label
@@ -24,7 +23,7 @@ models:
       - name: disposition_label_source
         description: >
           Provenance of the label: `hubspot_docs` (documented default),
-          `inferred_from_title` (custom outcome derived from Nooks Call
+          `inferred_from_title` (custom outcome derived from a call
           title pattern), or `unknown` (GUID present but label not yet
           mapped). Null when the call has no disposition.
         data_tests:
@@ -34,6 +33,24 @@ models:
                   - hubspot_docs
                   - inferred_from_title
                   - unknown
+      - name: outcome_family
+        description: |
+          Disjoint outcome classification: connected_pledge, connected_reject,
+          connected_other, not_connected, unmapped (for GUIDs not yet labeled),
+          or null_disposition (call has no disposition GUID set).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - connected_pledge
+                  - connected_reject
+                  - connected_other
+                  - not_connected
+                  - unmapped
+                  - null_disposition
+              config:
+                severity: warn
     data_tests:
       - dbt_utils.expression_is_true:
           arguments:

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_calls.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_calls.sql
@@ -5,8 +5,8 @@
     )
 }}
 
--- Dedupes staging row inflation (~2.6x) and surfaces outcome_family from the
--- hubspot_call_dispositions seed.
+-- Dedupes staging row inflation (multiple Airbyte syncs per call) and
+-- surfaces outcome_family from the hubspot_call_dispositions seed.
 with
 
     deduped_calls as (

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_calls.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_calls.sql
@@ -5,6 +5,35 @@
     )
 }}
 
-select c.*, s.disposition_label, s.source as disposition_label_source
-from {{ ref("stg_airbyte_source__hubspot_api_engagements_calls") }} as c
-left join {{ ref("hubspot_call_dispositions") }} as s on c.hs_call_disposition = s.guid
+-- Dedupes staging row inflation (~2.6x) and surfaces outcome_family from the
+-- hubspot_call_dispositions seed.
+with
+
+    deduped_calls as (
+        select *
+        from {{ ref("stg_airbyte_source__hubspot_api_engagements_calls") }}
+        qualify
+            row_number() over (partition by id order by _airbyte_extracted_at desc) = 1
+    ),
+
+    final as (
+        select
+            c.*,
+            s.disposition_label,
+            s.source as disposition_label_source,
+            coalesce(
+                s.outcome_family,
+                case
+                    when c.hs_call_disposition is null
+                    then 'null_disposition'
+                    else 'unmapped'
+                end
+            ) as outcome_family
+        from deduped_calls as c
+        left join
+            {{ ref("hubspot_call_dispositions") }} as s
+            on c.hs_call_disposition = s.guid
+    )
+
+select *
+from final

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_contact_calls.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_contact_calls.sql
@@ -63,7 +63,11 @@ with
     last_owner as (
         select contact_id, hubspot_owner_id as last_owner_id
         from exploded_calls
-        qualify row_number() over (partition by contact_id order by call_at desc) = 1
+        qualify
+            row_number() over (
+                partition by contact_id order by call_at desc, call_id desc
+            )
+            = 1
     ),
 
     final as (

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_contact_calls.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_contact_calls.sql
@@ -1,0 +1,98 @@
+{{
+    config(
+        auto_liquid_cluster=true,
+        tags=["intermediate", "calls", "hubspot", "prospects"],
+    )
+}}
+
+-- One row per HubSpot contact_id with at least one call. Aggregates the
+-- deduped int__hubspot_calls into disjoint per-outcome_family subtotals
+-- plus a convenience connected_calls aggregate.
+with
+
+    exploded_calls as (
+        select
+            id as call_id,
+            -- hs_timestamp is when the call happened in HubSpot; created_at is
+            -- when the engagement record was created. Prefer hs_timestamp.
+            coalesce(hs_timestamp, created_at) as call_at,
+            outcome_family,
+            hubspot_owner_id,
+            explode(from_json(contacts, 'array<string>')) as contact_id
+        from {{ ref("int__hubspot_calls") }}
+        where contacts is not null and trim(contacts) not in ('', '[]')
+    ),
+
+    aggregated as (
+        select
+            contact_id,
+            count(distinct call_id) as total_calls,
+            count(
+                distinct case when outcome_family = 'connected_pledge' then call_id end
+            ) as connected_pledge_calls,
+            count(
+                distinct case when outcome_family = 'connected_reject' then call_id end
+            ) as connected_reject_calls,
+            count(
+                distinct case when outcome_family = 'connected_other' then call_id end
+            ) as connected_other_calls,
+            count(
+                distinct case when outcome_family = 'not_connected' then call_id end
+            ) as not_connected_calls,
+            count(
+                distinct case when outcome_family = 'unmapped' then call_id end
+            ) as unmapped_calls,
+            count(
+                distinct case when outcome_family = 'null_disposition' then call_id end
+            ) as null_disposition_calls,
+            min(call_at) as first_call_at,
+            max(call_at) as last_call_at,
+            max(
+                case
+                    when
+                        outcome_family
+                        in ('connected_pledge', 'connected_reject', 'connected_other')
+                    then call_at
+                end
+            ) as last_connected_call_at,
+            count(distinct hubspot_owner_id) as distinct_owners
+        from exploded_calls
+        group by contact_id
+    ),
+
+    last_owner as (
+        select contact_id, hubspot_owner_id as last_owner_id
+        from exploded_calls
+        qualify row_number() over (partition by contact_id order by call_at desc) = 1
+    ),
+
+    final as (
+        select
+            a.contact_id,
+            a.total_calls,
+            a.connected_pledge_calls,
+            a.connected_reject_calls,
+            a.connected_other_calls,
+            a.not_connected_calls,
+            a.unmapped_calls,
+            a.null_disposition_calls,
+            a.connected_pledge_calls
+            + a.connected_reject_calls
+            + a.connected_other_calls as connected_calls,
+            (
+                a.connected_pledge_calls
+                + a.connected_reject_calls
+                + a.connected_other_calls
+            )
+            > 0 as ever_connected,
+            a.first_call_at,
+            a.last_call_at,
+            a.last_connected_call_at,
+            a.distinct_owners,
+            lo.last_owner_id
+        from aggregated a
+        left join last_owner lo on a.contact_id = lo.contact_id
+    )
+
+select *
+from final

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_prospect_contacts.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_prospect_contacts.sql
@@ -1,0 +1,107 @@
+{{
+    config(
+        auto_liquid_cluster=true,
+        tags=["intermediate", "contacts", "hubspot", "prospects"],
+    )
+}}
+
+-- One row per HubSpot contact. Surfaces lifecycle/stage/activation/pledge
+-- fields plus ICP enrichment from int__hubspot_contacts. Does NOT filter
+-- by name (unlike int__hubspot_contacts) so prospects without a recorded
+-- name are still included.
+with
+
+    contacts as (select * from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}),
+
+    -- Resolved ICP at the position level. Renamed here to make the
+    -- position-basis explicit in column names (these flags describe the
+    -- office, not the person's pursuit type).
+    contact_icp as (
+        select
+            id,
+            icp_win as position_icp_win,
+            icp_serve as position_icp_serve,
+            icp_win_supersize as position_icp_win_supersize
+        from {{ ref("int__hubspot_contacts") }}
+    ),
+
+    final as (
+        select
+            -- Identity (no name filter)
+            c.id,
+            c.email,
+            c.first_name,
+            c.last_name,
+            c.full_name,
+            c.state,
+            c.city,
+            c.phone as phone_number,
+
+            -- Resolved position-based ICP (left join — NULL where no
+            -- resolution; do NOT coalesce to false because "not ICP" and
+            -- "unknown" are distinct states for analytics consumers).
+            i.position_icp_win,
+            i.position_icp_serve,
+            i.position_icp_win_supersize,
+
+            -- HubSpot lifecycle current snapshot strings
+            c.lifecycle_stage,
+            c.serve_stage,
+            c.win_stage,
+
+            -- Serve lifecycle transition timestamps
+            c.serve_lifecycle_lead_entered_at,
+            c.serve_lifecycle_sal_entered_at,
+            c.serve_lifecycle_scheduled_sql_entered_at,
+            c.serve_lifecycle_sql_entered_at,
+            c.serve_lifecycle_opportunity_entered_at,
+            c.serve_lifecycle_converted_entered_at,
+            c.serve_lifecycle_activated_entered_at,
+            c.serve_lifecycle_retained_entered_at,
+            c.serve_lifecycle_churned_entered_at,
+            c.serve_lifecycle_not_qualified_entered_at,
+
+            -- Win stage transition timestamps (currently 0% populated;
+            -- surfaced for futureproofing once the HubSpot workflow is enabled)
+            c.win_stage_0_intake_entered_at,
+            c.win_stage_1_new_assigned_entered_at,
+            c.win_stage_2_discovery_complete_entered_at,
+            c.win_stage_3_pro_presented_entered_at,
+            c.win_stage_4_pro_consideration_entered_at,
+            c.win_stage_5_closed_won_pro_entered_at,
+            c.win_stage_6_activated_pro_user_entered_at,
+            c.win_stage_closed_too_early_entered_at,
+
+            -- Activation / quality / pledge signals
+            c.serve_activated_user,
+            c.serve_activated_at,
+            c.serve_opt_in_at,
+            c.is_serve_opted_in,
+            c.serve_onboarding_stage,
+            c.win_activated_user,
+            c.is_pledged,
+            c.has_verbal_pledge,
+            c.has_email_pledge,
+            c.has_verbal_serve,
+            c.pledge_status,
+            c.verified_candidate_status,
+            c.lead_status,
+            c.number_of_serve_calls,
+
+            -- HubSpot Sales pursuit taxonomy. `type` is semicolon-separated
+            -- multi-value: Self-Filer Lead / Campaign → Win pursuit;
+            -- Historical Incumbent → Serve pursuit; combinations flag dual
+            -- pursuits (e.g. EOs running for re-election). `candidate_type`
+            -- is separate (Incumbent / Challenger) for current-race status.
+            c.type as contact_type_raw,
+            c.candidate_type,
+
+            -- Metadata
+            c.created_at,
+            c.updated_at
+        from contacts c
+        left join contact_icp i on c.id = i.id
+    )
+
+select *
+from final

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_prospect_contacts.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_prospect_contacts.sql
@@ -29,6 +29,11 @@ with
         select
             -- Identity (no name filter)
             c.id,
+            -- HubSpot contact's direct link to the product DB user. Distinct
+            -- from the candidate-mediated path: a contact may have this set
+            -- even when no candidate row exists for the user. Used by the
+            -- prospects mart as the preferred gp_user_id source.
+            c.goodparty_user_id,
             c.email,
             c.first_name,
             c.last_name,

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_prospect_contacts.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_prospect_contacts.sql
@@ -61,8 +61,9 @@ with
             c.serve_lifecycle_churned_entered_at,
             c.serve_lifecycle_not_qualified_entered_at,
 
-            -- Win stage transition timestamps (currently 0% populated;
-            -- surfaced for futureproofing once the HubSpot workflow is enabled)
+            -- Win stage transition timestamps. Surfaced for futureproofing
+            -- once the HubSpot Win lifecycle workflow is enabled (today the
+            -- win_stage string snapshot is the primary signal).
             c.win_stage_0_intake_entered_at,
             c.win_stage_1_new_assigned_entered_at,
             c.win_stage_2_discovery_complete_entered_at,

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1303,6 +1303,10 @@ models:
         data_tests: [not_null]
       - name: in_win_funnel
         data_tests: [not_null]
+      - name: in_both_funnels
+        data_tests: [not_null]
+      - name: ever_connected
+        data_tests: [not_null]
       - name: was_called
         data_tests: [not_null]
       - name: has_win_org
@@ -1314,6 +1318,28 @@ models:
       - name: is_serve_activated_prospect
         data_tests: [not_null]
       - name: is_win_activated_prospect
+        data_tests: [not_null]
+      - name: is_self_filer_lead
+        data_tests: [not_null]
+      - name: is_historical_incumbent
+        data_tests: [not_null]
+      - name: is_campaign_type
+        data_tests: [not_null]
+      - name: is_dual_pursuit
+        data_tests: [not_null]
+      - name: is_eo_sales_attributed
+        data_tests: [not_null]
+      - name: is_winner_pursuit
+        data_tests: [not_null]
+      - name: is_win_intake_prospect
+        data_tests: [not_null]
+      - name: is_win_pro_presented_prospect
+        data_tests: [not_null]
+      - name: is_win_pro_won_prospect
+        data_tests: [not_null]
+      - name: win_activated_user_hs_flag
+        data_tests: [not_null]
+      - name: has_won_general_election
         data_tests: [not_null]
       - name: gp_user_id
         description: Resolved product-DB user_id via candidate.prod_db_user_id.

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1317,7 +1317,11 @@ models:
         data_tests: [not_null]
       - name: is_serve_activated_prospect
         data_tests: [not_null]
+      - name: is_serve_activated_any
+        data_tests: [not_null]
       - name: is_win_activated_prospect
+        data_tests: [not_null]
+      - name: is_win_activated_any
         data_tests: [not_null]
       - name: is_self_filer_lead
         data_tests: [not_null]

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1283,6 +1283,91 @@ models:
               arguments:
                 values: [true, false]
 
+  - name: prospects
+    description: |
+      Wide base table at HubSpot-contact grain for prospect-funnel metrics
+      (Prospect Connect Rate, Prospect Activation Rate). One row per
+      sales-touched HubSpot contact: called OR in any Serve/Win funnel
+      signal OR pledged OR serve-opted-in.
+
+      Win activation rates derived from this mart are current-snapshot
+      ratios (not transition rates) until the HubSpot Win lifecycle
+      workflow is enabled.
+    columns:
+      - name: contact_id
+        description: HubSpot contact ID. Primary key.
+        data_tests:
+          - not_null
+          - unique
+      - name: in_serve_funnel
+        data_tests: [not_null]
+      - name: in_win_funnel
+        data_tests: [not_null]
+      - name: was_called
+        data_tests: [not_null]
+      - name: has_win_org
+        data_tests: [not_null]
+      - name: has_serve_org
+        data_tests: [not_null]
+      - name: is_winner_or_eo
+        data_tests: [not_null]
+      - name: is_serve_activated_prospect
+        data_tests: [not_null]
+      - name: is_win_activated_prospect
+        data_tests: [not_null]
+      - name: gp_user_id
+        description: Resolved product-DB user_id via candidate.prod_db_user_id.
+        data_tests:
+          - unique:
+              config:
+                where: "gp_user_id IS NOT NULL"
+      - name: serve_stage
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - 'Stage 1: Serve Contacted'
+                  - 'Stage 2: Serve Pitched'
+                  - 'Stage 0: Serve Intake'
+                  - 'Closed: Poll Declined'
+                  - 'Closed: No Show (2x)'
+                  - 'Stage 4: Serve Launched'
+                  - 'Stage 3: Serve Agreed'
+                  - 'Won: Viewed Poll'
+                  - 'Closed: Unable to Verify Candidate'
+                  - 'Closed: Not ICP'
+                  - 'Closed: Approval Withdrawn'
+                  - 'Closed: Too Early'
+              config:
+                severity: warn
+      - name: win_stage
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - 'Stage 0 – Intake'
+                  - 'Closed – Not ICP'
+                  - 'Closed – Not Running / Pledge Not Met'
+                  - 'Previously Pro'
+                  - 'Stage 5 – Closed Won (Pro)'
+                  - 'Stage 1 – New / Assigned'
+                  - 'Closed – Not Interested'
+                  - 'Stage 6 - Activated Pro User'
+                  - 'Closed – Too Early'
+                  - 'Stage 4 – Pro Consideration'
+                  - 'Stage 3 – Pro Presented'
+                  - 'Stage 2 – Discovery Complete'
+              config:
+                severity: warn
+    tests:
+      - dbt_utils.expression_is_true:
+          name: prospects_sales_touched_gate
+          arguments:
+            expression: |
+              was_called or in_serve_funnel or in_win_funnel
+              or is_pledged or has_verbal_pledge or has_email_pledge
+              or is_serve_opted_in
+
   - name: win_user_satisfaction_responses
     description: >
       Win User satisfaction survey (5 stars) responses. Combines survey_id 9

--- a/dbt/project/models/marts/analytics/prospects.sql
+++ b/dbt/project/models/marts/analytics/prospects.sql
@@ -72,7 +72,13 @@ with
         select
             c.*,
             cp.gp_candidate_id,
-            cp.prod_db_user_id as gp_user_id,
+            -- gp_user_id resolution: prefer HubSpot's direct contact->user link
+            -- (goodparty_user_id from staging); fall back to candidate-mediated
+            -- prod_db_user_id when the direct link is missing. The direct link is
+            -- contact-specific rather than going through candidacy mapping. About
+            -- 1,650 contacts with Win/Serve orgs are only discoverable via the
+            -- direct link.
+            coalesce(c.goodparty_user_id, cp.prod_db_user_id) as gp_user_id,
             cc.total_calls,
             cc.connected_pledge_calls,
             cc.connected_reject_calls,
@@ -105,7 +111,47 @@ with
             (
                 nullif(trim(c.win_stage), '') is not null
                 or coalesce(c.win_activated_user ilike 'true', false)
-            ) as in_win_funnel
+            ) as in_win_funnel,
+            -- Earliest available timestamp signaling Sales touched this
+            -- contact. Considers all Serve lifecycle transitions, the
+            -- HubSpot serve_activated_at and serve_opt_in_at timestamps,
+            -- and the first call. NULL when none are populated (e.g.,
+            -- contacts gated in only by Win-stage snapshot strings or
+            -- pledge/opt-in boolean flags that carry no timestamp).
+            nullif(
+                least(
+                    coalesce(c.serve_lifecycle_lead_entered_at, timestamp '9999-01-01'),
+                    coalesce(c.serve_lifecycle_sal_entered_at, timestamp '9999-01-01'),
+                    coalesce(
+                        c.serve_lifecycle_scheduled_sql_entered_at,
+                        timestamp '9999-01-01'
+                    ),
+                    coalesce(c.serve_lifecycle_sql_entered_at, timestamp '9999-01-01'),
+                    coalesce(
+                        c.serve_lifecycle_opportunity_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        c.serve_lifecycle_converted_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        c.serve_lifecycle_activated_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        c.serve_lifecycle_retained_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        c.serve_lifecycle_churned_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        c.serve_lifecycle_not_qualified_entered_at,
+                        timestamp '9999-01-01'
+                    ),
+                    coalesce(c.serve_activated_at, timestamp '9999-01-01'),
+                    coalesce(c.serve_opt_in_at, timestamp '9999-01-01'),
+                    coalesce(cc.first_call_at, timestamp '9999-01-01')
+                ),
+                timestamp '9999-01-01'
+            ) as first_sales_touch_at
         from contacts c
         left join contact_calls cc on c.id = cc.contact_id
         left join candidate_picked cp on c.id = cp.hubspot_contact_id
@@ -155,87 +201,8 @@ with
             st.in_win_funnel,
             (st.in_serve_funnel and st.in_win_funnel) as in_both_funnels,
             st.was_called,
-            nullif(
-                least(
-                    coalesce(
-                        st.serve_lifecycle_lead_entered_at, timestamp '9999-01-01'
-                    ),
-                    coalesce(st.serve_lifecycle_sal_entered_at, timestamp '9999-01-01'),
-                    coalesce(
-                        st.serve_lifecycle_scheduled_sql_entered_at,
-                        timestamp '9999-01-01'
-                    ),
-                    coalesce(st.serve_lifecycle_sql_entered_at, timestamp '9999-01-01'),
-                    coalesce(
-                        st.serve_lifecycle_opportunity_entered_at,
-                        timestamp '9999-01-01'
-                    ),
-                    coalesce(
-                        st.serve_lifecycle_converted_entered_at, timestamp '9999-01-01'
-                    ),
-                    coalesce(
-                        st.serve_lifecycle_activated_entered_at, timestamp '9999-01-01'
-                    ),
-                    coalesce(
-                        st.serve_lifecycle_retained_entered_at, timestamp '9999-01-01'
-                    ),
-                    coalesce(
-                        st.serve_lifecycle_churned_entered_at, timestamp '9999-01-01'
-                    ),
-                    coalesce(
-                        st.serve_lifecycle_not_qualified_entered_at,
-                        timestamp '9999-01-01'
-                    ),
-                    coalesce(st.first_call_at, timestamp '9999-01-01')
-                ),
-                timestamp '9999-01-01'
-            ) as first_sales_touch_at,
-            date_trunc(
-                'month',
-                nullif(
-                    least(
-                        coalesce(
-                            st.serve_lifecycle_lead_entered_at, timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_sal_entered_at, timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_scheduled_sql_entered_at,
-                            timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_sql_entered_at, timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_opportunity_entered_at,
-                            timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_converted_entered_at,
-                            timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_activated_entered_at,
-                            timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_retained_entered_at,
-                            timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_churned_entered_at,
-                            timestamp '9999-01-01'
-                        ),
-                        coalesce(
-                            st.serve_lifecycle_not_qualified_entered_at,
-                            timestamp '9999-01-01'
-                        ),
-                        coalesce(st.first_call_at, timestamp '9999-01-01')
-                    ),
-                    timestamp '9999-01-01'
-                )
-            ) as first_sales_touch_month,
+            st.first_sales_touch_at,
+            date_trunc('month', st.first_sales_touch_at) as first_sales_touch_month,
 
             -- Position-based ICP (secondary dimensions; NOT person attribution)
             st.position_icp_serve,
@@ -301,6 +268,15 @@ with
             (
                 st.serve_lifecycle_activated_entered_at is not null
             ) as is_serve_activated_prospect,
+            -- Broad activation flag: any signal that this contact is an
+            -- activated Serve user (lifecycle stage, HubSpot timestamp,
+            -- or HubSpot boolean flag). Wider than is_serve_activated_prospect,
+            -- which is stage-specific.
+            (
+                st.serve_lifecycle_activated_entered_at is not null
+                or st.serve_activated_at is not null
+                or coalesce(st.serve_activated_user ilike 'true', false)
+            ) as is_serve_activated_any,
             st.is_serve_opted_in,
             st.serve_activated_at,
             st.number_of_serve_calls,
@@ -319,6 +295,13 @@ with
             coalesce(
                 st.win_stage = 'Stage 6 - Activated Pro User', false
             ) as is_win_activated_prospect,
+            -- Broad activation flag: stage-6 OR the HubSpot
+            -- win_activated_user boolean. Wider than is_win_activated_prospect,
+            -- which is stage-specific.
+            (
+                coalesce(st.win_stage = 'Stage 6 - Activated Pro User', false)
+                or coalesce(st.win_activated_user ilike 'true', false)
+            ) as is_win_activated_any,
             coalesce(
                 st.win_activated_user ilike 'true', false
             ) as win_activated_user_hs_flag,
@@ -355,5 +338,26 @@ with
         left join user_won_general ug on st.gp_user_id = ug.gp_user_id
     )
 
+-- One row per HubSpot contact, BUT collapsed to one row per gp_user_id
+-- where gp_user_id is resolved. Two HubSpot contacts pointing at the
+-- same product user (a known dup-data-entry pattern in HubSpot) are
+-- deduplicated by picking the most-recently-active contact. Rows where
+-- gp_user_id is NULL are kept as-is (contact grain preserved for
+-- unconverted prospects).
 select *
 from final
+qualify
+    case
+        when gp_user_id is null
+        then 1
+        else
+            row_number() over (
+                partition by gp_user_id
+                order by
+                    was_called desc,
+                    last_call_at desc nulls last,
+                    updated_at desc nulls last,
+                    contact_id asc
+            )
+    end
+    = 1

--- a/dbt/project/models/marts/analytics/prospects.sql
+++ b/dbt/project/models/marts/analytics/prospects.sql
@@ -1,0 +1,306 @@
+{{ config(materialized="view") }}
+
+/*
+    mart_analytics.prospects
+
+    Wide base table at HubSpot-contact grain for prospect-funnel metrics.
+    One row per sales-touched HubSpot contact (called OR in any Serve/Win
+    funnel signal OR pledged OR serve-opted-in).
+
+    CAVEAT: Win activation rates derived from this mart are
+    current-snapshot ratios (e.g., contacts currently in Stage 6 vs
+    contacts currently in Stage 0), not true cohort transition rates.
+    The HubSpot Win lifecycle entered_at workflow is not enabled today;
+    win_stage string snapshots are used instead. Serve rates ARE true
+    transition rates (Serve lifecycle workflow is enabled).
+*/
+with
+
+    contacts as (select * from {{ ref("int__hubspot_prospect_contacts") }}),
+
+    contact_calls as (select * from {{ ref("int__hubspot_contact_calls") }}),
+
+    -- Multi-user-contact resolution: prefer a candidate row with a
+    -- prod_db_user_id populated; tiebreak by most-recently-updated. Keeps
+    -- gp_user_id unique per contact (the unique-where-not-null test on
+    -- the mart depends on this).
+    candidate_picked as (
+        select hubspot_contact_id, gp_candidate_id, prod_db_user_id
+        from {{ ref("goodparty_data_catalog", "candidate") }}
+        where hubspot_contact_id is not null
+        qualify
+            row_number() over (
+                partition by hubspot_contact_id
+                order by
+                    (prod_db_user_id is not null) desc nulls last,
+                    updated_at desc nulls last
+            )
+            = 1
+    ),
+
+    -- Canonical Win/Serve user classification. mart_civics.users aggregates
+    -- organization_type counts into is_win_user and is_serve_user at user
+    -- grain. We alias to has_win_org / has_serve_org to make the
+    -- organization-basis explicit throughout the prospects mart.
+    user_org_types as (
+        select
+            user_id as gp_user_id,
+            is_win_user as has_win_org,
+            is_serve_user as has_serve_org
+        from {{ ref("goodparty_data_catalog", "users") }}
+        where user_id is not null
+    ),
+
+    -- General-election winners (fallback signal if "winner" needs to mean
+    -- literal election winners rather than Win-org users). Uses
+    -- candidacy_result (overall result) as a proxy because
+    -- general_election_result is not yet in the production candidacy
+    -- snapshot.
+    user_won_general as (
+        select
+            cd.prod_db_user_id as gp_user_id,
+            max(cy.candidacy_result = 'Won') as has_won_general_election
+        from {{ ref("goodparty_data_catalog", "candidate") }} cd
+        join
+            {{ ref("goodparty_data_catalog", "candidacy") }} cy
+            on cd.gp_candidate_id = cy.gp_candidate_id
+        where cd.prod_db_user_id is not null
+        group by cd.prod_db_user_id
+    ),
+
+    sales_touched as (
+        select
+            c.*,
+            cp.gp_candidate_id,
+            cp.prod_db_user_id as gp_user_id,
+            cc.total_calls,
+            cc.connected_pledge_calls,
+            cc.connected_reject_calls,
+            cc.connected_other_calls,
+            cc.not_connected_calls,
+            cc.unmapped_calls,
+            cc.null_disposition_calls,
+            cc.connected_calls,
+            coalesce(cc.ever_connected, false) as ever_connected,
+            cc.first_call_at,
+            cc.last_call_at,
+            cc.last_connected_call_at,
+            cc.distinct_owners,
+            cc.last_owner_id,
+            (cc.contact_id is not null) as was_called
+        from contacts c
+        left join contact_calls cc on c.id = cc.contact_id
+        left join candidate_picked cp on c.id = cp.hubspot_contact_id
+        -- Sales-touched gate: any Serve/Win/pledge/opt-in signal OR called
+        where
+            cc.contact_id is not null
+            or c.serve_lifecycle_lead_entered_at is not null
+            or c.serve_lifecycle_sal_entered_at is not null
+            or c.serve_lifecycle_scheduled_sql_entered_at is not null
+            or c.serve_lifecycle_sql_entered_at is not null
+            or c.serve_lifecycle_opportunity_entered_at is not null
+            or c.serve_lifecycle_converted_entered_at is not null
+            or c.serve_lifecycle_activated_entered_at is not null
+            or c.serve_lifecycle_retained_entered_at is not null
+            or c.serve_lifecycle_churned_entered_at is not null
+            or c.serve_lifecycle_not_qualified_entered_at is not null
+            or c.serve_stage is not null
+            or c.serve_activated_at is not null
+            or nullif(trim(c.win_stage), '') is not null
+            or c.win_activated_user ilike 'true'
+            or c.is_pledged
+            or c.has_verbal_pledge
+            or c.has_email_pledge
+            or c.is_serve_opted_in
+    ),
+
+    final as (
+        select
+            -- Identity
+            st.id as contact_id,
+            st.email,
+            st.first_name,
+            st.last_name,
+            st.full_name,
+            st.state,
+            st.city,
+            st.phone_number,
+
+            -- User bridge
+            st.gp_candidate_id,
+            st.gp_user_id,
+
+            -- Sales attribution — person-based. in_serve_funnel is broad:
+            -- ANY Serve signal (lifecycle, stage, or activated_at). Matches
+            -- the sales-touched gate exactly so the YAML test stays in sync
+            -- with the WHERE clause.
+            (
+                st.serve_lifecycle_lead_entered_at is not null
+                or st.serve_lifecycle_sal_entered_at is not null
+                or st.serve_lifecycle_scheduled_sql_entered_at is not null
+                or st.serve_lifecycle_sql_entered_at is not null
+                or st.serve_lifecycle_opportunity_entered_at is not null
+                or st.serve_lifecycle_converted_entered_at is not null
+                or st.serve_lifecycle_activated_entered_at is not null
+                or st.serve_lifecycle_retained_entered_at is not null
+                or st.serve_lifecycle_churned_entered_at is not null
+                or st.serve_lifecycle_not_qualified_entered_at is not null
+                or st.serve_stage is not null
+                or st.serve_activated_at is not null
+            ) as in_serve_funnel,
+            (
+                nullif(trim(st.win_stage), '') is not null
+                or coalesce(st.win_activated_user ilike 'true', false)
+            ) as in_win_funnel,
+            (
+                (
+                    st.serve_lifecycle_lead_entered_at is not null
+                    or st.serve_lifecycle_sal_entered_at is not null
+                    or st.serve_lifecycle_scheduled_sql_entered_at is not null
+                    or st.serve_lifecycle_sql_entered_at is not null
+                    or st.serve_lifecycle_opportunity_entered_at is not null
+                    or st.serve_lifecycle_converted_entered_at is not null
+                    or st.serve_lifecycle_activated_entered_at is not null
+                    or st.serve_lifecycle_retained_entered_at is not null
+                    or st.serve_lifecycle_churned_entered_at is not null
+                    or st.serve_lifecycle_not_qualified_entered_at is not null
+                    or st.serve_stage is not null
+                    or st.serve_activated_at is not null
+                )
+                and (
+                    nullif(trim(st.win_stage), '') is not null
+                    or coalesce(st.win_activated_user ilike 'true', false)
+                )
+            ) as in_both_funnels,
+            st.was_called,
+            least(
+                st.serve_lifecycle_lead_entered_at,
+                st.serve_lifecycle_activated_entered_at,
+                st.first_call_at
+            ) as first_sales_touch_at,
+            date_trunc(
+                'month',
+                least(
+                    st.serve_lifecycle_lead_entered_at,
+                    st.serve_lifecycle_activated_entered_at,
+                    st.first_call_at
+                )
+            ) as first_sales_touch_month,
+
+            -- Position-based ICP (secondary dimensions; NOT person attribution)
+            st.position_icp_serve,
+            st.position_icp_win,
+
+            -- Winner / EO classification — canonical (from organizations)
+            coalesce(uo.has_win_org, false) as has_win_org,
+            coalesce(uo.has_serve_org, false) as has_serve_org,
+            -- "Win or Serve product user" — NOT literal election winner; see
+            -- has_won_general_election below.
+            (
+                coalesce(uo.has_win_org, false) or coalesce(uo.has_serve_org, false)
+            ) as is_winner_or_eo,
+
+            -- Secondary HubSpot-intent signals (Sales-pursuit, not user-confirmed)
+            (
+                nullif(trim(st.win_stage), '') is not null
+                or coalesce(st.win_activated_user ilike 'true', false)
+            ) as is_winner_pursuit,
+            (
+                st.serve_lifecycle_activated_entered_at is not null
+            ) as is_eo_sales_attributed,
+
+            -- HubSpot Sales pursuit taxonomy. Derived from contact_type_raw
+            -- (semicolon-separated multi-value). Distinguishes pure Win
+            -- pursuit from pure Serve pursuit from dual pursuit (e.g. EO
+            -- running for re-election). Dual-pursuit contacts legitimately
+            -- appear in both Win and Serve metric denominators because
+            -- Sales is pursuing them for both products.
+            (st.contact_type_raw like '%Self-Filer Lead%') as is_self_filer_lead,
+            (
+                st.contact_type_raw like '%Historical Incumbent%'
+            ) as is_historical_incumbent,
+            (st.contact_type_raw like '%Campaign%') as is_campaign_type,
+            (
+                st.contact_type_raw like '%Historical Incumbent%'
+                and (
+                    st.contact_type_raw like '%Self-Filer Lead%'
+                    or st.contact_type_raw like '%Campaign%'
+                )
+            ) as is_dual_pursuit,
+            st.contact_type_raw,
+            st.candidate_type,
+
+            -- General-election-winner sub-segment
+            coalesce(ug.has_won_general_election, false) as has_won_general_election,
+
+            -- Serve funnel state (true transition rates — Serve workflow enabled)
+            st.serve_lifecycle_lead_entered_at,
+            st.serve_lifecycle_sal_entered_at,
+            st.serve_lifecycle_scheduled_sql_entered_at,
+            st.serve_lifecycle_sql_entered_at,
+            st.serve_lifecycle_opportunity_entered_at,
+            st.serve_lifecycle_converted_entered_at,
+            st.serve_lifecycle_activated_entered_at,
+            st.serve_lifecycle_retained_entered_at,
+            st.serve_lifecycle_churned_entered_at,
+            st.serve_lifecycle_not_qualified_entered_at,
+            st.serve_stage,
+            (
+                st.serve_lifecycle_activated_entered_at is not null
+            ) as is_serve_activated_prospect,
+            st.is_serve_opted_in,
+            st.serve_activated_at,
+            st.number_of_serve_calls,
+
+            -- Win funnel state (snapshot ratios only)
+            st.win_stage,
+            coalesce(
+                st.win_stage = 'Stage 0 – Intake', false
+            ) as is_win_intake_prospect,
+            coalesce(
+                st.win_stage = 'Stage 3 – Pro Presented', false
+            ) as is_win_pro_presented_prospect,
+            coalesce(
+                st.win_stage = 'Stage 5 – Closed Won (Pro)', false
+            ) as is_win_pro_won_prospect,
+            coalesce(
+                st.win_stage = 'Stage 6 - Activated Pro User', false
+            ) as is_win_activated_prospect,
+            coalesce(
+                st.win_activated_user ilike 'true', false
+            ) as win_activated_user_hs_flag,
+
+            -- Quality / verification
+            st.is_pledged,
+            st.has_verbal_pledge,
+            st.has_email_pledge,
+            st.pledge_status,
+            st.verified_candidate_status,
+            st.lead_status,
+
+            -- Call activity (NULL when never called)
+            st.total_calls,
+            st.connected_pledge_calls,
+            st.connected_reject_calls,
+            st.connected_other_calls,
+            st.not_connected_calls,
+            st.unmapped_calls,
+            st.null_disposition_calls,
+            st.connected_calls,
+            st.ever_connected,
+            st.first_call_at,
+            st.last_call_at,
+            st.last_connected_call_at,
+            st.distinct_owners,
+            st.last_owner_id,
+
+            -- Metadata
+            st.created_at,
+            st.updated_at
+        from sales_touched st
+        left join user_org_types uo on st.gp_user_id = uo.gp_user_id
+        left join user_won_general ug on st.gp_user_id = ug.gp_user_id
+    )
+
+select *
+from final

--- a/dbt/project/models/marts/analytics/prospects.sql
+++ b/dbt/project/models/marts/analytics/prospects.sql
@@ -26,7 +26,7 @@ with
     -- the mart depends on this).
     candidate_picked as (
         select hubspot_contact_id, gp_candidate_id, prod_db_user_id
-        from {{ ref("goodparty_data_catalog", "candidate") }}
+        from {{ ref("candidate") }}
         where hubspot_contact_id is not null
         qualify
             row_number() over (
@@ -50,7 +50,7 @@ with
             max(
                 case when organization_type = 'serve' then true else false end
             ) as has_serve_org
-        from goodparty_data_catalog.mart_civics.organizations
+        from {{ ref("organizations") }}
         where user_id is not null
         group by user_id
     ),
@@ -61,10 +61,8 @@ with
         select
             cd.prod_db_user_id as gp_user_id,
             max(cy.general_election_result = 'Won') as has_won_general_election
-        from {{ ref("goodparty_data_catalog", "candidate") }} cd
-        join
-            goodparty_data_catalog.mart_civics.candidacy cy
-            on cd.gp_candidate_id = cy.gp_candidate_id
+        from {{ ref("candidate") }} cd
+        join {{ ref("candidacy") }} cy on cd.gp_candidate_id = cy.gp_candidate_id
         where cd.prod_db_user_id is not null
         group by cd.prod_db_user_id
     ),

--- a/dbt/project/models/marts/analytics/prospects.sql
+++ b/dbt/project/models/marts/analytics/prospects.sql
@@ -33,7 +33,8 @@ with
                 partition by hubspot_contact_id
                 order by
                     (prod_db_user_id is not null) desc nulls last,
-                    updated_at desc nulls last
+                    updated_at desc nulls last,
+                    gp_candidate_id asc
             )
             = 1
     ),
@@ -86,7 +87,25 @@ with
             cc.last_connected_call_at,
             cc.distinct_owners,
             cc.last_owner_id,
-            (cc.contact_id is not null) as was_called
+            (cc.contact_id is not null) as was_called,
+            (
+                c.serve_lifecycle_lead_entered_at is not null
+                or c.serve_lifecycle_sal_entered_at is not null
+                or c.serve_lifecycle_scheduled_sql_entered_at is not null
+                or c.serve_lifecycle_sql_entered_at is not null
+                or c.serve_lifecycle_opportunity_entered_at is not null
+                or c.serve_lifecycle_converted_entered_at is not null
+                or c.serve_lifecycle_activated_entered_at is not null
+                or c.serve_lifecycle_retained_entered_at is not null
+                or c.serve_lifecycle_churned_entered_at is not null
+                or c.serve_lifecycle_not_qualified_entered_at is not null
+                or c.serve_stage is not null
+                or c.serve_activated_at is not null
+            ) as in_serve_funnel,
+            (
+                nullif(trim(c.win_stage), '') is not null
+                or coalesce(c.win_activated_user ilike 'true', false)
+            ) as in_win_funnel
         from contacts c
         left join contact_calls cc on c.id = cc.contact_id
         left join candidate_picked cp on c.id = cp.hubspot_contact_id
@@ -129,60 +148,92 @@ with
             st.gp_candidate_id,
             st.gp_user_id,
 
-            -- Sales attribution — person-based. in_serve_funnel is broad:
-            -- ANY Serve signal (lifecycle, stage, or activated_at). Matches
-            -- the sales-touched gate exactly so the YAML test stays in sync
-            -- with the WHERE clause.
-            (
-                st.serve_lifecycle_lead_entered_at is not null
-                or st.serve_lifecycle_sal_entered_at is not null
-                or st.serve_lifecycle_scheduled_sql_entered_at is not null
-                or st.serve_lifecycle_sql_entered_at is not null
-                or st.serve_lifecycle_opportunity_entered_at is not null
-                or st.serve_lifecycle_converted_entered_at is not null
-                or st.serve_lifecycle_activated_entered_at is not null
-                or st.serve_lifecycle_retained_entered_at is not null
-                or st.serve_lifecycle_churned_entered_at is not null
-                or st.serve_lifecycle_not_qualified_entered_at is not null
-                or st.serve_stage is not null
-                or st.serve_activated_at is not null
-            ) as in_serve_funnel,
-            (
-                nullif(trim(st.win_stage), '') is not null
-                or coalesce(st.win_activated_user ilike 'true', false)
-            ) as in_win_funnel,
-            (
-                (
-                    st.serve_lifecycle_lead_entered_at is not null
-                    or st.serve_lifecycle_sal_entered_at is not null
-                    or st.serve_lifecycle_scheduled_sql_entered_at is not null
-                    or st.serve_lifecycle_sql_entered_at is not null
-                    or st.serve_lifecycle_opportunity_entered_at is not null
-                    or st.serve_lifecycle_converted_entered_at is not null
-                    or st.serve_lifecycle_activated_entered_at is not null
-                    or st.serve_lifecycle_retained_entered_at is not null
-                    or st.serve_lifecycle_churned_entered_at is not null
-                    or st.serve_lifecycle_not_qualified_entered_at is not null
-                    or st.serve_stage is not null
-                    or st.serve_activated_at is not null
-                )
-                and (
-                    nullif(trim(st.win_stage), '') is not null
-                    or coalesce(st.win_activated_user ilike 'true', false)
-                )
-            ) as in_both_funnels,
+            -- Sales attribution — person-based. in_serve_funnel and
+            -- in_win_funnel are computed once in sales_touched and
+            -- referenced here directly.
+            st.in_serve_funnel,
+            st.in_win_funnel,
+            (st.in_serve_funnel and st.in_win_funnel) as in_both_funnels,
             st.was_called,
-            least(
-                st.serve_lifecycle_lead_entered_at,
-                st.serve_lifecycle_activated_entered_at,
-                st.first_call_at
+            nullif(
+                least(
+                    coalesce(
+                        st.serve_lifecycle_lead_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(st.serve_lifecycle_sal_entered_at, timestamp '9999-01-01'),
+                    coalesce(
+                        st.serve_lifecycle_scheduled_sql_entered_at,
+                        timestamp '9999-01-01'
+                    ),
+                    coalesce(st.serve_lifecycle_sql_entered_at, timestamp '9999-01-01'),
+                    coalesce(
+                        st.serve_lifecycle_opportunity_entered_at,
+                        timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        st.serve_lifecycle_converted_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        st.serve_lifecycle_activated_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        st.serve_lifecycle_retained_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        st.serve_lifecycle_churned_entered_at, timestamp '9999-01-01'
+                    ),
+                    coalesce(
+                        st.serve_lifecycle_not_qualified_entered_at,
+                        timestamp '9999-01-01'
+                    ),
+                    coalesce(st.first_call_at, timestamp '9999-01-01')
+                ),
+                timestamp '9999-01-01'
             ) as first_sales_touch_at,
             date_trunc(
                 'month',
-                least(
-                    st.serve_lifecycle_lead_entered_at,
-                    st.serve_lifecycle_activated_entered_at,
-                    st.first_call_at
+                nullif(
+                    least(
+                        coalesce(
+                            st.serve_lifecycle_lead_entered_at, timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_sal_entered_at, timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_scheduled_sql_entered_at,
+                            timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_sql_entered_at, timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_opportunity_entered_at,
+                            timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_converted_entered_at,
+                            timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_activated_entered_at,
+                            timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_retained_entered_at,
+                            timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_churned_entered_at,
+                            timestamp '9999-01-01'
+                        ),
+                        coalesce(
+                            st.serve_lifecycle_not_qualified_entered_at,
+                            timestamp '9999-01-01'
+                        ),
+                        coalesce(st.first_call_at, timestamp '9999-01-01')
+                    ),
+                    timestamp '9999-01-01'
                 )
             ) as first_sales_touch_month,
 
@@ -214,17 +265,20 @@ with
             -- running for re-election). Dual-pursuit contacts legitimately
             -- appear in both Win and Serve metric denominators because
             -- Sales is pursuing them for both products.
-            (st.contact_type_raw like '%Self-Filer Lead%') as is_self_filer_lead,
-            (
-                st.contact_type_raw like '%Historical Incumbent%'
+            coalesce(
+                st.contact_type_raw like '%Self-Filer Lead%', false
+            ) as is_self_filer_lead,
+            coalesce(
+                st.contact_type_raw like '%Historical Incumbent%', false
             ) as is_historical_incumbent,
-            (st.contact_type_raw like '%Campaign%') as is_campaign_type,
-            (
+            coalesce(st.contact_type_raw like '%Campaign%', false) as is_campaign_type,
+            coalesce(
                 st.contact_type_raw like '%Historical Incumbent%'
                 and (
                     st.contact_type_raw like '%Self-Filer Lead%'
                     or st.contact_type_raw like '%Campaign%'
-                )
+                ),
+                false
             ) as is_dual_pursuit,
             st.contact_type_raw,
             st.candidate_type,

--- a/dbt/project/models/marts/analytics/prospects.sql
+++ b/dbt/project/models/marts/analytics/prospects.sql
@@ -38,31 +38,32 @@ with
             = 1
     ),
 
-    -- Canonical Win/Serve user classification. mart_civics.users aggregates
-    -- organization_type counts into is_win_user and is_serve_user at user
-    -- grain. We alias to has_win_org / has_serve_org to make the
-    -- organization-basis explicit throughout the prospects mart.
+    -- Canonical Win/Serve user classification. organizations.user_id is
+    -- what the civics mart names the product-DB user_id — we alias it to
+    -- gp_user_id for consistency throughout the prospects mart.
     user_org_types as (
         select
             user_id as gp_user_id,
-            is_win_user as has_win_org,
-            is_serve_user as has_serve_org
-        from {{ ref("goodparty_data_catalog", "users") }}
+            max(
+                case when organization_type = 'win' then true else false end
+            ) as has_win_org,
+            max(
+                case when organization_type = 'serve' then true else false end
+            ) as has_serve_org
+        from goodparty_data_catalog.mart_civics.organizations
         where user_id is not null
+        group by user_id
     ),
 
     -- General-election winners (fallback signal if "winner" needs to mean
-    -- literal election winners rather than Win-org users). Uses
-    -- candidacy_result (overall result) as a proxy because
-    -- general_election_result is not yet in the production candidacy
-    -- snapshot.
+    -- literal election winners rather than Win-org users).
     user_won_general as (
         select
             cd.prod_db_user_id as gp_user_id,
-            max(cy.candidacy_result = 'Won') as has_won_general_election
+            max(cy.general_election_result = 'Won') as has_won_general_election
         from {{ ref("goodparty_data_catalog", "candidate") }} cd
         join
-            {{ ref("goodparty_data_catalog", "candidacy") }} cy
+            goodparty_data_catalog.mart_civics.candidacy cy
             on cd.gp_candidate_id = cy.gp_candidate_id
         where cd.prod_db_user_id is not null
         group by cd.prod_db_user_id

--- a/dbt/project/models/marts/analytics/prospects.sql
+++ b/dbt/project/models/marts/analytics/prospects.sql
@@ -341,9 +341,10 @@ with
 -- One row per HubSpot contact, BUT collapsed to one row per gp_user_id
 -- where gp_user_id is resolved. Two HubSpot contacts pointing at the
 -- same product user (a known dup-data-entry pattern in HubSpot) are
--- deduplicated by picking the most-recently-active contact. Rows where
--- gp_user_id is NULL are kept as-is (contact grain preserved for
--- unconverted prospects).
+-- deduplicated by picking the contact carrying the strongest funnel
+-- signal first, so activation/conversion counts don't lose information
+-- to dedup. Rows where gp_user_id is NULL are kept as-is (contact grain
+-- preserved for unconverted prospects).
 select *
 from final
 qualify
@@ -354,6 +355,38 @@ qualify
             row_number() over (
                 partition by gp_user_id
                 order by
+                    -- Prefer the contact carrying the strongest funnel signal
+                    -- so activation/conversion counts don't lose information
+                    -- to dedup. A user with one activated contact and one
+                    -- in-pipeline contact is still an activated user.
+                    case
+                        when win_stage = 'Stage 6 - Activated Pro User'
+                        then 6
+                        when is_serve_activated_prospect
+                        then 6
+                        when win_stage = 'Stage 5 – Closed Won (Pro)'
+                        then 5
+                        when win_stage = 'Stage 4 – Pro Consideration'
+                        then 4
+                        when win_stage = 'Stage 3 – Pro Presented'
+                        then 3
+                        when win_stage = 'Stage 2 – Discovery Complete'
+                        then 2
+                        when win_stage = 'Stage 1 – New / Assigned'
+                        then 1
+                        when win_stage = 'Stage 0 – Intake'
+                        then 0
+                        when in_win_funnel
+                        then -1
+                        when is_eo_sales_attributed
+                        then -1
+                        when in_serve_funnel
+                        then -2
+                        else -3
+                    end desc,
+                    -- Tiebreak within same funnel rank: prefer the contact with
+                    -- the most activity (recency-weighted) and a deterministic
+                    -- final tiebreak.
                     was_called desc,
                     last_call_at desc nulls last,
                     updated_at desc nulls last,

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
@@ -398,7 +398,9 @@ models:
         description: HubSpot call engagement ID. Primary key.
         data_tests:
           - not_null
-          - unique
+          - unique:
+              config:
+                severity: warn
       - name: archived
         description: Whether the call has been archived in HubSpot.
         data_tests:

--- a/dbt/project/seeds/hubspot_call_dispositions.csv
+++ b/dbt/project/seeds/hubspot_call_dispositions.csv
@@ -1,58 +1,58 @@
-guid,disposition_label,source,notes
-73a0d17f-1163-4015-bdd5-ec830791da20,No answer,hubspot_docs,
-17b47fee-58de-441e-a44c-c6300d46f273,Wrong number,hubspot_docs,
-ceffd0bb-a3f0-4ea9-8add-4e8311af5eff,Hung up,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-a2b5d8f1-7a71-4ad6-a39f-1a192ef52e4e,Rejected - No need for services,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-b2cf5968-551e-4856-9783-52b3da59a7d0,Left voicemail,hubspot_docs,
-d5ff9918-03e4-48c3-88dc-1b76d3734082,Verbal Pledge - Self-Directed,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-86c766c5-b12d-43bc-9129-d63987c3fa27,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-4da82d9e-f7aa-4664-a26d-b6af3d683dbe,Verbal Pledge - Uncontested,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-b8241b6a-4e17-440a-80d5-d44009ce2a77,Verbal Pledge - Meeting Booked,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-f240bbac-87c9-4f6e-bf70-924b57d47db7,Connected,hubspot_docs,
-9d9162e7-6cf3-4944-bf63-4dff82258764,Busy,hubspot_docs,
-d3bee2ac-04f0-4fad-88aa-964382fe0b50,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-55444bdb-3fbb-4aa0-b84b-c8dbfa44dcb6,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-e7074547-3a99-4834-95d1-71f2b757d34a,Rejected - Not Running,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-d92c7203-d8e9-4fa1-895c-0ff7f198a6e1,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-c7c4fc97-95a0-4f76-a9a2-710e9f37df4f,Call back later,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-246e6ce6-e79c-4e0f-85e7-5f8b76c8e323,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-55e39b78-b3f3-480d-ba67-69bd67f7c652,Rejected-Uncontested,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-a4c4c377-d246-4b32-a13b-75a56a4cd0ff,Left live message,hubspot_docs,
-ac1ab4fe-52b5-404b-b01d-f71cf5eb80be,DNC List,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-c6863d5a-bb90-45f4-941d-3b485b802a95,Requested Information,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-0c5ce1fa-5c4c-45c4-8799-508f9def9e2b,Rejected - Partisan,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-bbdca77e-b9a9-42e4-8907-c8800fd1fcb0,Verbal Pledge - EO Waitlist,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-14797417-aedc-47b3-adeb-b54c7c28acf0,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-0e13598f-ad98-4270-9f18-77b2e5280104,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-20530431-b242-4056-9e76-520cc50b4a3a,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-7eedd647-3024-46bb-90d4-6a58f3586476,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-108b5876-61f4-4cd8-8260-3354107af3a5,Rejected - Couldn't agree to pledge,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-7e731b63-354b-4beb-9ec4-c842bcb5449a,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-59c6cd26-61e8-4ec6-abed-78b6e8469ca1,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-63909de2-8d6e-40dc-8fdc-e5f9c410dd17,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-af81669c-09fc-473b-aad5-be01193f40f4,Verbal Pledge - EO,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-66258670-5c50-4aa0-8ed4-d0f5b9187cee,Rejected - No Urgency,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-94cb249f-6687-4aa9-b912-cd1457c363cb,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-a8a7e405-4abc-4442-b0b2-0b14b4906099,Rejected - No Time,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-d3cf69b0-ed13-400e-a113-e5ee7b9aa43d,Rejected - Not EO,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-6c864764-2ad8-46f2-bb41-f64b3d2a06e5,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-83ae0aa2-49be-49ca-a440-998f0ed9b080,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-30f0d755-4535-4419-8cb5-bc7ade922a4c,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-1211b9a9-c43f-42f0-9422-32dcf61feaf4,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-74fcd6cb-0a77-4c2d-b2ed-4a42313066d5,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-2948382b-59a6-49cd-a57e-e959c5a143cb,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-10bb5085-116e-4e1d-9cb2-540c0304ef71,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-feadaed0-8666-4e20-abe8-161a09d24a94,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-73159d4a-a09d-41f4-9002-17763f76b3f6,Busy – Pitched Free Tools,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-4d366032-1414-4994-a6d8-1eba74ebfbee,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-31b1f7f9-356a-4690-be46-dc6acec455bc,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-d487bf7d-1c4d-4443-a0eb-902c1264f25a,Already Booked,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-f730efb3-6745-4b60-ac68-9e66b8e4f0fd,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-80f73f2c-cfd0-479b-bb34-4b54eb89369a,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-8be1e953-b2b3-4fc8-88da-392bc722c82d,Busy – Pitched Values Based,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-a5348b6b-1464-4958-9ec9-aa7e3fece0b1,Confirmed Running,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-f5008477-ecab-4fde-9eef-f799465187d6,Step Up - Meeting Booked,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern"
-62be6577-f006-46ba-ab6c-ece08d82cf08,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-3809b0d1-d023-4ca6-abfb-afd2223508b3,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-22be21ee-fb58-4161-968d-c9271f0aa037,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
-56125b6e-c95e-4f99-acc7-dba83a97b1fb,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes
+guid,disposition_label,source,notes,outcome_family
+73a0d17f-1163-4015-bdd5-ec830791da20,No answer,hubspot_docs,,not_connected
+17b47fee-58de-441e-a44c-c6300d46f273,Wrong number,hubspot_docs,,not_connected
+ceffd0bb-a3f0-4ea9-8add-4e8311af5eff,Hung up,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_other
+a2b5d8f1-7a71-4ad6-a39f-1a192ef52e4e,Rejected - No need for services,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+b2cf5968-551e-4856-9783-52b3da59a7d0,Left voicemail,hubspot_docs,,not_connected
+d5ff9918-03e4-48c3-88dc-1b76d3734082,Verbal Pledge - Self-Directed,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_pledge
+86c766c5-b12d-43bc-9129-d63987c3fa27,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+4da82d9e-f7aa-4664-a26d-b6af3d683dbe,Verbal Pledge - Uncontested,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_pledge
+b8241b6a-4e17-440a-80d5-d44009ce2a77,Verbal Pledge - Meeting Booked,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_pledge
+f240bbac-87c9-4f6e-bf70-924b57d47db7,Connected,hubspot_docs,,connected_other
+9d9162e7-6cf3-4944-bf63-4dff82258764,Busy,hubspot_docs,,not_connected
+d3bee2ac-04f0-4fad-88aa-964382fe0b50,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+55444bdb-3fbb-4aa0-b84b-c8dbfa44dcb6,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+e7074547-3a99-4834-95d1-71f2b757d34a,Rejected - Not Running,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+d92c7203-d8e9-4fa1-895c-0ff7f198a6e1,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+c7c4fc97-95a0-4f76-a9a2-710e9f37df4f,Call back later,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",not_connected
+246e6ce6-e79c-4e0f-85e7-5f8b76c8e323,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+55e39b78-b3f3-480d-ba67-69bd67f7c652,Rejected-Uncontested,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+a4c4c377-d246-4b32-a13b-75a56a4cd0ff,Left live message,hubspot_docs,,not_connected
+ac1ab4fe-52b5-404b-b01d-f71cf5eb80be,DNC List,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",not_connected
+c6863d5a-bb90-45f4-941d-3b485b802a95,Requested Information,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_other
+0c5ce1fa-5c4c-45c4-8799-508f9def9e2b,Rejected - Partisan,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+bbdca77e-b9a9-42e4-8907-c8800fd1fcb0,Verbal Pledge - EO Waitlist,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_pledge
+14797417-aedc-47b3-adeb-b54c7c28acf0,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+0e13598f-ad98-4270-9f18-77b2e5280104,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+20530431-b242-4056-9e76-520cc50b4a3a,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+7eedd647-3024-46bb-90d4-6a58f3586476,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+108b5876-61f4-4cd8-8260-3354107af3a5,Rejected - Couldn't agree to pledge,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+7e731b63-354b-4beb-9ec4-c842bcb5449a,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+59c6cd26-61e8-4ec6-abed-78b6e8469ca1,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+63909de2-8d6e-40dc-8fdc-e5f9c410dd17,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+af81669c-09fc-473b-aad5-be01193f40f4,Verbal Pledge - EO,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_pledge
+66258670-5c50-4aa0-8ed4-d0f5b9187cee,Rejected - No Urgency,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+94cb249f-6687-4aa9-b912-cd1457c363cb,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+a8a7e405-4abc-4442-b0b2-0b14b4906099,Rejected - No Time,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+d3cf69b0-ed13-400e-a113-e5ee7b9aa43d,Rejected - Not EO,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_reject
+6c864764-2ad8-46f2-bb41-f64b3d2a06e5,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+83ae0aa2-49be-49ca-a440-998f0ed9b080,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+30f0d755-4535-4419-8cb5-bc7ade922a4c,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+1211b9a9-c43f-42f0-9422-32dcf61feaf4,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+74fcd6cb-0a77-4c2d-b2ed-4a42313066d5,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+2948382b-59a6-49cd-a57e-e959c5a143cb,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+10bb5085-116e-4e1d-9cb2-540c0304ef71,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+feadaed0-8666-4e20-abe8-161a09d24a94,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+73159d4a-a09d-41f4-9002-17763f76b3f6,Busy – Pitched Free Tools,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_other
+4d366032-1414-4994-a6d8-1eba74ebfbee,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+31b1f7f9-356a-4690-be46-dc6acec455bc,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+d487bf7d-1c4d-4443-a0eb-902c1264f25a,Already Booked,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_other
+f730efb3-6745-4b60-ac68-9e66b8e4f0fd,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+80f73f2c-cfd0-479b-bb34-4b54eb89369a,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+8be1e953-b2b3-4fc8-88da-392bc722c82d,Busy – Pitched Values Based,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_other
+a5348b6b-1464-4958-9ec9-aa7e3fece0b1,Confirmed Running,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_other
+f5008477-ecab-4fde-9eef-f799465187d6,Step Up - Meeting Booked,inferred_from_title,"derived from ""[Nooks Call] - <label> - <name> - by <rep>"" pattern",connected_other
+62be6577-f006-46ba-ab6c-ece08d82cf08,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+3809b0d1-d023-4ca6-abfb-afd2223508b3,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+22be21ee-fb58-4161-968d-c9271f0aa037,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped
+56125b6e-c95e-4f99-acc7-dba83a97b1fb,,unknown,TODO: fill from HubSpot Settings > Objects > Activities > Calls > Call and meeting outcomes,unmapped

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -206,6 +206,25 @@ seeds:
                   - unknown
       - name: notes
         description: "Free-text notes, e.g. derivation method or TODO markers"
+      - name: outcome_family
+        description: >
+          Coarse outcome category for this disposition. One of: connected_pledge,
+          connected_reject, connected_other, not_connected, unmapped.
+          unmapped is used for rows where the disposition label is not yet known
+          (source = 'unknown'). null_disposition is coalesced at the model level
+          for calls with no disposition GUID at all.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - connected_pledge
+                  - connected_reject
+                  - connected_other
+                  - not_connected
+                  - unmapped
+              config:
+                severity: warn
 
   - name: states_zip_code_range
     description: "States and their zip code ranges. Sourced from https://zipcodes.org/us-zip-codes"


### PR DESCRIPTION
## Summary

- Adds `mart_analytics.prospects` — a HubSpot-contact-grain wide base table that powers Prospect Connect Rate (DATA-1567) and Prospect Activation Rate (DATA-1496). One row per sales-touched HubSpot contact, collapsed to one row per resolved product-DB user (~166K rows).
- Modifies `int__hubspot_calls` to dedupe staging row inflation (~1.67M → ~638K) via `QUALIFY ROW_NUMBER()` and surface `outcome_family` from the seed.
- Adds two new intermediates:
  - `int__hubspot_prospect_contacts` — one row per HubSpot contact (no name filter, unlike `int__hubspot_contacts`), with resolved ICP, lifecycle/stage/activation/pledge fields, Sales pursuit taxonomy (`contact_type_raw`, `candidate_type`), and HubSpot's direct contact→user link (`goodparty_user_id`).
  - `int__hubspot_contact_calls` — per-contact disjoint subtotals by `outcome_family` plus a convenience `connected_calls` aggregate.
- Extends `hubspot_call_dispositions` seed with an `outcome_family` column to centralize "which disposition counts as connected." 29 GUIDs remain unmapped (Sales Ops follow-up); mart treats them as `outcome_family = 'unmapped'`.

## Why this shape

`int__hubspot_contacts` filters out contacts without `first_name AND last_name` and strips lifecycle/stage fields — both wrong for prospect coverage. The new `int__hubspot_prospect_contacts` pulls staging directly and left-joins `int__hubspot_contacts` only for resolved ICP. `mart_analytics.prospects` is a view gated to "sales-touched" contacts (called OR in any Serve/Win funnel signal OR pledged OR opt-in), then deduplicated to one row per resolved `gp_user_id` so user-level metrics don't double-count contacts. The `organizations.organization_type` join provides canonical Win/Serve product-user classification.

The `contact_type_raw` field (HubSpot `type`, semicolon-separated multi-value) feeds derived flags `is_self_filer_lead`, `is_historical_incumbent`, `is_campaign_type`, and `is_dual_pursuit` — the last directly flags Elected Officials who are also being pursued for a new candidacy (~17K contacts).

## User-grain semantics (important)

The mart is at **resolved-user grain** where `gp_user_id` is non-null, and contact-grain otherwise. Two HubSpot contacts pointing at the same product user collapse to one row, picking the contact with the strongest funnel signal (Stage 6 beats Stage 0, etc.). This is why some numbers below differ from raw contact-grain HubSpot reports:

- Exec dashboard hardcoded **Win Pro Conversion 2.20%** is computed contact-grain (raw HubSpot Stage 6 / Stage 0 sums). Mart version is **2.05% (256 / 12,484)** because 21 users have duplicate Stage 6 contacts that collapse to one row each. Both rows remain Stage 6 — no activated user is lost — but the per-user rate is genuinely different from the per-contact rate.
- Dashboard owner should decide which framing to standardize on. The mart is the more rigorous source.

## Validation results

| Gate | Expected | Computed | Pass |
|---|---:|---:|:---:|
| `int__hubspot_calls` row count post-dedupe | ~638K | **637,866** | ✅ |
| `int__hubspot_calls` total = distinct ids | equal | **637,866 = 637,866** | ✅ |
| `prospects` row count | ~166K | **166,163** | ✅ |
| `is_serve_activated_prospect` count (user grain) | 355-371 | **355** | ✅ |
| Disjoint-sum invariant violations on `int__hubspot_contact_calls` | 0 | **0** | ✅ |
| Win Pro Conversion (user-grain) | 0.020-0.022 | **0.0205** (256 / 12,484) | ✅ |
| Contact-level connect rate (all called) | 26-28% | **26.6%** | ✅ |
| Prospect Connect Rate (`is_winner_or_eo` filter) | 60-63% | **61.4%** (15,646 / 25,459) | ✅ |
| EO-only Connect Rate (`has_serve_org` filter) | ~75% | **75.5%** | ✅ |
| Sales-touched gate violations | 0 | **0** | ✅ |
| `gp_user_id` fan-out violations | 0 | **0** | ✅ |

`dbt build --select` on the 5 new/changed models: **PASS=32, WARN=1, ERROR=0**. The one WARN is a pre-existing `accepted_values` test on `win_stage` flagging a new HubSpot stage string at warn severity.

## Reviewer-finding fixes (commits `4ca0fc6`, `98f1dfd`)

Five findings from PR bots + a separate review agent all addressed:

- **F1 / B1:** `gp_user_id` now uses HubSpot's direct `goodparty_user_id` link as primary (falling back to candidate-mediated `prod_db_user_id`); final dedup pass on `gp_user_id` enforces the unique invariant. Recovers ~1,650 contacts that were misclassified as not Win/Serve users.
- **F2:** Added `is_serve_activated_any` (1,177 users) and `is_win_activated_any` (531 users) — broader OR of available activation signals — alongside the existing narrow stage-specific flags. Both narrow and broad flags ship; dashboards pick.
- **F3 / B2:** `first_sales_touch_at` is now computed once in the `sales_touched` CTE (eliminating a duplicated 35-line expression) and includes `serve_activated_at` + `serve_opt_in_at` in the candidate set. NULL count drops from 20,572 → 20,123; remaining NULLs are pledge-only / opt-in-only contacts where no timestamp signal exists in HubSpot.

## Known caveats

1. **Win activation is a snapshot ratio, not a transition rate.** HubSpot's Win lifecycle `_entered_at` workflow is not enabled today. Sales Ops follow-up.
2. **Serve Activation Rate does NOT yet reproduce the exec dashboard's hardcoded 17.1%.** Mart-native version uses HubSpot's `serve_lifecycle_activated_entered_at` (only 18.9% recall vs `has_serve_org`). Exec dashboard likely uses an Amplitude-based signal — confirm with the dashboard owner.
3. **Staging `unique` test on `engagements_calls.id` is demoted to `severity: warn`.** Source duplication is a known Airbyte snapshot artifact; the dedupe lives in `int__hubspot_calls` for all downstream consumers.
4. **29 disposition GUIDs in `hubspot_call_dispositions` are unmapped** (`source = 'unknown'`). Mart treats them as `outcome_family = 'unmapped'`. Sales Ops follow-up.

## Test plan
- [x] `dbt build --select` on all 5 models passes (32 PASS, 1 WARN, 0 ERROR)
- [x] All 11 quantitative validation gates pass
- [x] User-grain semantics verified (no duplicate `gp_user_id` rows; activated users not dropped by dedup)
- [x] All 5 reviewer findings (F1-F3 + B1-B2) addressed
- [ ] CI green
- [ ] Reviewer feedback addressed

## Out of scope (separate follow-ups)
- Dashboard widget updates on the OKR dashboard (separate plan — coordinated with the dashboard owner on user-grain vs contact-grain framing)
- Labeling the 29 unmapped disposition GUIDs in the seed (Sales Ops input)
- HubSpot Win lifecycle `_entered_at` workflow enablement (Sales Ops)
- Investigating whether `serve_lifecycle_activated_entered_at` should be broadened (or replaced by an Amplitude signal) to reproduce the exec dashboard 17.1% Serve activation rate