### PR TITLE
[DATA-1523] Phase 1, wire viability scoring into civics mart

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_2025.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_2025.sql
@@ -87,6 +87,7 @@ with
 
             -- assessments
             viability_scores.viability_rating_2_0 as viability_score,
+            viability_scores.viability_rating_automated as score_viability_automated,
             cast(cast(tbl_companies.win_number as float) as int) as win_number,
             tbl_companies.win_number_model,
 
@@ -180,6 +181,7 @@ select
     general_runoff_election_date,
     br_position_database_id,
     viability_score,
+    score_viability_automated,
     win_number,
     win_number_model,
     has_ddhq_match,

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
@@ -108,6 +108,11 @@ with
             = 1
     ),
 
+    viability_scoring as (
+        select techspeed_candidate_code, viability_rating_2_0, score_viability_automated
+        from {{ ref("int__techspeed_viability_scoring") }}
+    ),
+
     candidacies as (
         -- gp_candidate_id and gp_election_id use WINDOW propagation so all raw
         -- rows of the same person/election adopt BR's canonical if ANY candidacy
@@ -148,7 +153,7 @@ with
             cast(null as string) as hubspot_company_ids,
 
             'techspeed' as candidate_id_source,
-            techspeed_candidate_code as candidate_code,
+            source.techspeed_candidate_code as candidate_code,
 
             party as party_affiliation,
             is_incumbent,
@@ -178,7 +183,8 @@ with
 
             source.br_position_database_id,
 
-            cast(null as float) as viability_score,
+            vs.viability_rating_2_0 as viability_score,
+            vs.score_viability_automated,
             cast(null as int) as win_number,
             cast(null as string) as win_number_model,
 
@@ -189,8 +195,11 @@ with
         left join
             canonical_candidacy as xw
             on source.techspeed_candidate_code = xw.ts_source_candidate_id
+        left join
+            viability_scoring as vs
+            on source.techspeed_candidate_code = vs.techspeed_candidate_code
         where
-            techspeed_candidate_code is not null
+            source.techspeed_candidate_code is not null
             -- After the source CTE's BR fallback substitution, this passes
             -- rows that had EITHER a TS date OR a BR-resolved date.
             and coalesce(general_election_date_parsed, primary_election_date_parsed)

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -65,6 +65,7 @@ with
             is_incumbent,
             office_type,
             br_position_database_id,
+            cast(null as string) as score_viability_automated,
             array_compact(
                 array('hubspot', case when has_ddhq_match then 'ddhq' end)
             ) as source_systems
@@ -141,6 +142,7 @@ with
             br.viability_score,
             br.win_number,
             br.win_number_model,
+            ts.score_viability_automated,
             array_compact(
                 array(
                     case when br.gp_candidacy_id is not null then 'ballotready' end,
@@ -193,6 +195,7 @@ with
             is_incumbent,
             office_type,
             br_position_database_id,
+            score_viability_automated,
             source_systems
         from archive_2025
         union all
@@ -226,6 +229,7 @@ with
             is_incumbent,
             office_type,
             br_position_database_id,
+            score_viability_automated,
             source_systems
         from merged_since_2026
     ),
@@ -351,6 +355,7 @@ select
             effective_date="icp.icp_win_effective_date",
         )
     }} as is_win_supersize_icp,
+    deduplicated.score_viability_automated,
     deduplicated.source_systems,
     deduplicated.created_at,
     deduplicated.updated_at

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -65,7 +65,7 @@ with
             is_incumbent,
             office_type,
             br_position_database_id,
-            cast(null as string) as score_viability_automated,
+            score_viability_automated,
             array_compact(
                 array('hubspot', case when has_ddhq_match then 'ddhq' end)
             ) as source_systems

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -138,8 +138,10 @@ with
                 br.br_position_database_id,
                 ts.br_position_database_id
             ) as br_position_database_id,
-            -- BR-only viability fields
-            br.viability_score,
+            -- BR doesn't compute viability_score (always NULL upstream); TS's
+            -- MLflow score fills it in via int__civics_candidacy_techspeed.
+            -- win_number / win_number_model remain BR-only.
+            coalesce(br.viability_score, ts.viability_score) as viability_score,
             br.win_number,
             br.win_number_model,
             ts.score_viability_automated,

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -663,7 +663,34 @@ models:
                 error_if: ">300"
 
       - name: viability_score
