### PR TITLE
[DATA-1950] Fix G5420 school-district county/demographics

### DIFF
--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -62,6 +62,29 @@ with
         where rn = 1
     ),
 
+    -- One row per (state, normalized county name), most-populous — for the G5420
+    -- county match.
+    -- Distinct from deduped_cities (1 row per county_fips): a few states have a
+    -- county AND an
+    -- independent city sharing a name (e.g. VA Richmond city vs Richmond County), so
+    -- (state, county_name) is NOT unique in deduped_cities. Deduping by (state,
+    -- county_name)
+    -- here keeps the county join 1:1 (protects equal_rowcount).
+    deduped_counties_by_name as (
+        select * except (rn)
+        from
+            (
+                select
+                    *,
+                    row_number() over (
+                        partition by state_id, lower(county_name)
+                        order by population desc nulls last, county_fips asc
+                    ) as rn
+                from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }}
+            ) ranked
+        where rn = 1
+    ),
+
     -- mtfcc is read only to split the branches below; it is not in the final output
     places as (
         select database_id, geo_id, name, slug, state, updated_at, mtfcc
@@ -75,7 +98,9 @@ with
     -- added) so the same-snapshot non-G4110 diff stays 0. A null mtfcc routes here too
     -- (the legacy path); assert_place_mtfcc_present fails loudly if one appears, since
     -- mtfcc is the only branch signal and is non-null for all places today.
-    non_g4110_places as (select * from places where mtfcc <> 'G4110' or mtfcc is null),
+    non_g4110_places as (
+        select * from places where (mtfcc not in ('G4110', 'G5420')) or mtfcc is null
+    ),
     joined_by_geo_id as (
         select
             p.database_id,
@@ -309,12 +334,175 @@ with
         from g4110_ilike_deduped
     ),
 
