### PR TITLE
[DATA-1950] Fix G4110 place county/demographics

### DIFF
--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -8,6 +8,8 @@
 }}
 
 with
+    -- uscities deduped to most-populous city per county.
+    -- UNCHANGED: used only by the non-G4110 substring path.
     deduped_cities as (
         select *
         from
@@ -21,64 +23,126 @@ with
             ) ranked
         where rn = 1
     ),
-    joined_by_geo_id as (
-        select
-            tbl_place.database_id,
-            tbl_place.geo_id,
-            tbl_place.name,
-            tbl_place.slug,
-            tbl_place.state,
-            tbl_place.updated_at,
-            tbl_cities.county_name,
-            tbl_cities.county_fips,
-            tbl_cities.city,
-            tbl_cities.zips,
-            tbl_cities.csa_name,
-            tbl_cities.population,
-            tbl_cities.density,
-            tbl_cities.home_value,
-            tbl_cities.unemployment_rate,
-            tbl_cities.income_household_median
-        from {{ ref("stg_airbyte_source__ballotready_api_place") }} as tbl_place
-        left join
-            deduped_cities as tbl_cities
-            on substring(tbl_place.geo_id, 1, 5) = tbl_cities.county_fips
-            and tbl_place.state = tbl_cities.state_id
+
+    -- NEW: uscities deduped to most-populous city per (state, normalized city_ascii).
+    -- Used only by the G4110 exact path. Per-(state,name) dedup => the G4110 join is
+    -- 1:1
+    -- (protects equal_rowcount) and resolves same-name collisions deterministically.
+    deduped_cities_by_name as (
+        select * except (rn)
+        from
+            (
+                select
+                    *,
+                    lower(
+                        trim(
+                            regexp_replace(
+                                regexp_replace(city_ascii, ' *\\([^)]*\\) *$', ''),
+                                ' +',
+                                ' '
+                            )
+                        )
+                    ) as normalized_city,
+                    row_number() over (
+                        partition by
+                            state_id,
+                            lower(
+                                trim(
+                                    regexp_replace(
+                                        regexp_replace(
+                                            city_ascii, ' *\\([^)]*\\) *$', ''
+                                        ),
+                                        ' +',
+                                        ' '
+                                    )
+                                )
+                            )
+                        order by population desc nulls last, county_fips asc
+                    ) as rn
+                from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }}
+            ) ranked
+        where rn = 1
+    ),
+
+    -- place rows, carrying mtfcc internally (not emitted in final)
+    places as (
+        select database_id, geo_id, name, slug, state, updated_at, mtfcc
+        from {{ ref("stg_airbyte_source__ballotready_api_place") }}
         {% if is_incremental() %}
-            where tbl_place.updated_at > (select max(updated_at) from {{ this }})
+            where updated_at > (select max(updated_at) from {{ this }})
         {% endif %}
     ),