-        description: Model-generated viability rating
+        description: >
+          Numeric viability rating (0..5) from the TechSpeed-trained
+          MLflow model (int__techspeed_viability_scoring.viability_rating_2_0).
+          Populated for TS-sourced candidacies via join in
+          int__civics_candidacy_techspeed. NULL for non-TS rows that have
+          no upstream score and for the small fraction of TS rows the
+          MLflow model skips due to incomplete features.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 5
+
+      - name: score_viability_automated
+        description: >
+          String category derived from viability_score by the MLflow model.
+          Values: "No Chance" (score < 1), "Unlikely to Win" (1..2),
+          "Has a Chance" (2..3), "Likely to Win" (3..4), "Frontrunner"
+          (4..5). NULL where viability_score is NULL.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - "No Chance"
+                  - "Unlikely to Win"
+                  - "Has a Chance"
+                  - "Likely to Win"
+                  - "Frontrunner"
 
       - name: win_number
         description: Estimated votes needed to win

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -398,7 +398,9 @@ models:
         BR > TS > DDHQ (gp_api carries no value):
           is_open_seat
         BR-only:
-          hubspot_company_ids, viability_score, win_number, win_number_model
+          hubspot_company_ids, win_number, win_number_model
+        TS-derived (BR/DDHQ/gp_api don't compute viability):
+          viability_score, score_viability_automated
 
       created_at semantics: gp_api's created_at reflects "campaign registered
       in PD," which may post-date BR's data acquisition timestamp. Downstream

--- a/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
+++ b/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
@@ -5,12 +5,18 @@
     )
 }}
 
--- B3: warn if >30% of TS candidacies are missing viability_score (PR 1
--- baseline), error if >50%. PR 2 tightens these to 1%/2% once parsing
--- closes the candidate_code mismatch and coverage approaches MLflow ceiling.
+-- B3: PR-1 baseline guard on absolute counts of TS candidacies missing
+-- viability_score. Thresholds pegged at the PR-1 TS row count of ~51,748:
+-- warn_if=15524  (~30% of baseline)
+-- error_if=25874 (~50% of baseline)
+-- PR 2 (Task 12) recomputes both integers against the then-current row
+-- count and tightens to ~1%/~2% after the parser fix lifts coverage to
+-- the MLflow ceiling. Absolute counts are intentional here: a percentage-
+-- based denominator would silently absorb a regression as TS volume grows.
 --
--- Default severity is 'error' (not 'warn') so error_if produces an actual
--- error rather than being capped at warn.
+-- Default severity is 'error' (not 'warn'). Per dbt's severity reference,
+-- default 'error' evaluates error_if first, then warn_if; setting
+-- severity='warn' would cap max severity at warn and skip the error gate.
 select gp_candidacy_id
 from {{ ref("candidacy") }}
 where array_contains(source_systems, 'techspeed') and viability_score is null

--- a/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
+++ b/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        warn_if=">15524",
+        error_if=">25874",
+    )
+}}
+
+-- B3: warn if >30% of TS candidacies are missing viability_score (PR 1
+-- baseline), error if >50%. PR 2 tightens these to 1%/2% once parsing
+-- closes the candidate_code mismatch and coverage approaches MLflow ceiling.
+--
+-- Default severity is 'error' (not 'warn') so error_if produces an actual
+-- error rather than being capped at warn.
+select gp_candidacy_id
+from {{ ref("candidacy") }}
+where array_contains(source_systems, 'techspeed') and viability_score is null


### PR DESCRIPTION
## Summary

Phase 1 of three-PR DATA-1523 sequence. Wires the existing MLflow viability scoring (`int__techspeed_viability_scoring`) into `mart_civics.candidacy` via a LEFT JOIN on `techspeed_candidate_code`.

