### PR TITLE
[DATA-1523] Phase 2, fix TS staging name parsing

### DIFF
--- a/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_candidates_clean.sql
+++ b/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_candidates_clean.sql
@@ -98,68 +98,7 @@ with
                 else 'future_election'
             end as uploaded,
             _ab_source_file_url,
-            _airbyte_extracted_at,
-            -- Remove name suffixes (Jr, Sr, II, III, etc.)
-            {{ remove_name_suffixes("last_name") }} as last_name_no_suffix,
-            -- Remove trailing commas
-            regexp_replace(last_name_no_suffix, ',$', '') as last_name_no_comma,
-            -- Remove trailing single character after space
-            case
-                when
-                    length(last_name_no_comma) >= 2
-                    and substring(last_name_no_comma, length(last_name_no_comma) - 1, 1)
-                    = ' '
-                then substring(last_name_no_comma, 1, length(last_name_no_comma) - 2)
-                else last_name_no_comma
-            end as last_name_trimmed,
-            -- Handle middle initial with period but no space
-            case
-                when
-                    length(last_name_trimmed) >= 3
-                    and substring(last_name_trimmed, 2, 1) = '.'
-                    and substring(last_name_trimmed, 3, 1) != ' '
-                then substring(last_name_trimmed, 3)
-                else last_name_trimmed
-            end as last_name_clean,
-            -- Extract suggested last name (everything after last space)
-            case
-                when last_name_clean like '% %'
-                then
-                    case
-                        -- Handle special prefixes that should be kept
-                        when last_name_clean like '%De La %'
-                        then
-                            'De La ' || substring(
-                                last_name_clean,
-                                position('De La ' in last_name_clean) + 7
-                            )
-                        when last_name_clean like '%Van %'
-                        then
-                            'Van ' || substring(
-                                last_name_clean, position('Van ' in last_name_clean) + 4
-                            )
-                        when last_name_clean like '% van %'
-                        then
-                            ' van ' || substring(
-                                last_name_clean,
-                                position(' van ' in last_name_clean) + 5
-                            )
-                        when last_name_clean like '%Le %'
-                        then
-                            'Le ' || substring(
-                                last_name_clean, position('Le ' in last_name_clean) + 3
-                            )
-                        else
-                            -- Default: take everything after the last space
-                            substring(
-                                last_name_clean,
-                                length(last_name_clean)
-                                - position(' ' in reverse(last_name_clean))
-                                + 2
-                            )
-                    end
-                else last_name_clean
-            end as suggested_last
+            _airbyte_extracted_at
         from {{ ref("int__techspeed_candidates") }}
         {% if is_incremental() %}
             where
@@ -175,7 +114,7 @@ with
                 then null
                 when last_name is null
                 then null
-                when nullif(trim(suggested_last), '') is null
+                when nullif(trim(last_name), '') is null
                 then null
                 when state is null
                 then null