-    unmatched as (select * from joined_by_geo_id where county_fips is null),
-    string_matched_city_state as (
+
+    -- --------------------------------------------------------------
+    -- NON-G4110 BRANCH: existing logic, filtered to non-G4110.
+    -- Unchanged by construction.
+    -- --------------------------------------------------------------
+    non_g4110_places as (select * from places where mtfcc <> 'G4110' or mtfcc is null),
+    joined_by_geo_id as (
         select
-            tbl_unmatched.database_id,
-            tbl_unmatched.geo_id,
-            tbl_unmatched.name,
-            tbl_unmatched.slug,
-            tbl_unmatched.state,
-            tbl_unmatched.updated_at,
-            coalesce(tbl_unmatched.county_name, tbl_cities.county_name) as county_name,
-            coalesce(tbl_unmatched.county_fips, tbl_cities.county_fips) as county_fips,
-            coalesce(tbl_unmatched.city, tbl_cities.city) as city,
-            coalesce(tbl_unmatched.zips, tbl_cities.zips) as zips,
-            coalesce(tbl_unmatched.csa_name, tbl_cities.csa_name) as csa_name,
-            coalesce(tbl_unmatched.population, tbl_cities.population) as population,
-            coalesce(tbl_unmatched.density, tbl_cities.density) as density,
-            coalesce(tbl_unmatched.home_value, tbl_cities.home_value) as home_value,
-            coalesce(
-                tbl_unmatched.unemployment_rate, tbl_cities.unemployment_rate
-            ) as unemployment_rate,
-            coalesce(
-                tbl_unmatched.income_household_median,
-                tbl_cities.income_household_median
-            ) as income_household_median
-        from unmatched as tbl_unmatched
+            p.database_id,
+            p.geo_id,
+            p.name,
+            p.slug,
+            p.state,
+            p.updated_at,
+            c.county_name,
+            c.county_fips,
+            c.city,
+            c.zips,
+            c.csa_name,
+            c.population,
+            c.density,
+            c.home_value,
+            c.unemployment_rate,
+            c.income_household_median
+        from non_g4110_places as p
         left join
-            {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }} as tbl_cities
-            on tbl_unmatched.name ilike concat('%', tbl_cities.city, '%')
-            and tbl_unmatched.state = tbl_cities.state_id
+            deduped_cities as c
+            on substring(p.geo_id, 1, 5) = c.county_fips
+            and p.state = c.state_id
     ),
-    deduped_matched_by_string as (
+    non_g4110_unmatched as (select * from joined_by_geo_id where county_fips is null),
+    non_g4110_string_matched as (
+        select
+            u.database_id,
+            u.geo_id,
+            u.name,
+            u.slug,
+            u.state,
+            u.updated_at,
+            coalesce(u.county_name, c.county_name) as county_name,
+            coalesce(u.county_fips, c.county_fips) as county_fips,
+            coalesce(u.city, c.city) as city,
+            coalesce(u.zips, c.zips) as zips,
+            coalesce(u.csa_name, c.csa_name) as csa_name,
+            coalesce(u.population, c.population) as population,
+            coalesce(u.density, c.density) as density,
+            coalesce(u.home_value, c.home_value) as home_value,
+            coalesce(u.unemployment_rate, c.unemployment_rate) as unemployment_rate,
+            coalesce(
+                u.income_household_median, c.income_household_median
+            ) as income_household_median
+        from non_g4110_unmatched as u
+        left join
+            {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }} as c
+            on u.name ilike concat('%', c.city, '%')
+            and u.state = c.state_id
+    ),
+    non_g4110_string_deduped as (
+        select * except (rn)
+        from
+            (
+                select
+                    *,
+                    row_number() over (
+                        partition by database_id order by population desc
+                    ) as rn
+                from non_g4110_string_matched
+            ) ranked
+        where rn = 1
+    ),
+    non_g4110_resolved as (
         select
             database_id,
             geo_id,
@@ -96,24 +160,160 @@ with
             home_value,
             unemployment_rate,
             income_household_median
+        from joined_by_geo_id
+        where county_fips is not null
+        union all
+        select
+            database_id,
+            geo_id,
+            name,
+            slug,
+            state,
+            updated_at,
+            county_name,
+            county_fips,
+            city,
+            zips,
+            csa_name,
+            population,
+            density,
+            home_value,
+            unemployment_rate,
+            income_household_median
+        from non_g4110_string_deduped
+    ),
+
+    -- --------------------------------------------------------------
+    -- G4110 BRANCH: exact name+state match -> ILIKE fallback -> NULL
+    -- --------------------------------------------------------------
+    g4110_places as (
+        select
+            *,
+            lower(
+                trim(
+                    regexp_replace(
+                        regexp_replace(name, ' *\\([^)]*\\) *$', ''), ' +', ' '
+                    )
+                )
+            ) as normalized_name
+        from places
+        where mtfcc = 'G4110'
+    ),
+    g4110_exact as (
+        select
+            p.database_id,
+            p.geo_id,
+            p.name,
+            p.slug,
+            p.state,
+            p.updated_at,
+            c.county_name,
+            c.county_fips,
+            c.city,
+            c.zips,
+            c.csa_name,
+            c.population,
+            c.density,
+            c.home_value,
+            c.unemployment_rate,
+            c.income_household_median
+        from g4110_places as p
+        left join
+            deduped_cities_by_name as c
+            on p.state = c.state_id
+            and p.normalized_name = c.normalized_city
+    ),
+    g4110_exact_hit as (select * from g4110_exact where county_fips is not null),
+    g4110_exact_miss as (
+        select database_id, geo_id, name, slug, state, updated_at
+        from g4110_exact
+        where county_fips is null
+    ),
+    -- ILIKE fallback: same relation + order as the non-G4110 pass-2, so these rows
+    -- are bit-for-bit the current fallback result (no regression).
+    g4110_ilike as (
+        select
+            m.database_id,
+            m.geo_id,
+            m.name,
+            m.slug,
+            m.state,
+            m.updated_at,
+            c.county_name,
+            c.county_fips,
+            c.city,
+            c.zips,
+            c.csa_name,
+            c.population,
+            c.density,
+            c.home_value,
+            c.unemployment_rate,
+            c.income_household_median
+        from g4110_exact_miss as m
+        left join
+            {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }} as c
+            on m.name ilike concat('%', c.city, '%')
+            and m.state = c.state_id
+    ),
+    g4110_ilike_deduped as (
+        select * except (rn)
         from
             (
                 select
                     *,
                     row_number() over (
-                        partition by database_id order by population desc
+                        partition by database_id order by population desc nulls last
                     ) as rn
-                from string_matched_city_state
+                from g4110_ilike
             ) ranked
         where rn = 1
     ),