+    -- G5420 (school district) branch (spec D2/D3): strip the district-type suffix to
+    -- a candidate
+    -- place name; if it ends in " county" -> county match (or NULL, no city
+    -- fall-through);
+    -- otherwise city primary -> city retry (strip one trailing place-type word) ->
+    -- NULL. The
+    -- strip peels only trailing DESCRIPTOR words + district numbers/class codes and
+    -- KEEPS place
+    -- nouns so "Dodge City"/"Mount Union" survive. n0 reuses the SAME base
+    -- normalization as
+    -- g4110_places / deduped_cities_by_name — keep in sync. No same-select lateral
+    -- aliases
+    -- (n0 is a g5420_base column; city_cand a g5420_candidates column), so it
+    -- compiles broadly.
+    g5420_base as (
+        select
+            database_id,
+            geo_id,
+            name,
+            slug,
+            state,
+            updated_at,
+            lower(
+                trim(
+                    regexp_replace(
+                        regexp_replace(name, ' *\\([^)]*\\) *$', ''), ' +', ' '
+                    )
+                )
+            ) as n0
+        from places
+        where mtfcc = 'G5420'
+    ),
+    g5420_candidates as (
+        select
+            database_id,
+            geo_id,
+            name,
+            slug,
+            state,
+            updated_at,
+            n0,
+            trim(
+                regexp_replace(
+                    regexp_replace(
+                        regexp_replace(
+                            n0,
+                            ' ((no[.]?|number|#) ?)?([0-9][0-9a-z-]*|r-[ivxlc]+|re-?[0-9]+[a-z]?|[a-z]-[0-9]+[a-z]?) *$',
+                            ''
+                        ),
+                        ' ((union free|community consolidated|community unit|community|consolidated|independent|unified|central|area|regional|elementary|high|joint|cooperative|special|graded|common|metropolitan|public) )?(school district|school districts|school corporation|public schools|schools|school|district) *$',
+                        ''
+                    ),
+                    ' (r-[ivxlc]+|re-?[0-9]+[a-z]?|[a-z]-[0-9]+[a-z]?|[0-9]+) *$',
+                    ''
+                )
+            ) as city_cand
+        from g5420_base
+    ),
+    g5420_candidates2 as (
+        select
+            database_id,
+            geo_id,
+            name,
+            slug,
+            state,
+            updated_at,
+            city_cand,
+            case
+                when city_cand rlike ' county$'
+                then trim(regexp_replace(city_cand, ' county$', ''))
+            end as county_cand,
+            trim(
+                regexp_replace(
+                    city_cand, ' (city|town|township|twp|borough|boro|village) *$', ''
+                )
+            ) as city_cand_retry
+        from g5420_candidates
+    ),
+    g5420_resolved as (
+        select
+            c.database_id,
+            c.geo_id,
+            c.name,
+            c.slug,
+            c.state,
+            c.updated_at,
+            coalesce(
+                case when c.county_cand is not null then cnty.county_name end,
+                cp.county_name,
+                crt.county_name
+            ) as county_name,
+            coalesce(
+                case when c.county_cand is not null then cnty.county_fips end,
+                cp.county_fips,
+                crt.county_fips
+            ) as county_fips,
+            coalesce(
+                case when c.county_cand is not null then cnty.city end,
+                cp.city,
+                crt.city
+            ) as city,
+            coalesce(
+                case when c.county_cand is not null then cnty.zips end,
+                cp.zips,
+                crt.zips
+            ) as zips,
+            coalesce(
+                case when c.county_cand is not null then cnty.csa_name end,
+                cp.csa_name,
+                crt.csa_name
+            ) as csa_name,
+            coalesce(
+                case when c.county_cand is not null then cnty.population end,
+                cp.population,
+                crt.population
+            ) as population,
+            coalesce(
+                case when c.county_cand is not null then cnty.density end,
+                cp.density,
+                crt.density
+            ) as density,
+            coalesce(
+                case when c.county_cand is not null then cnty.home_value end,
+                cp.home_value,
+                crt.home_value
+            ) as home_value,
+            coalesce(
+                case when c.county_cand is not null then cnty.unemployment_rate end,
+                cp.unemployment_rate,
+                crt.unemployment_rate
+            ) as unemployment_rate,
+            coalesce(
+                case
+                    when c.county_cand is not null then cnty.income_household_median
+                end,
+                cp.income_household_median,
+                crt.income_household_median
+            ) as income_household_median
+        from g5420_candidates2 as c
+        left join
+            deduped_counties_by_name as cnty
+            on c.county_cand is not null
+            and cnty.state_id = c.state
+            and lower(cnty.county_name) = c.county_cand
+            and length(c.county_cand) >= 2
+        left join
+            deduped_cities_by_name as cp
+            on c.county_cand is null
+            and cp.state_id = c.state
+            and cp.normalized_city = c.city_cand
+            and length(c.city_cand) >= 3
+        left join
+            deduped_cities_by_name as crt
+            on c.county_cand is null
+            and crt.state_id = c.state
+            and crt.normalized_city = c.city_cand_retry
+            and crt.normalized_city <> c.city_cand
+            and length(c.city_cand_retry) >= 3
+    ),
+
     final as (
         select *
         from non_g4110_resolved
         union all
         select *
         from g4110_resolved
+        union all
+        select *
+        from g5420_resolved
     )
 
 select

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -81,6 +81,10 @@ with
                     substring(county_fips, 1, 2) as state_fips_prefix,
                     count(*) as n
                 from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }}
+                -- exclude null county_fips: a (state, NULL) bucket could otherwise
+                -- win the mode, making the prefix NULL, which the join below reads
+                -- as "no match" and silently drops the whole state. (PR #443 review.)
+                where county_fips is not null
                 group by state_id, substring(county_fips, 1, 2)
             ) counts
         qualify row_number() over (partition by state_id order by n desc) = 1

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -62,55 +62,63 @@ with
         where rn = 1
     ),
 
