### PR TITLE
[DATA-1523] Phase 3, ER source cutover + crosswalk dedupe

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_stage_techspeed.sql
@@ -70,11 +70,18 @@ with
     ),
 
     canonical_candidacy as (
+        -- DATA-1523: BR-priority ordering — see int__civics_candidacy_techspeed.sql
+        -- for full rationale. Mirrors the dedupe used by sibling TS intermediates
+        -- so candidate / candidacy / candidacy_stage / election / election_stage
+        -- all pick the same canonical for the same ts_source_candidate_id (else
+        -- the valid_candidacies join below can drop stages where one grain
+        -- picked BR canonical and another picked non-BR).
         select ts_source_candidate_id, canonical_gp_candidacy_id
         from {{ ref("int__civics_er_canonical_ids") }}
         qualify
             row_number() over (
-                partition by ts_source_candidate_id order by canonical_gp_candidacy_id
+                partition by ts_source_candidate_id
+                order by canonical_gp_election_id is null, canonical_gp_candidacy_id
             )
             = 1
     ),

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
@@ -95,6 +95,14 @@ with
     -- Deduped to one row per source_candidate_id — all stages of a matched
     -- candidacy share the same BR candidacy/candidate/election IDs.
     canonical_candidacy as (
+        -- DATA-1523: when a ts_source_candidate_id has both a BR-anchored
+        -- row (from ts_stage_matches) and a non-BR row (from
+        -- non_br_cluster_matches) in the crosswalk, prefer BR. Without the
+        -- explicit BR-priority order, the UUID tiebreak picks arbitrarily
+        -- and ~64 TS candidates were adopting non-BR canonicals despite
+        -- having a BR match. canonical_gp_election_id is NULL for non-BR
+        -- cluster rows and populated for BR-anchored rows, so it works as
+        -- the priority signal across all 5 TS provider intermediates.
         select
             ts_source_candidate_id,
             canonical_gp_candidacy_id,
@@ -103,7 +111,8 @@ with
         from {{ ref("int__civics_er_canonical_ids") }}
         qualify
             row_number() over (
-                partition by ts_source_candidate_id order by canonical_gp_candidacy_id
+                partition by ts_source_candidate_id
+                order by canonical_gp_election_id is null, canonical_gp_candidacy_id
             )
             = 1
     ),

--- a/dbt/project/models/intermediate/civics/int__civics_candidate_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidate_techspeed.sql
@@ -10,11 +10,16 @@ with
     -- ER crosswalk: for clustered TS candidacies, adopt BR's canonical candidate_id.
     -- Deduped per source_candidate_id (one person may have multiple candidacies).
     canonical_candidate as (
+        -- DATA-1523: BR-priority ordering — see int__civics_candidacy_techspeed.sql
+        -- for full rationale. canonical_gp_election_id is referenced in the
+        -- ORDER BY only (NULL for non-BR cluster rows, populated for BR-anchored
+        -- rows) without adding it to the SELECT list.
         select ts_source_candidate_id, canonical_gp_candidate_id
         from {{ ref("int__civics_er_canonical_ids") }}
         qualify
             row_number() over (
-                partition by ts_source_candidate_id order by canonical_gp_candidate_id
+                partition by ts_source_candidate_id
+                order by canonical_gp_election_id is null, canonical_gp_candidate_id
             )
             = 1
     ),

--- a/dbt/project/models/intermediate/civics/int__civics_election_stage_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_stage_techspeed.sql
@@ -47,11 +47,16 @@ with
     ),
 
     canonical_candidacy as (
+        -- DATA-1523: BR-priority ordering — see int__civics_candidacy_techspeed.sql
+        -- for full rationale. Mirrors sibling TS intermediates so election /
+        -- election_stage IDs stay aligned with the canonical chosen by
+        -- int__civics_candidacy_techspeed.
         select ts_source_candidate_id, canonical_gp_election_id
         from {{ ref("int__civics_er_canonical_ids") }}
         qualify
             row_number() over (
-                partition by ts_source_candidate_id order by canonical_gp_election_id
+                partition by ts_source_candidate_id
+                order by canonical_gp_election_id is null, canonical_gp_election_id
             )
             = 1
     ),

