### PR TITLE
Disable source freshness for dropped path_to_victory table

### DIFF
--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -108,6 +108,12 @@ sources:
         description: raw data load from gp_api_db postgres db from table `outreach`
       - name: gp_api_db_path_to_victory
         description: raw data load from gp_api_db postgres db from table `path_to_victory`
+        # The upstream `path_to_victory` table was dropped from gp-api on 2026-04-15
+        # (https://github.com/thegoodparty/gp-api/pull/1444). No new rows will load,
+        # so freshness is disabled here to stop the source from going STALE. Source
+        # is retained in dbt for now; remove once downstream usage is cleaned up.
+        config:
+          freshness: null
       - name: gp_api_db_position
         description: raw data load from gp_api_db postgres db from table `position`
         config:


### PR DESCRIPTION
## What

Disable dbt source freshness on `airbyte_source.gp_api_db_path_to_victory` by setting `config: freshness: null` on that source table in `dbt/project/models/staging/__sources.yaml`.

## Why

The upstream `path_to_victory` table was dropped from gp-api on 2026-04-15 (thegoodparty/gp-api#1444). No new rows load into this source, so the `dbt source freshness` job has been failing with `ERROR STALE` once the last loaded rows aged past the 31-day `error_after` threshold.

This change stops the failure while keeping the source and its downstream models in place. It matches the existing pattern used by other gp_api_db source tables that disable freshness (e.g. `gp_api_db_ecanvasser_interaction`, `gp_api_db_position`).

## Follow-up (not in this PR)

The source and downstream references are intentionally retained for now. Full retirement is a separate cleanup, which would touch:
- `stg_airbyte_source__gp_api_db_path_to_victory.sql`
- `int__hubspot_contacts_w_companies.sql`
- `int__hubspot_companies_w_contacts_2025.sql`

## Testing

- Pre-commit hooks pass (check yaml, pytest, etc.)
- YAML parses and the table entry resolves to `config: {freshness: null}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)