+    -- Canonical 2-digit FIPS prefix per state = the prefix shared by the MOST
+    -- uscities rows.
+    -- Strays are a tiny minority, so mode-by-count picks the real state prefix.
+    -- Robust where
+    -- simpler aggregates fail: MAX(case when population is not null ...) returns NULL
+    -- for an
+    -- all-null-population state (VI, 194 rows) and drops the whole state; MIN(prefix)
+    -- picks a
+    -- stray whose prefix sorts below the real one (TN's KY stray 21 < 47). (PR #443
+    -- delegate review.)
+    state_fips_prefixes as (
+        select state_id, state_fips_prefix
+        from
+            (
+                select
+                    state_id,
+                    substring(county_fips, 1, 2) as state_fips_prefix,
+                    count(*) as n
+                from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }}
+                group by state_id, substring(county_fips, 1, 2)
+            ) counts
+        qualify row_number() over (partition by state_id order by n desc) = 1
+    ),
+
     -- One row per (state, normalized county name) for the G5420 county match. Two
-    -- correctness rules beyond a plain dedup (DATA-1950 PR #443 Codex + delegate
-    -- review):
+    -- correctness
+    -- rules beyond a plain dedup (DATA-1950 PR #443 Codex + delegate review):
     -- 1. order by county_fips ASC (not population): when a county shares its name
     -- with an
     -- independent city in the same state (Baltimore, St. Louis MO, Richmond / Roanoke /
     -- Franklin VA), US FIPS numbers the independent city higher (510+), so the LOWER
     -- county_fips is the actual county. Population-desc would pick the bigger city.
-    -- 2. keep only county_fips whose 2-digit state prefix matches the state's OWN
-    -- prefix (the
-    -- prefix of its populated rows): drops degenerate cross-state stray rows (e.g. a
-    -- state_id='GA' row carrying TN county_fips 47139) that create false ambiguity.
-    -- This
-    -- targets the real symptom (state/FIPS mismatch), NOT a null-population proxy, so
-    -- it
-    -- keeps legitimate population-less counties (e.g. GA Echols 13101, VA James City)
-    -- that
-    -- a `population is not null` filter would silently NULL. The state-prefix filter
-    -- runs
-    -- BEFORE row_number(), so a stray can never win the dedup.
+    -- 2. join to state_fips_prefixes: keep only rows whose county_fips is in the
+    -- state's own FIPS
+    -- prefix, dropping degenerate cross-state stray rows (e.g. a state_id='GA' row
+    -- carrying TN
+    -- county_fips 47139). The join filters BEFORE row_number(), so a stray can never
+    -- win the
+    -- dedup, and it keeps legitimate population-less counties (GA Echols 13101, VA
+    -- James City,
+    -- the VI district) that a null-population proxy would silently NULL.
     -- Keeps the (state, county_name) join key 1:1 (protects equal_rowcount).
     deduped_counties_by_name as (
         select * except (rn)
         from
             (
                 select
-                    * except (state_fips_prefix),
+                    c.*,
                     row_number() over (
-                        partition by state_id, lower(county_name)
-                        order by county_fips asc, population desc nulls last
+                        partition by c.state_id, lower(c.county_name)
+                        order by c.county_fips asc, c.population desc nulls last
                     ) as rn
-                from
-                    (
-                        select
-                            *,
-                            max(
-                                case
-                                    when population is not null
-                                    then substring(county_fips, 1, 2)
-                                end
-                            ) over (partition by state_id) as state_fips_prefix
-                        from
-                            {{
-                                ref(
-                                    "stg_airbyte_source__ballotready_s3_uscities_v1_77"
-                                )
-                            }}
-                    ) prefixed
-                where substring(county_fips, 1, 2) = state_fips_prefix
+                from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }} as c
+                join
+                    state_fips_prefixes as p
+                    on p.state_id = c.state_id
+                    and substring(c.county_fips, 1, 2) = p.state_fips_prefix
             ) ranked
         where rn = 1
     ),

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -87,7 +87,13 @@ with
                 where county_fips is not null
                 group by state_id, substring(county_fips, 1, 2)
             ) counts
-        qualify row_number() over (partition by state_id order by n desc) = 1
+        -- order-by tie-breaker is deterministic (state_fips_prefix asc) so the mode
+        -- is reproducible across builds; a count tie is not reachable on today's data.
+        qualify
+            row_number() over (
+                partition by state_id order by n desc, state_fips_prefix asc
+            )
+            = 1
     ),
 
     -- One row per (state, normalized county name) for the G5420 county match. Two
