### PR TITLE
[DATA-1945] Add int__amplitude_event_taxonomy single-source event classification

### DIFF
--- a/dbt/project/macros/amplitude_event_taxonomy.sql
+++ b/dbt/project/macros/amplitude_event_taxonomy.sql
@@ -1,0 +1,142 @@
+{% macro amplitude_event_family(event_type_col) %}
+    {#
+        Classify an Amplitude event_type into a product-feature family.
+
+        Pattern-based (LIKE / IN), so new event_types within a known family
+        classify automatically as the product ships them (e.g. the onboarding
+        redesign of ~2026-05-06 added many 'Onboarding -%' events that land in
+        win_onboarding with no change here). Patterns are grounded in the
+        webapp event catalog (gp-webapp/helpers/analyticsHelper.ts EVENTS map)
+        and runbook win.md section 4.
+
+        Win families are prefixed `win_`; the is_win flag downstream is derived
+        as `family like 'win_%'`. Anything unmatched falls through to 'other'
+        so unclassified events surface for triage rather than silently dropping.
+
+        Args:
+            event_type_col: SQL expression producing the event_type string.
+
+        Usage:
+            {{ amplitude_event_family('event_type') }} as family
+    #}
+    case
+        -- Win product families
+        when
+            {{ event_type_col }} like 'Onboarding -%'
+            or {{ event_type_col }} like 'Onboarding:%'
+            or {{ event_type_col }}
+            in ('onboarding_complete', 'Invalid Party', 'Sign Up Clicked')
+        then 'win_onboarding'
+        when {{ event_type_col }} like 'Dashboard -%'
+        then 'win_dashboard'
+        when {{ event_type_col }} like 'Voter Outreach -%'
+        then 'win_voter_outreach'
+        when {{ event_type_col }} like 'Outreach -%'
+        then 'win_outreach_planning'
+        when
+            {{ event_type_col }} like 'Schedule Text Campaign%'
+            or {{ event_type_col }} like 'schedule_campaign%'
+        then 'win_outreach_scheduling'
+        when
+            {{ event_type_col }} like 'Content Builder%'
+            or {{ event_type_col }} like 'ai_content_%'
+            or {{ event_type_col }} like 'campaign_assistant%'
+        then 'win_content_builder'
+        when
+            {{ event_type_col }} like 'Voter Data -%'
+            or {{ event_type_col }} like 'Voter Data:%'
+            or {{ event_type_col }} like 'Download Voter%'
+            or {{ event_type_col }} like 'Custom Voter%'
+        then 'win_voter_data'
+        when {{ event_type_col }} like 'Profile -%'
+        then 'win_candidate_profile'
+        when
+            {{ event_type_col }} like 'Pro Upgrade -%'
+            or {{ event_type_col }} like 'Pro Upgrade:%'
+            or {{ event_type_col }} = 'pro_upgrade_complete'
+        then 'win_pro_upgrade'
+        when {{ event_type_col }} like 'P2P Upgrade -%'
+        then 'win_p2p_upgrade'
+        when {{ event_type_col }} like 'Candidate Website%'
+        then 'win_candidate_website'
+        when {{ event_type_col }} like 'Candidacy -%'
+        then 'win_candidacy_self_report'
+        when
+            {{ event_type_col }} like 'Campaign Verify%'
+            or {{ event_type_col }} like 'Campaign Plan%'
+            or {{ event_type_col }} like '10 DLC Compliance%'
+            or {{ event_type_col }} like '10DLC%'
+        then 'win_compliance_or_planning'
+        when
+            {{ event_type_col }} like 'AI Assistant%'
+            or {{ event_type_col }} = 'question_complete'
+        then 'win_ai_assistant'
+        when {{ event_type_col }} like 'Briefings -%'
+        then 'win_briefings'
+        when {{ event_type_col }} like 'Contacts -%'
+        then 'win_contacts'
+        when {{ event_type_col }} like 'Resources -%'
+        then 'win_resources'
+        -- Non-Win / cross-product / noise
+        when
+            {{ event_type_col }} like 'Serve Onboarding%'
+            or {{ event_type_col }} like 'Poll - %'
+            or {{ event_type_col }} like 'Polls -%'
+            or {{ event_type_col }} like 'Polls:%'
+            or {{ event_type_col }} like 'Payment -%'
+        then 'serve'
+        when
+            {{ event_type_col }} like 'Sign In:%'
+            or {{ event_type_col }} like 'Sign Up:%'
+            or {{ event_type_col }} like 'Set Password:%'
+            or {{ event_type_col }} like 'Account -%'
+            or {{ event_type_col }} like 'Settings -%'
+        then 'auth_or_settings'
+        when
+            {{ event_type_col }} like 'Navigation -%'
+            or {{ event_type_col }} like 'Navigation Top -%'
+        then 'navigation'
+        when {{ event_type_col }} = 'Viewed'
+        then 'viewed_generic'
+        when {{ event_type_col }} like '[Amplitude]%'
+        then 'amplitude_autotrack'
+        when
+            {{ event_type_col }} like '[Experiment]%'
+            or {{ event_type_col }} = 'Experiment Viewed'
+        then 'experiment_assignment'
+        when
+            {{ event_type_col }} in (
+                'Scroll Depth',
+                'session_start',
+                'session_end',
+                'page_view',
+                'Page Viewed',
+                'Page',
+                'usersnap_submission'
+            )
+            or {{ event_type_col }} like 'Segment Consent%'
+        then 'session_or_browser'
+        else 'other'
+    end
+{% endmacro %}
+
+
+{% macro amplitude_event_is_recurrent(event_type_col) %}
+    {#
+        Flag recurrent-activity events vs one-off lifecycle milestones.
+
+        Recurrence is an event-level property (not a family property), so this
+        is a short explicit allowlist rather than a pattern. The set matches
+        exactly the events modeled by the Win activity rollups
+        (int__amplitude_win_activity and its weekly variant). Extend this list
+        when a genuinely recurrent activity event is added to those rollups.
+
+        Args:
+            event_type_col: SQL expression producing the event_type string.
+
+        Usage:
+            {{ amplitude_event_is_recurrent('event_type') }} as is_recurrent
+    #}
+    {{ event_type_col }}
+    in ('Voter Outreach - Campaign Completed', 'Dashboard - Candidate Dashboard Viewed')
+{% endmacro %}

--- a/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
@@ -464,3 +464,93 @@ models:
             expression: "recipient_count >= 0"
           config:
             where: "recipient_count is not null"
+
+  - name: int__amplitude_event_taxonomy
+    description: >
+      Single source of truth for Amplitude event-family classification. One row
+      per distinct event_type, bucketed into a product-feature family via
+      pattern matching (amplitude_event_family macro). Replaces event-type logic
+      previously duplicated across int__amplitude_win_activity,
+      int__amplitude_user_milestones, the analytics helper, and the runbook
+      (DATA-1945). Pattern-based so new event_types in known families classify
+      automatically; first_seen_date enables drift control via
+      WHERE first_seen_date <= '<cutoff>'.
+
+      Grain: one row per distinct event_type. Source:
+      stg_airbyte_source__amplitude_api_events.
+    columns:
+      - name: event_type
+        description: Distinct Amplitude event name. Primary key for this model.
+        data_tests:
+          - unique
+          - not_null
+
+      - name: family
+        description: >
+          Product-feature bucket. Win families are prefixed `win_`; non-Win
+          buckets cover serve, auth/settings, navigation, and anonymous noise.
+          Unmatched event_types fall through to 'other' for triage.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - win_onboarding
+                  - win_dashboard
+                  - win_voter_outreach
+                  - win_outreach_planning
+                  - win_outreach_scheduling
+                  - win_content_builder
+                  - win_voter_data
+                  - win_candidate_profile
+                  - win_pro_upgrade
+                  - win_p2p_upgrade
+                  - win_candidate_website
+                  - win_candidacy_self_report
+                  - win_compliance_or_planning
+                  - win_ai_assistant
+                  - win_briefings
+                  - win_contacts
+                  - win_resources
+                  - serve
+                  - auth_or_settings
+                  - navigation
+                  - viewed_generic
+                  - amplitude_autotrack
+                  - experiment_assignment
+                  - session_or_browser
+                  - other
+
+      - name: is_win
+        description: >
+          True for Win-product candidate-attributed families (family like 'win_%').
+          False for serve / cross-product / noise.
+        data_tests:
+          - not_null
+
+      - name: is_recurrent
+        description: >
+          True for recurrent-activity events (vs one-off lifecycle milestones).
+          Determines which events belong in the Win activity rollups. Event-level
+          allowlist, not a pattern (see amplitude_event_is_recurrent macro).
+        data_tests:
+          - not_null
+
+      - name: first_seen_date
+        description: >
+          Date of first appearance in the raw event stream. Use as a drift cutoff
+          to exclude late-arriving event families from retrospective analyses.
+        data_tests:
+          - not_null
+
+      - name: event_count
+        description: Total occurrences of this event_type in the raw stream (volume context).
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_win or not is_recurrent"

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_event_taxonomy.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_event_taxonomy.sql
@@ -1,0 +1,58 @@
+{{ config(materialized="table") }}
+
+/*
+    int__amplitude_event_taxonomy
+
+    Purpose:
+        Single source of truth for Amplitude event-family classification.
+        One row per distinct event_type, classified into a product-feature
+        family via pattern matching. Replaces event-type logic that was
+        duplicated across int__amplitude_win_activity, int__amplitude_user_milestones,
+        the analytics helper, and the runbook (DATA-1945, calibration finding C1).
+
+    Grain:
+        One row per distinct event_type seen in the raw event stream.
+
+    Source:
+        {{ ref('stg_airbyte_source__amplitude_api_events') }}
+
+    Columns:
+        - event_type      : distinct Amplitude event name (primary key)
+        - family          : product-feature bucket (see amplitude_event_family macro)
+        - is_win          : Win-product candidate-attributed family (family like 'win_%')
+        - is_recurrent    : recurrent activity vs one-off lifecycle milestone
+                            (see amplitude_event_is_recurrent macro)
+        - first_seen_date : first appearance in the raw stream; enables drift control
+                            via WHERE first_seen_date <= '<cutoff>'
+        - event_count     : total occurrences (volume context for drift triage)
+
+    Notes:
+        - Classification is pattern-based, so new event_types in known families
+          classify automatically (e.g. the ~2026-05-06 onboarding redesign events).
+        - Materialized as a table (not a view like sibling int__amplitude models)
+          because it is a full-stream aggregation feeding many consumers, including
+          notebooks that SELECT/JOIN it directly via databricks-sql-connector and
+          cannot call dbt macros. It is tiny (~one row per event_type).
+        - The _list catalog (stg_airbyte_source__amplitude_api_events_list) is used
+          only as a dev-time coverage cross-check, not unioned into the grain, so we
+          do not classify catalog-defined events that never fired.
+*/
+with
+    event_stream as (
+        select
+            event_type,
+            min(cast(event_time as date)) as first_seen_date,
+            count(*) as event_count
+        from {{ ref("stg_airbyte_source__amplitude_api_events") }}
+        where event_type is not null
+        group by event_type
+    )
+
+select
+    event_type,
+    {{ amplitude_event_family("event_type") }} as family,
+    family like 'win_%' as is_win,
+    {{ amplitude_event_is_recurrent("event_type") }} as is_recurrent,
+    first_seen_date,
+    event_count
+from event_stream

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_user_milestones.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_user_milestones.sql
@@ -78,6 +78,11 @@ with
         where
             user_id is not null
             and try_cast(user_id as bigint) is not null
+            -- This is a bespoke milestone pick (specific named lifecycle events),
+            -- not a taxonomy family, so the list stays explicit here. The
+            -- single-source classifier is int__amplitude_event_taxonomy
+            -- (DATA-1945); a singular test (assert_milestone_events_classified)
+            -- guards that every event below classifies to a non-'other' family.
             and event_type in (
                 'Onboarding - Registration Completed',
                 'onboarding_complete',

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity.sql
@@ -54,9 +54,14 @@ with
         where
             user_id is not null
             and try_cast(user_id as bigint) is not null
+            -- Recurrent-activity events come from the single-source taxonomy
+            -- (DATA-1945) instead of a hardcoded list. Resolves to the same 2
+            -- events: 'Voter Outreach - Campaign Completed',
+            -- 'Dashboard - Candidate Dashboard Viewed'.
             and event_type in (
-                'Voter Outreach - Campaign Completed',
-                'Dashboard - Candidate Dashboard Viewed'
+                select event_type
+                from {{ ref("int__amplitude_event_taxonomy") }}
+                where is_recurrent
             )
     ),
 

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity_weekly.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity_weekly.sql
@@ -61,9 +61,14 @@ with
         where
             user_id is not null
             and try_cast(user_id as bigint) is not null
+            -- Recurrent-activity events come from the single-source taxonomy
+            -- (DATA-1945) instead of a hardcoded list. Resolves to the same 2
+            -- events: 'Voter Outreach - Campaign Completed',
+            -- 'Dashboard - Candidate Dashboard Viewed'.
             and event_type in (
-                'Voter Outreach - Campaign Completed',
-                'Dashboard - Candidate Dashboard Viewed'
+                select event_type
+                from {{ ref("int__amplitude_event_taxonomy") }}
+                where is_recurrent
             )
     ),
 

--- a/dbt/project/tests/assert_milestone_events_classified.sql
+++ b/dbt/project/tests/assert_milestone_events_classified.sql
@@ -1,0 +1,29 @@
+-- Drift guard for DATA-1945: every event_type that int__amplitude_user_milestones
+-- aggregates must classify to a real (non-'other') family in the single-source
+-- taxonomy. Classification is checked directly through the amplitude_event_family
+-- macro (not via the materialized model), so this guards the pattern logic itself
+-- regardless of whether each event has appeared in the current stream window.
+--
+-- Fails (returns rows) if a milestone event falls through to 'other', i.e. the
+-- pattern set no longer covers it. Keep this list in sync with the event_type
+-- filter in int__amplitude_user_milestones.sql.
+with
+    milestone_events(event_type) as (
+        values
+            ('Onboarding - Registration Completed'),
+            ('onboarding_complete'),
+            ('pro_upgrade_complete'),
+            ('Voter Outreach - Campaign Completed'),
+            ('Dashboard - Candidate Dashboard Viewed'),
+            ('Serve Onboarding - Getting Started Viewed'),
+            ('Serve Onboarding - Constituency Profile Viewed'),
+            ('Serve Onboarding - Poll Value Props Viewed'),
+            ('Serve Onboarding - Poll Strategy Viewed'),
+            ('Serve Onboarding - Add Image Viewed'),
+            ('Serve Onboarding - Poll Preview Viewed'),
+            ('Serve Onboarding - SMS Poll Sent')
+    )
+
+select event_type, {{ amplitude_event_family("event_type") }} as family
+from milestone_events
+where {{ amplitude_event_family("event_type") }} = 'other'


### PR DESCRIPTION
## What

Adds `int__amplitude_event_taxonomy`, a single source of truth for Amplitude
event-family classification, replacing event-type logic that was duplicated across
multiple models (DATA-1945, surfaced as calibration finding C1).

One row per distinct `event_type` with: `family`, `is_win`, `is_recurrent`,
`first_seen_date`, `event_count`. Classification is pattern-based (`LIKE`/`IN`) and
lives in a reusable dbt macro, so new events in known families classify
automatically; the model is materialized as a table so notebooks using
`databricks-sql-connector` (which cannot call dbt macros) can `SELECT`/`JOIN` it.

## Why pattern-based

Concrete validation: the onboarding redesign launched ~2026-05-06 added many new
`Onboarding -%` events (Welcome / Ballot Status / Know Your Voters / Path To Victory
/ step events). They all land in `win_onboarding` with no change here, and their
`first_seen_date` reads 2026-05-07/08 in the model. Drift is now controllable with
`WHERE first_seen_date <= '<cutoff>'` instead of hand-maintained exclusions.

## Changes

- `macros/amplitude_event_taxonomy.sql` — `amplitude_event_family` (the pattern
  CASE, grounded in the webapp `EVENTS` catalog cross-checked against runbook §4) and
  `amplitude_event_is_recurrent` (a short event-level allowlist, since recurrence is
  not a family property).
- `int__amplitude_event_taxonomy.sql` — the model (materialized table).
- `int__amplitude.yaml` — docs + tests (`unique`/`not_null` on `event_type`,
  `accepted_values` on `family`, `not_null` on the flags, and a recurrent-implies-win
  invariant).
- `int__amplitude_win_activity.sql` — consumes the taxonomy via an `is_recurrent`
  semijoin instead of a hardcoded 2-event list. Output is unchanged: the subquery
  resolves to exactly the same two events.
- `int__amplitude_user_milestones.sql` — keeps its bespoke milestone list (a
  specific named-event pick the family taxonomy cannot cleanly express); adds a
  comment pointing to the taxonomy as the canonical classifier.
- `tests/assert_milestone_events_classified.sql` — singular test guarding that every
  milestone event classifies to a non-`other` family.

## Validation (dev schema `private_tristan`)

- Built and `inspect_data`-checked: 317 event types, all columns 100% populated.
- Family distribution reviewed; the `other` catch-all holds only anonymous noise and
  a few ambiguous long-tail events (no high-volume Win event misrouted). Long-tail
  events were deliberately left in `other` rather than over-fitting patterns.
- `is_recurrent` resolves to exactly the two activity events.
- `_list` catalog cross-check: no catalog event missing from the stream-derived grain.
- `dbt build` on the model + `int__amplitude_win_activity` + the singular test:
  36/36 pass.

## Scope note (deferred)

This PR is dbt-only. The two remaining DATA-1945 acceptance criteria — updating
`analytics/lib/win_analysis.py` to read the model and deriving/syncing runbook §4
from it — touch files that do not exist on `main` (they live on the analytics
working branch). They will be done as a follow-up on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Win activity events are selected (now via the taxonomy table) and defines the shared classification contract used by future analytics; mis-patterns would skew buckets/KPIs, though monthly Win activity is intended to stay equivalent and tests guard milestones and recurrent⊂win.
> 
> **Overview**
> Introduces a **single source of truth** for Amplitude `event_type` classification (DATA-1945): reusable dbt macros **`amplitude_event_family`** (pattern-based `LIKE`/`IN` buckets, including `win_*` families and an `other` catch-all) and **`amplitude_event_is_recurrent`** (explicit allowlist for the two Win activity events).
> 
> Adds materialized **`int__amplitude_event_taxonomy`** (one row per distinct `event_type` from the raw stream) with `family`, `is_win`, `is_recurrent`, `first_seen_date`, and `event_count`, plus schema tests in **`int__amplitude.yaml`** (`accepted_values` on `family`, invariant that recurrent events are Win).
> 
> **`int__amplitude_win_activity`** now filters events via `int__amplitude_event_taxonomy` where `is_recurrent` instead of a hardcoded two-event list (intended to resolve to the same events). **`int__amplitude_user_milestones`** keeps its explicit milestone event list but documents the taxonomy as canonical and adds singular test **`assert_milestone_events_classified`** so those events never classify as `other`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9bdf19efe65b0420f99b9cf6badb6591ab8bdf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->