+    g4110_resolved as (
+        select
+            database_id,
+            geo_id,
+            name,
+            slug,
+            state,
+            updated_at,
+            county_name,
+            county_fips,
+            city,
+            zips,
+            csa_name,
+            population,
+            density,
+            home_value,
+            unemployment_rate,
+            income_household_median
+        from g4110_exact_hit
+        union all
+        select
+            database_id,
+            geo_id,
+            name,
+            slug,
+            state,
+            updated_at,
+            county_name,
+            county_fips,
+            city,
+            zips,
+            csa_name,
+            population,
+            density,
+            home_value,
+            unemployment_rate,
+            income_household_median
+        from g4110_ilike_deduped
+    ),
+
     final as (
         select *
-        from joined_by_geo_id
-        where county_fips is not null
+        from non_g4110_resolved
         union all
         select *
-        from deduped_matched_by_string
+        from g4110_resolved
     )
 
 select

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -71,8 +71,10 @@ with
         {% endif %}
     ),
 
-    -- Non-G4110 branch: byte-identical to the pre-fix model (only the mtfcc filter
-    -- is added). Keep it that way so the same-snapshot non-G4110 diff stays 0.
+    -- Non-G4110 branch: byte-identical to the pre-fix model (only the mtfcc filter is
+    -- added) so the same-snapshot non-G4110 diff stays 0. A null mtfcc routes here too
+    -- (the legacy path); assert_place_mtfcc_present fails loudly if one appears, since
+    -- mtfcc is the only branch signal and is non-null for all places today.
     non_g4110_places as (select * from places where mtfcc <> 'G4110' or mtfcc is null),
     joined_by_geo_id as (
         select

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -218,6 +218,11 @@ with
             c.unemployment_rate,
             c.income_household_median
         from g4110_places as p
+        -- NOTE: normalized_name (g4110_places) and normalized_city
+        -- (deduped_cities_by_name) MUST use the identical normalization
+        -- expression. If you edit one, edit BOTH, or this exact-match join
+        -- silently returns zero matches and every G4110 place falls through
+        -- to the ILIKE/NULL path.
         left join
             deduped_cities_by_name as c
             on p.state = c.state_id

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -8,8 +8,7 @@
 }}
 
 with
-    -- uscities deduped to most-populous city per county.
-    -- UNCHANGED: used only by the non-G4110 substring path.
+    -- per-county dedup; used only by the non-G4110 substring path below
     deduped_cities as (
         select *
         from
@@ -24,10 +23,9 @@ with
         where rn = 1
     ),
 