@@ -116,7 +122,14 @@ with
                     c.*,
                     row_number() over (
                         partition by c.state_id, lower(c.county_name)
-                        order by c.county_fips asc, c.population desc nulls last
+                        -- county_fips asc is the correctness key (picks the county
+                        -- over a same-named independent city); population desc then
+                        -- city_ascii asc make the representative-city demographics
+                        -- deterministic on a population tie.
+                        order by
+                            c.county_fips asc,
+                            c.population desc nulls last,
+                            c.city_ascii asc
                     ) as rn
                 from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }} as c
                 join

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -63,29 +63,54 @@ with
     ),
 
     -- One row per (state, normalized county name) for the G5420 county match. Two
-    -- correctness rules beyond a plain dedup (see DATA-1950 PR #443 Codex review):
-    -- 1. order by county_fips ASC (not population): when a county shares its name with
-    -- an independent city in the same state (Baltimore, St. Louis MO, Richmond /
-    -- Roanoke / Franklin VA), US FIPS always numbers the independent city higher
-    -- (510+), so the LOWER county_fips is the actual county. Population-desc would
-    -- wrongly pick the larger independent city (e.g. Baltimore County PS -> Baltimore
-    -- city). The lower-FIPS county is correct.
-    -- 2. where population is not null: drops degenerate cross-state stray rows (e.g. a
-    -- state_id='GA' row carrying TN county_fips 47139) that create false ambiguity and
-    -- could otherwise win county_fips-asc from the wrong state (e.g. OH Allen vs IN).
+    -- correctness rules beyond a plain dedup (DATA-1950 PR #443 Codex + delegate
+    -- review):
+    -- 1. order by county_fips ASC (not population): when a county shares its name
+    -- with an
+    -- independent city in the same state (Baltimore, St. Louis MO, Richmond / Roanoke /
+    -- Franklin VA), US FIPS numbers the independent city higher (510+), so the LOWER
+    -- county_fips is the actual county. Population-desc would pick the bigger city.
+    -- 2. keep only county_fips whose 2-digit state prefix matches the state's OWN
+    -- prefix (the
+    -- prefix of its populated rows): drops degenerate cross-state stray rows (e.g. a
+    -- state_id='GA' row carrying TN county_fips 47139) that create false ambiguity.
+    -- This
+    -- targets the real symptom (state/FIPS mismatch), NOT a null-population proxy, so
+    -- it
+    -- keeps legitimate population-less counties (e.g. GA Echols 13101, VA James City)
+    -- that
+    -- a `population is not null` filter would silently NULL. The state-prefix filter
+    -- runs
+    -- BEFORE row_number(), so a stray can never win the dedup.
     -- Keeps the (state, county_name) join key 1:1 (protects equal_rowcount).
     deduped_counties_by_name as (
         select * except (rn)
         from
             (
                 select
-                    *,
+                    * except (state_fips_prefix),
                     row_number() over (
                         partition by state_id, lower(county_name)
                         order by county_fips asc, population desc nulls last
                     ) as rn
-                from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }}
-                where population is not null
+                from
+                    (
+                        select
+                            *,
+                            max(
+                                case
+                                    when population is not null
+                                    then substring(county_fips, 1, 2)
+                                end
+                            ) over (partition by state_id) as state_fips_prefix
+                        from
+                            {{
+                                ref(
+                                    "stg_airbyte_source__ballotready_s3_uscities_v1_77"
+                                )
+                            }}
+                    ) prefixed
+                where substring(county_fips, 1, 2) = state_fips_prefix
             ) ranked
         where rn = 1
     ),

--- a/dbt/project/models/intermediate/int__place_fast_facts.sql
+++ b/dbt/project/models/intermediate/int__place_fast_facts.sql
@@ -62,14 +62,18 @@ with
         where rn = 1
     ),
 
