### PR TITLE
[DATA-1948] Address review follow-ups: gitignore scope + lib schema note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,10 +70,6 @@ analytics/projects/*/notebooks/**
 # Scout project dependency pins are local working artifacts too.
 analytics/projects/*/requirements.txt
 
-# Local-only shared analytics scripts (per-contributor Databricks sync/pull
-# helpers that hardcode user-specific Workspace paths).
-analytics/scripts/
-
 # Ad-hoc analysis notebooks + briefs are personal working experiments by
 # default. Promote a specific analysis with `git add -f` if it should be
 # team-shared. See win.md §7 "Lightweight analysis pattern" for the convention.

--- a/analytics/lib/win_analysis.py
+++ b/analytics/lib/win_analysis.py
@@ -22,6 +22,11 @@ from typing import Callable, Mapping
 
 import pandas as pd
 
+# Fully-qualified prod table paths. These are intentionally hardcoded to the
+# ``goodparty_data_catalog`` prod schemas (``dbt_staging`` for raw staging, ``dbt``
+# for intermediates, ``mart_analytics`` for marts) rather than resolved via dbt
+# ``ref()``: this module runs outside dbt (notebooks / ad-hoc), where ``ref()`` can
+# resolve to stale dev artifacts (runbook §7). Repoint these for a dev/test catalog.
 EVENTS_TABLE = (
     "goodparty_data_catalog.dbt_staging.stg_airbyte_source__amplitude_api_events"
 )


### PR DESCRIPTION
Follow-ups on review feedback from #428 (DATA-1948).

## Changes
- **`.gitignore`**: drop the user-specific `analytics/scripts/` entry from the shared repo ignore. Per the review, the tracked `.gitignore` should cover project-created artifacts, not per-contributor helpers. Those scripts (local Databricks `pull.sh`/`sync.sh` that hardcode user-specific Workspace paths) are now ignored via repo-local `.git/info/exclude` instead, so they stay out of `git status` on the author's clone without affecting the team or other repos.
- **`analytics/lib/win_analysis.py`**: add a comment explaining why the table constants hardcode the `goodparty_data_catalog` prod schemas (`dbt_staging` / `dbt` / `mart_analytics`) rather than resolving via dbt `ref()` — the lib runs outside dbt (notebooks / ad-hoc) where `ref()` can resolve to stale dev artifacts (runbook §7). No behavior change.

## Reviewed, no change
- `dbt/project/tests/assert_recurrent_events_are_win.sql` was questioned as possibly redundant with the `is_win or not is_recurrent` invariant on `int__amplitude_event_taxonomy`. Kept: it is a **static** allowlist guard that fires even when those events are absent from the stream, which the observed-rows invariant cannot do. The two cover different failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and ignore-policy only; no query logic or production code paths change.
> 
> **Overview**
> Addresses review follow-ups from DATA-1948 with **no runtime behavior changes**.
> 
> The shared **`.gitignore`** no longer ignores `analytics/scripts/`. That path was meant for per-contributor Databricks helpers with user-specific Workspace paths; those stay local via each clone’s **`.git/info/exclude`** instead of a team-wide ignore rule.
> 
> **`analytics/lib/win_analysis.py`** documents why `EVENTS_TABLE`, `USERS_WIN_CANDIDACY`, and `EVENT_TAXONOMY` use fully qualified `goodparty_data_catalog` prod tables instead of dbt `ref()`—the library runs in notebooks/ad-hoc outside dbt, where `ref()` can point at stale dev builds (runbook §7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8f0cfacce37d892e24672f4f18f381f137a920. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->