### PR TITLE
chore(dbt): clear deprecations and document conventions

### DIFF
--- a/dbt/project/CLAUDE.md
+++ b/dbt/project/CLAUDE.md
@@ -77,6 +77,56 @@ dbt show --inline "select distinct candidate_office from {{ ref('int__civics_can
 - Avoid subqueries in favor of CTEs
 - Prefer to keep join blocks flat with minimal transformations in the join
   condition by moving the needed transformation up to the SELECT clause
+- **Wrap generic test arguments under `arguments:`.** Top-level args on a
+  generic test (`relationships`, `accepted_values`, `dbt_utils.*`,
+  `dbt_expectations.*`, etc.) are deprecated.
+    - Good:
+      ```yaml
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [a, b]
+      ```
+    - Bad (deprecated):
+      ```yaml
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [a, b]
+      ```
+- **Custom config keys live under `config.meta`, not top-level `config`.**
+  dbt's canonical config keys (`tags`, `materialized`, `unique_key`,
+  `on_schema_change`, `meta`, etc.) stay at the top level of `config:`. Any
+  other key (env-var-driven secrets, per-model settings, ownership tags) goes
+  inside `meta:`.
+    - Good:
+      ```yaml
+      config:
+        tags: ["monthly"]
+        meta:
+          dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+          owner: "Data Engineering Team"
+      ```
+    - Bad (deprecated):
+      ```yaml
+      config:
+        tags: ["monthly"]
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        meta:
+          owner: "Data Engineering Team"
+      ```
+- **Python models read custom config via `meta`.** When a custom config value
+  lives in `config.meta`, read it through `dbt.config.get("meta")` rather than
+  `dbt.config.get("the_key")` directly. For models with multiple accesses,
+  bind `meta` once.
+    - Good:
+      ```python
+      meta = dbt.config.get("meta")
+      dbt_env = meta["dbt_environment"]
+      db_host = meta["election_db_host"]
+      flags_dir = meta.get("l2_haystaq_flags_sftp_dir", "/default")
+      ```
+    - Bad:
+      ```python
+      dbt_env = dbt.config.get("dbt_environment")
+      ```
 
 ## Building and Testing Models
 

--- a/dbt/project/CLAUDE.md
+++ b/dbt/project/CLAUDE.md
@@ -112,20 +112,24 @@ dbt show --inline "select distinct candidate_office from {{ ref('int__civics_can
         meta:
           owner: "Data Engineering Team"
       ```
-- **Python models read custom config via `meta`.** When a custom config value
-  lives in `config.meta`, read it through `dbt.config.get("meta")` rather than
-  `dbt.config.get("the_key")` directly. For models with multiple accesses,
-  bind `meta` once.
+- **Python models read custom config via `dbt.config.meta_get`.** The
+  dbt-databricks Python materialization populates `meta_dict` only for keys
+  accessed through `dbt.config.meta_get(key)` in the Python source. Other
+  patterns (`dbt.config.get("meta")[key]`, `dbt.config.get("meta").get(key)`)
+  resolve to `None` at runtime — the wrapper macro does not expose the full
+  `meta` dict.
     - Good:
       ```python
-      meta = dbt.config.get("meta")
-      dbt_env = meta["dbt_environment"]
-      db_host = meta["election_db_host"]
-      flags_dir = meta.get("l2_haystaq_flags_sftp_dir", "/default")
+      dbt_env = dbt.config.meta_get("dbt_environment")
+      db_host = dbt.config.meta_get("election_db_host")
+      flags_dir = dbt.config.meta_get(
+          "l2_haystaq_flags_sftp_dir", "/default"
+      )
       ```
     - Bad:
       ```python