-    -- One row per (state, normalized county name), most-populous — for the G5420
-    -- county match.
-    -- Distinct from deduped_cities (1 row per county_fips): a few states have a
-    -- county AND an
-    -- independent city sharing a name (e.g. VA Richmond city vs Richmond County), so
-    -- (state, county_name) is NOT unique in deduped_cities. Deduping by (state,
-    -- county_name)
-    -- here keeps the county join 1:1 (protects equal_rowcount).
+    -- One row per (state, normalized county name) for the G5420 county match. Two
+    -- correctness rules beyond a plain dedup (see DATA-1950 PR #443 Codex review):
+    -- 1. order by county_fips ASC (not population): when a county shares its name with
+    -- an independent city in the same state (Baltimore, St. Louis MO, Richmond /
+    -- Roanoke / Franklin VA), US FIPS always numbers the independent city higher
+    -- (510+), so the LOWER county_fips is the actual county. Population-desc would
+    -- wrongly pick the larger independent city (e.g. Baltimore County PS -> Baltimore
+    -- city). The lower-FIPS county is correct.
+    -- 2. where population is not null: drops degenerate cross-state stray rows (e.g. a
+    -- state_id='GA' row carrying TN county_fips 47139) that create false ambiguity and
+    -- could otherwise win county_fips-asc from the wrong state (e.g. OH Allen vs IN).
+    -- Keeps the (state, county_name) join key 1:1 (protects equal_rowcount).
     deduped_counties_by_name as (
         select * except (rn)
         from
@@ -78,9 +82,10 @@ with
                     *,
                     row_number() over (
                         partition by state_id, lower(county_name)
-                        order by population desc nulls last, county_fips asc
+                        order by county_fips asc, population desc nulls last
                     ) as rn
                 from {{ ref("stg_airbyte_source__ballotready_s3_uscities_v1_77") }}
+                where population is not null
             ) ranked
         where rn = 1
     ),

--- a/dbt/project/tests/assert_g5420_classification_stable.sql
+++ b/dbt/project/tests/assert_g5420_classification_stable.sql
@@ -1,0 +1,13 @@
+-- DATA-1950 (G5420): every staging G5420 place appears in the model exactly once
+-- (anti-join per database_id so a missing row cannot be masked by a duplicate).
+with
+    staging_g5420 as (
+        select database_id
+        from {{ ref("stg_airbyte_source__ballotready_api_place") }}
+        where mtfcc = 'G5420'
+    )
+select s.database_id, count(f.database_id) as n_in_model
+from staging_g5420 as s
+left join {{ ref("int__place_fast_facts") }} as f on f.database_id = s.database_id
+group by s.database_id
+having count(f.database_id) <> 1

--- a/dbt/project/tests/assert_g5420_county_null_ceiling.sql
+++ b/dbt/project/tests/assert_g5420_county_null_ceiling.sql
@@ -1,0 +1,10 @@
+-- DATA-1950 (G5420): NULL county rises BY DESIGN (~859 mart / ~3,183 intermediate
+-- today).
+-- This caps a strip regression that over-nulls; it is NOT a "stays near today" guard.
+select count(*) as g5420_null_county
+from {{ ref("int__place_fast_facts") }} as f
+join
+    {{ ref("stg_airbyte_source__ballotready_api_place") }} as p
+    on p.database_id = f.database_id
+where p.mtfcc = 'G5420' and f.county_fips is null
+having count(*) > 3600

--- a/dbt/project/tests/assert_g5420_no_new_sink.sql
+++ b/dbt/project/tests/assert_g5420_no_new_sink.sql
@@ -1,0 +1,19 @@
+-- DATA-1950 (G5420): the boilerplate bug pinned many distinct districts onto one place
+-- (93 -> Broome). Guard the recurrence: no (state, county_name, population) shared by
+-- >= 12
+-- distinct resolved G5420 districts. Measured max legit cluster = 7 (SC/WY numbered
+-- county
+-- districts, correct county); the old bug pinned 50-93, so 12 sits in the gap.
+with
+    g5420_resolved_rows as (
+        select f.state, f.county_name, f.population, f.database_id
+        from {{ ref("int__place_fast_facts") }} as f
+        join
+            {{ ref("stg_airbyte_source__ballotready_api_place") }} as p
+            on p.database_id = f.database_id
+        where p.mtfcc = 'G5420' and f.county_fips is not null
+    )
+select state, county_name, population, count(distinct database_id) as n_districts
+from g5420_resolved_rows
+group by state, county_name, population
+having count(distinct database_id) >= 12