-    -- NEW: uscities deduped to most-populous city per (state, normalized city_ascii).
-    -- Used only by the G4110 exact path. Per-(state,name) dedup => the G4110 join is
-    -- 1:1
-    -- (protects equal_rowcount) and resolves same-name collisions deterministically.
+    -- Per-(state, normalized name) dedup for the G4110 exact join: one row per key
+    -- keeps the join 1:1 (protects equal_rowcount) and resolves same-name collisions
+    -- to the most-populous match, deterministically.
     deduped_cities_by_name as (
         select * except (rn)
         from
@@ -64,7 +62,7 @@ with
         where rn = 1
     ),
 
-    -- place rows, carrying mtfcc internally (not emitted in final)
+    -- mtfcc is read only to split the branches below; it is not in the final output
     places as (
         select database_id, geo_id, name, slug, state, updated_at, mtfcc
         from {{ ref("stg_airbyte_source__ballotready_api_place") }}
@@ -73,10 +71,8 @@ with
         {% endif %}
     ),
 
-    -- --------------------------------------------------------------
-    -- NON-G4110 BRANCH: existing logic, filtered to non-G4110.
-    -- Unchanged by construction.
-    -- --------------------------------------------------------------
+    -- Non-G4110 branch: byte-identical to the pre-fix model (only the mtfcc filter
+    -- is added). Keep it that way so the same-snapshot non-G4110 diff stays 0.
     non_g4110_places as (select * from places where mtfcc <> 'G4110' or mtfcc is null),
     joined_by_geo_id as (
         select
@@ -183,9 +179,7 @@ with
         from non_g4110_string_deduped
     ),
 