@@ -185,7 +124,7 @@ with
                     {{
                         generate_candidate_code(
                             "first_name",
-                            "suggested_last",
+                            "last_name",
                             "state",
                             "office_type",
                             "city",
@@ -199,7 +138,7 @@ with
             and trim(first_name) <> ''
             and trim(last_name) is not null
             and trim(last_name) <> ''
-            and nullif(trim(suggested_last), '') is not null
+            and nullif(trim(last_name), '') is not null
             and trim(state) is not null
             and trim(state) <> ''
             and trim(city) is not null
@@ -236,7 +175,7 @@ with
 select
     candidate_id_source,
     first_name,
-    suggested_last as last_name,
+    last_name,
     candidate_type,
     email,
     techspeed_candidate_code,

--- a/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_candidates_clean.sql
+++ b/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_candidates_clean.sql
@@ -138,7 +138,6 @@ with
             and trim(first_name) <> ''
             and trim(last_name) is not null
             and trim(last_name) <> ''
-            and nullif(trim(last_name), '') is not null
             and trim(state) is not null
             and trim(state) <> ''
             and trim(city) is not null

--- a/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_to_hubspot.yaml
+++ b/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_to_hubspot.yaml
@@ -65,7 +65,7 @@ models:
           - not_null
 
   - name: int__techspeed_candidates_clean
-    description: "Further cleaned techspeed candidate data with name standardization and district cleaning"
+    description: "Filtered and deduped techspeed candidates with district/office_type/city normalization and primary-key (techspeed_candidate_code) generation. Last-name standardization happens upstream in staging."
     columns:
       - name: candidate_id_source
         description: "Unique identifier for the candidate from source system"
@@ -74,12 +74,12 @@ models:
         tests:
           - not_null
       - name: last_name
-        description: "Cleaned last name without suffixes"
+        description: "Last name passed through from staging (cleaning happens in stg_airbyte_source__techspeed_gdrive_candidates)."
         tests:
           - not_null
           - last_name_cleaning_quality
       - name: techspeed_candidate_code
-        description: "Generated unique code for the candidate"
+        description: "Unique candidate code from first_name + last_name + state + office_type + city. Value depends on the staging last_name parser and shifts when the parser changes."
         tests:
           - not_null
           - unique

--- a/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive_candidates.sql
+++ b/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive_candidates.sql
@@ -16,17 +16,21 @@ with
             -- Candidate identity
             trim(first_name) as first_name,
             -- Strip middle-initial pollution from last_name (DATA-1523).
-            -- Two regex_replace passes: (1) strip one-or-more leading
-            -- initial tokens ("A.", "A. ", "A ", "M.J. ", "E L ") that
-            -- look like middle initials but were merged with the surname
-            -- in TS source data; (2) strip a trailing " X" pattern.
+            -- Three regex_replace passes after remove_name_suffixes:
+            -- (1) strip a trailing comma left behind by suffix removal
+            -- ("Smith, Jr." -> "Smith," -> "Smith"); (2) strip one-or-more
+            -- leading initial tokens ("A.", "A. ", "A ", "M.J. ", "E L ")
+            -- that look like middle initials but were merged with the
+            -- surname in TS source data; (3) strip a trailing " X" pattern.
             -- Lookarounds prevent over-stripping legitimate compound
             -- surnames ("De La Cruz", "Da Silva", "St. John", "AB Smith"),
             -- which have no period or space between the leading cap(s)
             -- and the next character.
             regexp_replace(
                 regexp_replace(
-                    {{ remove_name_suffixes("trim(last_name)") }},
+                    regexp_replace(
+                        {{ remove_name_suffixes("trim(last_name)") }}, ',$', ''
+                    ),
                     '^([A-Z][.] ?|[A-Z] )+(?=[A-Za-z])',
                     ''
                 ),

--- a/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive_candidates.sql
+++ b/dbt/project/models/staging/airbyte_source/techspeed_grive/stg_airbyte_source__techspeed_gdrive_candidates.sql
@@ -15,7 +15,24 @@ with
 
             -- Candidate identity
             trim(first_name) as first_name,
-            trim(last_name) as last_name,
+            -- Strip middle-initial pollution from last_name (DATA-1523).
+            -- Two regex_replace passes: (1) strip one-or-more leading
+            -- initial tokens ("A.", "A. ", "A ", "M.J. ", "E L ") that
+            -- look like middle initials but were merged with the surname
+            -- in TS source data; (2) strip a trailing " X" pattern.
+            -- Lookarounds prevent over-stripping legitimate compound
+            -- surnames ("De La Cruz", "Da Silva", "St. John", "AB Smith"),
+            -- which have no period or space between the leading cap(s)
+            -- and the next character.
+            regexp_replace(
+                regexp_replace(
+                    {{ remove_name_suffixes("trim(last_name)") }},
+                    '^([A-Z][.] ?|[A-Z] )+(?=[A-Za-z])',
+                    ''
+                ),
+                '(?<=[A-Za-z]) [A-Z]$',
+                ''
+            ) as last_name,
             trim(regexp_replace(src.state, '[^A-Za-z ]', '')) as state,
             coalesce(
                 cs.state_cleaned_postal_code,

--- a/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
+++ b/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
@@ -1,14 +1,42 @@
 {{
     config(
-        warn_if="> 517",
-        error_if="> 1034",
+        severity="error",
+        warn_if=">= 1",
+        error_if=">= 2",
     )
 }}
 
--- B3: warn if >1% of TS candidacies are missing viability_score,
--- error if >2%. Empirical MLflow floor is ~0.3%, so 1% absorbs
--- legitimate skips plus small ingestion drift. Default severity
--- 'error' (not 'warn') so error_if produces an actual error.
-select gp_candidacy_id
-from {{ ref("candidacy") }}
-where array_contains(source_systems, 'techspeed') and viability_score is null
+-- B3: emit one indicator row per breached threshold.
+-- 0 rows = TS viability coverage healthy
+-- 1 row  = WARN: >1% of TS candidacies missing viability_score
+-- 2 rows = ERROR: >2% (both indicator rows fire)
+-- Empirical MLflow floor is ~0.3%; 1% absorbs legitimate skips plus
+-- small ingestion drift. Computed dynamically against the current
+-- denominator so the contract holds regardless of TS volume drift
+-- (prior fixed-integer thresholds went stale with population shifts).
+with
+    stats as (
+        select
+            count(*) as total_ts,
+            sum(case when viability_score is null then 1 else 0 end) as missing_count
+        from {{ ref("candidacy") }}
+        where array_contains(source_systems, 'techspeed')
+    )
+
+select
+    'warn_gt_1pct' as breach,
+    total_ts,
+    missing_count,
+    cast(missing_count * 1.0 / total_ts as decimal(5, 4)) as pct_missing
+from stats
+where missing_count * 1.0 / total_ts > 0.01
+
+union all
+
+select
+    'error_gt_2pct' as breach,
+    total_ts,
+    missing_count,
+    cast(missing_count * 1.0 / total_ts as decimal(5, 4)) as pct_missing
+from stats
+where missing_count * 1.0 / total_ts > 0.02

--- a/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
+++ b/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
@@ -1,22 +1,14 @@
 {{
     config(
-        warn_if=">15524",
-        error_if=">25874",
+        warn_if="> 517",
+        error_if="> 1034",
     )
 }}
 
--- B3: PR-1 baseline guard on absolute counts of TS candidacies missing
--- viability_score. Thresholds pegged at the PR-1 TS row count of ~51,748:
--- warn_if=15524  (~30% of baseline)
--- error_if=25874 (~50% of baseline)
--- PR 2 (Task 12) recomputes both integers against the then-current row
--- count and tightens to ~1%/~2% after the parser fix lifts coverage to
--- the MLflow ceiling. Absolute counts are intentional here: a percentage-
--- based denominator would silently absorb a regression as TS volume grows.
---
--- Default severity is 'error' (not 'warn'). Per dbt's severity reference,
--- default 'error' evaluates error_if first, then warn_if; setting
--- severity='warn' would cap max severity at warn and skip the error gate.
+-- B3: warn if >1% of TS candidacies are missing viability_score,
+-- error if >2%. Empirical MLflow floor is ~0.3%, so 1% absorbs
+-- legitimate skips plus small ingestion drift. Default severity
+-- 'error' (not 'warn') so error_if produces an actual error.
 select gp_candidacy_id
 from {{ ref("candidacy") }}
 where array_contains(source_systems, 'techspeed') and viability_score is null

--- a/dbt/project/tests/mart_candidate_techspeed_last_name_no_middle_initial.sql
+++ b/dbt/project/tests/mart_candidate_techspeed_last_name_no_middle_initial.sql
@@ -1,6 +1,7 @@
 -- A2: end-to-end assertion on mart_civics.candidate for TS-source-systems
 -- rows. Filtered to exclude rows that ALSO carry the 'hubspot' source
--- (legacy 2025 archive, addressed by a separate ticket).
+-- (legacy 2025 archive, addressed by a separate ticket). Matches the
+-- staging-layer A1 bug-pattern set plus a trailing-comma guard.
 select gp_candidate_id, last_name, source_systems
 from {{ ref("candidate") }}
 where
@@ -11,4 +12,5 @@ where
         last_name rlike '^[A-Z][.] ?[A-Za-z]'
         or last_name rlike '^[A-Z] [A-Za-z]'
         or last_name rlike '[A-Za-z] [A-Z]$'
+        or last_name rlike ',$'
     )

--- a/dbt/project/tests/mart_candidate_techspeed_last_name_no_middle_initial.sql
+++ b/dbt/project/tests/mart_candidate_techspeed_last_name_no_middle_initial.sql
@@ -1,0 +1,14 @@
+-- A2: end-to-end assertion on mart_civics.candidate for TS-source-systems
+-- rows. Filtered to exclude rows that ALSO carry the 'hubspot' source
+-- (legacy 2025 archive, addressed by a separate ticket).
+select gp_candidate_id, last_name, source_systems
+from {{ ref("candidate") }}
+where
+    last_name is not null
+    and array_contains(source_systems, 'techspeed')
+    and not array_contains(source_systems, 'hubspot')
+    and (
+        last_name rlike '^[A-Z][.] ?[A-Za-z]'
+        or last_name rlike '^[A-Z] [A-Za-z]'
+        or last_name rlike '[A-Za-z] [A-Z]$'
+    )

--- a/dbt/project/tests/parser_idempotency_techspeed_staging.sql
+++ b/dbt/project/tests/parser_idempotency_techspeed_staging.sql
@@ -24,8 +24,10 @@ with
             ('Mac Donald', 'Mac Donald'),
             ('O''Brien', 'O''Brien'),
             ('AB Smith', 'AB Smith'),
-            -- Suffix-bearing (suffix stripped)
-            ('Smith Jr.', 'Smith')
+            -- Suffix-bearing (suffix stripped; trailing comma cleanup)
+            ('Smith Jr.', 'Smith'),
+            ('Smith, Jr.', 'Smith'),
+            ('Smith,', 'Smith')
     ),
 
     parser as (
@@ -34,7 +36,7 @@ with
             expected,
             regexp_replace(
                 regexp_replace(
-                    {{ remove_name_suffixes("input") }},
+                    regexp_replace({{ remove_name_suffixes("input") }}, ',$', ''),
                     '^([A-Z][.] ?|[A-Z] )+(?=[A-Za-z])',
                     ''
                 ),
@@ -51,7 +53,7 @@ with
             parsed_once,
             regexp_replace(
                 regexp_replace(
-                    {{ remove_name_suffixes("parsed_once") }},
+                    regexp_replace({{ remove_name_suffixes("parsed_once") }}, ',$', ''),
                     '^([A-Z][.] ?|[A-Z] )+(?=[A-Za-z])',
                     ''
                 ),

--- a/dbt/project/tests/parser_idempotency_techspeed_staging.sql
+++ b/dbt/project/tests/parser_idempotency_techspeed_staging.sql
@@ -1,0 +1,66 @@
+-- A3: assert the parser produces expected outputs on a fixed fixture
+-- AND is idempotent (applying it twice equals applying it once).
+with
+    fixture(input, expected) as (
+        values
+            -- Bug shapes to clean
+            ('A Bressler', 'Bressler'),
+            ('A. Bressler', 'Bressler'),
+            ('A.Bressler', 'Bressler'),
+            ('Bressler A', 'Bressler'),
+            ('A. C. Campbell', 'Campbell'),
+            ('A.C. Claytor', 'Claytor'),
+            ('E L Zumpano', 'Zumpano'),
+            ('M.J. Holbrook', 'Holbrook'),
+            -- Already-clean inputs (unchanged)
+            ('Smith', 'Smith'),
+            ('Bressler', 'Bressler'),
+            ('Smith-Jones', 'Smith-Jones'),
+            -- Compound surnames (must be preserved)
+            ('De La Cruz', 'De La Cruz'),
+            ('De Leon', 'De Leon'),
+            ('Da Silva', 'Da Silva'),
+            ('St. John', 'St. John'),
+            ('Mac Donald', 'Mac Donald'),
+            ('O''Brien', 'O''Brien'),
+            ('AB Smith', 'AB Smith'),
+            -- Suffix-bearing (suffix stripped)
+            ('Smith Jr.', 'Smith')
+    ),
+
+    parser as (
+        select
+            input,
+            expected,
+            regexp_replace(
+                regexp_replace(
+                    {{ remove_name_suffixes("input") }},
+                    '^([A-Z][.] ?|[A-Z] )+(?=[A-Za-z])',
+                    ''
+                ),
+                '(?<=[A-Za-z]) [A-Z]$',
+                ''
+            ) as parsed_once
+        from fixture
+    ),
+
+    idempotency as (
+        select
+            input,
+            expected,
+            parsed_once,
+            regexp_replace(
+                regexp_replace(
+                    {{ remove_name_suffixes("parsed_once") }},
+                    '^([A-Z][.] ?|[A-Z] )+(?=[A-Za-z])',
+                    ''
+                ),
+                '(?<=[A-Za-z]) [A-Z]$',
+                ''
+            ) as parsed_twice
+        from parser
+    )
+
+select input, expected, parsed_once, parsed_twice
+from idempotency
+where parsed_once != expected or parsed_once != parsed_twice

--- a/dbt/project/tests/stg_techspeed_last_name_no_middle_initial.sql
+++ b/dbt/project/tests/stg_techspeed_last_name_no_middle_initial.sql
@@ -1,0 +1,14 @@
+-- A1: staging last_name should not match the bug-pattern regex after
+-- the Phase 2 parser is applied. Covers leading single-initial, leading
+-- multi-initial (catches "A. C. Campbell"-style cases), and trailing
+-- single-initial. Compound surnames are excluded by the parser's
+-- lookarounds and shouldn't match either.
+select last_name
+from {{ ref("stg_airbyte_source__techspeed_gdrive_candidates") }}
+where
+    last_name is not null
+    and (
+        last_name rlike '^[A-Z][.] ?[A-Za-z]'
+        or last_name rlike '^[A-Z] [A-Za-z]'
+        or last_name rlike '[A-Za-z] [A-Z]$'
+    )

--- a/dbt/project/tests/stg_techspeed_last_name_no_middle_initial.sql
+++ b/dbt/project/tests/stg_techspeed_last_name_no_middle_initial.sql
@@ -1,8 +1,9 @@
 -- A1: staging last_name should not match the bug-pattern regex after
 -- the Phase 2 parser is applied. Covers leading single-initial, leading
--- multi-initial (catches "A. C. Campbell"-style cases), and trailing
--- single-initial. Compound surnames are excluded by the parser's
--- lookarounds and shouldn't match either.
+-- multi-initial (catches "A. C. Campbell"-style cases), trailing
+-- single-initial, and trailing comma (left behind by suffix removal on
+-- "Smith, Jr."-style inputs). Compound surnames are excluded by the
+-- parser's lookarounds and shouldn't match either.
 select last_name
 from {{ ref("stg_airbyte_source__techspeed_gdrive_candidates") }}
 where
@@ -11,4 +12,5 @@ where
         last_name rlike '^[A-Z][.] ?[A-Za-z]'
         or last_name rlike '^[A-Z] [A-Za-z]'
         or last_name rlike '[A-Za-z] [A-Z]$'
+        or last_name rlike ',$'
     )


### PR DESCRIPTION
## Summary

Phase 2 of three-PR DATA-1523 sequence. Pairs with PR #411 (Phase 1 viability join). Fixes the upstream `last_name` parsing bug that prevents Phase 1's viability join from matching ~26% of TS candidacies — post-merge full-refresh should lift mart coverage from ~69.7% to ~99.7%.

- `stg_airbyte_source__techspeed_gdrive_candidates`: replace `trim(last_name)` with a chained `regexp_replace` minimal parser. Strips leading initial tokens ("A Bressler", "A. C. Campbell", "M.J. Holbrook") and trailing single-initial ("Bressler A") while preserving compound surnames (De La, Da, St., Mac, O'Brien, AB Smith) via lookarounds.
- `int__techspeed_candidates_clean`: drop the buggy 5-step lateral chain (compound-name destruction: "De La Cruz" → "Cruz"; off-by-one substring formulas; trailing-char heuristics). Refactor the 5 `suggested_last` references to consume staging's parsed `last_name` directly. Refresh stale yaml descriptions ("name standardization happens upstream in staging").
- Tests:
  - **A1** (`stg_techspeed_last_name_no_middle_initial`) — staging-layer regex regression
  - **A2** (`mart_candidate_techspeed_last_name_no_middle_initial`) — end-to-end at `mart_civics.candidate`
  - **A3** (`parser_idempotency_techspeed_staging`) — 19-row fixture asserting correctness + idempotency
  - **B3** (`mart_candidacy_techspeed_viability_coverage_warn`) — threshold tightened from `warn_if=15524 (~30%) / error_if=25874 (~50%)` to `warn_if=517 (1%) / error_if=1034 (2%)`, recomputed against current TS row count of 51,749.

## Local validation

- `dbt build` of the full Phase 2 chain through the marts: 122 PASS, 3 ERROR, 118 SKIP. The 3 errors are the same dev-deferral cascade PR #411 hit (`int__er_prematch_candidacy_stages`, `candidate`, `election_stage`) — not caused by these changes. CI's preview schema will rebuild from prod state and run the SKIPped mart-layer tests.
- A1 and A3: PASS locally (0 rows each).
- A2 and B3: deferred to CI verification — both depend on the `candidate`/`candidacy` mart which cascaded locally.
- Parser fixture (Task 8 Step 2) verified all 11 spec cases (compound-name preservation + middle-initial stripping). The 19-row A3 fixture extends this to cover suffix-bearing and "AB Smith"-style false-positive bait.
- **Symmetry query** post-build: `civics_codes=59,684, viab_codes=57,489, matched=44,484`. The matched count is barely above PR-1's 44,042 because `int__techspeed_viability_scoring` is a Python/MLflow incremental model that didn't full-refresh under new parser codes. **Production's post-merge `state:modified+ --full-refresh` rebuilds both intermediates with the new codes and is where Phase 2's actual ~99.7% match rate will materialize.** No manual full-refresh from this side per project pattern.

## Identity churn

~11K TS-only `gp_candidate_id`s rotate (parser changes `last_name` → code hash shifts). Additional ~4.5K rows lose BR canonical mapping until Phase 3 lands (matcha re-cluster). The mapping CSV generated after Phase 3 documents old → new transitions for Sales reconciliation.

## Follow-ups (Phase 3)

1. Wait for dbt cloud post-merge job (state:modified+ --full-refresh) and re-verify the symmetry/coverage queries.
2. Re-run matcha against the now-parsed staging (plan Task 14, `goodparty_data_catalog.er_source.clustered_candidacy_stages<DATE>` — note no `er_` prefix on the table name).
3. Phase 3 PR: update `__sources.yaml` identifier to point at the new matcha output (plan Task 17).
4. Generate `id_migration_table.csv` (plan Task 19) and re-run upload exports (plan Task 20).

## Known follow-up: parser regex duplication

A3 hardcodes the same two `regexp_replace` patterns the staging model uses. If a future change touches the staging parser without updating A3, the test will silently desync. Worth a follow-up ticket to extract the patterns into a `strip_leading_trailing_initials` macro so both call sites stay in lockstep (the model already does this for the `remove_name_suffixes` half of the parser).

## Test plan

- [x] Local: A1 passes (0 rows)
- [x] Local: A3 passes (0 rows; 19-fixture verifies correctness + idempotency)
- [x] Local: B3 file edits sanity-check; threshold integers recomputed via production query
- [x] Local: Phase 2 chain `dbt build` — 122 PASS, 3 known-cascade ERROR, 118 mart-test SKIP
- [x] Local: parser fixture verifies all 11 verbatim spec cases
- [x] Pre-merge: pre-PR2 snapshot at `dbt_sroberts.candidate_techspeed_pre_data_1523` (PR 1 session, 64,081 rows)
- [ ] Post-merge: dbt cloud job completes without errors
- [ ] Post-merge: A1, A2, A3 return 0 rows
- [ ] Post-merge: B3 warn/error gates pass (coverage well under 1% null)
- [ ] Post-merge: symmetry query shows matched_count approaching civics_codes (~99.7%)
- [ ] Post-merge: BR canonical mappings recover after Phase 3 lands

Design: `.tickets/DATA-1523/20_viability_completeness_design_v2.md`
Plan: `.tickets/DATA-1523/24_viability_completeness_plan_v3.md` (Tasks 8-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how TechSpeed candidate identity keys are derived (staging parser → techspeed_candidate_code → marts) and will rotate many gp_candidate_id values until full-refresh and Phase 3 reconciliation; viability join coverage depends on post-merge rebuild.
> 
> **Overview**
> Moves **TechSpeed `last_name` cleanup upstream** into `stg_airbyte_source__techspeed_gdrive_candidates`, replacing plain `trim(last_name)` with `remove_name_suffixes` plus two `regexp_replace` passes that strip merged middle initials (leading and trailing) while preserving compound surnames via lookarounds.
> 
> **`int__techspeed_candidates_clean`** drops the old multi-step `suggested_last` logic (suffix/comma/trim/compound heuristics) and builds `techspeed_candidate_code` and mart output from staging’s `last_name` directly; YAML now documents that name standardization lives in staging and that codes can shift when the parser changes.
> 
> Adds **regression tests** at staging (A1), mart candidate (A2), and a 19-row **idempotency fixture** (A3), and **tightens** `mart_candidacy_techspeed_viability_coverage_warn` from ~30%/50% missing viability to **1%/2%** (~517/1034 rows) after the parser fix.
> 
> **Expect identity churn**: `techspeed_candidate_code` / `gp_candidate_id` hashes change for many TS-only rows until production full-refresh and follow-on matcha (Phase 3); viability coverage should improve materially post-merge refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f67a7f8d5848f3588481f4282b12f18967316d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->