--- a/dbt/project/tests/assert_g5420_school_district_county_known_values.sql
+++ b/dbt/project/tests/assert_g5420_school_district_county_known_values.sql
@@ -21,6 +21,8 @@ with
                     ('4216020', '42061'),  -- Mount Union Area SD     -> Huntingdon PA
                     ('2400120', '24005'),  -- Baltimore County PS     -> Baltimore County MD (not city 24510)
                     ('5103270', '51159'),  -- Richmond County PS (VA)  -> Richmond County VA (not city 51760)
+                    ('1301950', '13101'),  -- Echols County SD (GA)   -> Echols (population-less county kept by the FIPS-prefix filter)
+                    ('2901000', '29019'),  -- Columbia 93 SD (MO)     -> Boone (MO "Town NN" district number stripped in pass 3)
                     ('1739090', cast(null as string)),  -- Cumberland CUSD 77      -> NULL (honest; v2)
                     ('1741690', cast(null as string))  -- Indian Prairie CUSD 204 -> NULL (honest; v2)
             ) as t(geo_id, expected_county_fips)

--- a/dbt/project/tests/assert_g5420_school_district_county_known_values.sql
+++ b/dbt/project/tests/assert_g5420_school_district_county_known_values.sql
@@ -1,0 +1,29 @@
+-- DATA-1950 (G5420): fails if a known school district gets the wrong county, OR an
+-- anchor row
+-- is dropped from the model. Ground truth independent of the suffix-strip match.
+-- geo_id-keyed.
+-- LEFT JOIN from fixtures + `f.geo_id is null` also catches a dropped (incl.
+-- null-expected) anchor.
+with
+    expected as (
+        select *
+        from
+            (
+                values
+                    ('3602880', '36103'),  -- Amagansett UFSD         -> Suffolk NY
+                    ('3603840', '36059'),  -- Baldwin UFSD            -> Nassau NY
+                    ('3604080', '36103'),  -- Bay Shore UFSD          -> Suffolk NY
+                    ('3606840', '36103'),  -- Center Moriches UFSD    -> Suffolk NY
+                    ('3610080', '36119'),  -- Eastchester UFSD        -> Westchester NY
+                    ('1727300', '17009'),  -- Brown County CUSD 1     -> Brown IL (county match)
+                    ('2005580', '20057'),  -- Dodge City USD 443      -> Ford KS (city primary)
+                    ('0634320', '06073'),  -- San Diego City Unified  -> San Diego CA (city retry)
+                    ('4216020', '42061'),  -- Mount Union Area SD     -> Huntingdon PA
+                    ('1739090', cast(null as string)),  -- Cumberland CUSD 77      -> NULL (honest; v2)
+                    ('1741690', cast(null as string))  -- Indian Prairie CUSD 204 -> NULL (honest; v2)
+            ) as t(geo_id, expected_county_fips)
+    )
+select e.geo_id, f.name, f.county_fips, e.expected_county_fips
+from expected as e
+left join {{ ref("int__place_fast_facts") }} as f on f.geo_id = e.geo_id
+where f.county_fips is distinct from e.expected_county_fips or f.geo_id is null

--- a/dbt/project/tests/assert_g5420_school_district_county_known_values.sql
+++ b/dbt/project/tests/assert_g5420_school_district_county_known_values.sql
@@ -19,6 +19,8 @@ with
                     ('2005580', '20057'),  -- Dodge City USD 443      -> Ford KS (city primary)
                     ('0634320', '06073'),  -- San Diego City Unified  -> San Diego CA (city retry)
                     ('4216020', '42061'),  -- Mount Union Area SD     -> Huntingdon PA