- `int__civics_candidacy_techspeed`: adds `viability_scoring` CTE and LEFT JOIN; replaces `cast(null as float) as viability_score` with the joined value; surfaces `score_viability_automated` (string category).
- `mart_civics.candidacy`: surfaces both columns (`viability_score`, `score_viability_automated`) through `archive_2025`, `merged_since_2026`, the `combined` UNION ALL arms, and the final SELECT.
- `m_civics.yaml`: expands `viability_score` description; adds `score_viability_automated` doc + `accepted_values` test; adds `accepted_range(0..5)` test on `viability_score`.
- `tests/mart_candidacy_techspeed_viability_coverage_warn.sql`: new B3 threshold test — warn at >30% missing (15,524 rows), error at >50% (25,874 rows). Default `severity='error'` so `error_if` actually fires.

PR 2 (to follow) fixes the upstream name-parsing bug that prevents the remaining ~26% of TS rows from matching, taking coverage to ~99.7%.

## Why this PR alone is loose-thresholded

Distinct-code match rate today: ~65% (39,136 / 59,860). The plan expected ~74%; the gap is a freshness mismatch — `int__techspeed_viability_scoring` last refreshed 2026-05-24 while `int__civics_candidacy_techspeed` rebuilds with current TS data. Either the next scheduled run of viability scoring narrows the gap, or PR 2's parser fix replaces the bottleneck entirely (since codes shift under the parser change, post-Phase-2 coverage will be set by whatever matches against the freshly-rebuilt viability table, not by today's snapshot).

## Test plan

Local environment couldn't run the mart-level `dbt build` due to an unrelated dev-schema deferral cascade on `int__civics_candidacy_gp_api`. CI will rebuild from scratch against deferred prod.

After CI builds in its preview schema:
- [ ] `int__civics_candidacy_techspeed` and `candidacy` build cleanly
- [ ] B1 (`accepted_range(0..5)` on `viability_score`) passes
- [ ] B2 (`accepted_values` on `score_viability_automated`) passes
- [ ] B3 (coverage threshold) passes — well below warn threshold
- [ ] Spot check: ≥10 TS-source rows on candidacy with non-null `viability_score` and matching string category

What I verified locally before pushing:
- [x] `int__civics_candidacy_techspeed` builds; pre-existing tests still pass
- [x] 10-row spot check on `int__civics_candidacy_techspeed` returns non-null `viability_score` (0..5) with matching `score_viability_automated`
- [x] `dbt parse` + `dbt compile --select mart_candidacy_techspeed_viability_coverage_warn` succeed
- [x] yaml `accepted_values` list matches the branching in `int__techspeed_viability_scoring.py` (5 categories, exact strings/order)

## Design

`.tickets/DATA-1523/20_viability_completeness_design_v2.md` (canonical spec) and `.tickets/DATA-1523/24_viability_completeness_plan_v3.md` (this PR = Tasks 2-6).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new mart columns and changes how `viability_score` is populated for merged candidacies; impact is analytical/data-contract rather than runtime security, with partial TS coverage expected until a follow-up PR.
> 
> **Overview**
> **Phase 1 (DATA-1523)** connects existing TechSpeed MLflow viability output into the civics **`candidacy`** mart instead of leaving `viability_score` null for TechSpeed rows.
> 
> `int__civics_candidacy_techspeed` adds a `viability_scoring` CTE and **LEFT JOIN** on `techspeed_candidate_code`, mapping `viability_rating_2_0` → `viability_score` and exposing **`score_viability_automated`**. Minor qualify/filter fixes qualify `candidate_code` via `source`.
> 
> `candidacy` passes both fields through archive and 2026+ merge paths: **`viability_score`** becomes `coalesce(br.viability_score, ts.viability_score)` (BR stays null upstream; TS supplies the score), and **`score_viability_automated`** comes from TS only (2025 archive gets `cast(null)`).
> 
> `m_civics.yaml` documents the columns and adds **`accepted_range(0..5)`** on `viability_score` and **`accepted_values`** on the five automated category strings. New test **`mart_candidacy_techspeed_viability_coverage_warn`** fails if more than ~30% of TechSpeed-tagged mart rows lack `viability_score` (loose until a follow-up PR tightens join coverage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a530bdd4333f01bb6d359b88759a18e52397c5aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->