### PR TITLE
[DATA-1523] Loosen B3 viability coverage thresholds (Phase 2 follow-up)

### DIFF
--- a/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
+++ b/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
@@ -8,12 +8,16 @@
 
 -- B3: emit one indicator row per breached threshold.
 -- 0 rows = TS viability coverage healthy
--- 1 row  = WARN: >1% of TS candidacies missing viability_score
--- 2 rows = ERROR: >2% (both indicator rows fire)
--- Empirical MLflow floor is ~0.3%; 1% absorbs legitimate skips plus
--- small ingestion drift. Computed dynamically against the current
--- denominator so the contract holds regardless of TS volume drift
--- (prior fixed-integer thresholds went stale with population shifts).
+-- 1 row  = WARN: >2.5% of TS candidacies missing viability_score
+-- 2 rows = ERROR: >4% (both indicator rows fire)
+-- Post-Phase-2 (DATA-1523) prod observed 2.06% missing on candidacy mart;
+-- ~1,182 TS candidacies are clean-orphaned upstream (int__civics_candidacy_techspeed
+-- preserves candidacy-stage grain straight from staging, while
+-- int__techspeed_candidates_clean dedupes and filters out null/empty required
+-- fields). Those rows can never reach viability scoring regardless of parser
+-- changes. Warn 2.5% absorbs the structural floor plus small ingestion drift;
+-- error 4% catches material coverage regressions. Computed dynamically against
+-- the current denominator so the contract holds regardless of TS volume.
 with
     stats as (
         select
@@ -24,19 +28,19 @@ with
     )
 
 select
-    'warn_gt_1pct' as breach,
+    'warn_gt_2_5pct' as breach,
     total_ts,
     missing_count,
     cast(missing_count * 1.0 / total_ts as decimal(5, 4)) as pct_missing
 from stats
-where missing_count * 1.0 / total_ts > 0.01
+where missing_count * 1.0 / total_ts > 0.025
 
 union all
 
 select
-    'error_gt_2pct' as breach,
+    'error_gt_4pct' as breach,
     total_ts,
     missing_count,
     cast(missing_count * 1.0 / total_ts as decimal(5, 4)) as pct_missing
 from stats
-where missing_count * 1.0 / total_ts > 0.02
+where missing_count * 1.0 / total_ts > 0.04

--- a/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
+++ b/dbt/project/tests/mart_candidacy_techspeed_viability_coverage_warn.sql
@@ -31,9 +31,9 @@ select
     'warn_gt_2_5pct' as breach,
     total_ts,
     missing_count,
-    cast(missing_count * 1.0 / total_ts as decimal(5, 4)) as pct_missing
+    cast(missing_count * 1.0 / nullif(total_ts, 0) as decimal(5, 4)) as pct_missing
 from stats
-where missing_count * 1.0 / total_ts > 0.025
+where missing_count * 1.0 / nullif(total_ts, 0) > 0.025
 
 union all
 
@@ -41,6 +41,6 @@ select
     'error_gt_4pct' as breach,
     total_ts,
     missing_count,
-    cast(missing_count * 1.0 / total_ts as decimal(5, 4)) as pct_missing
+    cast(missing_count * 1.0 / nullif(total_ts, 0) as decimal(5, 4)) as pct_missing
 from stats
-where missing_count * 1.0 / total_ts > 0.04
+where missing_count * 1.0 / nullif(total_ts, 0) > 0.04


### PR DESCRIPTION
## Summary

Follow-up to PR #416. Bumps B3 thresholds from warn-1% / error-2% to warn-2.5% / error-4%, reflecting the structural ceiling we discovered post-merge.

## Why

Plan v3 expected Phase 2 to lift TS viability coverage to ~99.7%. Actual post-merge prod numbers:

| Metric | Pre-merge | Plan target | Actual prod |
|---|---:|---:|---:|
| TS match rate (candidacy ⨝ viability codes) | 74.5% | ~99.7% | **97.85%** |
| Mart `viability_score` coverage | ~69.7% | ~99.7% | **97.94%** |

Phase 2 delivered the parser fix correctly (+23pp matched). The 99.7% prediction was wrong because of a structural gap we hadn't accounted for:

- `int__civics_candidacy_techspeed` builds **directly from staging** at candidacy-stage grain (table-materialized, full rebuild each run).
- `int__techspeed_candidates_clean` builds from the same staging but dedupes on `techspeed_candidate_code` and filters out rows missing required fields (first_name, city, state, office_type).
- Result: 1,182 candidacies exist in civics_candidacy whose candidate_code is filtered out of clean. They can never reach `int__techspeed_viability_scoring` (which is downstream of clean) no matter what we change upstream.

`int__techspeed_candidates_clean` and `int__techspeed_viability_scoring` are at full parity post-merge (both 63,223 distinct codes). The gap is entirely upstream of clean, not in the join.

## Threshold rationale

- **Warn at 2.5%** (~0.5pp above today's prod) absorbs the structural floor plus small ingestion drift.
- **Error at 4%** still catches material coverage regressions.
- Both computed dynamically against the live denominator (no fixed integers, per `feedback_no_hardcode_thresholds`).

## Out of scope

The 1,182 clean-orphaned candidacies are a real data-quality observation but not in this PR's scope. Possible follow-up: investigate whether some of those should pass clean's `WHERE` guards (e.g., backfill missing fields upstream in TS) or whether civics_candidacy should filter to candidacies with a live candidate match.

## Test plan

- [x] Local edit verified (mart_civics.candidacy not buildable locally per the known cascade — relying on CI)
- [ ] CI: B3 returns 0 indicator rows at current 2.06% missing (under 2.5% warn threshold)
- [ ] Post-merge: prod B3 continues to pass at ~2% missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dbt test threshold and documentation change only; no pipeline logic or scoring behavior is modified.
> 
> **Overview**
> Relaxes the **B3** dbt contract on TechSpeed candidacies missing `viability_score` on the `candidacy` mart: the warn branch now fires above **2.5%** (was 1%) and the error branch above **4%** (was 2%), with matching `breach` labels (`warn_gt_2_5pct`, `error_gt_4pct`).
> 
> Header comments are expanded to document why post–Phase 2 prod sits around **~2%** missing (structural clean-orphan candidacies upstream of viability scoring) while keeping the same dynamic ratio logic and dbt `warn_if` / `error_if` row-count semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa387731fac420e91996dd6b3042a7ab5afb4897. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->