+                    ('2400120', '24005'),  -- Baltimore County PS     -> Baltimore County MD (not city 24510)
+                    ('5103270', '51159'),  -- Richmond County PS (VA)  -> Richmond County VA (not city 51760)
                     ('1739090', cast(null as string)),  -- Cumberland CUSD 77      -> NULL (honest; v2)
                     ('1741690', cast(null as string))  -- Indian Prairie CUSD 204 -> NULL (honest; v2)
             ) as t(geo_id, expected_county_fips)

--- a/dbt/project/tests/assert_g5420_strip_mangle.sql
+++ b/dbt/project/tests/assert_g5420_strip_mangle.sql
@@ -1,0 +1,82 @@
+-- DATA-1950 (G5420): pins the suffix-strip contract so an edit that mangles place
+-- names (e.g.
+-- eats interior "Union", or breaks coded "X County R-V") fails loudly. MUST mirror
+-- the model's
+-- g5420_candidates/g5420_candidates2 expressions exactly; if you change the model
+-- strip, change this.
+with
+    t(name, expected_city_cand, expected_county_cand) as (
+        values
+            ('Mount Union Area School District', 'mount union', cast(null as string)),
+            (
+                'Dodge City Unified School District 443',
+                'dodge city',
+                cast(null as string)
+            ),
+            (
+                'Amagansett Union Free School District',
+                'amagansett',
+                cast(null as string)
+            ),
+            (
+                'San Diego City Unified School District',
+                'san diego city',
+                cast(null as string)
+            ),
+            ('Canton R-V School District', 'canton', cast(null as string)),
+            ('Brown County Community Unit School District 1', 'brown county', 'brown'),
+            ('Echols County R-V School District', 'echols county', 'echols')
+    ),
+    base as (
+        select
+            name,
+            expected_city_cand,
+            expected_county_cand,
+            lower(
+                trim(
+                    regexp_replace(
+                        regexp_replace(name, ' *\\([^)]*\\) *$', ''), ' +', ' '
+                    )
+                )
+            ) as n0
+        from t
+    ),
+    stripped as (
+        select
+            name,
+            expected_city_cand,
+            expected_county_cand,
+            trim(
+                regexp_replace(
+                    regexp_replace(
+                        regexp_replace(
+                            n0,
+                            ' ((no[.]?|number|#) ?)?([0-9][0-9a-z-]*|r-[ivxlc]+|re-?[0-9]+[a-z]?|[a-z]-[0-9]+[a-z]?) *$',
+                            ''
+                        ),
+                        ' ((union free|community consolidated|community unit|community|consolidated|independent|unified|central|area|regional|elementary|high|joint|cooperative|special|graded|common|metropolitan|public) )?(school district|school districts|school corporation|public schools|schools|school|district) *$',
+                        ''
+                    ),
+                    ' (r-[ivxlc]+|re-?[0-9]+[a-z]?|[a-z]-[0-9]+[a-z]?|[0-9]+) *$',
+                    ''
+                )
+            ) as city_cand
+        from base
+    ),
+    computed as (
+        select
+            name,
+            expected_city_cand,
+            expected_county_cand,
+            city_cand,
+            case
+                when city_cand rlike ' county$'
+                then trim(regexp_replace(city_cand, ' county$', ''))
+            end as county_cand
+        from stripped
+    )
+select name, city_cand, expected_city_cand, county_cand, expected_county_cand
+from computed
+where
+    city_cand is distinct from expected_city_cand
+    or county_cand is distinct from expected_county_cand

