### PR TITLE
Exclude gp_api-only candidacies from election-api civics pulls

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api__candidacy.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__candidacy.sql
@@ -95,7 +95,15 @@ with
                 max_by(is_incumbent, updated_at)
             ) as is_incumbent
         from {{ ref("candidacy") }}
-        where gp_candidate_id is not null and br_position_database_id is not null
+        where
+            gp_candidate_id is not null
+            and br_position_database_id is not null
+            -- Exclude candidacies whose only provenance is the GP product DB
+            -- (gp_api). A singular gp_api source means the candidacy exists
+            -- only because someone signed up in our product, with no external
+            -- (BallotReady / TechSpeed / DDHQ / HubSpot) corroboration, so it
+            -- should not feed the election-api.
+            and not (size(source_systems) = 1 and source_systems[0] = 'gp_api')
         group by gp_candidate_id, br_position_database_id
     ),
     enhanced_candidacy as (

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -57,7 +57,14 @@ with
             max(official_office_name) as official_office_name,
             max(office_level) as office_level
         from {{ ref("candidacy") }}
-        where gp_election_id is not null
+        where
+            gp_election_id is not null
+            -- Exclude candidacies whose only provenance is the GP product DB
+            -- (gp_api). A singular gp_api source means the candidacy exists
+            -- only because someone signed up in our product, with no external
+            -- (BallotReady / TechSpeed / DDHQ / HubSpot) corroboration, so it
+            -- should not feed the election-api.
+            and not (size(source_systems) = 1 and source_systems[0] = 'gp_api')
         group by gp_election_id
     )
 


### PR DESCRIPTION
## Summary

The election_api mart enriches its BallotReady-spined candidacy and race models with attributes pulled from the civics `candidacy` table. This change requires those candidacies to carry a source other than a singular `gp_api` source before they feed the election-api.

Candidacies whose only provenance is the GP product DB (`source_systems = ['gp_api']`) exist only because someone signed up in our product, with no external BallotReady / TechSpeed / DDHQ / HubSpot corroboration. They should not influence the data exposed to the election-api.

## Changes

Added the same filter to both civics `candidacy` reads in the election_api mart:

```sql
and not (size(source_systems) = 1 and source_systems[0] = 'gp_api')
```

- `m_election_api__candidacy` — `civics_candidacy_attrs` CTE (drives `is_incumbent`)
- `m_election_api__race` — `civics_race_attrs` CTE (drives race-level attributes aggregated from candidacies)

`source_systems` is a non-null, non-empty array; values are `gp_api`, `ballotready`, `techspeed`, `ddhq`, `hubspot`. Any candidacy with at least one non-`gp_api` source is retained (e.g. `['gp_api','ballotready']` stays; `['gp_api']` is dropped). The `election` and `election_stage` civics refs are election/race grain, not candidacies, and were left unchanged.

## Verification

- Distribution: 10,349 gp_api-only candidacies (across 6,720 elections) are excluded; 259,744 candidacies with another source are retained.
- `dbt build` on `m_election_api__race`, `m_election_api__candidacy`, and `m_election_api__stance` — all models materialize and all tests pass.

## Note

Both civics reads are `LEFT JOIN` enrichments onto a BallotReady candidacy spine, so this filter changes enrichment values (`is_incumbent`; race `office_type` / `is_partisan` / etc.) rather than dropping rows from the exposed candidacy/race sets. gp_api-only candidacies do not enter the BallotReady spine in the first place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped dbt mart filter on enrichment joins; no auth or API contract changes, with verified build/tests and left-join semantics preserving row counts.
> 
> **Overview**
> **Filters out product-only civics candidacies** when the election-api mart pulls attributes from the civics `candidacy` table. Rows where `source_systems` is exactly `['gp_api']` are excluded; any record with at least one external source (BallotReady, TechSpeed, DDHQ, HubSpot) still counts.
> 
> The same predicate is applied in **`m_election_api__candidacy`** (`civics_candidacy_attrs`, affecting **`is_incumbent`**) and **`m_election_api__race`** (`civics_race_attrs`, affecting race-level fields like **`is_partisan`**, **`office_type`**, etc.). Because those civics reads are **left joins** onto the BallotReady spine, exposed candidacy/race rows are unchanged; only enrichment values can shift (~10k gp_api-only candidacies no longer influence aggregates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfec0e4fb7291d6d33687b0e175d40d897131775. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->