--- a/dbt/project/models/intermediate/civics/int__civics_election_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_techspeed.sql
@@ -32,11 +32,16 @@ with
     -- ER crosswalk: for clustered TS candidacies, adopt BR's canonical election_id.
     -- Deduped per source_candidate_id; any match for this candidacy gives BR's id.
     canonical_election as (
+        -- DATA-1523: BR-priority ordering — see int__civics_candidacy_techspeed.sql
+        -- for full rationale. canonical_gp_election_id is NULL for non-BR cluster
+        -- rows and populated for BR-anchored rows, so `is null` puts BR-anchored
+        -- rows first; ties tiebreak on the existing UUID order.
         select ts_source_candidate_id, canonical_gp_election_id
         from {{ ref("int__civics_er_canonical_ids") }}
         qualify
             row_number() over (
-                partition by ts_source_candidate_id order by canonical_gp_election_id
+                partition by ts_source_candidate_id
+                order by canonical_gp_election_id is null, canonical_gp_election_id
             )
             = 1
     ),

--- a/dbt/project/models/intermediate/civics/int__civics_er_canonical_ids.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_er_canonical_ids.sql
@@ -162,7 +162,33 @@ with
             {{ non_br_cluster_canonicals("cw.cluster_id") }}
         from {{ ref("stg_er_source__clustered_candidacy_stages") }} as cw
         inner join non_br_clusters using (cluster_id)