-      dbt_env = dbt.config.get("dbt_environment")
+      dbt_env = dbt.config.get("dbt_environment")        # custom key at top of config: triggers deprecation
+      dbt_env = dbt.config.get("meta")["dbt_environment"]  # returns None on dbt-databricks
       ```
 
 ## Building and Testing Models

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_candidacy.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_candidacy.py
@@ -282,7 +282,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get api token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_candidacy.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_candidacy.py
@@ -282,7 +282,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get api token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_endorsement.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_endorsement.py
@@ -292,7 +292,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_endorsement.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_endorsement.py
@@ -292,7 +292,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
@@ -193,7 +193,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get API token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
@@ -193,7 +193,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get API token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_geofence.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_geofence.py
@@ -279,7 +279,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get API token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_geofence.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_geofence.py
@@ -279,7 +279,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get API token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_issue.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_issue.py
@@ -183,7 +183,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get api token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_issue.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_issue.py
@@ -183,7 +183,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get api token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_normalized_position.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_normalized_position.py
@@ -247,7 +247,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_normalized_position.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_normalized_position.py
@@ -247,7 +247,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_party.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_party.py
@@ -257,7 +257,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_party.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_party.py
@@ -257,7 +257,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_person.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_person.py
@@ -329,7 +329,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get api token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_person.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_person.py
@@ -329,7 +329,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # get api token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_position_election_frequency.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_position_election_frequency.py
@@ -224,7 +224,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_position_election_frequency.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_position_election_frequency.py
@@ -224,7 +224,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_py.yaml
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_py.yaml
@@ -7,8 +7,8 @@ models:
       This model retrieves and processes candidate data from the CivicEngine API since the source
       candidacies_v3 csv file does not contain all the fields needed.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: true
     columns:
@@ -29,8 +29,8 @@ models:
       It contains endorsement information for political candidates, including their endorsements
       from various organizations.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -46,8 +46,8 @@ models:
       It contains filing period information for political candidates, including their endorsements
       from various organizations.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -66,8 +66,8 @@ models:
     description: >
       This model retrieves and processes geofence data from the CivicEngine API.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -95,8 +95,8 @@ models:
       This model retrieves and processes issue data from the CivicEngine API: https://developers.civicengine.com/docs/api/graphql/reference/objects/issue
       It is used to retrieve the issue data for the [`stance`](https://developers.civicengine.com/docs/api/graphql/reference/objects/stance) table.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -124,8 +124,8 @@ models:
       This model retrieves normalized position data from the CivicEngine API. It uses the `position_id` from the position table
       to retrieve ids on which to query the normalized position data.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -146,8 +146,8 @@ models:
       It contains endorsement information for political candidates, including their endorsements
       from various organizations.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
 
@@ -155,8 +155,8 @@ models:
     description: >
       This model retrieves and processes person data from the CivicEngine API.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -176,8 +176,8 @@ models:
       This model retrieves and processes position election frequency data from the CivicEngine API.
       See https://developers.civicengine.com/docs/api/graphql/reference/objects/position-election-frequency
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -193,8 +193,8 @@ models:
       It contains stance information for political candidates, including their positions
       on various issues.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     tests:

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_stance.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_stance.py
@@ -266,7 +266,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("dbt_environment")
+    dbt_env = dbt.config.get("meta")["dbt_environment"]
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_stance.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_stance.py
@@ -266,7 +266,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Get API token from Databricks secrets
-    dbt_env = dbt.config.get("meta")["dbt_environment"]
+    dbt_env = dbt.config.meta_get("dbt_environment")
     ce_api_token = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="civic-engine-api-token"
     )

--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -58,11 +58,12 @@ models:
     description: "Combined Haystaq issue model flags from all states (loaded from per-state L2 Haystaq flags tables)"
     config:
       tags: ["monthly"]
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      # optional: comma/space-separated list like \"AK,AL\" for iterative runs
-      l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
-      # optional override if your user doesn't have permissions on the default source schema
-      l2_haystaq_databricks_schema: "{{ var('l2_haystaq_databricks_schema', '') }}"
+      meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        # optional: comma/space-separated list like \"AK,AL\" for iterative runs
+        l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
+        # optional override if your user doesn't have permissions on the default source schema
+        l2_haystaq_databricks_schema: "{{ var('l2_haystaq_databricks_schema', '') }}"
     columns:
       - name: LALVOTERID
         description: "The ID of the voter"
@@ -74,11 +75,12 @@ models:
     description: "Combined Haystaq issue model scores from all states (loaded from per-state L2 Haystaq scores tables)"
     config:
       tags: ["monthly"]
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      # optional: comma/space-separated list like \"AK,AL\" for iterative runs
-      l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
-      # optional override if your user doesn't have permissions on the default source schema
-      l2_haystaq_databricks_schema: "{{ var('l2_haystaq_databricks_schema', '') }}"
+      meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        # optional: comma/space-separated list like \"AK,AL\" for iterative runs
+        l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
+        # optional override if your user doesn't have permissions on the default source schema
+        l2_haystaq_databricks_schema: "{{ var('l2_haystaq_databricks_schema', '') }}"
     columns:
       - name: LALVOTERID
         description: "The ID of the voter"
@@ -90,9 +92,10 @@ models:
     description: "Nationwide uniform voter file data with Haystaq flags and scores joined on LALVOTERID"
     config:
       tags: ["monthly"]
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      # optional: comma/space-separated list like \"AK,AL\" for iterative runs
-      l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
+      meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        # optional: comma/space-separated list like \"AK,AL\" for iterative runs
+        l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
     columns:
       - name: state_postal_code
         description: "Uppercase two-letter state postal code"

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_flags.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_flags.py
@@ -44,9 +44,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["intermediate", "l2", "nationwide_haystaq", "haystaq", "flags"],
     )
 
-    state_allowlist = _parse_state_allowlist(
-        dbt.config.get("meta")["l2_state_allowlist"]
-    )
+    state_allowlist = _parse_state_allowlist(dbt.config.meta_get("l2_state_allowlist"))
 
     this_df: Optional[DataFrame] = None
     if dbt.is_incremental:

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_flags.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_flags.py
@@ -44,7 +44,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["intermediate", "l2", "nationwide_haystaq", "haystaq", "flags"],
     )
 
-    state_allowlist = _parse_state_allowlist(dbt.config.get("l2_state_allowlist"))
+    state_allowlist = _parse_state_allowlist(
+        dbt.config.get("meta")["l2_state_allowlist"]
+    )
 
     this_df: Optional[DataFrame] = None
     if dbt.is_incremental:

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_scores.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_scores.py
@@ -44,9 +44,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["intermediate", "l2", "nationwide_haystaq", "haystaq", "scores"],
     )
 
-    state_allowlist = _parse_state_allowlist(
-        dbt.config.get("meta")["l2_state_allowlist"]
-    )
+    state_allowlist = _parse_state_allowlist(dbt.config.meta_get("l2_state_allowlist"))
 
     this_df: Optional[DataFrame] = None
     if dbt.is_incremental:

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_scores.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_scores.py
@@ -44,7 +44,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["intermediate", "l2", "nationwide_haystaq", "haystaq", "scores"],
     )
 
-    state_allowlist = _parse_state_allowlist(dbt.config.get("l2_state_allowlist"))
+    state_allowlist = _parse_state_allowlist(
+        dbt.config.get("meta")["l2_state_allowlist"]
+    )
 
     this_df: Optional[DataFrame] = None
     if dbt.is_incremental:

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
@@ -46,7 +46,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         ],
     )
 
-    state_allowlist = _parse_state_allowlist(dbt.config.get("l2_state_allowlist"))
+    state_allowlist = _parse_state_allowlist(
+        dbt.config.get("meta")["l2_state_allowlist"]
+    )
 
     uniform_df: DataFrame = dbt.ref("int__l2_nationwide_uniform").withColumn(
         "LALVOTERID", col("LALVOTERID").cast(StringType())

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
@@ -46,9 +46,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         ],
     )
 
-    state_allowlist = _parse_state_allowlist(
-        dbt.config.get("meta")["l2_state_allowlist"]
-    )
+    state_allowlist = _parse_state_allowlist(dbt.config.meta_get("l2_state_allowlist"))
 
     uniform_df: DataFrame = dbt.ref("int__l2_nationwide_uniform").withColumn(
         "LALVOTERID", col("LALVOTERID").cast(StringType())

--- a/dbt/project/models/load/load.yaml
+++ b/dbt/project/models/load/load.yaml
@@ -6,18 +6,18 @@ models:
     description: >
       This model loads data from the L2 SFTP server to S3.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      l2_sftp_host: "{{ env_var('DBT_L2_SFTP_HOST') }}"
-      l2_sftp_port: "{{ env_var('DBT_L2_SFTP_PORT') }}"
-      l2_sftp_user: "{{ env_var('DBT_L2_SFTP_USER') }}"
-      l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
-      l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
-      # TODO: use dbt cloud account id for temp volume path s3 staging prefix
-      # see https://docs.getdbt.com/docs/build/environment-variables#special-environment-variables
-      # current env vars listed in docs are not available
-      # dbt_cloud_account_id: "{{ env_var('DBT_CLOUD_ACCOUNT_ID') }}"
-      # dbt_cloud_account: "{{ env_var('DBT_CLOUD_ACCOUNT') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        l2_sftp_host: "{{ env_var('DBT_L2_SFTP_HOST') }}"
+        l2_sftp_port: "{{ env_var('DBT_L2_SFTP_PORT') }}"
+        l2_sftp_user: "{{ env_var('DBT_L2_SFTP_USER') }}"
+        l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
+        l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
+        # TODO: use dbt cloud account id for temp volume path s3 staging prefix
+        # see https://docs.getdbt.com/docs/build/environment-variables#special-environment-variables
+        # current env vars listed in docs are not available
+        # dbt_cloud_account_id: "{{ env_var('DBT_CLOUD_ACCOUNT_ID') }}"
+        # dbt_cloud_account: "{{ env_var('DBT_CLOUD_ACCOUNT') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -38,10 +38,10 @@ models:
     description: >
       This model loads data from S3 to Databricks.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
-      l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
+        l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -69,18 +69,18 @@ models:
     description: >
       This model loads Haystaq issue model data from the L2 SFTP server to S3.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      l2_sftp_host: "{{ env_var('DBT_L2_SFTP_HOST') }}"
-      l2_sftp_port: "{{ env_var('DBT_L2_SFTP_PORT') }}"
-      l2_sftp_user: "{{ env_var('DBT_L2_SFTP_USER') }}"
-      l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
-      l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
-      # optional: comma/space-separated list like "AK,AL" for iterative runs
-      l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
-      # folders live alongside VM2Uniform on the SFTP server
-      l2_haystaq_flags_sftp_dir: "/L2-Haystaq Issue Model Flags for Voters"
-      l2_haystaq_scores_sftp_dir: "/L2-Haystaq Issue Model Scores"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        l2_sftp_host: "{{ env_var('DBT_L2_SFTP_HOST') }}"
+        l2_sftp_port: "{{ env_var('DBT_L2_SFTP_PORT') }}"
+        l2_sftp_user: "{{ env_var('DBT_L2_SFTP_USER') }}"
+        l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
+        l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
+        # optional: comma/space-separated list like "AK,AL" for iterative runs
+        l2_state_allowlist: "{{ var('l2_state_allowlist', '') }}"
+        # folders live alongside VM2Uniform on the SFTP server
+        l2_haystaq_flags_sftp_dir: "/L2-Haystaq Issue Model Flags for Voters"
+        l2_haystaq_scores_sftp_dir: "/L2-Haystaq Issue Model Scores"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -101,12 +101,12 @@ models:
     description: >
       This model loads Haystaq issue model data from S3 to Databricks.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
-      l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
-      # optional override if your user doesn't have CREATE TABLE on the shared source schema
-      l2_haystaq_databricks_schema: "{{ var('l2_haystaq_databricks_schema', '') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        l2_s3_bucket: "{{ env_var('DBT_S3_BUCKET') }}"
+        l2_s3_access_key: "{{ env_var('DBT_S3_ACCESS_KEY') }}"
+        # optional override if your user doesn't have CREATE TABLE on the shared source schema
+        l2_haystaq_databricks_schema: "{{ var('l2_haystaq_databricks_schema', '') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:

--- a/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
@@ -51,9 +51,8 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["l2", "haystaq", "s3", "databricks", "load"],
     )
 
-    meta = dbt.config.get("meta")
-    s3_bucket = meta["l2_s3_bucket"]
-    databricks_schema_override = meta["l2_haystaq_databricks_schema"]
+    s3_bucket = dbt.config.meta_get("l2_s3_bucket")
+    databricks_schema_override = dbt.config.meta_get("l2_haystaq_databricks_schema")
 
     if databricks_schema_override:
         databricks_schema = databricks_schema_override

--- a/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
@@ -51,8 +51,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["l2", "haystaq", "s3", "databricks", "load"],
     )
 
-    s3_bucket = dbt.config.get("l2_s3_bucket")
-    databricks_schema_override = dbt.config.get("l2_haystaq_databricks_schema")
+    meta = dbt.config.get("meta")
+    s3_bucket = meta["l2_s3_bucket"]
+    databricks_schema_override = meta["l2_haystaq_databricks_schema"]
 
     if databricks_schema_override:
         databricks_schema = databricks_schema_override

--- a/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
@@ -272,26 +272,28 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["l2", "haystaq", "sftp", "s3", "load"],
     )
 
+    meta = dbt.config.get("meta")
+
     # sftp server configuration
-    sftp_host = dbt.config.get("l2_sftp_host")
-    sftp_port = int(dbt.config.get("l2_sftp_port"))
-    sftp_user = dbt.config.get("l2_sftp_user")
-    dbt_env_name = dbt.config.get("dbt_environment")
+    sftp_host = meta["l2_sftp_host"]
+    sftp_port = int(meta["l2_sftp_port"])
+    sftp_user = meta["l2_sftp_user"]
+    dbt_env_name = meta["dbt_environment"]
     sftp_password = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="l2-sftp-password"
     )
 
-    flags_remote_dir = dbt.config.get(
+    flags_remote_dir = meta.get(
         "l2_haystaq_flags_sftp_dir", "/L2-Haystaq Issue Model Flags for Voters"
     )
-    scores_remote_dir = dbt.config.get(
+    scores_remote_dir = meta.get(
         "l2_haystaq_scores_sftp_dir", "/L2-Haystaq Issue Model Scores"
     )
-    state_allowlist_raw = dbt.config.get("l2_state_allowlist")
+    state_allowlist_raw = meta["l2_state_allowlist"]
 
     # S3 configuration
-    s3_bucket = dbt.config.get("l2_s3_bucket")
-    s3_access_key = dbt.config.get("l2_s3_access_key")
+    s3_bucket = meta["l2_s3_bucket"]
+    s3_access_key = meta["l2_s3_access_key"]
     s3_secret_key = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="s3-secret-key"
     )

--- a/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
@@ -272,28 +272,26 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["l2", "haystaq", "sftp", "s3", "load"],
     )
 
-    meta = dbt.config.get("meta")
-
     # sftp server configuration
-    sftp_host = meta["l2_sftp_host"]
-    sftp_port = int(meta["l2_sftp_port"])
-    sftp_user = meta["l2_sftp_user"]
-    dbt_env_name = meta["dbt_environment"]
+    sftp_host = dbt.config.meta_get("l2_sftp_host")
+    sftp_port = int(dbt.config.meta_get("l2_sftp_port"))
+    sftp_user = dbt.config.meta_get("l2_sftp_user")
+    dbt_env_name = dbt.config.meta_get("dbt_environment")
     sftp_password = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="l2-sftp-password"
     )
 
-    flags_remote_dir = meta.get(
+    flags_remote_dir = dbt.config.meta_get(
         "l2_haystaq_flags_sftp_dir", "/L2-Haystaq Issue Model Flags for Voters"
     )
-    scores_remote_dir = meta.get(
+    scores_remote_dir = dbt.config.meta_get(
         "l2_haystaq_scores_sftp_dir", "/L2-Haystaq Issue Model Scores"
     )
-    state_allowlist_raw = meta["l2_state_allowlist"]
+    state_allowlist_raw = dbt.config.meta_get("l2_state_allowlist")
 
     # S3 configuration
-    s3_bucket = meta["l2_s3_bucket"]
-    s3_access_key = meta["l2_s3_access_key"]
+    s3_bucket = dbt.config.meta_get("l2_s3_bucket")
+    s3_access_key = dbt.config.meta_get("l2_s3_access_key")
     s3_secret_key = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="s3-secret-key"
     )

--- a/dbt/project/models/load/load__l2_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_s3_to_databricks.py
@@ -109,7 +109,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["l2", "s3", "databricks", "load"],
     )
 
-    s3_bucket = dbt.config.get("meta")["l2_s3_bucket"]
+    s3_bucket = dbt.config.meta_get("l2_s3_bucket")
     databricks_schema = f"{dbt.this.schema}_source"
 
     # get files loaded from sftp server into s3

--- a/dbt/project/models/load/load__l2_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_s3_to_databricks.py
@@ -109,7 +109,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["l2", "s3", "databricks", "load"],
     )
 
-    s3_bucket = dbt.config.get("l2_s3_bucket")
+    s3_bucket = dbt.config.get("meta")["l2_s3_bucket"]
     databricks_schema = f"{dbt.this.schema}_source"
 
     # get files loaded from sftp server into s3

--- a/dbt/project/models/load/load__l2_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_sftp_to_s3.py
@@ -323,18 +323,20 @@ def model(dbt, session: SparkSession):
         tags=["l2", "sftp", "s3", "load"],
     )
 
+    meta = dbt.config.get("meta")
+
     # sftp server configuration
-    sftp_host = dbt.config.get("l2_sftp_host")
-    sftp_port = int(dbt.config.get("l2_sftp_port"))
-    sftp_user = dbt.config.get("l2_sftp_user")
-    dbt_env_name = dbt.config.get("dbt_environment")
+    sftp_host = meta["l2_sftp_host"]
+    sftp_port = int(meta["l2_sftp_port"])
+    sftp_user = meta["l2_sftp_user"]
+    dbt_env_name = meta["dbt_environment"]
     sftp_password = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="l2-sftp-password"
     )
 
     # S3 configuration
-    s3_bucket = dbt.config.get("l2_s3_bucket")
-    s3_access_key = dbt.config.get("l2_s3_access_key")
+    s3_bucket = meta["l2_s3_bucket"]
+    s3_access_key = meta["l2_s3_access_key"]
     s3_secret_key = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="s3-secret-key"
     )

--- a/dbt/project/models/load/load__l2_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_sftp_to_s3.py
@@ -323,20 +323,18 @@ def model(dbt, session: SparkSession):
         tags=["l2", "sftp", "s3", "load"],
     )
 
-    meta = dbt.config.get("meta")
-
     # sftp server configuration
-    sftp_host = meta["l2_sftp_host"]
-    sftp_port = int(meta["l2_sftp_port"])
-    sftp_user = meta["l2_sftp_user"]
-    dbt_env_name = meta["dbt_environment"]
+    sftp_host = dbt.config.meta_get("l2_sftp_host")
+    sftp_port = int(dbt.config.meta_get("l2_sftp_port"))
+    sftp_user = dbt.config.meta_get("l2_sftp_user")
+    dbt_env_name = dbt.config.meta_get("dbt_environment")
     sftp_password = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="l2-sftp-password"
     )
 
     # S3 configuration
-    s3_bucket = meta["l2_s3_bucket"]
-    s3_access_key = meta["l2_s3_access_key"]
+    s3_bucket = dbt.config.meta_get("l2_s3_bucket")
+    s3_access_key = dbt.config.meta_get("l2_s3_access_key")
     s3_secret_key = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="s3-secret-key"
     )

--- a/dbt/project/models/marts/mban2026/m_mban2026.yml
+++ b/dbt/project/models/marts/mban2026/m_mban2026.yml
@@ -285,9 +285,10 @@ models:
 
     data_tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - hubspot_id
-            - outreach_id
+          arguments:
+            combination_of_columns:
+              - hubspot_id
+              - outreach_id
 
   - name: mban_election_results
     description: |
@@ -423,7 +424,8 @@ models:
 
     data_tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - hubspot_company_id
-            - election_date
-            - election_type
+          arguments:
+            combination_of_columns:
+              - hubspot_company_id
+              - election_date
+              - election_type

--- a/dbt/project/models/staging/airbyte_source/ballotready_api/stg_airbyte_source__ballotready_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/ballotready_api/stg_airbyte_source__ballotready_api.yaml
@@ -22,7 +22,8 @@ models:
               # BallotReady special elections in 2026+ have 1-6 races; a
               # match with >10 races likely indicates a regular election
               # whose name coincidentally contains "special".
-              expression: "<= 10"
+              arguments:
+                expression: "<= 10"
               config:
                 where: "lower(name) like '%special%' and election_day >= '2026-01-01'"
   - name: stg_airbyte_source__ballotready_api_issue

--- a/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
+++ b/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
@@ -17,13 +17,14 @@ models:
       - name: election_result
         data_tests:
           - accepted_values:
-              values:
-                - WON
-                - LOST
-                - RUNOFF
-                - GENERAL_WIN
-                - PRIMARY_WIN
-                - LOSS
+              arguments:
+                values:
+                  - WON
+                  - LOST
+                  - RUNOFF
+                  - GENERAL_WIN
+                  - PRIMARY_WIN
+                  - LOSS
       - name: is_judicial
         description: Whether the position is judicial
         data_tests:

--- a/dbt/project/models/staging/airflow_source/stg_airflow_source__l2_expired_voters.yaml
+++ b/dbt/project/models/staging/airflow_source/stg_airflow_source__l2_expired_voters.yaml
@@ -8,9 +8,10 @@ models:
       flagged as expired on L2's SFTP server.
     tests:
       - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - lalvoterid
-            - dag_run_id
+          arguments:
+            combination_of_columns:
+              - lalvoterid
+              - dag_run_id
     columns:
       - name: lalvoterid
         description: The L2 voter identifier that has been expired

--- a/dbt/project/models/staging/airflow_source/stg_airflow_source__l2_expired_voters_loads.yaml
+++ b/dbt/project/models/staging/airflow_source/stg_airflow_source__l2_expired_voters_loads.yaml
@@ -25,7 +25,8 @@ models:
         tests:
           - not_null
           - dbt_utils.accepted_range:
-              min_value: 0
+              arguments:
+                min_value: 0
       - name: loaded_at
         description: Timestamp when the load completed successfully
         tests:

--- a/dbt/project/models/staging/er_source/__er_source.yaml
+++ b/dbt/project/models/staging/er_source/__er_source.yaml
@@ -41,7 +41,8 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready", "techspeed", "ddhq", "gp_api"]
+              arguments:
+                values: ["ballotready", "techspeed", "ddhq", "gp_api"]
       - name: first_name
         description: Candidate first name (lowercased, trimmed in prematch).
       - name: last_name
@@ -71,15 +72,16 @@ models:
         description: Election stage (Primary, General, Runoff, or Special variants).
         data_tests:
           - accepted_values:
-              values:
-                - "Primary"
-                - "General"
-                - "Primary Runoff"
-                - "General Runoff"
-                - "Primary Special"
-                - "General Special"
-                - "Primary Special Runoff"
-                - "General Special Runoff"
+              arguments:
+                values:
+                  - "Primary"
+                  - "General"
+                  - "Primary Runoff"
+                  - "General Runoff"
+                  - "Primary Special"
+                  - "General Special"
+                  - "Primary Special Runoff"
+                  - "General Special Runoff"
       - name: email
         description: Candidate email address (sparse — used as a high-signal comparison in matching).
       - name: phone
@@ -138,13 +140,15 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready", "techspeed", "ddhq", "gp_api"]
+              arguments:
+                values: ["ballotready", "techspeed", "ddhq", "gp_api"]
       - name: source_name_r
         description: Origin source for the right record.
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready", "techspeed", "ddhq", "gp_api"]
+              arguments:
+                values: ["ballotready", "techspeed", "ddhq", "gp_api"]
       - name: source_id_l
         description: Left record's source-specific identifier.
       - name: source_id_r
@@ -352,7 +356,8 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready_techspeed", "gp_api"]
+              arguments:
+                values: ["ballotready_techspeed", "gp_api"]
       - name: first_name
         description: Official's first name (lowercased, trimmed in prematch).
       - name: last_name
@@ -443,8 +448,9 @@ models:
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
-              min_value: 0.01
-              max_value: 1.0
+              arguments:
+                min_value: 0.01
+                max_value: 1.0
       - name: unique_id_l
         description: Composite key (source_name|source_id) for the left record.
         data_tests:
@@ -458,13 +464,15 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready_techspeed", "gp_api"]
+              arguments:
+                values: ["ballotready_techspeed", "gp_api"]
       - name: source_name_r
         description: Origin source for the right record.
         data_tests:
           - not_null
           - accepted_values:
-              values: ["ballotready_techspeed", "gp_api"]
+              arguments:
+                values: ["ballotready_techspeed", "gp_api"]
       - name: source_id_l
         description: Source-specific identifier for the left record.
       - name: source_id_r
@@ -654,5 +662,6 @@ models:
           2=state+last_name, 3=phone exact, 4=email exact.
         data_tests:
           - dbt_utils.accepted_range:
-              min_value: 0
-              max_value: 4
+              arguments:
+                min_value: 0
+                max_value: 4

--- a/dbt/project/models/write/write.yaml
+++ b/dbt/project/models/write/write.yaml
@@ -6,14 +6,14 @@ models:
     description: >
       This model writes data to the election api database.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      election_db_host: "{{ env_var('DBT_ELECTION_DB_HOST') }}"
-      election_db_port: "{{ env_var('DBT_ELECTION_DB_PORT') }}"
-      election_db_name: "{{ env_var('DBT_ELECTION_DB_NAME') }}"
-      election_db_schema: "{{ env_var('DBT_ELECTION_DB_SCHEMA') }}"
-      election_db_user: "{{ env_var('DBT_ELECTION_DB_USER') }}"
-      staging_schema: "{{ env_var('DBT_STAGING_SCHEMA') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        election_db_host: "{{ env_var('DBT_ELECTION_DB_HOST') }}"
+        election_db_port: "{{ env_var('DBT_ELECTION_DB_PORT') }}"
+        election_db_name: "{{ env_var('DBT_ELECTION_DB_NAME') }}"
+        election_db_schema: "{{ env_var('DBT_ELECTION_DB_SCHEMA') }}"
+        election_db_user: "{{ env_var('DBT_ELECTION_DB_USER') }}"
+        staging_schema: "{{ env_var('DBT_STAGING_SCHEMA') }}"
         owner: "Data Engineering Team"
         contains_pii: true
     columns:
@@ -33,14 +33,14 @@ models:
     description: >
       This model writes data from Databricks to the voter db in gp-api.
     config:
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      staging_schema: "{{ env_var('DBT_STAGING_SCHEMA') }}"
-      voter_db_host: "{{ env_var('DBT_VOTER_DB_HOST') }}"
-      voter_db_port: "{{ env_var('DBT_VOTER_DB_PORT') }}"
-      voter_db_name: "{{ env_var('DBT_VOTER_DB_NAME') }}"
-      voter_db_schema: "{{ env_var('DBT_VOTER_DB_SCHEMA') }}"
-      voter_db_user: "{{ env_var('DBT_VOTER_DB_USER') }}"
       meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        staging_schema: "{{ env_var('DBT_STAGING_SCHEMA') }}"
+        voter_db_host: "{{ env_var('DBT_VOTER_DB_HOST') }}"
+        voter_db_port: "{{ env_var('DBT_VOTER_DB_PORT') }}"
+        voter_db_name: "{{ env_var('DBT_VOTER_DB_NAME') }}"
+        voter_db_schema: "{{ env_var('DBT_VOTER_DB_SCHEMA') }}"
+        voter_db_user: "{{ env_var('DBT_VOTER_DB_USER') }}"
         owner: "Data Engineering Team"
         contains_pii: false
     columns:
@@ -61,10 +61,11 @@ models:
       This model writes data from Databricks to the people api database.
     config:
       tags: ["monthly"]
-      dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
-      staging_schema: "{{ env_var('DBT_STAGING_SCHEMA') }}"
-      people_db_host: "{{ env_var('DBT_PEOPLE_DB_HOST') }}"
-      people_db_port: "{{ env_var('DBT_PEOPLE_DB_PORT') }}"
-      people_db_name: "{{ env_var('DBT_PEOPLE_DB_NAME') }}"
-      people_db_schema: "{{ env_var('DBT_PEOPLE_DB_SCHEMA') }}"
-      people_db_user: "{{ env_var('DBT_PEOPLE_DB_USER') }}"
+      meta:
+        dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
+        staging_schema: "{{ env_var('DBT_STAGING_SCHEMA') }}"
+        people_db_host: "{{ env_var('DBT_PEOPLE_DB_HOST') }}"
+        people_db_port: "{{ env_var('DBT_PEOPLE_DB_PORT') }}"
+        people_db_name: "{{ env_var('DBT_PEOPLE_DB_NAME') }}"
+        people_db_schema: "{{ env_var('DBT_PEOPLE_DB_SCHEMA') }}"
+        people_db_user: "{{ env_var('DBT_PEOPLE_DB_USER') }}"

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -509,17 +509,16 @@ def model(dbt, session: SparkSession) -> DataFrame:
     )
 
     # get db configs
-    meta = dbt.config.get("meta")
-    staging_schema = meta["staging_schema"]
-    db_host = meta["election_db_host"]
-    db_port = int(meta["election_db_port"])
-    db_user = meta["election_db_user"]
-    dbt_env = meta["dbt_environment"]
+    staging_schema = dbt.config.meta_get("staging_schema")
+    db_host = dbt.config.meta_get("election_db_host")
+    db_port = int(dbt.config.meta_get("election_db_port"))
+    db_user = dbt.config.meta_get("election_db_user")
+    dbt_env = dbt.config.meta_get("dbt_environment")
     db_pw = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="election-db-password"
     )
-    db_name = meta["election_db_name"]
-    db_schema = meta["election_db_schema"]
+    db_name = dbt.config.meta_get("election_db_name")
+    db_schema = dbt.config.meta_get("election_db_schema")
 
     # get the data to write
     candidacy_df: DataFrame = dbt.ref("m_election_api__candidacy")

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -509,16 +509,17 @@ def model(dbt, session: SparkSession) -> DataFrame:
     )
 
     # get db configs
-    staging_schema = dbt.config.get("staging_schema")
-    db_host = dbt.config.get("election_db_host")
-    db_port = int(dbt.config.get("election_db_port"))
-    db_user = dbt.config.get("election_db_user")
-    dbt_env = dbt.config.get("dbt_environment")
+    meta = dbt.config.get("meta")
+    staging_schema = meta["staging_schema"]
+    db_host = meta["election_db_host"]
+    db_port = int(meta["election_db_port"])
+    db_user = meta["election_db_user"]
+    dbt_env = meta["dbt_environment"]
     db_pw = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env}", key="election-db-password"
     )
-    db_name = dbt.config.get("election_db_name")
-    db_schema = dbt.config.get("election_db_schema")
+    db_name = meta["election_db_name"]
+    db_schema = meta["election_db_schema"]
 
     # get the data to write
     candidacy_df: DataFrame = dbt.ref("m_election_api__candidacy")

--- a/dbt/project/models/write/write__l2_databricks_to_gp_api.py
+++ b/dbt/project/models/write/write__l2_databricks_to_gp_api.py
@@ -1017,15 +1017,14 @@ def model(dbt, session: SparkSession) -> DataFrame:
     )
 
     # get dbt configs
-    meta = dbt.config.get("meta")
-    staging_schema = meta["staging_schema"]
-    db_host = meta["voter_db_host"]
-    db_port = int(meta["voter_db_port"])
-    db_user = meta["voter_db_user"]
-    dbt_env = meta["dbt_environment"]
+    staging_schema = dbt.config.meta_get("staging_schema")
+    db_host = dbt.config.meta_get("voter_db_host")
+    db_port = int(dbt.config.meta_get("voter_db_port"))
+    db_user = dbt.config.meta_get("voter_db_user")
+    dbt_env = dbt.config.meta_get("dbt_environment")
     db_pw = dbutils.secrets.get(scope=f"dbt-secrets-{dbt_env}", key="voter-db-password")  # type: ignore[name-defined]
-    db_name = meta["voter_db_name"]
-    db_schema = meta["voter_db_schema"]
+    db_name = dbt.config.meta_get("voter_db_name")
+    db_schema = dbt.config.meta_get("voter_db_schema")
 
     # get latest files loaded to databricks, filtering for uniform files
     loaded_to_databricks: DataFrame = dbt.ref("load__l2_s3_to_databricks").filter(

--- a/dbt/project/models/write/write__l2_databricks_to_gp_api.py
+++ b/dbt/project/models/write/write__l2_databricks_to_gp_api.py
@@ -1017,14 +1017,15 @@ def model(dbt, session: SparkSession) -> DataFrame:
     )
 
     # get dbt configs
-    staging_schema = dbt.config.get("staging_schema")
-    db_host = dbt.config.get("voter_db_host")
-    db_port = int(dbt.config.get("voter_db_port"))
-    db_user = dbt.config.get("voter_db_user")
-    dbt_env = dbt.config.get("dbt_environment")
+    meta = dbt.config.get("meta")
+    staging_schema = meta["staging_schema"]
+    db_host = meta["voter_db_host"]
+    db_port = int(meta["voter_db_port"])
+    db_user = meta["voter_db_user"]
+    dbt_env = meta["dbt_environment"]
     db_pw = dbutils.secrets.get(scope=f"dbt-secrets-{dbt_env}", key="voter-db-password")  # type: ignore[name-defined]
-    db_name = dbt.config.get("voter_db_name")
-    db_schema = dbt.config.get("voter_db_schema")
+    db_name = meta["voter_db_name"]
+    db_schema = meta["voter_db_schema"]
 
     # get latest files loaded to databricks, filtering for uniform files
     loaded_to_databricks: DataFrame = dbt.ref("load__l2_s3_to_databricks").filter(

--- a/dbt/project/models/write/write__people_api_db.py
+++ b/dbt/project/models/write/write__people_api_db.py
@@ -657,13 +657,14 @@ def model(dbt, session: SparkSession) -> DataFrame:
     )
 
     # get dbt configs
-    staging_schema = dbt.config.get("staging_schema")
-    db_host = dbt.config.get("people_db_host")
-    db_port = int(dbt.config.get("people_db_port"))
-    db_name = dbt.config.get("people_db_name")
-    db_schema = dbt.config.get("people_db_schema")
-    db_user = dbt.config.get("people_db_user")
-    dbt_env_name = dbt.config.get("dbt_environment")
+    meta = dbt.config.get("meta")
+    staging_schema = meta["staging_schema"]
+    db_host = meta["people_db_host"]
+    db_port = int(meta["people_db_port"])
+    db_name = meta["people_db_name"]
+    db_schema = meta["people_db_schema"]
+    db_user = meta["people_db_user"]
+    dbt_env_name = meta["dbt_environment"]
     db_pw = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="people-db-password"
     )

--- a/dbt/project/models/write/write__people_api_db.py
+++ b/dbt/project/models/write/write__people_api_db.py
@@ -657,14 +657,13 @@ def model(dbt, session: SparkSession) -> DataFrame:
     )
 
     # get dbt configs
-    meta = dbt.config.get("meta")
-    staging_schema = meta["staging_schema"]
-    db_host = meta["people_db_host"]
-    db_port = int(meta["people_db_port"])
-    db_name = meta["people_db_name"]
-    db_schema = meta["people_db_schema"]
-    db_user = meta["people_db_user"]
-    dbt_env_name = meta["dbt_environment"]
+    staging_schema = dbt.config.meta_get("staging_schema")
+    db_host = dbt.config.meta_get("people_db_host")
+    db_port = int(dbt.config.meta_get("people_db_port"))
+    db_name = dbt.config.meta_get("people_db_name")
+    db_schema = dbt.config.meta_get("people_db_schema")
+    db_user = dbt.config.meta_get("people_db_user")
+    dbt_env_name = dbt.config.meta_get("dbt_environment")
     db_pw = dbutils.secrets.get(  # type: ignore[name-defined]
         scope=f"dbt-secrets-{dbt_env_name}", key="people-db-password"
     )


### PR DESCRIPTION
## Summary

Clears the two dbt deprecation warnings on every dbt Cloud run ([example run](https://yx558.us1.dbt.com/deploy/70471823433531/projects/70471823438007/runs/70471880995321/)). `dbt parse --no-partial-parse` is clean afterward.

## Changes

### `CustomKeyInConfigDeprecation` (was 61 occurrences)

Moved custom config keys (`dbt_environment`, `staging_schema`, `*_db_*`, `l2_sftp_*`, `l2_s3_*`, `l2_state_allowlist`, `l2_haystaq_*`) from the top of `config:` into `config.meta` across `write.yaml`, `load.yaml`, `int__l2.yaml`, and `int__ballotready_py.yaml` (20 models).

Python models that read these values now use `dbt.config.meta_get(key)`. The first push tried `dbt.config.get("meta")[key]` and broke Python models on dbt-databricks: the adapter's wrapper macro (`build_config_dict` in dbt-adapters' `python_model/python.sql`) only populates `meta_dict` for keys actually referenced via `meta_get(...)`, so `dbt.config.get("meta")` returns `None`. Fix verified locally — compile artifacts show `meta_dict` correctly populated; `dbt build --select int__l2_nationwide_haystaq_flags --vars 'l2_state_allowlist: AK'` runs past the meta lookup.

### `MissingArgumentsPropertyInGenericTestDeprecation` (was 9+ occurrences)

Wrapped top-level test args under `arguments:` for `unique_combination_of_columns`, `accepted_values`, `accepted_range`, and `expression_is_true` across 6 yaml files.

### `dbt/project/CLAUDE.md`

Documented both conventions with good/bad examples, and explicitly flagged that `dbt.config.get("meta")[key]` returns `None` on dbt-databricks — use `dbt.config.meta_get(key)`.

## Pre-merge data parity (`dbt_cloud_pr_70471823431465_420` vs `dbt`)

PR's code changes are pure refactoring; the merge from main brought DATA-1582 changes already deployed to prod. Spot-checked across 31 models:

- **Schemas (column sets)**: identical for every model spot-checked, including the largest row-count gaps. No columns dropped or added.
- **Static / non-incremental models**: exact match — `int__enhanced_race` 1,593,856 = 1,593,856; `m_election_api__place` 48,435; `m_election_api__race` 263,649; `m_election_api__zip_to_position` 1,101,852; `m_general__contest` / `election` / `election_stage` all match.
- **Incremental models — small positive delta in PR** (full-refresh captured rows that landed after prod's last incremental):
  - `int__ballotready_candidacy` +0.2%, `_endorsement` +0.4%, `_geofence` +2.5%, `_stance` +0.2%
  - `m_election_api__candidacy` +5%, `m_general__*` within ~0.1%
- **L2 haystaq nationwide — PR has fewer rows** (212.5M vs 221.8M): full-refresh vs incremental-accumulation pattern. Prod has accumulated rows from many historical loads; PR reflects current source state. Both valid; PR is the "fresh" snapshot.
- **Distribution sanity checks**:
  - Party mix in `m_election_api__candidacy` matches expected DATA-1922 widening: Republican 8,833 / 8,243; Democratic 5,944 / 5,719; Nonpartisan 4,926 / 4,771; same minor-party long tail.
  - `is_incumbent` ratio: PR 42.5% true (1,155 / 2,720 non-null), prod 43.1% true (1,148 / 2,663) — essentially identical.

## Out of scope

The original prod run surfaced a `dbt source freshness` error on `gp_api_db_path_to_victory`. Investigated and deferred: the source inherits the `airbyte_source` default (`warn>10d, error>31d`) and is past the threshold. Siblings that don't refresh (`ecanvasser_interaction`, `election_type`, `position`, `top_issue`) opt out with `config: { freshness: null }`; `path_to_victory` does not. It's referenced by `int__hubspot_contacts_w_companies.sql` and `int__hubspot_companies_w_contacts_2025.sql`, so the gp_api_db ingest owner needs to either refresh upstream or opt out.

## References

- [dbt-adapters `python_model/python.sql`](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/src/dbt/include/global_project/macros/python_model/python.sql) — the macro that builds the runtime config dict
- [dbt-databricks `python_submissions.py`](https://github.com/databricks/dbt-databricks/blob/main/dbt/adapters/databricks/python_models/python_submissions.py) — the Python materialization
- [dbt-core issue #12314](https://github.com/dbt-labs/dbt-core/issues/12314) — known `CustomKeyInConfigDeprecation` false-positive context

## Test plan

- [x] `dbt parse --no-partial-parse` returns zero deprecation warnings
- [x] `pre-commit run --all-files` passes
- [x] Local `dbt build` confirms `meta_get` resolves at runtime
- [x] dbt Cloud CI on this PR passes (post haystaq view rebuild via monthly job)
- [x] PR-schema vs prod data parity verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)