### PR TITLE
Surface serve_waitlist flag on hubspot contacts

### DIFF
--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api.yaml
@@ -168,6 +168,16 @@ models:
           - accepted_values:
               arguments:
                 values: [true, false]
+      - name: is_on_serve_waitlist
+        description: >
+          Whether the contact is on the Serve waitlist (HubSpot
+          `serve_waitlist` property, extracted from the `properties` JSON
+          blob). The deprecated top-level `properties_serve_waitlist` column
+          in the snapshot is stale and should not be used.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
       - name: product_line
         description: HubSpot product line classification for the contact.
       - name: product_stage

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_contacts.sql
@@ -45,6 +45,8 @@ select
     as has_verbal_pro,
     {{ cast_to_boolean("get_json_object(properties, '$.verbal_serve')") }}
     as has_verbal_serve,
+    {{ cast_to_boolean("get_json_object(properties, '$.serve_waitlist')") }}
+    as is_on_serve_waitlist,
     properties_verified_candidate_status as verified_candidate_status,
     properties_type as type,
     properties_product_user as product_user,


### PR DESCRIPTION
## What

Adds `is_on_serve_waitlist` to the HubSpot contacts staging model, which surfaces it in the `hubspot_contacts` mart and Sigma.

## Why

To analyze characteristics of contacts on the Serve waitlist. The flag lived only in the stale top-level `properties_serve_waitlist` snapshot column (44 values, all March 2026), because Airbyte stopped promoting it as a top-level column. The current values are in the `properties` JSON blob, which this model now reads.

## Change

- Staging model: extract `is_on_serve_waitlist` from `properties` using the existing `cast_to_boolean` pattern.
- Staging yaml: column description + `accepted_values` test.
- No mart edit needed: `hubspot_contacts` is a `select *` passthrough.

## Verification

`dbt build` on both models: 27 pass, 0 errors. The mart shows 614 contacts with `is_on_serve_waitlist = true`.

## Heads up on the count

This surfaces ~614 contacts, not the 900+ that was mentioned. 614 is every contact with `serve_waitlist = true` in synced HubSpot data. If 900+ is expected, the gap is on the HubSpot/sync side, not the modeling, so it's worth confirming which figure is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)