-    -- --------------------------------------------------------------
-    -- G4110 BRANCH: exact name+state match -> ILIKE fallback -> NULL
-    -- --------------------------------------------------------------
+    -- G4110 resolution chain: exact name+state match -> ILIKE fallback -> NULL
     g4110_places as (
         select
             *,

--- a/dbt/project/tests/assert_g4110_classification_stable.sql
+++ b/dbt/project/tests/assert_g4110_classification_stable.sql
@@ -1,19 +1,23 @@
 -- dbt/project/tests/assert_g4110_classification_stable.sql
--- DATA-1950: every staging G4110 place appears exactly once in the model.
+-- DATA-1950: every staging G4110 place must appear EXACTLY ONCE in the model.
+-- Uses an anti-join + per-id count rather than comparing aggregate totals, so a
+-- missing G4110 row cannot be masked by a duplicate elsewhere (a count-only test
+-- can stay green when one row is dropped and another duplicated). Returns a row
+-- for any staging G4110 place that is absent from the model (model_count = 0) or
+-- present more than once (model_count > 1).
 with
-    model_g4110 as (
-        select count(*) as c
-        from {{ ref("int__place_fast_facts") }} as f
-        join
-            {{ ref("stg_airbyte_source__ballotready_api_place") }} as p
-            on p.database_id = f.database_id
-        where p.mtfcc = 'G4110'
-    ),
     src_g4110 as (
-        select count(*) as c
+        select database_id
         from {{ ref("stg_airbyte_source__ballotready_api_place") }}
         where mtfcc = 'G4110'
+    ),
+    model_counts as (
+        select f.database_id, count(*) as n
+        from {{ ref("int__place_fast_facts") }} as f
+        join src_g4110 as s on s.database_id = f.database_id
+        group by f.database_id
     )
-select model_g4110.c as model_count, src_g4110.c as src_count
-from model_g4110, src_g4110
-where model_g4110.c <> src_g4110.c
+select s.database_id, coalesce(m.n, 0) as model_count
+from src_g4110 as s
+left join model_counts as m on m.database_id = s.database_id
+where m.database_id is null or m.n <> 1

--- a/dbt/project/tests/assert_g4110_classification_stable.sql
+++ b/dbt/project/tests/assert_g4110_classification_stable.sql
@@ -1,0 +1,19 @@
+-- dbt/project/tests/assert_g4110_classification_stable.sql
+-- DATA-1950: every staging G4110 place appears exactly once in the model.
+with
+    model_g4110 as (
+        select count(*) as c
+        from {{ ref("int__place_fast_facts") }} as f
+        join
+            {{ ref("stg_airbyte_source__ballotready_api_place") }} as p
+            on p.database_id = f.database_id
+        where p.mtfcc = 'G4110'
+    ),
+    src_g4110 as (
+        select count(*) as c
+        from {{ ref("stg_airbyte_source__ballotready_api_place") }}
+        where mtfcc = 'G4110'
+    )
+select model_g4110.c as model_count, src_g4110.c as src_count
+from model_g4110, src_g4110
+where model_g4110.c <> src_g4110.c

--- a/dbt/project/tests/assert_g4110_county_null_ceiling.sql
+++ b/dbt/project/tests/assert_g4110_county_null_ceiling.sql
@@ -1,0 +1,9 @@
+-- dbt/project/tests/assert_g4110_county_null_ceiling.sql
+-- DATA-1950: G4110 places with no resolvable county should stay near the measured 247.
+select count(*) as g4110_null_county
+from {{ ref("int__place_fast_facts") }} as f
+join
+    {{ ref("stg_airbyte_source__ballotready_api_place") }} as p
+    on p.database_id = f.database_id
+where p.mtfcc = 'G4110' and f.county_fips is null
+having count(*) > 300

--- a/dbt/project/tests/assert_g4110_place_county_known_values.sql
+++ b/dbt/project/tests/assert_g4110_place_county_known_values.sql
@@ -1,8 +1,10 @@
 -- dbt/project/tests/assert_g4110_place_county_known_values.sql
--- DATA-1950: fails if a known incorporated place is assigned the wrong county.
--- Stable, high-confidence ground truth (independent of the uscities name-match).
--- Keyed on geo_id (the stable, unique place identifier) — NOT name+state, which
--- can match multiple rows (a G4110 place and a same-name county-equivalent).
+-- DATA-1950: fails if a known incorporated place is MISSING from the model or
+-- assigned the wrong county. Keyed on geo_id (the stable, unique place
+-- identifier) — NOT name+state, which can match multiple rows (a G4110 place and
+-- a same-name county-equivalent). LEFT JOIN from the fixtures so a regression that
+-- drops a fixture row (e.g. Beverly Hills disappears) also fails, not only a wrong
+-- county_fips.
 with
     expected as (
         select *
@@ -16,7 +18,7 @@ with
                     ('0608954', '06037')  -- Burbank        -> Los Angeles
             ) as t(geo_id, expected_county_fips)
     )
-select f.geo_id, f.name, f.county_fips, e.expected_county_fips
-from {{ ref("int__place_fast_facts") }} as f
-join expected as e on f.geo_id = e.geo_id
-where f.county_fips is distinct from e.expected_county_fips
+select e.geo_id, e.expected_county_fips, f.county_fips
+from expected as e
+left join {{ ref("int__place_fast_facts") }} as f on f.geo_id = e.geo_id
+where f.geo_id is null or f.county_fips is distinct from e.expected_county_fips

--- a/dbt/project/tests/assert_g4110_place_county_known_values.sql
+++ b/dbt/project/tests/assert_g4110_place_county_known_values.sql
@@ -1,0 +1,22 @@
+-- dbt/project/tests/assert_g4110_place_county_known_values.sql
+-- DATA-1950: fails if a known incorporated place is assigned the wrong county.
+-- Stable, high-confidence ground truth (independent of the uscities name-match).
+-- Keyed on geo_id (the stable, unique place identifier) — NOT name+state, which
+-- can match multiple rows (a G4110 place and a same-name county-equivalent).
+with
+    expected as (
+        select *
+        from
+            (
+                values
+                    ('0606308', '06037'),  -- Beverly Hills  -> Los Angeles
+                    ('5182000', '51810'),  -- Virginia Beach -> Virginia Beach (independent city)
+                    ('0603526', '06029'),  -- Bakersfield    -> Kern
+                    ('4845384', '48215'),  -- McAllen        -> Hidalgo
+                    ('0608954', '06037')  -- Burbank        -> Los Angeles
+            ) as t(geo_id, expected_county_fips)
+    )
+select f.geo_id, f.name, f.county_fips, e.expected_county_fips
+from {{ ref("int__place_fast_facts") }} as f
+join expected as e on f.geo_id = e.geo_id
+where f.county_fips is distinct from e.expected_county_fips