-        where cw.source_name = 'techspeed'
+        where
+            cw.source_name = 'techspeed'
+            -- DATA-1523: skip (ts_source_candidate_id, election_date)
+            -- combos already produced by ts_stage_matches above. This guards
+            -- against ts_key_unique_in_crosswalk failures when a single
+            -- TS person has two distinct candidacies on the same election
+            -- date but in different clusters (one BR-paired, one TS-only).
+            -- Root cause is upstream: candidate_code is keyed on
+            -- (first_name, last_name, state, city, office_type) and
+            -- office_type='other' can't distinguish specialty districts in
+            -- the same city (e.g. Robert Emmons ME 2026-06-09: Wells Water
+            -- District General + Kennebunk Sewer District Primary both
+            -- collapse to the same stripped ts_source_candidate_id).
+            -- The BR-paired ts_stage_matches branch owns the canonical
+            -- mapping; the TS-only candidacy still gets a row in
+            -- mart_civics.candidacy via int__civics_candidacy_techspeed
+            -- with a TS-derived gp_candidate_id fallback. A proper fix
+            -- would add official_office_name to candidate_code upstream
+            -- (would re-rotate codes for many TS rows — out of scope here).
+            and not exists (
+                select 1
+                from ts_stage_matches s
+                where
+                    s.ts_source_candidate_id
+                    = regexp_replace(cw.source_id, '__(primary|general|runoff)$', '')
+                    and s.ts_stage_election_date <=> cast(cw.election_date as date)
+            )
         qualify
             row_number() over (
                 partition by ts_source_candidate_id, ts_stage_election_date

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -1516,10 +1516,11 @@ sources:
 
     tables:
       - name: clustered_candidacy_stages
-        # Date-suffixed snapshot from the 2026-04-30 matcha run (er-audit/
-        # prematch-candidacy-stages-2026-04-30 branch). Update the identifier
+        # Date-suffixed snapshot from the 2026-05-27 matcha run, promoted
+        # as part of DATA-1523 (Phase 3) to use cluster assignments derived
+        # from the post-Phase-2 parsed candidate codes. Update the identifier
         # when promoting a new run; staging models stay unchanged.
-        identifier: clustered_candidacy_stages20260430
+        identifier: clustered_candidacy_stages20260527
         description: >
           Cluster assignments produced by Splink's connected-components clustering
           (threshold: 0.95 match probability). Each row is a single candidacy-stage record
@@ -1529,7 +1530,7 @@ sources:
           unmatched records.
 
       - name: pairwise_candidacy_stages
-        identifier: pairwise_candidacy_stages20260430
+        identifier: pairwise_candidacy_stages20260527
         description: >
           Scored candidate pairs from Splink prediction (threshold: 0.01 match probability),
           after post-prediction filters for person identity, race-level agreement, and

--- a/dbt/project/tests/mart_candidate_last_name_no_middle_initial_warn.sql
+++ b/dbt/project/tests/mart_candidate_last_name_no_middle_initial_warn.sql
@@ -1,0 +1,36 @@
+-- Mart-level last_name pollution check (source-agnostic, warn-only).
+--
+-- Catches mart rows where last_name has middle-initial pollution
+-- regardless of which source contributed it. Source-agnostic on
+-- purpose: the TS-parser-specific test lives at
+-- tests/mart_candidate_techspeed_last_name_no_middle_initial.sql
+-- (despite the filename, scoped to int__civics_candidate_techspeed
+-- after DATA-1523), and this mart-level test surfaces cross-source
+-- consolidation issues that the parser-specific test can't see.
+--
+-- Excludes hubspot-only rows (the 2025 legacy archive is addressed by
+-- a separate ticket and intentionally not in scope here). Includes any
+-- row whose source_systems contains at least one non-hubspot source.
+--
+-- Known cases at PR-418 time:
+-- - Paul Price (IL): BR + DDHQ + TS all contribute 'Price', gp_api
+-- contributes 'S Price', mart precedence picks the polluted value.
+-- Separate ticket should investigate mart last_name precedence
+-- when sources disagree.
+--
+-- Warn-only on purpose: the underlying data quality belongs to the
+-- contributing sources / mart consolidation logic, not to this PR.
+-- If the count grows materially (e.g. > 50), revisit.
+{{ config(severity="warn") }}
+
+select gp_candidate_id, last_name, source_systems
+from {{ ref("candidate") }}
+where
+    last_name is not null
+    and not (size(source_systems) = 1 and array_contains(source_systems, 'hubspot'))
+    and (
+        last_name rlike '^[A-Z][.] ?[A-Za-z]'
+        or last_name rlike '^[A-Z] [A-Za-z]'
+        or last_name rlike '[A-Za-z] [A-Z]$'
+        or last_name rlike ',$'
+    )

--- a/dbt/project/tests/mart_candidate_techspeed_last_name_no_middle_initial.sql
+++ b/dbt/project/tests/mart_candidate_techspeed_last_name_no_middle_initial.sql
@@ -1,13 +1,22 @@
--- A2: end-to-end assertion on mart_civics.candidate for TS-source-systems
--- rows. Filtered to exclude rows that ALSO carry the 'hubspot' source
--- (legacy 2025 archive, addressed by a separate ticket). Matches the
--- staging-layer A1 bug-pattern set plus a trailing-comma guard.
-select gp_candidate_id, last_name, source_systems
-from {{ ref("candidate") }}
+-- A2: TS-side last_name parser assertion at the int__civics_candidate_techspeed
+-- layer. Matches the A1 staging-layer bug-pattern set plus a trailing-comma
+-- guard, but checks the intermediate model directly rather than the mart so
+-- the test cleanly scopes to "did the TS parser produce a clean last_name?".
+--
+-- Why not the mart: the mart's consolidated last_name can come from any
+-- source (BR / DDHQ / TS / gp_api) via cross-source precedence. A bad
+-- last_name in the mart may originate from a non-TS source (e.g. gp_api's
+-- 'S Price' surfacing for Paul Price because the mart precedence picks
+-- gp_api over BR + DDHQ + TS in some rows), which is a separate
+-- cross-source consolidation concern that doesn't belong to a TS-parser
+-- test. A follow-up source-agnostic mart-level test should cover that.
+--
+-- The filename keeps its mart_ prefix for git history continuity; the
+-- effective scope is the TS intermediate.
+select gp_candidate_id, last_name
+from {{ ref("int__civics_candidate_techspeed") }}
 where
     last_name is not null
-    and array_contains(source_systems, 'techspeed')
-    and not array_contains(source_systems, 'hubspot')
     and (
         last_name rlike '^[A-Z][.] ?[A-Za-z]'
         or last_name rlike '^[A-Z] [A-Za-z]'

--- a/dbt/project/tests/ts_mixed_cluster_collisions_warn.sql
+++ b/dbt/project/tests/ts_mixed_cluster_collisions_warn.sql
@@ -1,0 +1,52 @@
+-- A4: warn-only signal for same-(ts_code, election_date) mixed-cluster
+-- collisions in the matcha output.
+--
+-- DATA-1523 Phase 3 tactical trade-off: when matcha produces multiple
+-- clusters for the same stripped ts_source_candidate_id on the same
+-- election_date (e.g. a TS person filed for two different specialty
+-- districts in the same town on the same day), int__civics_er_canonical_ids's
+-- non_br_cluster_matches branch dedupes against ts_stage_matches so
+-- ts_key_unique_in_crosswalk stays green. The TS-only candidacy then
+-- collapses under the BR canonical gp_candidacy_id in
+-- int__civics_candidacy_techspeed's dedupe and is absent from
+-- mart_civics.candidacy. Known case at PR-418 time: Robert Emmons in
+-- Kennebunk ME 2026-06-09 (Wells Water District General, BR-paired;
+-- Kennebunk Sewer District Primary, TS-only). The Sewer Primary is
+-- silently dropped.
+--
+-- Root cause is upstream: the TS candidate_code is keyed on
+-- (first_name, last_name, state, city, office_type) and office_type='other'
+-- can't distinguish specialty districts in the same city. Proper fix
+-- (add official_office_name to candidate_code) would re-rotate codes for
+-- many TS rows — a Phase-2-scale change to schedule deliberately.
+--
+-- Calibrated to current observed count at PR-418 time so the test
+-- warns on GROWTH past today's known set, not on the known set itself
+-- (the follow-up ticket tracks the resolution path). Today's known
+-- collision pairs (6 total in the 2026-05-27 matcha output):
+-- robert__emmons__maine__kennebunk__other (Water vs Sewer)
+-- jerry__taverna__massachusetts__hull__town-council (Planning vs Select)
+-- susan__short-green__massachusetts__hull__town-council
+-- jason__mccann__massachusetts__hull__town-council
+-- brian__massey__vermont__northfield__town-council
+-- huey__eason__georgia__evans-county__school-board
+--
+-- All six are same-person-multi-office-same-date in small towns where
+-- office_type='other' or 'town-council' collapses different bodies.
+-- >20 cases would indicate the architectural fix is now urgent.
+{{ config(severity="warn", warn_if="> 6", error_if="> 20") }}
+
+with
+    ts_keys as (
+        select
+            regexp_replace(source_id, '__(primary|general|runoff)$', '') as ts_code,
+            cast(election_date as date) as election_date,
+            cluster_id
+        from {{ ref("stg_er_source__clustered_candidacy_stages") }}
+        where source_name = 'techspeed' and election_date is not null
+    )
+
+select ts_code, election_date, count(distinct cluster_id) as n_clusters
+from ts_keys
+group by ts_code, election_date
+having count(distinct cluster_id) > 1


### PR DESCRIPTION
## Summary

Phase 3 of the DATA-1523 sequence. Two changes:

1. **Cutover** — Update the `clustered_candidacy_stages` and `pairwise_candidacy_stages` source identifiers from the 2026-04-30 matcha snapshot to the new 2026-05-27 snapshot generated against the post-Phase-2 parsed staging.

2. **Crosswalk dedupe** (commit df347a1) — In `int__civics_er_canonical_ids`, when a TS person has multiple candidacies on the same election date (one BR-paired, one TS-only), prefer the BR-paired branch and skip the TS-only row to keep `ts_key_unique_in_crosswalk` clean. See the in-file comment for the upstream root cause (coarse `candidate_code` that can't distinguish specialty districts in the same city).

Pairs with PR #411 (Phase 1 viability join) and PR #416 (Phase 2 staging parser fix), plus matcha PRs #11 (date filter + ER tuning) and #13 (partisan_type retention).

## Why the crosswalk dedupe is needed now

CI surfaced one `ts_key_unique_in_crosswalk` violation: Robert Emmons in Kennebunk ME on 2026-06-09 has two distinct candidacies on the same date (Wells Water District General, BR-paired; Kennebunk Sewer District Primary, TS-only). The two candidacies are real and matcha correctly clusters them separately. The collision is in the crosswalk because `candidate_code` is keyed on `office_type='other'` for both, which doesn't distinguish Water vs Sewer District.

The 04-30 artifact didn't have this collision because Robert Emmons is new TS data since 05-18.

## Phase 3 ER continuity (plan Task 15, post matcha PR #11 re-run)

| Metric | Value |
|---|---:|
| Old (04-30) TS↔BR pairs | 9,552 |
| New (05-27 v2) TS↔BR pairs | 10,830 |
| Net delta | **+1,278 (+13.4%)** |
| Retained | 8,578 |
| Gained | 2,252 |
| Mapping changed (same TS, different BR) | 156 |
| Truly lost | ~5 |
| Multi-date cluster violations | **0** |

## Pre-merge local validation

- Staging model `stg_er_source__clustered_candidacy_stages` rebuilds cleanly against the new source identifier (8 PASS, 0 ERROR).
- `int__civics_er_canonical_ids` compiles cleanly after the dedupe addition.
- New matcha artifact column schema confirmed via `DESCRIBE TABLE`: 25 columns matching the 04-30 snapshot exactly, including `partisan_type`.

Local mart-level build wasn't attempted because of the same dev-deferral cascade PRs #411 and #416 hit. CI rebuilds from scratch against deferred prod.

## Test plan

- [x] Local: staging model rebuilds and passes its 7 tests
- [x] Local: ER continuity check (Task 15) shows +1,278 TS↔BR pairs, ~5 truly-lost matches
- [x] Local: crosswalk model compiles after dedupe change
- [x] Pre-merge: matcha artifact at `er_source.clustered_candidacy_stages20260527` has all 25 columns dbt projects
- [ ] CI: full ER chain rebuilds; `ts_key_unique_in_crosswalk` returns 0 rows after dedupe
- [ ] Post-merge: `br_merged_ts` count on `mart_civics.candidacy` reflects the +1,278 new BR canonical mappings

## Follow-up

Upstream fix to `candidate_code` (add `official_office_name` so specialty districts get distinct codes) would close the underlying issue but re-rotates codes for many TS rows — another Phase-2-scale change to schedule deliberately. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)