--- a/dbt/project/tests/assert_g5420_strip_mangle.sql
+++ b/dbt/project/tests/assert_g5420_strip_mangle.sql
@@ -8,6 +8,8 @@ with
     t(name, expected_city_cand, expected_county_cand) as (
         values
             ('Mount Union Area School District', 'mount union', cast(null as string)),
+            ('Region 10 School District', 'region', cast(null as string)),
+            ('Columbia 93 School District', 'columbia', cast(null as string)),
             (
                 'Dodge City Unified School District 443',
                 'dodge city',


### PR DESCRIPTION
## What
Fix wrong county + demographics on school-district pages (mtfcc `G5420`) in `int__place_fast_facts`. School districts resolved their county via the non-G4110 ILIKE name-match, which hit boilerplate words in the district-type suffix: "X Union Free School District" matched the town of Union, Broome County NY (93 NY districts pinned to Broome); "X Community Unit School District" matched Unity, Alexander IL (54 IL districts). Roughly a third of the county-assigned user-facing G5420 had a wrong county AND wrong demographics on SEO-indexed pages.

## How
Mirror the merged G4110 fix: add a dedicated `G5420` branch and carve G5420 out of the non-G4110 filter, so every other branch (including G4110) stays byte-identical. The G5420 branch strips the district-type suffix to a candidate place name, then resolves: county-name match (or NULL) for "X County ..." names; else city primary-strip; else city retry-strip; else NULL. Reuses `deduped_cities_by_name` (city) and a new `deduped_counties_by_name` (county). Demographics: city match takes the matched city's own; county match takes the county's most-populous-city; no match is NULL.

## Impact counts (clarified)
- **11,042** G5420 at the intermediate grain (`int__place_fast_facts`); **~10,194** user-facing in the mart (`m_election_api__place`).
- Resolution at the intermediate grain: **71.2% resolved** (53.7% city-primary + 7.2% city-retry + 10.2% county), **28.8% honest NULL**.
- **5,656** G5420 rows change `county_fips` vs current prod; ~5,825 differ on any field. The unchanged ~5,200 already resolved correctly via the old path or were NULL in both.

## Coverage + safety (measured on a same-snapshot dev build; CI is the authoritative build/test)
- Non-G5420 same-snapshot diff = **0/0** (G4110 and every other branch unchanged).
- `equal_rowcount` preserved (73,470 == 73,470, no fan-out; the county join is 1:1).
- Zero new sinks (max resolved (state,county,population) cluster 7; the old bug pinned 50-93).
- Examples: Amagansett UFSD to Suffolk (own pop 663, was Broome/56,047), Mount Union Area to Huntingdon, Brown County CUSD to Brown, Dodge City USD to Ford, San Diego City Unified to San Diego.

## Independent (Codex) PR review — addressed
A code-only review by a different model flagged that ambiguous county names (12 keys where a county shares its name with an independent city, e.g. Baltimore, St. Louis MO, Richmond/Roanoke/Franklin VA) could pick the independent **city** over the **county**. Fixed: `deduped_counties_by_name` now orders by `county_fips asc` (US FIPS numbers independent cities 510+, so the lower FIPS is the actual county) and drops null-population cross-state stray rows. Verified: Baltimore County PS -> Baltimore County (24005, was city 24510), Richmond County VA -> 51159, Roanoke -> 51161, Fairfax stays 51059. Added Baltimore County and Richmond County VA as known-value fixtures.

## Tests
5 singular tests: known-values (geo_id-keyed, 15 fixtures incl. 2 NULL anchors + 2 ambiguous-county, red to green), null-ceiling (<= 3,600), classification-stable (anti-join), no-new-sink (>= 12), strip-mangle (pins the suffix-strip contract).

## Out of this PR / pre-merge
Spec, plan, measurement, and the diagnostic query are in `.tickets/DATA-1950/`. **Pre-merge gate:** a stratified correctness audit against an independent Census/NCES source (30 city-primary + 30 county + 40 city-retry). Propagation to election-api Postgres needs a full-refresh of the place chain + the `write__election_api_db` writer, owned by a teammate with prod write perms (per the runbook), with a direct-Postgres rollback. Follow-up: v2 GEOID-to-census/NCES SD-county crosswalk to close the ~29% NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Post-deploy (required)
After merge, run a one-time `dbt run --full-refresh --select int__place_fast_facts` (then the rest of the place chain) so the ~10k historical G5420 rows recompute through the new branch; the incremental `merge` will not backfill rows BallotReady has not re-synced. The prod build handles this. Verify live afterward: `ny/amagansett-union-free-school-district` should return Suffolk / 663.