--- a/dbt/project/tests/assert_g4110_same_name_collision_ceiling.sql
+++ b/dbt/project/tests/assert_g4110_same_name_collision_ceiling.sql
@@ -1,0 +1,22 @@
+-- dbt/project/tests/assert_g4110_same_name_collision_ceiling.sql
+-- DATA-1950: (state, normalized city_ascii) groups spanning >1 county should stay
+-- near the measured ~226; a spike means normalization merged distinct names.
+with
+    collisions as (
+        select
+            state_id,
+            lower(
+                trim(
+                    regexp_replace(
+                        regexp_replace(city_ascii, ' *\\([^)]*\\) *$', ''), ' +', ' '
+                    )
+                )
+            ) as ncity,
+            count(distinct county_fips) as nc
+        from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }}
+        group by 1, 2
+        having count(distinct county_fips) > 1
+    )
+select count(*) as colliding_groups
+from collisions
+having count(*) > 260

--- a/dbt/project/tests/assert_place_mtfcc_present.sql
+++ b/dbt/project/tests/assert_place_mtfcc_present.sql
@@ -1,0 +1,11 @@
+-- dbt/project/tests/assert_place_mtfcc_present.sql
+-- DATA-1950: int__place_fast_facts routes each place into the G4110 vs non-G4110
+-- branch by mtfcc. mtfcc is the only branch signal and is non-null for every place
+-- today. A null mtfcc would fall into the non-G4110 (substring) path and, if the
+-- place is actually an incorporated city, inherit a coincidental wrong county that
+-- the G4110 guard tests (which filter on mtfcc = 'G4110') cannot see. Fail loudly if
+-- an ingestion gap ever introduces a null so its routing is decided consciously
+-- rather than defaulting silently to the legacy path.
+select database_id, name, state
+from {{ ref("stg_airbyte_source__ballotready_api_place") }}
+where mtfcc is null


### PR DESCRIPTION
## Summary

`int__place_fast_facts` assigned a county to every place by treating the first 5
digits of the place `geo_id` as a `state(2)+county(3)` FIPS code and joining to a
per-county-deduped `uscities` table. That rule is correct for county geoids but
wrong for incorporated places (mtfcc `G4110`), whose geoid is `state(2)+place(5)`.
When a place's 5-digit prefix coincidentally equals a real county FIPS, the place
was attached to the wrong county and inherited that county's largest city's
demographics. Beverly Hills CA (`0606308`, prefix `06063` = Plumas) resolved to
Plumas County with East Quincy's facts instead of Los Angeles County.

This change corrects county and demographics for G4110 places. Non-G4110 rows are
unchanged.

## Root cause

`substring(geo_id, 1, 5) = county_fips` is only valid for county-prefixed geoids.
G4110 place codes are not nested under counties, so a prefix collision produced a
real-but-wrong county, and the correct name-based fallback never ran because the
coincidental match short-circuited it.

## Fix

Branch the model by mtfcc, then union:

- Non-G4110 (`mtfcc <> 'G4110' or mtfcc is null`): the existing substring + ILIKE
  logic, filtered. Unchanged by construction.
- G4110 (`mtfcc = 'G4110'`): resolve via exact normalized name+state match against
  a uscities table deduped to one row per `(state, normalized city_ascii)`, then
  the existing ILIKE fallback, then NULL. The per-(state,name) dedup keeps the
  join 1:1 (protects `equal_rowcount`).

No new output columns; `mtfcc` stays internal. Field flow downstream
(`int__enhanced_place` to `m_election_api__place` to `write__election_api_db`) is
unchanged, so no downstream model edits.

## Verification (measured on live data, same source snapshot)

The local dbt CLI is dbt Fusion (preview) and cannot parse this project locally
(unset project-wide env vars), so the pre-fix and post-fix logic were each
materialized to a dev table directly from the committed SQL and diffed. CI's
preview schema is the dbt build/test authority and runs all tests for real.

Hard gates, all green:

| check | result |
|---|---|
| model rowcount == staging place count (1 row/place) | 73,470 == 73,470 |
| model G4110 count == staging G4110 count | 19,815 == 19,815 |
| non-G4110 rows changed (same-snapshot EXCEPT, both directions) | 0 / 0 |
| G4110 rows changed | 3,171 (in the expected [1,500, 8,000] band) |
| known-place ground-truth test (Beverly Hills, Virginia Beach, Bakersfield, McAllen, Burbank) | 0 mismatches |
| G4110 null county | 247 (ceiling 300) |
| same-name collision groups | 226 (ceiling 260) |

G4110 change breakdown (n = 19,815): 2,841 county corrections, 324
demographics-only corrections, 6 coincidental counties nulled, 0 lost a correct
county, 16,644 unchanged. The 0/0 non-G4110 diff confirms the refactor touched
only G4110.

Known residuals (documented, not regressions): 247 null county
(territories/remote; `Place.countyName` is nullable); 102 G4110 places exposed to
a same-name collision where the most-populous same-named place's county is used
(generic Pennsylvania township names dominate; none of the headline repairs are
affected). Full detail in `.tickets/DATA-1950/measurement.md`.

## Tests added

- `assert_g4110_place_county_known_values` (ground truth, was red, now green)
- `assert_g4110_county_null_ceiling` (fails if G4110 null county > 300)
- `assert_g4110_classification_stable` (fails if model G4110 count != staging)
- `assert_g4110_same_name_collision_ceiling` (fails if collision groups > 260)

The existing `dbt_utils.equal_rowcount` and `database_id` unique/not_null/
relationships tests are retained.

## Propagation (required before prod, owner-gated)

`Place` syncs via the legacy `write__election_api_db` python model. Its
`is_incremental` `updated_at` filter is dead code (it rebinds a throwaway
loop-local frame and always full-upserts every Place row from
`m_election_api__place`). This fix does not bump `updated_at`, so the real
requirement is a full-refresh of the incremental dbt chain through
`m_election_api__place`, then a normal writer run. That step needs Databricks prod
write perms plus the `election-db-password` secret and must be owned and scheduled
in the same release window. See the rollout runbook and
`.tickets/DATA-1950/plan-g4110-place-county-fix.md` (Task 8).

## Remaining before merge

- Frontend confirmation that the webapp renders a null county segment as "no data"
  for the 247 null places (marketing/Win owner).
- Owned, scheduled prod propagation (above).

## Refs

- Spec: `.tickets/DATA-1950/spec-g4110-place-county-fix.md`
- Plan: `.tickets/DATA-1950/plan-g4110-place-county-fix.md`
- Diagnosis: `.tickets/DATA-1950/diagnosis-and-evidence.md`
- Measurement: `.tickets/DATA-1950/measurement.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes county and demographic facts for ~19k G4110 places feeding enhanced place and election API sync; logic is scoped and tested but requires coordinated full-refresh/prod propagation to avoid stale wrong data in production.
> 
> **Overview**
> **`int__place_fast_facts`** no longer uses the first five `geo_id` digits as county FIPS for incorporated places (`mtfcc = 'G4110'`). Those rows now resolve county and uscities demographics via a **normalized name + state** exact match (with per-state/name dedup), then the existing **ILIKE** fallback, then **NULL**. All other places keep the prior substring + ILIKE pipeline, isolated in a **non-G4110** branch and unioned with the G4110 results so row shape and columns are unchanged.
> 
> Four **dbt** tests guard regressions: known `geo_id` → county FIPS fixtures, G4110 row-count parity with staging, a ceiling on G4110 null counties, and a ceiling on same-name uscities collision groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 665387c197291993b6d9c218639a8a45a739123f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->