### PR TITLE
Repo-wide ruff unification (per-directory CI, step 1)

### DIFF
--- a/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/dbt_failure_handler.py
@@ -12,9 +12,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-DEFAULT_OUTPUT_DIR = (
-    Path(__file__).resolve().parent.parent / "dbt_logs" / "failure_handler"
-)
+DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parent.parent / "dbt_logs" / "failure_handler"
 
 
 def _run_cmd(cmd: list[str], cwd: Path | None = None) -> tuple[int, str]:

--- a/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
+++ b/.claude/skills/l2-uniform-drift-remediator/scripts/l2_uniform_preflight_tool.py
@@ -134,9 +134,7 @@ def _preflight_command_argv(metadata_catalog: str | None) -> list[str]:
 
 def _build_plan(summary: dict[str, Any]) -> dict[str, Any]:
     impacted_states: list[str] = summary["impacted_states"]
-    staging_selectors = [
-        f"stg_dbt_source__l2_s3_{state.lower()}_uniform" for state in impacted_states
-    ]
+    staging_selectors = [f"stg_dbt_source__l2_s3_{state.lower()}_uniform" for state in impacted_states]
 
     safe_command_argv: list[list[str]] = []
     if staging_selectors:
@@ -185,9 +183,7 @@ def _print_analysis(summary: dict[str, Any]) -> None:
     print("# L2 Uniform Preflight Analysis")
     print(f"- status: {summary['status']}")
     print(f"- strict: {summary['strict']}")
-    print(
-        f"- metadata_catalog: {summary['metadata_catalog'] or '(not provided in log)'}"
-    )
+    print(f"- metadata_catalog: {summary['metadata_catalog'] or '(not provided in log)'}")
     print(f"- finding_count: {summary['finding_count']}")
     print(f"- impacted_states: {', '.join(summary['impacted_states']) or '(none)'}")
     print("")
@@ -271,8 +267,7 @@ def main() -> int:
 
     if args.json_out:
         args.json_out.write_text(
-            json.dumps({"summary": summary, "plan": plan}, indent=2, sort_keys=True)
-            + "\n",
+            json.dumps({"summary": summary, "plan": plan}, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
 

--- a/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
+++ b/.claude/skills/l2-uniform-drift-remediator/tests/test_scripts.py
@@ -84,16 +84,10 @@ class TestL2UniformPreflightTool(unittest.TestCase):
             self.assertEqual(summary["finding_count"], 1)
             self.assertEqual(summary["impacted_states"], ["ME"])
             self.assertTrue(
-                any(
-                    "stg_dbt_source__l2_s3_me_uniform" in command
-                    for command in plan["safe_commands"]
-                )
+                any("stg_dbt_source__l2_s3_me_uniform" in command for command in plan["safe_commands"])
             )
             self.assertTrue(
-                any(
-                    "l2_uniform_schema_preflight" in command
-                    for command in plan["safe_commands"]
-                )
+                any("l2_uniform_schema_preflight" in command for command in plan["safe_commands"])
             )
 
     def test_tool_returns_2_when_manual_actions_exist(self) -> None:
@@ -101,9 +95,7 @@ class TestL2UniformPreflightTool(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             log_file = tmp_path / "preflight.log"
-            log_file.write_text(
-                sample_preflight_log_with_manual_actions(), encoding="utf-8"
-            )
+            log_file.write_text(sample_preflight_log_with_manual_actions(), encoding="utf-8")
             json_out = tmp_path / "triage.json"
 
             result = subprocess.run(
@@ -151,9 +143,7 @@ class TestL2UniformPreflightTool(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             log_file = tmp_path / "preflight.log"
-            log_file.write_text(
-                sample_preflight_log_with_string_strict_false(), encoding="utf-8"
-            )
+            log_file.write_text(sample_preflight_log_with_string_strict_false(), encoding="utf-8")
             json_out = tmp_path / "triage.json"
 
             result = subprocess.run(
@@ -213,9 +203,7 @@ class TestFailureHandler(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             log_file = tmp_path / "preflight.log"
-            log_file.write_text(
-                sample_preflight_log_with_manual_actions(), encoding="utf-8"
-            )
+            log_file.write_text(sample_preflight_log_with_manual_actions(), encoding="utf-8")
             output_dir = tmp_path / "out"
 
             result = subprocess.run(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# Install both hook types so `pre-commit install` wires up the pre-push test
+# check below in addition to the per-commit lint/format hooks.
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -35,3 +39,16 @@ repos:
     -   id: sqlfmt
         language_version: python
         additional_dependencies: ['.[jinjafmt]']
+
+-   repo: local
+    hooks:
+    -   id: pytest
+        name: Run pytest (local pre-push check)
+        # Local-only quick check before pushing. Scoped to the repo-level tests/
+        # dir (matches python_tests.yml). The pre-push stage keeps it OUT of the
+        # CI `pre-commit run --all-files` job (default pre-commit stage), so the
+        # tests are not duplicated in CI; CI test coverage is python_tests.yml.
+        entry: pytest tests
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,32 +10,12 @@ repos:
     -   id: check-case-conflict
     -   id: detect-private-key
 
--   repo: https://github.com/psf/black
-    rev: 25.1.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.4
     hooks:
-    -   id: black
-        language_version: python3
-        args: ["--line-length=88"]
-        exclude: ^people-api-loader/
-
--   repo: https://github.com/pycqa/isort
-    rev: 6.0.0
-    hooks:
-    -   id: isort
-        args: ["--profile", "black", "--line-length=88"]
-        exclude: ^people-api-loader/
-
--   repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
-    hooks:
-    -   id: flake8
-        args: ['--extend-ignore=D100,D103,D200,D205,D400,D401,E203,E501,F821,W503', '--max-line-length=88']
-        exclude: ^people-api-loader/
-        additional_dependencies: [
-            'flake8-docstrings',
-            'flake8-bugbear',
-            'flake8-comprehensions',
-        ]
+    -   id: ruff
+        args: ['--fix']
+    -   id: ruff-format
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
@@ -55,14 +35,3 @@ repos:
     -   id: sqlfmt
         language_version: python
         additional_dependencies: ['.[jinjafmt]']
-
--   repo: local
-    hooks:
-    -   id: pytest
-        name: Run pytest
-        # Scope to the repo-level tests/ dir (matches python_tests.yml). Bare
-        # `pytest` collects the whole tree, including people-api-loader/, which
-        # has its own uv env and isn't importable in this environment.
-        entry: pytest tests
-        language: system
-        pass_filenames: false

--- a/airflow/astro/.astro/test_dag_integrity_default.py
+++ b/airflow/astro/.astro/test_dag_integrity_default.py
@@ -18,9 +18,7 @@ initdb()
 
 # =========== MONKEYPATCH BaseHook.get_connection() ===========
 def basehook_get_connection_monkeypatch(key: str, *args, **kwargs):
-    print(
-        f"Attempted to fetch connection during parse returning an empty Connection object for {key}"
-    )
+    print(f"Attempted to fetch connection during parse returning an empty Connection object for {key}")
     return Connection(key)
 
 
@@ -34,17 +32,13 @@ def os_getenv_monkeypatch(key: str, *args, **kwargs):
     if args:
         default = args[0]  # os.getenv should get at most 1 arg after the key
     if kwargs:
-        default = kwargs.get(
-            "default", None
-        )  # and sometimes kwarg if people are using the sig
+        default = kwargs.get("default", None)  # and sometimes kwarg if people are using the sig
 
     env_value = os.environ.get(key, None)
 
     if env_value:
         return env_value  # if the env_value is set, return it
-    if (
-        key == "JENKINS_HOME" and default is None
-    ):  # fix https://github.com/astronomer/astro-cli/issues/601
+    if key == "JENKINS_HOME" and default is None:  # fix https://github.com/astronomer/astro-cli/issues/601
         return None
     if default:
         return default  # otherwise return whatever default has been passed
@@ -73,9 +67,7 @@ _no_default = object()  # allow falsey defaults
 
 
 def variable_get_monkeypatch(key: str, default_var=_no_default, deserialize_json=False):
-    print(
-        f"Attempted to get Variable value during parse, returning a mocked value for {key}"
-    )
+    print(f"Attempted to get Variable value during parse, returning a mocked value for {key}")
 
     if default_var is not _no_default:
         return default_var
@@ -128,9 +120,7 @@ def get_import_errors():
         return result
 
 
-@pytest.mark.parametrize(
-    "rel_path, rv", get_import_errors(), ids=[x[0] for x in get_import_errors()]
-)
+@pytest.mark.parametrize("rel_path, rv", get_import_errors(), ids=[x[0] for x in get_import_errors()])
 def test_file_imports(rel_path, rv):
     """Test for import errors on a file"""
     if rv != "No import errors":

--- a/airflow/astro/dags/example_etl_galaxies.py
+++ b/airflow/astro/dags/example_etl_galaxies.py
@@ -64,7 +64,6 @@ _NUM_GALAXIES_TOTAL = int(os.getenv("NUM_GALAXIES_TOTAL", 20))
     is_paused_upon_creation=False,  # start running the DAG as soon as its created
 )
 def example_etl_galaxies():  # by default the dag_id is the name of the decorated function
-
     # ---------------- #
     # Task Definitions #
     # ---------------- #
@@ -136,23 +135,15 @@ def example_etl_galaxies():  # by default the dag_id is the name of the decorate
             pd.DataFrame: A DataFrame containing filtered galaxy data.
         """
         # retrieve param values from the context
-        closeness_threshold_light_years = context["params"][
-            _CLOSENESS_THRESHOLD_LY_PARAMETER_NAME
-        ]
+        closeness_threshold_light_years = context["params"][_CLOSENESS_THRESHOLD_LY_PARAMETER_NAME]
 
-        t_log.info(
-            f"Filtering for galaxies closer than {closeness_threshold_light_years} light years."
-        )
+        t_log.info(f"Filtering for galaxies closer than {closeness_threshold_light_years} light years.")
 
-        filtered_galaxy_df = galaxy_df[
-            galaxy_df["distance_from_milkyway"] < closeness_threshold_light_years
-        ]
+        filtered_galaxy_df = galaxy_df[galaxy_df["distance_from_milkyway"] < closeness_threshold_light_years]
 
         return filtered_galaxy_df
 
-    @task(
-        outlets=[Asset(_DUCKDB_TABLE_URI)]
-    )  # Define that this task produces updates to an Airflow Dataset.
+    @task(outlets=[Asset(_DUCKDB_TABLE_URI)])  # Define that this task produces updates to an Airflow Dataset.
     # Downstream DAGs can be scheduled based on combinations of Dataset updates
     # coming from tasks in the same Airflow instance or calls to the Airflow API.
     # See: https://www.astronomer.io/docs/learn/airflow-datasets
@@ -171,9 +162,7 @@ def example_etl_galaxies():  # by default the dag_id is the name of the decorate
         """
         t_log.info("Loading galaxy data into DuckDB.")
         cursor = duckdb.connect(duckdb_instance_name)
-        cursor.sql(
-            f"INSERT OR IGNORE INTO {table_name} BY NAME SELECT * FROM filtered_galaxy_df;"
-        )
+        cursor.sql(f"INSERT OR IGNORE INTO {table_name} BY NAME SELECT * FROM filtered_galaxy_df;")
         t_log.info("Galaxy data loaded into DuckDB.")
 
     @task
@@ -193,9 +182,7 @@ def example_etl_galaxies():  # by default the dag_id is the name of the decorate
         """
         cursor = duckdb.connect(duckdb_instance_name)
         near_galaxies_df = cursor.sql(f"SELECT * FROM {table_name};").df()
-        near_galaxies_df = near_galaxies_df.sort_values(
-            by="distance_from_milkyway", ascending=True
-        )
+        near_galaxies_df = near_galaxies_df.sort_values(by="distance_from_milkyway", ascending=True)
         t_log.info(tabulate(near_galaxies_df, headers="keys", tablefmt="pretty"))
 
     # ------------------------------------ #
@@ -212,9 +199,7 @@ def example_etl_galaxies():  # by default the dag_id is the name of the decorate
 
     # you can set explicit dependencies using the chain function (or bit-shift operators)
     # See: https://www.astronomer.io/docs/learn/managing-dependencies
-    chain(
-        create_galaxy_table_in_duckdb_obj, load_galaxy_data_obj, print_loaded_galaxies()
-    )
+    chain(create_galaxy_table_in_duckdb_obj, load_galaxy_data_obj, print_loaded_galaxies())
 
 
 # Instantiate the DAG

--- a/airflow/astro/dags/l2_expired_voters.py
+++ b/airflow/astro/dags/l2_expired_voters.py
@@ -39,12 +39,10 @@ from include.custom_functions.databricks_utils import (
 )
 from include.custom_functions.l2_sftp import (
     create_sftp_connection,
+    parse_expired_voter_ids,
 )
 from include.custom_functions.l2_sftp import (
     download_expired_voter_files as download_files,
-)
-from include.custom_functions.l2_sftp import (
-    parse_expired_voter_ids,
 )
 from pendulum import datetime, duration
 
@@ -71,7 +69,6 @@ DATABRICKS_CATALOG = "goodparty_data_catalog"
     is_paused_upon_creation=True,
 )
 def l2_expired_voters():
-
     @task
     def fetch_processed_files() -> List[str]:
         """
@@ -89,9 +86,7 @@ def l2_expired_voters():
             client_secret=db_conn.password,
         )
         try:
-            processed = get_processed_files(
-                connection=connection, catalog=DATABRICKS_CATALOG, schema=schema
-            )
+            processed = get_processed_files(connection=connection, catalog=DATABRICKS_CATALOG, schema=schema)
         finally:
             connection.close()
 
@@ -155,14 +150,11 @@ def l2_expired_voters():
                     return f"{basename}|{mtime}"
 
                 # Filter out already-processed files
-                new_paths = [
-                    p for p in extracted_paths if _file_key(p) not in already_processed
-                ]
+                new_paths = [p for p in extracted_paths if _file_key(p) not in already_processed]
                 if not new_paths:
                     skipped = [_file_key(p) for p in extracted_paths]
                     t_log.info(
-                        f"All {len(extracted_paths)} file(s) already processed, "
-                        f"skipping: {skipped}"
+                        f"All {len(extracted_paths)} file(s) already processed, " f"skipping: {skipped}"
                     )
                     return {
                         "count": 0,
@@ -171,19 +163,14 @@ def l2_expired_voters():
                     }
 
                 if len(new_paths) < len(extracted_paths):
-                    skipped = [
-                        _file_key(p)
-                        for p in extracted_paths
-                        if _file_key(p) in already_processed
-                    ]
+                    skipped = [_file_key(p) for p in extracted_paths if _file_key(p) in already_processed]
                     t_log.info(f"Skipping already-processed files: {skipped}")
 
                 lalvoterids = parse_expired_voter_ids(new_paths)
                 source_files = [os.path.basename(p) for p in new_paths]
                 # Keep only timestamps for new (non-skipped) files
                 new_timestamps = {
-                    os.path.basename(p): file_timestamps.get(os.path.basename(p), "")
-                    for p in new_paths
+                    os.path.basename(p): file_timestamps.get(os.path.basename(p), "") for p in new_paths
                 }
 
         finally:

--- a/airflow/astro/dags/load_people_api.py
+++ b/airflow/astro/dags/load_people_api.py
@@ -99,7 +99,6 @@ DISTRICT_STATS_COLUMNS = [
     },
 )
 def load_people_api():
-
     @task
     def load_districts():
         """Read District from Databricks and upsert into PostgreSQL.
@@ -108,9 +107,7 @@ def load_people_api():
         Must complete before DistrictStats due to foreign key constraint.
         """
         params = get_current_context()["params"]
-        skip_watermark = params.get("full_reload") or params.get(
-            "full_reload_districts"
-        )
+        skip_watermark = params.get("full_reload") or params.get("full_reload_districts")
         catalog = Variable.get("databricks_catalog")
         schema = Variable.get("databricks_dbt_schema")
         batch_size = 5000
@@ -163,9 +160,7 @@ def load_people_api():
         Streams rows in batches to stay within the Astro worker memory limit.
         """
         params = get_current_context()["params"]
-        skip_watermark = params.get("full_reload") or params.get(
-            "full_reload_district_stats"
-        )
+        skip_watermark = params.get("full_reload") or params.get("full_reload_district_stats")
         catalog = Variable.get("databricks_catalog")
         schema = Variable.get("databricks_dbt_schema")
         batch_size = 5000
@@ -205,10 +200,7 @@ def load_people_api():
                             row[2],  # total_constituents
                             row[3],  # total_constituents_with_cell_phone
                             Json(  # buckets — parse and fix camelCase keys
-                                {
-                                    _BUCKET_KEY_MAP.get(k, k): v
-                                    for k, v in json.loads(row[4]).items()
-                                }
+                                {_BUCKET_KEY_MAP.get(k, k): v for k, v in json.loads(row[4]).items()}
                             ),
                         )
                         for row in batch

--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -194,10 +194,7 @@ def _dti_constraint_ddl() -> list[str]:
     sn, nt = DTI.staging_schema, DTI.new_table
     target_schema = DTI.target_schema
     return [
-        (
-            f'ALTER TABLE "{sn}"."{nt}" '
-            f'ADD CONSTRAINT "{DTI.stage_name(DTI.pk_name)}" PRIMARY KEY (id)'
-        ),
+        (f'ALTER TABLE "{sn}"."{nt}" ' f'ADD CONSTRAINT "{DTI.stage_name(DTI.pk_name)}" PRIMARY KEY (id)'),
         (
             f"CREATE UNIQUE INDEX "
             f'"{DTI.stage_name("DistrictTopIssue_district_id_issue_key")}" '
@@ -217,14 +214,8 @@ def _ztp_constraint_ddl() -> list[str]:
     sn, nt = ZTP.staging_schema, ZTP.new_table
     target_schema = ZTP.target_schema
     return [
-        (
-            f'ALTER TABLE "{sn}"."{nt}" '
-            f'ADD CONSTRAINT "{ZTP.stage_name(ZTP.pk_name)}" PRIMARY KEY (id)'
-        ),
-        (
-            f'CREATE INDEX "{ZTP.stage_name("ZipToPosition_zip_code_idx")}" '
-            f'ON "{sn}"."{nt}" (zip_code)'
-        ),
+        (f'ALTER TABLE "{sn}"."{nt}" ' f'ADD CONSTRAINT "{ZTP.stage_name(ZTP.pk_name)}" PRIMARY KEY (id)'),
+        (f'CREATE INDEX "{ZTP.stage_name("ZipToPosition_zip_code_idx")}" ' f'ON "{sn}"."{nt}" (zip_code)'),
         (
             f'CREATE INDEX "{ZTP.stage_name("ZipToPosition_position_id_idx")}" '
             f'ON "{sn}"."{nt}" (position_id)'
@@ -266,10 +257,8 @@ def _ztp_constraint_ddl() -> list[str]:
     is_paused_upon_creation=True,
 )
 def sync_election_api():
-
     @task_group(group_id="zip_to_position")
     def zip_to_position():
-
         @task
         def build_staging() -> None:
             with _open_pg() as conn:
@@ -301,22 +290,16 @@ def sync_election_api():
         @task
         def quality_checks(loaded_count: int) -> None:
             if loaded_count < 1_000:
-                raise ValueError(
-                    f"Only {loaded_count} rows loaded (<1000) — refusing to swap"
-                )
+                raise ValueError(f"Only {loaded_count} rows loaded (<1000) — refusing to swap")
             with _open_pg() as conn:
                 cur = conn.cursor()
                 try:
                     cur.execute(
-                        f"SELECT COUNT(DISTINCT state) "
-                        f'FROM "{ZTP.staging_schema}"."{ZTP.new_table}"'
+                        f"SELECT COUNT(DISTINCT state) " f'FROM "{ZTP.staging_schema}"."{ZTP.new_table}"'
                     )
                     distinct_states = cur.fetchone()[0]
                     if distinct_states < 30:
-                        raise ValueError(
-                            f"Only {distinct_states} distinct states "
-                            f"— refusing to swap"
-                        )
+                        raise ValueError(f"Only {distinct_states} distinct states " f"— refusing to swap")
                     cur.execute(
                         f"SELECT MIN(election_date), MAX(election_date) "
                         f'FROM "{ZTP.staging_schema}"."{ZTP.new_table}"'
@@ -352,7 +335,6 @@ def sync_election_api():
 
     @task_group(group_id="district_top_issues")
     def district_top_issues():
-
         @task
         def build_staging() -> None:
             with _open_pg() as conn:

--- a/airflow/astro/include/custom_functions/databricks_utils.py
+++ b/airflow/astro/include/custom_functions/databricks_utils.py
@@ -18,9 +18,7 @@ def _validate_lalvoterids(values: List[str]) -> None:
     """Raise ValueError if any value doesn't match the expected LALVOTERID format."""
     bad = [v for v in values if not LALVOTERID_PATTERN.match(v)]
     if bad:
-        raise ValueError(
-            f"{len(bad)} invalid LALVOTERID(s) — refusing to build SQL: {bad[:5]}"
-        )
+        raise ValueError(f"{len(bad)} invalid LALVOTERID(s) — refusing to build SQL: {bad[:5]}")
 
 
 # OAuth credential failures (rotated/expired service-principal secret, wrong
@@ -87,9 +85,7 @@ def get_databricks_connection(
                 )
                 raise
             if attempt == max_retries - 1:
-                logger.error(
-                    f"Databricks connection failed after {max_retries} attempts: {e}"
-                )
+                logger.error(f"Databricks connection failed after {max_retries} attempts: {e}")
                 raise
             logger.warning(
                 f"Databricks connection attempt {attempt + 1}/{max_retries} failed: {e}. "
@@ -178,17 +174,12 @@ def stage_expired_voter_ids(
     # files with the same name but new content are re-processed.
     file_ts = file_timestamps or {}
     source_keys = [f"{f}|{file_ts.get(f, '')}" for f in source_files]
-    source_file_keys_str = (
-        ", ".join(source_keys).replace("\\", "\\\\").replace("'", "\\'")
-    )
+    source_file_keys_str = ", ".join(source_keys).replace("\\", "\\\\").replace("'", "\\'")
 
     latest_ts = max(file_ts.values()) if file_ts else None
     ts_sql = f"'{latest_ts}'" if latest_ts else "NULL"
 
-    merge_cols = (
-        "lalvoterid, source_files, source_file_keys, "
-        "file_modified_at, ingested_at, dag_run_id"
-    )
+    merge_cols = "lalvoterid, source_files, source_file_keys, " "file_modified_at, ingested_at, dag_run_id"
 
     cursor = connection.cursor()
     try:
@@ -213,9 +204,7 @@ def stage_expired_voter_ids(
         )
 
         # Clean up any previous load record for this dag_run_id (idempotent retry)
-        cursor.execute(
-            f"DELETE FROM {loads_table} WHERE dag_run_id = '{dag_run_id_safe}'"
-        )
+        cursor.execute(f"DELETE FROM {loads_table} WHERE dag_run_id = '{dag_run_id_safe}'")
 
         total_upserted = 0
         for i in range(0, len(lalvoterids), batch_size):
@@ -256,8 +245,7 @@ def stage_expired_voter_ids(
             f"{total_upserted}, current_timestamp())"
         )
         logger.info(
-            f"Recorded load completion in {loads_table}: "
-            f"{total_upserted} rows, dag_run_id={dag_run_id}"
+            f"Recorded load completion in {loads_table}: " f"{total_upserted} rows, dag_run_id={dag_run_id}"
         )
 
         logger.info(f"Total upserted to {full_table_name}: {total_upserted} rows")
@@ -313,8 +301,7 @@ def read_databricks_table(
                 if not transient or attempt == max_retries - 1:
                     raise
                 logger.warning(
-                    "Databricks execute attempt %d/%d hit transient error: %s. "
-                    "Retrying in %ds...",
+                    "Databricks execute attempt %d/%d hit transient error: %s. " "Retrying in %ds...",
                     attempt + 1,
                     max_retries,
                     msg,

--- a/airflow/astro/include/custom_functions/election_api_utils.py
+++ b/airflow/astro/include/custom_functions/election_api_utils.py
@@ -108,10 +108,7 @@ def bulk_insert_from_databricks(
     _col_names, batches = read_databricks_table(source_query, batch_size=batch_size)
 
     col_list = ", ".join(f'"{c}"' for c in target_columns)
-    insert_sql = (
-        f'INSERT INTO "{spec.staging_schema}"."{spec.new_table}" '
-        f"({col_list}) VALUES %s"
-    )
+    insert_sql = f'INSERT INTO "{spec.staging_schema}"."{spec.new_table}" ' f"({col_list}) VALUES %s"
 
     total = 0
     try:
@@ -121,9 +118,7 @@ def bulk_insert_from_databricks(
                 rows = [transform_row(r) if transform_row else tuple(r) for r in batch]
                 if not rows:
                     continue
-                psycopg2.extras.execute_values(
-                    cur, insert_sql, rows, page_size=batch_size
-                )
+                psycopg2.extras.execute_values(cur, insert_sql, rows, page_size=batch_size)
                 total += len(rows)
                 if total % 50_000 < batch_size:
                     logger.info("Inserted %d rows so far", total)
@@ -170,8 +165,7 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
         statements: List[str] = []
         if target_exists:
             statements.append(
-                f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" '
-                f'RENAME TO "{spec.old_table}"'
+                f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" ' f'RENAME TO "{spec.old_table}"'
             )
             statements.append(
                 f'ALTER INDEX "{spec.target_schema}"."{spec.pk_name}" '
@@ -179,8 +173,7 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
             )
             for idx in spec.indexes:
                 statements.append(
-                    f'ALTER INDEX "{spec.target_schema}"."{idx}" '
-                    f'RENAME TO "{spec.archive_name(idx)}"'
+                    f'ALTER INDEX "{spec.target_schema}"."{idx}" ' f'RENAME TO "{spec.archive_name(idx)}"'
                 )
             for fk in spec.fkeys:
                 statements.append(
@@ -190,12 +183,10 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
                 )
 
         statements.append(
-            f'ALTER TABLE "{spec.staging_schema}"."{spec.new_table}" '
-            f'SET SCHEMA "{spec.target_schema}"'
+            f'ALTER TABLE "{spec.staging_schema}"."{spec.new_table}" ' f'SET SCHEMA "{spec.target_schema}"'
         )
         statements.append(
-            f'ALTER TABLE "{spec.target_schema}"."{spec.new_table}" '
-            f'RENAME TO "{spec.target_table}"'
+            f'ALTER TABLE "{spec.target_schema}"."{spec.new_table}" ' f'RENAME TO "{spec.target_table}"'
         )
         statements.append(
             f'ALTER INDEX "{spec.target_schema}"."{spec.stage_name(spec.pk_name)}" '
@@ -203,8 +194,7 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
         )
         for idx in spec.indexes:
             statements.append(
-                f'ALTER INDEX "{spec.target_schema}"."{spec.stage_name(idx)}" '
-                f'RENAME TO "{idx}"'
+                f'ALTER INDEX "{spec.target_schema}"."{spec.stage_name(idx)}" ' f'RENAME TO "{idx}"'
             )
         for fk in spec.fkeys:
             statements.append(

--- a/airflow/astro/include/custom_functions/l2_sftp.py
+++ b/airflow/astro/include/custom_functions/l2_sftp.py
@@ -85,15 +85,10 @@ def download_expired_voter_files(
         if file_timestamps is not None:
             stat = sftp_client.stat(remote_path)
             mtime_iso = (
-                datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
-                if stat.st_mtime
-                else None
+                datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat() if stat.st_mtime else None
             )
 
-        logger.info(
-            f"Downloading {remote_path}"
-            + (f" (modified: {mtime_iso})" if mtime_iso else "")
-        )
+        logger.info(f"Downloading {remote_path}" + (f" (modified: {mtime_iso})" if mtime_iso else ""))
         sftp_client.get(
             remotepath=remote_path,
             localpath=local_path,
@@ -153,8 +148,7 @@ def parse_expired_voter_ids(
 
         if "LALVOTERID" not in df.columns:
             logger.warning(
-                f"LALVOTERID column not found in {file_path}. "
-                f"Available columns: {list(df.columns)}"
+                f"LALVOTERID column not found in {file_path}. " f"Available columns: {list(df.columns)}"
             )
             continue
 

--- a/airflow/astro/include/custom_functions/postgres_utils.py
+++ b/airflow/astro/include/custom_functions/postgres_utils.py
@@ -79,9 +79,7 @@ def get_postgres_via_ssh(
     # Build SSH auth kwargs — prefer key-based auth, fall back to password.
     ssh_kwargs: dict = {}
     pem_data = bastion.extra_dejson.get("private_key", "")
-    passphrase = (
-        bastion.extra_dejson.get("private_key_passphrase") or bastion.password or None
-    )
+    passphrase = bastion.extra_dejson.get("private_key_passphrase") or bastion.password or None
     if pem_data:
         # Try each key class until one parses the key successfully.
         pkey = None

--- a/airflow/astro/tests/dags/test_dag_example.py
+++ b/airflow/astro/tests/dags/test_dag_example.py
@@ -31,9 +31,7 @@ def get_import_errors():
             return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
 
         # prepend "(None,None)" to ensure that a test object is always created even if it's a no op.
-        return [(None, None)] + [
-            (strip_path_prefix(k), v.strip()) for k, v in dag_bag.import_errors.items()
-        ]
+        return [(None, None)] + [(strip_path_prefix(k), v.strip()) for k, v in dag_bag.import_errors.items()]
 
 
 def get_dags():
@@ -49,9 +47,7 @@ def get_dags():
     return [(k, v, strip_path_prefix(v.fileloc)) for k, v in dag_bag.dags.items()]
 
 
-@pytest.mark.parametrize(
-    "rel_path,rv", get_import_errors(), ids=[x[0] for x in get_import_errors()]
-)
+@pytest.mark.parametrize("rel_path,rv", get_import_errors(), ids=[x[0] for x in get_import_errors()])
 def test_file_imports(rel_path, rv):
     """Test for import errors on a file"""
     if rel_path and rv:
@@ -61,9 +57,7 @@ def test_file_imports(rel_path, rv):
 APPROVED_TAGS: dict[str, str] = {}
 
 
-@pytest.mark.parametrize(
-    "dag_id,dag,fileloc", get_dags(), ids=[x[2] for x in get_dags()]
-)
+@pytest.mark.parametrize("dag_id,dag,fileloc", get_dags(), ids=[x[2] for x in get_dags()])
 def test_dag_tags(dag_id, dag, fileloc):
     """
     Test if a DAG is tagged and if those TAGs are in the approved list
@@ -73,13 +67,9 @@ def test_dag_tags(dag_id, dag, fileloc):
         assert not set(dag.tags) - APPROVED_TAGS
 
 
-@pytest.mark.parametrize(
-    "dag_id,dag, fileloc", get_dags(), ids=[x[2] for x in get_dags()]
-)
+@pytest.mark.parametrize("dag_id,dag, fileloc", get_dags(), ids=[x[2] for x in get_dags()])
 def test_dag_retries(dag_id, dag, fileloc):
     """
     Test if a DAG has retries set
     """
-    assert (
-        dag.default_args.get("retries", None) >= 2
-    ), f"{dag_id} in {fileloc} must have task retries >= 2."
+    assert dag.default_args.get("retries", None) >= 2, f"{dag_id} in {fileloc} must have task retries >= 2."

--- a/airflow/astro/tests/test_postgres_utils.py
+++ b/airflow/astro/tests/test_postgres_utils.py
@@ -59,9 +59,7 @@ class TestUpsertRows:
         conn, cursor = self._make_conn()
         rows = [(1, "a"), (2, "b")]
 
-        with patch(
-            "include.custom_functions.postgres_utils.psycopg2.extras.execute_values"
-        ) as mock_ev:
+        with patch("include.custom_functions.postgres_utils.psycopg2.extras.execute_values") as mock_ev:
             upsert_rows(
                 conn=conn,
                 schema="public",
@@ -80,9 +78,7 @@ class TestUpsertRows:
         conn, cursor = self._make_conn()
         rows = [("v1", "d1", 100)]
 
-        with patch(
-            "include.custom_functions.postgres_utils.psycopg2.extras.execute_values"
-        ) as mock_ev:
+        with patch("include.custom_functions.postgres_utils.psycopg2.extras.execute_values") as mock_ev:
             upsert_rows(
                 conn=conn,
                 schema="public",
@@ -101,9 +97,7 @@ class TestUpsertRows:
         conn, cursor = self._make_conn()
         rows = [("d1", "2024-01-01", 100, 50, "{}")]
 
-        with patch(
-            "include.custom_functions.postgres_utils.psycopg2.extras.execute_values"
-        ) as mock_ev:
+        with patch("include.custom_functions.postgres_utils.psycopg2.extras.execute_values") as mock_ev:
             upsert_rows(
                 conn=conn,
                 schema="public",
@@ -132,9 +126,7 @@ class TestUpsertRows:
         conn, cursor = self._make_conn()
         rows = [(i, f"name_{i}") for i in range(12)]
 
-        with patch(
-            "include.custom_functions.postgres_utils.psycopg2.extras.execute_values"
-        ) as mock_ev:
+        with patch("include.custom_functions.postgres_utils.psycopg2.extras.execute_values") as mock_ev:
             total = upsert_rows(
                 conn=conn,
                 schema="public",
@@ -177,9 +169,7 @@ class TestGetPostgresViaSsh:
     @patch("include.custom_functions.postgres_utils.BaseHook.get_connection")
     def test_lifecycle(self, mock_get_conn, mock_tunnel_cls, mock_pg_connect):
         """Tunnel starts, connection opens, both close on exit."""
-        bastion_conn = MagicMock(
-            host="bastion.example.com", port=22, login="user", password="pw"
-        )
+        bastion_conn = MagicMock(host="bastion.example.com", port=22, login="user", password="pw")
         bastion_conn.extra_dejson = {}
         pg_conn = MagicMock(
             host="pg.internal",
@@ -210,9 +200,7 @@ class TestGetPostgresViaSsh:
     @patch("include.custom_functions.postgres_utils.BaseHook.get_connection")
     def test_cleanup_on_error(self, mock_get_conn, mock_tunnel_cls, mock_pg_connect):
         """Tunnel and connection close even when task raises."""
-        bastion_conn = MagicMock(
-            host="bastion.example.com", port=22, login="user", password="pw"
-        )
+        bastion_conn = MagicMock(host="bastion.example.com", port=22, login="user", password="pw")
         bastion_conn.extra_dejson = {}
         pg_conn = MagicMock(
             host="pg.internal",

--- a/analytics/lib/win_analysis.py
+++ b/analytics/lib/win_analysis.py
@@ -155,14 +155,10 @@ def build_win_working_set(
     """
     _require_date("event_floor", event_floor)
     if preelection_days <= 0:
-        raise ValueError(
-            f"preelection_days must be a positive integer, got: {preelection_days!r}"
-        )
+        raise ValueError(f"preelection_days must be a positive integer, got: {preelection_days!r}")
     for dim in slice_dims:
         if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", dim):
-            raise ValueError(
-                f"slice_dims element must be a plain SQL identifier, got: {dim!r}"
-            )
+            raise ValueError(f"slice_dims element must be a plain SQL identifier, got: {dim!r}")
     win_types = _win_event_types_sql(drift_cutoff)  # also validates drift_cutoff
     dim_cols = "".join(f", MAX({d}) AS {d}" for d in slice_dims)
 

--- a/apps/genie-slack-bot/config.py
+++ b/apps/genie-slack-bot/config.py
@@ -34,7 +34,5 @@ class Config:
         ]
         missing = [v for v in required if not getattr(cls, v)]
         if missing:
-            raise ValueError(
-                f"Missing required environment variables: {', '.join(missing)}"
-            )
+            raise ValueError(f"Missing required environment variables: {', '.join(missing)}")
         return True

--- a/apps/genie-slack-bot/databricks_genie_client.py
+++ b/apps/genie-slack-bot/databricks_genie_client.py
@@ -110,8 +110,7 @@ class DatabricksGenieClient:
                 if is_retryable and attempt < max_retries - 1:
                     wait_seconds = min(2**attempt, 8)
                     logger.warning(
-                        "Retryable API error on %s %s (status=%s, attempt=%s/%s): %s. "
-                        "Retrying in %ss",
+                        "Retryable API error on %s %s (status=%s, attempt=%s/%s): %s. " "Retrying in %ss",
                         method,
                         path,
                         status_code,
@@ -134,9 +133,7 @@ class DatabricksGenieClient:
                 return None
         return None
 
-    def send_message(
-        self, conversation_id: Optional[str], message: str
-    ) -> Optional[Dict[str, Any]]:
+    def send_message(self, conversation_id: Optional[str], message: str) -> Optional[Dict[str, Any]]:
         """
         Send a message to the Genie space
 
@@ -184,9 +181,7 @@ class DatabricksGenieClient:
             "raw_response": result,
         }
 
-    def get_message_status(
-        self, conversation_id: str, message_id: str
-    ) -> Optional[Dict[str, Any]]:
+    def get_message_status(self, conversation_id: str, message_id: str) -> Optional[Dict[str, Any]]:
         """
         Get the status and response of a message
 
@@ -249,9 +244,7 @@ class DatabricksGenieClient:
                 if empty_polls >= max_empty_polls:
                     return None
                 time.sleep(current_poll_interval)
-                current_poll_interval = min(
-                    current_poll_interval + 1, max_poll_interval
-                )
+                current_poll_interval = min(current_poll_interval + 1, max_poll_interval)
                 continue
 
             empty_polls = 0
@@ -339,9 +332,7 @@ class DatabricksGenieClient:
         actual_conversation_id = message_result.get("conversation_id", conversation_id)
         message_id = message_result.get("id") or message_result.get("message_id")
 
-        if not isinstance(actual_conversation_id, str) or not isinstance(
-            message_id, str
-        ):
+        if not isinstance(actual_conversation_id, str) or not isinstance(message_id, str):
             return {
                 "success": False,
                 "conversation_id": conversation_id,
@@ -416,30 +407,18 @@ class DatabricksGenieClient:
                     query_attachment_id,
                 )
                 if attachment_result:
-                    statement_response = attachment_result.get(
-                        "statement_response", attachment_result
-                    )
+                    statement_response = attachment_result.get("statement_response", attachment_result)
                     result_data = {
                         "data": statement_response.get("result", {}),
-                        "schema": statement_response.get("manifest", {}).get(
-                            "schema", {}
-                        ),
+                        "schema": statement_response.get("manifest", {}).get("schema", {}),
                     }
 
             if not response_text.strip():
                 content = response.get("content")
-                response_text = (
-                    content
-                    if isinstance(content, str) and content
-                    else "No response generated"
-                )
+                response_text = content if isinstance(content, str) and content else "No response generated"
 
             raw_suggested_questions = response.get("suggested_questions")
-            suggested_questions = (
-                raw_suggested_questions
-                if isinstance(raw_suggested_questions, list)
-                else []
-            )
+            suggested_questions = raw_suggested_questions if isinstance(raw_suggested_questions, list) else []
 
             return {
                 "success": True,
@@ -456,9 +435,7 @@ class DatabricksGenieClient:
             raw_error = response.get("error")
             if isinstance(raw_error, dict):
                 error_message = raw_error.get("message")
-                error_msg = (
-                    error_message if isinstance(error_message, str) else "Unknown error"
-                )
+                error_msg = error_message if isinstance(error_message, str) else "Unknown error"
             elif isinstance(raw_error, str) and raw_error:
                 error_msg = raw_error
             else:

--- a/apps/genie-slack-bot/slack_bot.py
+++ b/apps/genie-slack-bot/slack_bot.py
@@ -99,21 +99,15 @@ class SlackGenieBot:
             if event.get("bot_id"):
                 return
 
-            if not isinstance(channel_value, str) or not isinstance(
-                thread_ts_value, str
-            ):
-                logger.warning(
-                    "Skipping Slack event with missing channel or thread_ts: %s", event
-                )
+            if not isinstance(channel_value, str) or not isinstance(thread_ts_value, str):
+                logger.warning("Skipping Slack event with missing channel or thread_ts: %s", event)
                 return
 
             channel = channel_value
             thread_ts = thread_ts_value
             conversation_scope = self._get_conversation_key(channel, thread_ts)
             event_ts = event.get("ts")
-            if isinstance(event_ts, str) and self._is_duplicate_event(
-                channel, event_ts
-            ):
+            if isinstance(event_ts, str) and self._is_duplicate_event(channel, event_ts):
                 logger.info(
                     "Skipping duplicate Slack event for channel=%s ts=%s",
                     channel,
@@ -165,9 +159,7 @@ class SlackGenieBot:
             thinking_ts = thinking_resp.get("ts")
 
             # Get or create Databricks conversation
-            conversation_id = self._get_mapping(
-                self.conversation_map, conversation_scope
-            )
+            conversation_id = self._get_mapping(self.conversation_map, conversation_scope)
             logger.info(
                 "Routing Slack message channel=%s channel_type=%s thread_ts=%s "
                 "conversation_key=%s existing_conversation=%s",
@@ -269,9 +261,7 @@ class SlackGenieBot:
             # Send suggested follow-up questions
             suggested_questions = result.get("suggested_questions", [])
             if suggested_questions:
-                self._send_suggested_questions(
-                    channel, thread_ts, suggested_questions, client
-                )
+                self._send_suggested_questions(channel, thread_ts, suggested_questions, client)
 
             # Send feedback buttons as the last message
             if result.get("success"):
@@ -284,9 +274,7 @@ class SlackGenieBot:
                 )
 
                 if isinstance(conv_id, str) and isinstance(msg_id, str):
-                    feedback_msg = self._send_feedback_buttons(
-                        channel, thread_ts, client
-                    )
+                    feedback_msg = self._send_feedback_buttons(channel, thread_ts, client)
                     if feedback_msg:
                         fb_ts = feedback_msg.get("ts")
                         if isinstance(fb_ts, str):
@@ -303,9 +291,7 @@ class SlackGenieBot:
                                 msg_id,
                             )
                 else:
-                    logger.warning(
-                        "Missing conversation_id or message_id - cannot create feedback buttons"
-                    )
+                    logger.warning("Missing conversation_id or message_id - cannot create feedback buttons")
 
             # --- Structured observability log ---
             if result.get("success"):
@@ -327,10 +313,7 @@ class SlackGenieBot:
         except Exception as error:
             logger.error("Error handling message: %s", error, exc_info=True)
             if isinstance(channel_value, str) and isinstance(thread_ts_value, str):
-                error_text = (
-                    "Sorry, I encountered an error processing your request. "
-                    "Please try again."
-                )
+                error_text = "Sorry, I encountered an error processing your request. " "Please try again."
                 if thinking_ts:
                     try:
                         self._update_message(
@@ -342,8 +325,7 @@ class SlackGenieBot:
                         return
                     except Exception as update_error:
                         logger.warning(
-                            "Failed to update thinking message with error state, "
-                            "posting new: %s",
+                            "Failed to update thinking message with error state, " "posting new: %s",
                             update_error,
                         )
 
@@ -454,9 +436,7 @@ class SlackGenieBot:
             )
             return False
 
-    def _remember_mapping(
-        self, mapping: OrderedDict[str, Any], key: str, value: Any, max_size: int
-    ) -> None:
+    def _remember_mapping(self, mapping: OrderedDict[str, Any], key: str, value: Any, max_size: int) -> None:
         with self.state_lock:
             mapping[key] = value
             mapping.move_to_end(key)
@@ -485,9 +465,7 @@ class SlackGenieBot:
                 return
 
             columns = schema.get("columns", [])
-            column_names = [
-                col.get("name", f"col_{i}") for i, col in enumerate(columns)
-            ]
+            column_names = [col.get("name", f"col_{i}") for i, col in enumerate(columns)]
 
             max_rows = 10
             table_text = self._format_data_array(column_names, data_array[:max_rows])
@@ -519,9 +497,7 @@ class SlackGenieBot:
         except Exception as error:
             logger.error("Error sending suggested questions: %s", error)
 
-    def _send_feedback_buttons(
-        self, channel: str, thread_ts: str, client
-    ) -> Optional[dict]:
+    def _send_feedback_buttons(self, channel: str, thread_ts: str, client) -> Optional[dict]:
         try:
             blocks: List[Dict[str, Any]] = [
                 {
@@ -656,9 +632,7 @@ class SlackGenieBot:
     # Table formatting
     # ------------------------------------------------------------------
 
-    def _format_data_array(
-        self, column_names: List[str], data_array: List[list]
-    ) -> str:
+    def _format_data_array(self, column_names: List[str], data_array: List[list]) -> str:
         if not data_array:
             return "No data"
 
@@ -679,9 +653,7 @@ class SlackGenieBot:
 
         lines = []
 
-        header_parts = [
-            name[:w].strip().center(w) for name, w in zip(column_names, col_widths)
-        ]
+        header_parts = [name[:w].strip().center(w) for name, w in zip(column_names, col_widths)]
         lines.append("│".join(header_parts))
         lines.append("┼".join("─" * w for w in col_widths))
 
@@ -690,9 +662,7 @@ class SlackGenieBot:
             for i, (w, num) in enumerate(zip(col_widths, col_types)):
                 val = row[i] if i < len(row) else None
                 s = str(val)[:w].strip() if val is not None else ""
-                parts.append(
-                    s.rjust(w) if num and self._is_numeric(val) else s.ljust(w)
-                )
+                parts.append(s.rjust(w) if num and self._is_numeric(val) else s.ljust(w))
             lines.append("│".join(parts))
 
         return "\n".join(lines)

--- a/apps/genie-tools/src/genie_tools/cli.py
+++ b/apps/genie-tools/src/genie_tools/cli.py
@@ -10,9 +10,7 @@ from .validate_space import validate_space_file
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Export and validate Databricks Genie space config"
-    )
+    parser = argparse.ArgumentParser(description="Export and validate Databricks Genie space config")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     export_parser = subparsers.add_parser(

--- a/apps/genie-tools/src/genie_tools/export_space.py
+++ b/apps/genie-tools/src/genie_tools/export_space.py
@@ -66,9 +66,7 @@ def _parse_serialized_space(serialized_space: Any) -> tuple[dict[str, Any], str]
         try:
             payload = json.loads(serialized_space)
         except json.JSONDecodeError as exc:
-            raise RuntimeError(
-                "serialized_space was returned but did not contain valid JSON"
-            ) from exc
+            raise RuntimeError("serialized_space was returned but did not contain valid JSON") from exc
         if not isinstance(payload, dict):
             raise RuntimeError("serialized_space JSON must decode to an object")
         return payload, serialized_space
@@ -76,9 +74,7 @@ def _parse_serialized_space(serialized_space: Any) -> tuple[dict[str, Any], str]
     if isinstance(serialized_space, dict):
         return serialized_space, json.dumps(serialized_space, ensure_ascii=False)
 
-    raise RuntimeError(
-        "serialized_space returned an unexpected type; expected a JSON string export"
-    )
+    raise RuntimeError("serialized_space returned an unexpected type; expected a JSON string export")
 
 
 def _build_metadata(
@@ -91,12 +87,8 @@ def _build_metadata(
 ) -> dict[str, Any]:
     metadata: dict[str, Any] = {
         "requested_space_id": requested_space_id,
-        "exported_at_utc": datetime.now(timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z"),
-        "serialized_space_sha256": hashlib.sha256(
-            serialized_space.encode("utf-8")
-        ).hexdigest(),
+        "exported_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "serialized_space_sha256": hashlib.sha256(serialized_space.encode("utf-8")).hexdigest(),
         "top_level_keys": sorted(payload),
     }
     if host:

--- a/apps/genie-tools/src/genie_tools/redact_space.py
+++ b/apps/genie-tools/src/genie_tools/redact_space.py
@@ -21,9 +21,7 @@ TEXTUAL_ENV_REPLACEMENTS = {
     "DATABRICKS_GENIE_SPACE_ID": "<SPACE_ID>",
     "DATABRICKS_WORKSPACE_ID": "<WORKSPACE_ID>",
 }
-ABSOLUTE_PATH_RE = re.compile(
-    r"(?:/Users/[^\s\"']+|/Workspace/[^\s\"']+|/Volumes/[^\s\"']+|dbfs:/[^\s\"']+)"
-)
+ABSOLUTE_PATH_RE = re.compile(r"(?:/Users/[^\s\"']+|/Workspace/[^\s\"']+|/Volumes/[^\s\"']+|dbfs:/[^\s\"']+)")
 DATABRICKS_URL_RE = re.compile(
     r"https://[A-Za-z0-9._:-]+"
     r"(?:cloud\.databricks\.com|azuredatabricks\.net|gcp\.databricks\.com|databricksapps\.com)"
@@ -36,9 +34,7 @@ OPAQUE_ID_RE = re.compile(
 BACKTICK_FQN_RE = re.compile(
     r"`([A-Za-z_][A-Za-z0-9_]*)`\.`([A-Za-z_][A-Za-z0-9_]*)`\.`([A-Za-z_][A-Za-z0-9_]*)`"
 )
-PLAIN_FQN_RE = re.compile(
-    r"\b([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b"
-)
+PLAIN_FQN_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b")
 PLAIN_FQN_EXACT_RE = re.compile(
     r"^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$"
 )
@@ -122,9 +118,7 @@ def _should_replace_plain_fqn(text: str, key_hint: str | None) -> bool:
     return SQL_CONTEXT_RE.search(text) is not None
 
 
-def _placeholder_for_key(
-    key_hint: str | None, value: Any, context: _RedactionContext
-) -> str | None:
+def _placeholder_for_key(key_hint: str | None, value: Any, context: _RedactionContext) -> str | None:
     if not key_hint:
         return None
 
@@ -152,9 +146,7 @@ def _placeholder_for_key(
     return None
 
 
-def _replace_text(
-    text: str, key_hint: str | None = None, context: _RedactionContext | None = None
-) -> str:
+def _replace_text(text: str, key_hint: str | None = None, context: _RedactionContext | None = None) -> str:
     if context is None:
         context = _RedactionContext()
 
@@ -188,10 +180,7 @@ def redact_obj(
         return placeholder
 
     if isinstance(obj, dict):
-        return {
-            key: redact_obj(value, key_hint=key, context=context)
-            for key, value in obj.items()
-        }
+        return {key: redact_obj(value, key_hint=key, context=context) for key, value in obj.items()}
     if isinstance(obj, list):
         return [redact_obj(value, key_hint=key_hint, context=context) for value in obj]
     if isinstance(obj, str):

--- a/apps/genie-tools/src/genie_tools/validate_space.py
+++ b/apps/genie-tools/src/genie_tools/validate_space.py
@@ -29,25 +29,17 @@ def validate_space_payload(payload: Any) -> None:
     if not payload:
         raise ValueError("Top-level JSON object is empty")
 
-    structured_keys = [
-        key for key, value in payload.items() if isinstance(value, (dict, list))
-    ]
+    structured_keys = [key for key, value in payload.items() if isinstance(value, (dict, list))]
     if not structured_keys:
-        raise ValueError(
-            "Top-level JSON object does not contain any structured Genie config sections"
-        )
+        raise ValueError("Top-level JSON object does not contain any structured Genie config sections")
 
     present_known_sections = sorted(KNOWN_GENIE_SECTION_KEYS.intersection(payload))
     if not present_known_sections:
-        raise ValueError(
-            "Top-level JSON object does not contain any recognized Genie sections"
-        )
+        raise ValueError("Top-level JSON object does not contain any recognized Genie sections")
 
     for key in present_known_sections:
         if not isinstance(payload[key], (dict, list)):
-            raise ValueError(
-                f"Top-level section {key!r} must be a JSON object or array"
-            )
+            raise ValueError(f"Top-level section {key!r} must be a JSON object or array")
 
 
 def validate_space_file(path: Path) -> None:

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_candidacy.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_candidacy.py
@@ -171,19 +171,13 @@ def _get_candidacy_batch(
         # process each entry (rename, handle timestamps)
         for candidacy in candidacies:
             if candidacy:
-                candidacy["candidate_database_id"] = int(
-                    candidacy["candidate"]["databaseId"]
-                )
+                candidacy["candidate_database_id"] = int(candidacy["candidate"]["databaseId"])
                 candidacy["created_at"] = pd.to_datetime(candidacy["createdAt"])
                 candidacy["database_id"] = int(candidacy["databaseId"])
-                candidacy["election_database_id"] = int(
-                    candidacy["election"]["databaseId"]
-                )
+                candidacy["election_database_id"] = int(candidacy["election"]["databaseId"])
                 candidacy["is_certified"] = candidacy["isCertified"]
                 candidacy["is_hidden"] = candidacy["isHidden"]
-                candidacy["position_database_id"] = int(
-                    candidacy["position"]["databaseId"]
-                )
+                candidacy["position_database_id"] = int(candidacy["position"]["databaseId"])
                 candidacy["race_database_id"] = int(candidacy["race"]["databaseId"])
                 candidacy["updated_at"] = pd.to_datetime(candidacy["updatedAt"])
         return candidacies
@@ -290,9 +284,7 @@ def model(dbt, session) -> DataFrame:
         raise ValueError("Missing required secret: civic-engine-api-token")
 
     # get candidacies
-    candidacies_s3: DataFrame = dbt.ref(
-        "stg_airbyte_source__ballotready_s3_candidacies_v3"
-    )
+    candidacies_s3: DataFrame = dbt.ref("stg_airbyte_source__ballotready_s3_candidacies_v3")
 
     if dbt.is_incremental:
         existing_table = session.table(f"{dbt.this}")
@@ -300,9 +292,7 @@ def model(dbt, session) -> DataFrame:
         max_updated_at = max_updated_at_row[0] if max_updated_at_row else None
 
         if max_updated_at:
-            candidacies_s3 = candidacies_s3.filter(
-                candidacies_s3["candidacy_updated_at"] >= max_updated_at
-            )
+            candidacies_s3 = candidacies_s3.filter(candidacies_s3["candidacy_updated_at"] >= max_updated_at)
 
     # get distinct candidacy IDs
     candidacy_ids = candidacies_s3.select("br_candidacy_id").distinct()
@@ -320,9 +310,7 @@ def model(dbt, session) -> DataFrame:
     # this is a slow operation; it helps to downsample during development with
     # dataframe.sample(False, 0.1).limit(1000)
     get_candidacy = _get_candidacy_token(ce_api_token)
-    candidacies = candidacy_ids.withColumn(
-        "candidacy", get_candidacy(col("br_candidacy_id"))
-    )
+    candidacies = candidacy_ids.withColumn("candidacy", get_candidacy(col("br_candidacy_id")))
 
     candidacies = candidacies.select(
         col("candidacy.candidate_database_id").alias("candidate_database_id"),

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_endorsement.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_endorsement.py
@@ -145,9 +145,7 @@ def _get_endorsements_batch(
                 endorsement["updatedAt"] = pd.to_datetime(endorsement["updatedAt"])
                 all_endorsements.append(endorsement)
 
-        logging.debug(
-            f"Retrieved {len(all_endorsements)} endorsements for {len(candidacy_ids)} candidacies"
-        )
+        logging.debug(f"Retrieved {len(all_endorsements)} endorsements for {len(candidacy_ids)} candidacies")
         return all_endorsements
 
     except (KeyError, TypeError) as e:
@@ -256,9 +254,7 @@ def _get_candidacy_endorsements_token(ce_api_token: str) -> Callable:
                 logging.error(f"Error processing batch {i//batch_size}: {str(e)}")
 
         # Create result series mapping each candidacy ID to its endorsements array
-        result = pd.Series(
-            [endorsements_by_candidacy.get(int(cid), []) for cid in candidacy_ids]
-        )
+        result = pd.Series([endorsements_by_candidacy.get(int(cid), []) for cid in candidacy_ids])
         return result
 
     return get_candidacy_endorsements
@@ -287,9 +283,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Configure logging
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
     # Get API token from Databricks secrets
     dbt_env = dbt.config.meta_get("dbt_environment")
@@ -300,17 +294,13 @@ def model(dbt, session) -> DataFrame:
         raise ValueError("Missing required secret: civic-engine-api-token")
 
     # Get references to required models
-    candidacies: DataFrame = dbt.ref(
-        "stg_airbyte_source__ballotready_s3_candidacies_v3"
-    )
+    candidacies: DataFrame = dbt.ref("stg_airbyte_source__ballotready_s3_candidacies_v3")
 
     # Handle incremental loading
     if dbt.is_incremental:
         logging.info("INFO: Running in incremental mode")
         existing_table = session.table(f"{dbt.this}")
-        existing_timestamps = existing_table.select(
-            "candidacy_id", "created_at"
-        ).distinct()
+        existing_timestamps = existing_table.select("candidacy_id", "created_at").distinct()
 
         # Get maximum updated_at from existing table
         max_updated_at_row = existing_table.agg({"updated_at": "max"}).collect()[0]
@@ -318,18 +308,12 @@ def model(dbt, session) -> DataFrame:
 
         if max_updated_at:
             # Filter source to only process records updated since last run
-            candidacies = candidacies.filter(
-                candidacies["candidacy_updated_at"] >= max_updated_at
-            )
-            logging.info(
-                f"INFO: Filtered to candidacies updated since {max_updated_at}"
-            )
+            candidacies = candidacies.filter(candidacies["candidacy_updated_at"] >= max_updated_at)
+            logging.info(f"INFO: Filtered to candidacies updated since {max_updated_at}")
         else:
             # Fallback to 30-day window if no max_updated_at found
             thirty_days_ago = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
-            candidacies = candidacies.filter(
-                candidacies["candidacy_updated_at"] >= thirty_days_ago
-            )
+            candidacies = candidacies.filter(candidacies["candidacy_updated_at"] >= thirty_days_ago)
             logging.info(
                 f"INFO: No max updated_at found. Filtered to candidacies updated since {thirty_days_ago}"
             )
@@ -361,15 +345,11 @@ def model(dbt, session) -> DataFrame:
     logging.info("INFO: Starting parallel processing of candidacies using pandas UDF")
 
     # Create a DataFrame with just candidacy_ids for processing
-    endorsement = candidacies.select(
-        col("br_candidacy_id").cast("integer").alias("candidacy_id")
-    )
+    endorsement = candidacies.select(col("br_candidacy_id").cast("integer").alias("candidacy_id"))
 
     # Apply the pandas UDF to get endorsements for each candidacy
     get_candidacy_endorsements = _get_candidacy_endorsements_token(ce_api_token)
-    endorsement = endorsement.withColumn(
-        "endorsements", get_candidacy_endorsements("candidacy_id")
-    )
+    endorsement = endorsement.withColumn("endorsements", get_candidacy_endorsements("candidacy_id"))
 
     # Add timestamp metadata
     current_time_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
@@ -379,9 +359,7 @@ def model(dbt, session) -> DataFrame:
         existing_created_at_lookup = existing_timestamps
 
         # Left join with this lookup to preserve original created_at values for existing records
-        endorsement = endorsement.join(
-            existing_created_at_lookup, on="candidacy_id", how="left"
-        )
+        endorsement = endorsement.join(existing_created_at_lookup, on="candidacy_id", how="left")
 
         # Use coalesce to keep original created_at for existing records, and set current time for new ones
         endorsement = endorsement.withColumn(
@@ -390,14 +368,10 @@ def model(dbt, session) -> DataFrame:
         )
     else:
         # For full refresh, set created_at to current time for all records
-        endorsement = endorsement.withColumn(
-            "created_at", lit(current_time_utc).cast(TimestampType())
-        )
+        endorsement = endorsement.withColumn("created_at", lit(current_time_utc).cast(TimestampType()))
 
     # Set updated_at to current time for all records
-    endorsement = endorsement.withColumn(
-        "updated_at", lit(current_time_utc).cast(TimestampType())
-    )
+    endorsement = endorsement.withColumn("updated_at", lit(current_time_utc).cast(TimestampType()))
 
     # Count and log the final row count
     row_count = endorsement.count()

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
@@ -38,9 +38,7 @@ def _get_filing_periods_batch(
     url = "https://bpi.civicengine.com/graphql"
 
     # Encode all filing period IDs
-    encoded_ids = [
-        _base64_encode_id(filing_period_id) for filing_period_id in filing_period_ids
-    ]
+    encoded_ids = [_base64_encode_id(filing_period_id) for filing_period_id in filing_period_ids]
 
     # Construct the payload with the nodes query
     payload = {
@@ -87,9 +85,7 @@ def _get_filing_periods_batch(
 
     except (KeyError, TypeError) as e:
         logging.error(f"Error processing filing periods batch: {str(e)}")
-        raise ValueError(
-            f"Failed to parse filing period data from API response: {str(e)}"
-        )
+        raise ValueError(f"Failed to parse filing period data from API response: {str(e)}")
     except requests.exceptions.RequestException as e:
         logging.error(f"API request failed for filing periods batch: {str(e)}")
         raise RuntimeError(f"Failed to fetch filing period data from API: {str(e)}")
@@ -139,14 +135,10 @@ def _get_filing_period_token(ce_api_token: str) -> Callable:
                 for filing_period in batch_filing_periods:
                     # process ints and timestamps
                     filing_period["databaseId"] = int(filing_period["databaseId"])
-                    filing_period["createdAt"] = pd.Timestamp(
-                        filing_period["createdAt"]
-                    )
+                    filing_period["createdAt"] = pd.Timestamp(filing_period["createdAt"])
                     filing_period["endOn"] = pd.Timestamp(filing_period["endOn"])
                     filing_period["startOn"] = pd.Timestamp(filing_period["startOn"])
-                    filing_period["updatedAt"] = pd.Timestamp(
-                        filing_period["updatedAt"]
-                    )
+                    filing_period["updatedAt"] = pd.Timestamp(filing_period["updatedAt"])
 
                     # organize by database id
                     filing_period_id = filing_period["databaseId"]
@@ -157,9 +149,7 @@ def _get_filing_period_token(ce_api_token: str) -> Callable:
         # create a list of dictionaries for each filing period in order of input
         result_data: List[Dict[str, Any]] = []
         for filing_period_id in filing_period_ids:
-            filing_period = filing_periods_by_filing_period_id.get(
-                int(filing_period_id), {}
-            )  # type: ignore
+            filing_period = filing_periods_by_filing_period_id.get(int(filing_period_id), {})  # type: ignore
             if filing_period:
                 result_data.append(filing_period)
             else:
@@ -218,9 +208,9 @@ def model(dbt, session) -> DataFrame:
     filing_periods: DataFrame = race.select("filing_periods").withColumn(
         "filing_periods", explode("filing_periods")
     )
-    filing_periods = (
-        filing_periods.select("filing_periods.databaseId").distinct()
-    ).withColumnRenamed("databaseId", "database_id")
+    filing_periods = (filing_periods.select("filing_periods.databaseId").distinct()).withColumnRenamed(
+        "databaseId", "database_id"
+    )
     filing_periods = filing_periods.filter(col("database_id").isNotNull())
 
     # Trigger a cache to ensure these transformations are applied. This is important for incremental models to avoid unnecessary API calls
@@ -252,9 +242,7 @@ def model(dbt, session) -> DataFrame:
     get_filing_period = _get_filing_period_token(ce_api_token)
 
     # First get the filing period data as a struct, then extract each field into its own column
-    filing_periods = filing_periods.withColumn(
-        "filing_period_data", get_filing_period(col("database_id"))
-    )
+    filing_periods = filing_periods.withColumn("filing_period_data", get_filing_period(col("database_id")))
     result = filing_periods.select(
         col("filing_period_data.createdAt").alias("created_at"),
         col("filing_period_data.databaseId").alias("database_id"),

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_geofence.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_geofence.py
@@ -207,9 +207,7 @@ def _get_geofence_token(ce_api_token: str) -> Callable:
                                 else None
                             ),
                             "validTo": (
-                                pd.to_datetime(geofence["validTo"]).date()
-                                if geofence["validTo"]
-                                else None
+                                pd.to_datetime(geofence["validTo"]).date() if geofence["validTo"] else None
                             ),
                         }
                     )
@@ -287,22 +285,16 @@ def model(dbt, session) -> DataFrame:
         raise ValueError("Missing required secret: civic-engine-api-token")
 
     # get all candidacy and position data
-    candidacy_df: DataFrame = dbt.ref(
-        "stg_airbyte_source__ballotready_s3_candidacies_v3"
-    )
+    candidacy_df: DataFrame = dbt.ref("stg_airbyte_source__ballotready_s3_candidacies_v3")
 
     # handle incremental loading
     if dbt.is_incremental:
         logging.info("INFO: Running in incremental mode")
         existing_table = session.table(f"{dbt.this}")
-        existing_timestamps = existing_table.select(
-            "database_id", "created_at", "updated_at"
-        ).distinct()
+        existing_timestamps = existing_table.select("database_id", "created_at", "updated_at").distinct()
 
         # get the latest updated_at date
-        latest_updated_at = existing_timestamps.agg({"updated_at": "max"}).collect()[0][
-            0
-        ]
+        latest_updated_at = existing_timestamps.agg({"updated_at": "max"}).collect()[0][0]
 
         # get all unique geo id after the latest updated_at date
         geofence = (
@@ -311,9 +303,7 @@ def model(dbt, session) -> DataFrame:
             .dropDuplicates(["br_geofence_id"])
         )
     else:
-        geofence = candidacy_df.select("br_geofence_id").dropDuplicates(
-            ["br_geofence_id"]
-        )
+        geofence = candidacy_df.select("br_geofence_id").dropDuplicates(["br_geofence_id"])
 
     # Trigger a cache to ensure these transformations are applied before the filter
     # if geofence_id is empty, return empty DataFrame

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_issue.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_issue.py
@@ -125,7 +125,6 @@ def _get_issue_batch(
 
 
 def _get_issue_token(ce_api_token: str) -> Callable:
-
     @pandas_udf(ISSUE_BR_SCHEMA)
     def get_issue(issue_database_id: pd.Series) -> pd.DataFrame:
         """
@@ -163,9 +162,7 @@ def _get_issue_token(ce_api_token: str) -> Callable:
                 empty_issue[field.name] = {}
             else:
                 empty_issue[field.name] = None
-        issues_list = [
-            issues_by_issue_db_id.get(id, empty_issue) for id in issue_database_id
-        ]
+        issues_list = [issues_by_issue_db_id.get(id, empty_issue) for id in issue_database_id]
         return pd.DataFrame(issues_list)
 
     return get_issue
@@ -194,9 +191,7 @@ def model(dbt, session) -> DataFrame:
     stances: DataFrame = dbt.ref("int__ballotready_stance")
 
     # First, explode the stances array to get individual stance records then extract the issue database IDs
-    exploded_stances = stances.select("stances").withColumn(
-        "stance", explode("stances")
-    )
+    exploded_stances = stances.select("stances").withColumn("stance", explode("stances"))
     issue_database_ids = exploded_stances.select(
         col("stance.issue.databaseId").alias("database_id")
     ).distinct()
@@ -251,7 +246,6 @@ def model(dbt, session) -> DataFrame:
 
     # add in created_at and updated_at timestamps
     if dbt.is_incremental:
-
         # get new issues that do not exist in the existing table and add created_at and updated_at timestamps
         new_issues = issue.join(
             other=existing_table,

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_normalized_position.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_normalized_position.py
@@ -164,9 +164,7 @@ def _get_normalized_position_token(ce_api_token: str) -> Callable:
             logging.debug(f"Processing {batch_size_info}")
 
             try:
-                batch_normalized_positions = _get_normalized_positions_batch(
-                    batch, ce_api_token
-                )
+                batch_normalized_positions = _get_normalized_positions_batch(batch, ce_api_token)
                 """
                 sample data:
                 [
@@ -187,9 +185,7 @@ def _get_normalized_position_token(ce_api_token: str) -> Callable:
                 for normalized_position in batch_normalized_positions:
                     if normalized_position:
                         normalized_position_id = normalized_position["databaseId"]
-                        normalized_positions_by_database_id[normalized_position_id] = (
-                            normalized_position
-                        )
+                        normalized_positions_by_database_id[normalized_position_id] = normalized_position
 
             except Exception as e:
                 logging.error(f"Error processing batch {i}: {e}")
@@ -289,9 +285,9 @@ def model(dbt, session) -> DataFrame:
         logging.warning("No positions found in source table")
         empty_df: DataFrame = session.createDataFrame(
             [],
-            normalized_position_schema.add(
-                StructField("created_at", TimestampType())
-            ).add(StructField("updated_at", TimestampType())),
+            normalized_position_schema.add(StructField("created_at", TimestampType())).add(
+                StructField("updated_at", TimestampType())
+            ),
         )
         empty_df = empty_df.withColumnRenamed("databaseId", "database_id")
         return empty_df
@@ -332,17 +328,13 @@ def model(dbt, session) -> DataFrame:
         )
     else:
         # For initial load, all records get current timestamp
-        normalized_positions = normalized_positions.withColumn(
-            "created_at", current_timestamp()
-        )
+        normalized_positions = normalized_positions.withColumn("created_at", current_timestamp())
 
     # deduplicate
     normalized_positions = normalized_positions.dropDuplicates(["id"])
 
     # updated_at is always set to current timestamp
-    normalized_positions = normalized_positions.withColumn(
-        "updated_at", current_timestamp()
-    )
+    normalized_positions = normalized_positions.withColumn("updated_at", current_timestamp())
 
     # Drop rows with negative databaseId values, where -1 was a placeholder for failed records
     # Trigger a cache to ensure preceding transformations are applied before the filter

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_party.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_party.py
@@ -144,23 +144,17 @@ def _get_parties_batch(
             # Handle API rate limiting
             if response.status_code == 429:
                 sleep_time = base_sleep * (2**attempt) + random.random() * jitter_factor
-                logging.warning(
-                    f"Rate limited. Retrying in {sleep_time:.2f} seconds..."
-                )
+                logging.warning(f"Rate limited. Retrying in {sleep_time:.2f} seconds...")
                 time.sleep(sleep_time)
                 continue
 
             # Handle other errors
-            logging.error(
-                f"API request failed with status code {response.status_code}: {response.text}"
-            )
+            logging.error(f"API request failed with status code {response.status_code}: {response.text}")
             return []
 
         except requests.exceptions.RequestException as e:
             sleep_time = base_sleep * (2**attempt) + random.random() * jitter_factor
-            logging.warning(
-                f"Request error: {e}. Retrying in {sleep_time:.2f} seconds..."
-            )
+            logging.warning(f"Request error: {e}. Retrying in {sleep_time:.2f} seconds...")
             time.sleep(sleep_time)
 
     logging.error(f"Failed to fetch parties after {max_retries} attempts.")
@@ -221,9 +215,7 @@ def _get_candidacy_parties_token(ce_api_token: str) -> Callable:
                 parties_by_candidacy[cid].append(party)
 
         # Create result series mapping each candidacy ID to its endorsements array
-        result = pd.Series(
-            [parties_by_candidacy.get(int(cid), []) for cid in candidacy_ids]
-        )
+        result = pd.Series([parties_by_candidacy.get(int(cid), []) for cid in candidacy_ids])
         return pd.Series(result)
 
     return get_candidacy_parties
@@ -252,9 +244,7 @@ def model(dbt, session) -> DataFrame:
     )
 
     # Configure logging
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
     # Get API token from Databricks secrets
     dbt_env = dbt.config.meta_get("dbt_environment")
@@ -265,17 +255,13 @@ def model(dbt, session) -> DataFrame:
         raise ValueError("Missing required secret: civic-engine-api-token")
 
     # Get references to required models
-    candidacies: DataFrame = dbt.ref(
-        "stg_airbyte_source__ballotready_s3_candidacies_v3"
-    )
+    candidacies: DataFrame = dbt.ref("stg_airbyte_source__ballotready_s3_candidacies_v3")
 
     # Check for incremental run
     if dbt.is_incremental:
         logging.info("INFO: Running in incremental mode")
         existing_table = session.table(f"{dbt.this}")
-        existing_timestamps = existing_table.select(
-            "candidacy_id", "created_at"
-        ).distinct()
+        existing_timestamps = existing_table.select("candidacy_id", "created_at").distinct()
 
         # Get maximum updated_at from existing table
         max_updated_at_row = existing_table.agg({"updated_at": "max"}).collect()[0]
@@ -283,18 +269,12 @@ def model(dbt, session) -> DataFrame:
 
         if max_updated_at:
             # Filter source to only process records updated since last run
-            candidacies = candidacies.filter(
-                candidacies["candidacy_updated_at"] >= max_updated_at
-            )
-            logging.info(
-                f"INFO: Filtered to candidacies updated since {max_updated_at}"
-            )
+            candidacies = candidacies.filter(candidacies["candidacy_updated_at"] >= max_updated_at)
+            logging.info(f"INFO: Filtered to candidacies updated since {max_updated_at}")
         else:
             # Fallback to 30-day window if no max_updated_at found
             thirty_days_ago = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
-            candidacies = candidacies.filter(
-                candidacies["candidacy_updated_at"] >= thirty_days_ago
-            )
+            candidacies = candidacies.filter(candidacies["candidacy_updated_at"] >= thirty_days_ago)
             logging.info(
                 f"INFO: No max updated_at found. Filtered to candidacies updated since {thirty_days_ago}"
             )
@@ -326,9 +306,7 @@ def model(dbt, session) -> DataFrame:
     logging.info("INFO: Starting parallel processing of candidacies using pandas UDF")
 
     # Create a DataFrame with just candidacy_ids for processing
-    party = candidacies.select(
-        col("br_candidacy_id").cast("integer").alias("candidacy_id")
-    )
+    party = candidacies.select(col("br_candidacy_id").cast("integer").alias("candidacy_id"))
 
     # Apply the pandas UDF to get parties for each candidacy
     get_candidacy_parties = _get_candidacy_parties_token(ce_api_token)
@@ -352,9 +330,7 @@ def model(dbt, session) -> DataFrame:
         )
     else:
         # For full refresh, set created_at to current time for all records
-        party = party.withColumn(
-            "created_at", lit(current_time_utc).cast(TimestampType())
-        )
+        party = party.withColumn("created_at", lit(current_time_utc).cast(TimestampType()))
 
     # Set updated_at to current time for all records
     party = party.withColumn("updated_at", lit(current_time_utc).cast(TimestampType()))

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_position_election_frequency.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_position_election_frequency.py
@@ -54,10 +54,7 @@ def _get_position_election_frequency_batch(
     url = "https://bpi.civicengine.com/graphql"
 
     # Encode all position IDs
-    encoded_ids = [
-        _base64_encode_id(position_database_id)
-        for position_database_id in position_database_ids
-    ]
+    encoded_ids = [_base64_encode_id(position_database_id) for position_database_id in position_database_ids]
 
     # Construct the payload with the nodes query
     payload = {
@@ -147,9 +144,7 @@ def _get_position_election_frequency_token(ce_api_token: str) -> Callable:
             raise ValueError("Missing required environment variable: CE_API_TOKEN")
 
         # Create a map to store stances by candidacy ID
-        position_election_frequency_by_database_id: Dict[int, Dict[str, Any] | None] = (
-            {}
-        )
+        position_election_frequency_by_database_id: Dict[int, Dict[str, Any] | None] = {}
 
         # Set batch size for API calls
         batch_size = 100
@@ -161,8 +156,8 @@ def _get_position_election_frequency_token(ce_api_token: str) -> Callable:
             logging.debug(f"Processing {batch_size_info}")
 
             try:
-                batch_position_election_frequency = (
-                    _get_position_election_frequency_batch(batch, ce_api_token)
+                batch_position_election_frequency = _get_position_election_frequency_batch(
+                    batch, ce_api_token
                 )
             except Exception as e:
                 logging.error(f"Error processing batch {i}: {e}")
@@ -170,12 +165,10 @@ def _get_position_election_frequency_token(ce_api_token: str) -> Callable:
 
             for position_election_frequency in batch_position_election_frequency:
                 if position_election_frequency:
-                    position_election_frequency_id = position_election_frequency[
-                        "databaseId"
-                    ]
-                    position_election_frequency_by_database_id[
-                        position_election_frequency_id
-                    ] = position_election_frequency
+                    position_election_frequency_id = position_election_frequency["databaseId"]
+                    position_election_frequency_by_database_id[position_election_frequency_id] = (
+                        position_election_frequency
+                    )
 
                     # handle timestamp columns
                     position_election_frequency["validFrom"] = pd.to_datetime(
@@ -197,9 +190,7 @@ def _get_position_election_frequency_token(ce_api_token: str) -> Callable:
         }
 
         position_election_frequency_by_database_id = [
-            position_election_frequency_by_database_id.get(
-                position_database_id, empty_dictionary
-            )
+            position_election_frequency_by_database_id.get(position_database_id, empty_dictionary)
             for position_database_id in position_database_ids
         ]  # type: ignore
 
@@ -240,13 +231,12 @@ def model(dbt, session) -> DataFrame:
         .withColumn("election_frequency", explode("election_frequencies"))
         .select(col("election_frequency.databaseId").alias("database_id"))
     )
-    position_election_frequency = position_election_frequency.select(
-        "database_id"
-    ).dropDuplicates(["database_id"])
+    position_election_frequency = position_election_frequency.select("database_id").dropDuplicates(
+        ["database_id"]
+    )
 
     # Filter if incremental by updated_at
     if dbt.is_incremental:
-
         # Get existing database_ids from the incremental table
         existing_records = session.table(f"{dbt.this}")
 
@@ -260,9 +250,7 @@ def model(dbt, session) -> DataFrame:
         # Trigger a cache to ensure these transformations are applied. This is important for incremental models to avoid unnecessary API calls
         position_election_frequency.cache()
         position_count = position_election_frequency.count()
-        logging.info(
-            f"Found {position_count} new position election frequencies to process"
-        )
+        logging.info(f"Found {position_count} new position election frequencies to process")
 
     # Validate source data
     if position_election_frequency.count() == 0:
@@ -288,9 +276,7 @@ def model(dbt, session) -> DataFrame:
     # 200
     # )
 
-    get_position_election_frequency = _get_position_election_frequency_token(
-        ce_api_token
-    )
+    get_position_election_frequency = _get_position_election_frequency_token(ce_api_token)
     position_election_frequency = position_election_frequency.withColumn(
         "api_data", get_position_election_frequency(col("database_id"))
     )
@@ -309,7 +295,5 @@ def model(dbt, session) -> DataFrame:
     # in pandas UDF. Trigger a cache to ensure these transformations are applied before filtering
     position_election_frequency.cache()
     position_election_frequency.count()
-    position_election_frequency = position_election_frequency.filter(
-        col("database_id") >= 0
-    )
+    position_election_frequency = position_election_frequency.filter(col("database_id") >= 0)
     return position_election_frequency

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_stance.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_stance.py
@@ -140,9 +140,7 @@ def _get_stances_batch(
                 stance["encoded_candidacy_id"] = encoded_candidacy_id
                 all_stances.append(stance)
 
-        logging.debug(
-            f"Retrieved {len(all_stances)} stances for {len(candidacy_ids)} candidacies"
-        )
+        logging.debug(f"Retrieved {len(all_stances)} stances for {len(candidacy_ids)} candidacies")
         return all_stances
 
     except (KeyError, TypeError) as e:
@@ -228,9 +226,7 @@ def _get_candidacy_stances_token(ce_api_token: str) -> Callable:
                 logging.error(f"Error processing batch {i//batch_size}: {str(e)}")
 
         # Create result series mapping each candidacy ID to its stances array
-        result = pd.Series(
-            [stances_by_candidacy.get(int(cid), []) for cid in candidacy_ids]
-        )
+        result = pd.Series([stances_by_candidacy.get(int(cid), []) for cid in candidacy_ids])
         return result
 
     return get_candidacy_stances
@@ -302,9 +298,7 @@ def model(dbt, session) -> DataFrame:
     if dbt.is_incremental:
         logging.info("INFO: Running in incremental mode")
         existing_table = session.table(f"{dbt.this}")
-        existing_timestamps = existing_table.select(
-            "candidacy_id", "created_at"
-        ).distinct()
+        existing_timestamps = existing_table.select("candidacy_id", "created_at").distinct()
 
         # Get maximum updated_at from existing table
         max_updated_at_row = existing_table.agg({"updated_at": "max"}).collect()[0]
@@ -312,18 +306,12 @@ def model(dbt, session) -> DataFrame:
 
         if max_updated_at:
             # Filter source to only process records updated since last run
-            candidacies = candidacies.filter(
-                candidacies["updated_at"] >= max_updated_at
-            )
-            logging.info(
-                f"INFO: Filtered to candidacies updated since {max_updated_at}"
-            )
+            candidacies = candidacies.filter(candidacies["updated_at"] >= max_updated_at)
+            logging.info(f"INFO: Filtered to candidacies updated since {max_updated_at}")
         else:
             # Fallback to 30-day window if no max_updated_at found
             thirty_days_ago = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
-            candidacies = candidacies.filter(
-                candidacies["updated_at"] >= thirty_days_ago
-            )
+            candidacies = candidacies.filter(candidacies["updated_at"] >= thirty_days_ago)
             logging.info(
                 f"INFO: No max updated_at found. Filtered to candidacies updated since {thirty_days_ago}"
             )
@@ -358,9 +346,7 @@ def model(dbt, session) -> DataFrame:
     logging.info("INFO: Starting parallel processing of candidacies using pandas UDF")
 
     # Create a DataFrame with just candidacy_ids for processing
-    stance = candidacies.select(
-        col("database_id").cast("integer").alias("candidacy_id")
-    )
+    stance = candidacies.select(col("database_id").cast("integer").alias("candidacy_id"))
 
     # Apply the pandas UDF to get stances for each candidacy
     get_candidacy_stances = _get_candidacy_stances_token(ce_api_token)
@@ -384,13 +370,9 @@ def model(dbt, session) -> DataFrame:
         )
     else:
         # For initial load, set created_at for all records
-        stance = stance.withColumn(
-            "created_at", lit(current_time_utc).cast(TimestampType())
-        )
+        stance = stance.withColumn("created_at", lit(current_time_utc).cast(TimestampType()))
 
-    stance = stance.withColumn(
-        "updated_at", lit(current_time_utc).cast(TimestampType())
-    )
+    stance = stance.withColumn("updated_at", lit(current_time_utc).cast(TimestampType()))
 
     # Count and log the final row count
     row_count = stance.count()

--- a/dbt/project/models/intermediate/ballotready_to_hubspot/int__ballotready_candidates_fuzzy_deduped.py
+++ b/dbt/project/models/intermediate/ballotready_to_hubspot/int__ballotready_candidates_fuzzy_deduped.py
@@ -68,9 +68,7 @@ def create_fuzzy_matching_udf(
 
     # Prepare HubSpot data for fuzzy matching
     hubspot_codes = (
-        hubspot_df[hubspot_df[hubspot_code_field_name].notna()][hubspot_code_field_name]
-        .unique()
-        .tolist()
+        hubspot_df[hubspot_df[hubspot_code_field_name].notna()][hubspot_code_field_name].unique().tolist()
     )
 
     # Create lookup dictionary for HubSpot data
@@ -100,15 +98,11 @@ def create_fuzzy_matching_udf(
         for candidate_code in candidate_codes:
             if pd.isna(candidate_code):
                 # Handle null candidate codes
-                fuzzy_results.append(
-                    _create_null_result(candidate_code, candidate_code_field_name)
-                )
+                fuzzy_results.append(_create_null_result(candidate_code, candidate_code_field_name))
                 continue
 
             # Find fuzzy matches
-            matches = process.extract(
-                candidate_code, hubspot_codes, scorer=fuzz.ratio, limit=top_n
-            )
+            matches = process.extract(candidate_code, hubspot_codes, scorer=fuzz.ratio, limit=top_n)
 
             # Process matches above threshold
             match_found = False
@@ -130,9 +124,7 @@ def create_fuzzy_matching_udf(
 
             # If no match found above threshold, add null entry
             if not match_found:
-                fuzzy_results.append(
-                    _create_null_result(candidate_code, candidate_code_field_name)
-                )
+                fuzzy_results.append(_create_null_result(candidate_code, candidate_code_field_name))
 
         return pd.DataFrame(fuzzy_results)
 
@@ -176,9 +168,7 @@ def _create_null_result(candidate_code: str, candidate_code_field_name: str) -> 
     }
 
 
-def add_match_type_column(
-    df, match_indicator_col: str = "fuzzy_matched_hubspot_candidate_code"
-):
+def add_match_type_column(df, match_indicator_col: str = "fuzzy_matched_hubspot_candidate_code"):
     """
     Adds a match_type column to the DataFrame based on whether fuzzy matches were found.
 
@@ -243,15 +233,11 @@ def model(dbt, session: SparkSession) -> DataFrame:
         ),
         col("fuzzy_results.fuzzy_match_score").alias("fuzzy_match_score"),
         col("fuzzy_results.fuzzy_match_rank").alias("fuzzy_match_rank"),
-        col("fuzzy_results.fuzzy_matched_hubspot_contact_id").alias(
-            "fuzzy_matched_hubspot_contact_id"
-        ),
+        col("fuzzy_results.fuzzy_matched_hubspot_contact_id").alias("fuzzy_matched_hubspot_contact_id"),
         col("fuzzy_results.fuzzy_matched_first_name").alias("fuzzy_matched_first_name"),
         col("fuzzy_results.fuzzy_matched_last_name").alias("fuzzy_matched_last_name"),
         col("fuzzy_results.fuzzy_matched_state").alias("fuzzy_matched_state"),
-        col("fuzzy_results.fuzzy_matched_office_type").alias(
-            "fuzzy_matched_office_type"
-        ),
+        col("fuzzy_results.fuzzy_matched_office_type").alias("fuzzy_matched_office_type"),
     )
 
     # Add match type column using shared utility

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_flags.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_flags.py
@@ -54,14 +54,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Alabama
     if state_allowlist is None or "AL" in state_allowlist:
-        al_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_al_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("AL"))
+        al_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_al_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("AL")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AL")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AL").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 al_df = al_df.filter(col("loaded_at") > max_loaded_at)
@@ -69,14 +67,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Alaska
     if state_allowlist is None or "AK" in state_allowlist:
-        ak_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ak_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("AK"))
+        ak_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ak_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("AK")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AK")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AK").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ak_df = ak_df.filter(col("loaded_at") > max_loaded_at)
@@ -84,14 +80,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Arizona
     if state_allowlist is None or "AZ" in state_allowlist:
-        az_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_az_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("AZ"))
+        az_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_az_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("AZ")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AZ")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AZ").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 az_df = az_df.filter(col("loaded_at") > max_loaded_at)
@@ -99,14 +93,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Arkansas
     if state_allowlist is None or "AR" in state_allowlist:
-        ar_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ar_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("AR"))
+        ar_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ar_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("AR")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AR")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AR").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ar_df = ar_df.filter(col("loaded_at") > max_loaded_at)
@@ -114,14 +106,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # California
     if state_allowlist is None or "CA" in state_allowlist:
-        ca_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ca_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("CA"))
+        ca_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ca_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("CA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "CA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "CA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ca_df = ca_df.filter(col("loaded_at") > max_loaded_at)
@@ -129,14 +119,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Colorado
     if state_allowlist is None or "CO" in state_allowlist:
-        co_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_co_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("CO"))
+        co_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_co_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("CO")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "CO")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "CO").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 co_df = co_df.filter(col("loaded_at") > max_loaded_at)
@@ -144,14 +132,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Connecticut
     if state_allowlist is None or "CT" in state_allowlist:
-        ct_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ct_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("CT"))
+        ct_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ct_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("CT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "CT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "CT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ct_df = ct_df.filter(col("loaded_at") > max_loaded_at)
@@ -159,14 +145,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Delaware
     if state_allowlist is None or "DE" in state_allowlist:
-        de_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_de_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("DE"))
+        de_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_de_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("DE")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "DE")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "DE").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 de_df = de_df.filter(col("loaded_at") > max_loaded_at)
@@ -174,14 +158,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Washington DC
     if state_allowlist is None or "DC" in state_allowlist:
-        dc_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_dc_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("DC"))
+        dc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_dc_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("DC")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "DC")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "DC").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 dc_df = dc_df.filter(col("loaded_at") > max_loaded_at)
@@ -189,14 +171,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Florida
     if state_allowlist is None or "FL" in state_allowlist:
-        fl_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_fl_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("FL"))
+        fl_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_fl_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("FL")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "FL")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "FL").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 fl_df = fl_df.filter(col("loaded_at") > max_loaded_at)
@@ -204,14 +184,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Georgia
     if state_allowlist is None or "GA" in state_allowlist:
-        ga_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ga_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("GA"))
+        ga_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ga_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("GA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "GA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "GA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ga_df = ga_df.filter(col("loaded_at") > max_loaded_at)
@@ -219,14 +197,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Hawaii
     if state_allowlist is None or "HI" in state_allowlist:
-        hi_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_hi_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("HI"))
+        hi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_hi_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("HI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "HI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "HI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 hi_df = hi_df.filter(col("loaded_at") > max_loaded_at)
@@ -234,14 +210,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Idaho
     if state_allowlist is None or "ID" in state_allowlist:
-        id_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_id_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("ID"))
+        id_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_id_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("ID")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "ID")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "ID").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 id_df = id_df.filter(col("loaded_at") > max_loaded_at)
@@ -249,14 +223,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Illinois
     if state_allowlist is None or "IL" in state_allowlist:
-        il_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_il_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("IL"))
+        il_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_il_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("IL")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "IL")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "IL").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 il_df = il_df.filter(col("loaded_at") > max_loaded_at)
@@ -264,14 +236,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Indiana
     if state_allowlist is None or "IN" in state_allowlist:
-        in_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_in_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("IN"))
+        in_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_in_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("IN")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "IN")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "IN").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 in_df = in_df.filter(col("loaded_at") > max_loaded_at)
@@ -279,14 +249,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Iowa
     if state_allowlist is None or "IA" in state_allowlist:
-        ia_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ia_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("IA"))
+        ia_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ia_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("IA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "IA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "IA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ia_df = ia_df.filter(col("loaded_at") > max_loaded_at)
@@ -294,14 +262,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Kansas
     if state_allowlist is None or "KS" in state_allowlist:
-        ks_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ks_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("KS"))
+        ks_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ks_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("KS")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "KS")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "KS").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ks_df = ks_df.filter(col("loaded_at") > max_loaded_at)
@@ -309,14 +275,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Kentucky
     if state_allowlist is None or "KY" in state_allowlist:
-        ky_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ky_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("KY"))
+        ky_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ky_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("KY")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "KY")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "KY").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ky_df = ky_df.filter(col("loaded_at") > max_loaded_at)
@@ -324,14 +288,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Louisiana
     if state_allowlist is None or "LA" in state_allowlist:
-        la_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_la_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("LA"))
+        la_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_la_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("LA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "LA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "LA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 la_df = la_df.filter(col("loaded_at") > max_loaded_at)
@@ -339,14 +301,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Maine
     if state_allowlist is None or "ME" in state_allowlist:
-        me_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_me_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("ME"))
+        me_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_me_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("ME")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "ME")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "ME").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 me_df = me_df.filter(col("loaded_at") > max_loaded_at)
@@ -354,14 +314,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Maryland
     if state_allowlist is None or "MD" in state_allowlist:
-        md_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_md_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("MD"))
+        md_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_md_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("MD")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MD")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MD").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 md_df = md_df.filter(col("loaded_at") > max_loaded_at)
@@ -369,14 +327,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Massachusetts
     if state_allowlist is None or "MA" in state_allowlist:
-        ma_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ma_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("MA"))
+        ma_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ma_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("MA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ma_df = ma_df.filter(col("loaded_at") > max_loaded_at)
@@ -384,14 +340,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Michigan
     if state_allowlist is None or "MI" in state_allowlist:
-        mi_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mi_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("MI"))
+        mi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mi_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("MI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mi_df = mi_df.filter(col("loaded_at") > max_loaded_at)
@@ -399,14 +353,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Minnesota
     if state_allowlist is None or "MN" in state_allowlist:
-        mn_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mn_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("MN"))
+        mn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mn_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("MN")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MN")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MN").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mn_df = mn_df.filter(col("loaded_at") > max_loaded_at)
@@ -414,14 +366,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Mississippi
     if state_allowlist is None or "MS" in state_allowlist:
-        ms_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ms_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("MS"))
+        ms_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ms_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("MS")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MS")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MS").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ms_df = ms_df.filter(col("loaded_at") > max_loaded_at)
@@ -429,14 +379,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Missouri
     if state_allowlist is None or "MO" in state_allowlist:
-        mo_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mo_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("MO"))
+        mo_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mo_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("MO")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MO")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MO").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mo_df = mo_df.filter(col("loaded_at") > max_loaded_at)
@@ -444,14 +392,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Montana
     if state_allowlist is None or "MT" in state_allowlist:
-        mt_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mt_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("MT"))
+        mt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mt_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("MT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mt_df = mt_df.filter(col("loaded_at") > max_loaded_at)
@@ -459,14 +405,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Nebraska
     if state_allowlist is None or "NE" in state_allowlist:
-        ne_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ne_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("NE"))
+        ne_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ne_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("NE")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NE")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NE").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ne_df = ne_df.filter(col("loaded_at") > max_loaded_at)
@@ -474,14 +418,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Nevada
     if state_allowlist is None or "NV" in state_allowlist:
-        nv_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nv_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("NV"))
+        nv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nv_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("NV")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NV")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NV").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nv_df = nv_df.filter(col("loaded_at") > max_loaded_at)
@@ -489,14 +431,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New Hampshire
     if state_allowlist is None or "NH" in state_allowlist:
-        nh_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nh_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("NH"))
+        nh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nh_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("NH")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NH")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NH").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nh_df = nh_df.filter(col("loaded_at") > max_loaded_at)
@@ -504,14 +444,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New Jersey
     if state_allowlist is None or "NJ" in state_allowlist:
-        nj_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nj_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("NJ"))
+        nj_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nj_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("NJ")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NJ")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NJ").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nj_df = nj_df.filter(col("loaded_at") > max_loaded_at)
@@ -519,14 +457,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New Mexico
     if state_allowlist is None or "NM" in state_allowlist:
-        nm_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nm_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("NM"))
+        nm_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nm_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("NM")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NM")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NM").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nm_df = nm_df.filter(col("loaded_at") > max_loaded_at)
@@ -534,14 +470,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New York
     if state_allowlist is None or "NY" in state_allowlist:
-        ny_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ny_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("NY"))
+        ny_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ny_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("NY")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NY")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NY").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ny_df = ny_df.filter(col("loaded_at") > max_loaded_at)
@@ -549,14 +483,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # North Carolina
     if state_allowlist is None or "NC" in state_allowlist:
-        nc_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nc_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("NC"))
+        nc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nc_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("NC")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NC")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NC").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nc_df = nc_df.filter(col("loaded_at") > max_loaded_at)
@@ -564,14 +496,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # North Dakota
     if state_allowlist is None or "ND" in state_allowlist:
-        nd_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nd_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("ND"))
+        nd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nd_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("ND")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "ND")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "ND").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nd_df = nd_df.filter(col("loaded_at") > max_loaded_at)
@@ -579,14 +509,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Ohio
     if state_allowlist is None or "OH" in state_allowlist:
-        oh_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_oh_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("OH"))
+        oh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_oh_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("OH")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "OH")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "OH").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 oh_df = oh_df.filter(col("loaded_at") > max_loaded_at)
@@ -594,14 +522,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Oklahoma
     if state_allowlist is None or "OK" in state_allowlist:
-        ok_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ok_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("OK"))
+        ok_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ok_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("OK")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "OK")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "OK").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ok_df = ok_df.filter(col("loaded_at") > max_loaded_at)
@@ -609,14 +535,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Oregon
     if state_allowlist is None or "OR" in state_allowlist:
-        or_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_or_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("OR"))
+        or_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_or_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("OR")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "OR")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "OR").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 or_df = or_df.filter(col("loaded_at") > max_loaded_at)
@@ -624,14 +548,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Pennsylvania
     if state_allowlist is None or "PA" in state_allowlist:
-        pa_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_pa_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("PA"))
+        pa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_pa_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("PA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "PA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "PA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 pa_df = pa_df.filter(col("loaded_at") > max_loaded_at)
@@ -639,14 +561,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Rhode Island
     if state_allowlist is None or "RI" in state_allowlist:
-        ri_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ri_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("RI"))
+        ri_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ri_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("RI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "RI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "RI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ri_df = ri_df.filter(col("loaded_at") > max_loaded_at)
@@ -654,14 +574,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # South Carolina
     if state_allowlist is None or "SC" in state_allowlist:
-        sc_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_sc_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("SC"))
+        sc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sc_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("SC")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "SC")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "SC").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 sc_df = sc_df.filter(col("loaded_at") > max_loaded_at)
@@ -669,14 +587,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # South Dakota
     if state_allowlist is None or "SD" in state_allowlist:
-        sd_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_sd_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("SD"))
+        sd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sd_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("SD")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "SD")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "SD").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 sd_df = sd_df.filter(col("loaded_at") > max_loaded_at)
@@ -684,14 +600,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Tennessee
     if state_allowlist is None or "TN" in state_allowlist:
-        tn_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_tn_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("TN"))
+        tn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tn_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("TN")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "TN")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "TN").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 tn_df = tn_df.filter(col("loaded_at") > max_loaded_at)
@@ -699,14 +613,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Texas
     if state_allowlist is None or "TX" in state_allowlist:
-        tx_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_tx_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("TX"))
+        tx_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tx_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("TX")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "TX")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "TX").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 tx_df = tx_df.filter(col("loaded_at") > max_loaded_at)
@@ -714,14 +626,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Utah
     if state_allowlist is None or "UT" in state_allowlist:
-        ut_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ut_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("UT"))
+        ut_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ut_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("UT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "UT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "UT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ut_df = ut_df.filter(col("loaded_at") > max_loaded_at)
@@ -729,14 +639,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Vermont
     if state_allowlist is None or "VT" in state_allowlist:
-        vt_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_vt_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("VT"))
+        vt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_vt_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("VT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "VT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "VT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 vt_df = vt_df.filter(col("loaded_at") > max_loaded_at)
@@ -744,14 +652,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Virginia
     if state_allowlist is None or "VA" in state_allowlist:
-        va_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_va_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("VA"))
+        va_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_va_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("VA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "VA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "VA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 va_df = va_df.filter(col("loaded_at") > max_loaded_at)
@@ -759,14 +665,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Washington
     if state_allowlist is None or "WA" in state_allowlist:
-        wa_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wa_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("WA"))
+        wa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wa_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("WA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wa_df = wa_df.filter(col("loaded_at") > max_loaded_at)
@@ -774,14 +678,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # West Virginia
     if state_allowlist is None or "WV" in state_allowlist:
-        wv_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wv_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("WV"))
+        wv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wv_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("WV")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WV")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WV").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wv_df = wv_df.filter(col("loaded_at") > max_loaded_at)
@@ -789,14 +691,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Wisconsin
     if state_allowlist is None or "WI" in state_allowlist:
-        wi_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wi_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("WI"))
+        wi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wi_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("WI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wi_df = wi_df.filter(col("loaded_at") > max_loaded_at)
@@ -804,14 +704,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Wyoming
     if state_allowlist is None or "WY" in state_allowlist:
-        wy_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wy_haystaq_dna_flags"
-        ).withColumn("state_postal_code", lit("WY"))
+        wy_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wy_haystaq_dna_flags").withColumn(
+            "state_postal_code", lit("WY")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WY")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WY").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wy_df = wy_df.filter(col("loaded_at") > max_loaded_at)

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_scores.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_haystaq_scores.py
@@ -54,14 +54,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Alabama
     if state_allowlist is None or "AL" in state_allowlist:
-        al_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_al_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("AL"))
+        al_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_al_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("AL")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AL")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AL").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 al_df = al_df.filter(col("loaded_at") > max_loaded_at)
@@ -69,14 +67,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Alaska
     if state_allowlist is None or "AK" in state_allowlist:
-        ak_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ak_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("AK"))
+        ak_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ak_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("AK")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AK")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AK").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ak_df = ak_df.filter(col("loaded_at") > max_loaded_at)
@@ -84,14 +80,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Arizona
     if state_allowlist is None or "AZ" in state_allowlist:
-        az_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_az_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("AZ"))
+        az_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_az_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("AZ")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AZ")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AZ").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 az_df = az_df.filter(col("loaded_at") > max_loaded_at)
@@ -99,14 +93,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Arkansas
     if state_allowlist is None or "AR" in state_allowlist:
-        ar_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ar_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("AR"))
+        ar_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ar_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("AR")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "AR")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "AR").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ar_df = ar_df.filter(col("loaded_at") > max_loaded_at)
@@ -114,14 +106,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # California
     if state_allowlist is None or "CA" in state_allowlist:
-        ca_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ca_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("CA"))
+        ca_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ca_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("CA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "CA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "CA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ca_df = ca_df.filter(col("loaded_at") > max_loaded_at)
@@ -129,14 +119,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Colorado
     if state_allowlist is None or "CO" in state_allowlist:
-        co_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_co_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("CO"))
+        co_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_co_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("CO")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "CO")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "CO").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 co_df = co_df.filter(col("loaded_at") > max_loaded_at)
@@ -144,14 +132,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Connecticut
     if state_allowlist is None or "CT" in state_allowlist:
-        ct_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ct_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("CT"))
+        ct_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ct_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("CT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "CT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "CT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ct_df = ct_df.filter(col("loaded_at") > max_loaded_at)
@@ -159,14 +145,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Delaware
     if state_allowlist is None or "DE" in state_allowlist:
-        de_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_de_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("DE"))
+        de_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_de_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("DE")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "DE")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "DE").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 de_df = de_df.filter(col("loaded_at") > max_loaded_at)
@@ -174,14 +158,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Washington DC
     if state_allowlist is None or "DC" in state_allowlist:
-        dc_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_dc_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("DC"))
+        dc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_dc_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("DC")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "DC")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "DC").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 dc_df = dc_df.filter(col("loaded_at") > max_loaded_at)
@@ -189,14 +171,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Florida
     if state_allowlist is None or "FL" in state_allowlist:
-        fl_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_fl_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("FL"))
+        fl_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_fl_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("FL")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "FL")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "FL").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 fl_df = fl_df.filter(col("loaded_at") > max_loaded_at)
@@ -204,14 +184,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Georgia
     if state_allowlist is None or "GA" in state_allowlist:
-        ga_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ga_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("GA"))
+        ga_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ga_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("GA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "GA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "GA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ga_df = ga_df.filter(col("loaded_at") > max_loaded_at)
@@ -219,14 +197,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Hawaii
     if state_allowlist is None or "HI" in state_allowlist:
-        hi_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_hi_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("HI"))
+        hi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_hi_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("HI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "HI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "HI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 hi_df = hi_df.filter(col("loaded_at") > max_loaded_at)
@@ -234,14 +210,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Idaho
     if state_allowlist is None or "ID" in state_allowlist:
-        id_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_id_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("ID"))
+        id_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_id_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("ID")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "ID")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "ID").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 id_df = id_df.filter(col("loaded_at") > max_loaded_at)
@@ -249,14 +223,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Illinois
     if state_allowlist is None or "IL" in state_allowlist:
-        il_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_il_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("IL"))
+        il_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_il_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("IL")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "IL")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "IL").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 il_df = il_df.filter(col("loaded_at") > max_loaded_at)
@@ -264,14 +236,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Indiana
     if state_allowlist is None or "IN" in state_allowlist:
-        in_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_in_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("IN"))
+        in_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_in_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("IN")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "IN")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "IN").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 in_df = in_df.filter(col("loaded_at") > max_loaded_at)
@@ -279,14 +249,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Iowa
     if state_allowlist is None or "IA" in state_allowlist:
-        ia_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ia_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("IA"))
+        ia_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ia_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("IA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "IA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "IA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ia_df = ia_df.filter(col("loaded_at") > max_loaded_at)
@@ -294,14 +262,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Kansas
     if state_allowlist is None or "KS" in state_allowlist:
-        ks_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ks_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("KS"))
+        ks_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ks_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("KS")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "KS")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "KS").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ks_df = ks_df.filter(col("loaded_at") > max_loaded_at)
@@ -309,14 +275,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Kentucky
     if state_allowlist is None or "KY" in state_allowlist:
-        ky_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ky_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("KY"))
+        ky_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ky_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("KY")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "KY")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "KY").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ky_df = ky_df.filter(col("loaded_at") > max_loaded_at)
@@ -324,14 +288,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Louisiana
     if state_allowlist is None or "LA" in state_allowlist:
-        la_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_la_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("LA"))
+        la_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_la_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("LA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "LA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "LA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 la_df = la_df.filter(col("loaded_at") > max_loaded_at)
@@ -339,14 +301,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Maine
     if state_allowlist is None or "ME" in state_allowlist:
-        me_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_me_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("ME"))
+        me_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_me_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("ME")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "ME")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "ME").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 me_df = me_df.filter(col("loaded_at") > max_loaded_at)
@@ -354,14 +314,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Maryland
     if state_allowlist is None or "MD" in state_allowlist:
-        md_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_md_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("MD"))
+        md_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_md_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("MD")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MD")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MD").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 md_df = md_df.filter(col("loaded_at") > max_loaded_at)
@@ -369,14 +327,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Massachusetts
     if state_allowlist is None or "MA" in state_allowlist:
-        ma_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ma_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("MA"))
+        ma_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ma_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("MA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ma_df = ma_df.filter(col("loaded_at") > max_loaded_at)
@@ -384,14 +340,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Michigan
     if state_allowlist is None or "MI" in state_allowlist:
-        mi_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mi_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("MI"))
+        mi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mi_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("MI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mi_df = mi_df.filter(col("loaded_at") > max_loaded_at)
@@ -399,14 +353,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Minnesota
     if state_allowlist is None or "MN" in state_allowlist:
-        mn_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mn_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("MN"))
+        mn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mn_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("MN")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MN")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MN").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mn_df = mn_df.filter(col("loaded_at") > max_loaded_at)
@@ -414,14 +366,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Mississippi
     if state_allowlist is None or "MS" in state_allowlist:
-        ms_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ms_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("MS"))
+        ms_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ms_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("MS")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MS")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MS").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ms_df = ms_df.filter(col("loaded_at") > max_loaded_at)
@@ -429,14 +379,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Missouri
     if state_allowlist is None or "MO" in state_allowlist:
-        mo_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mo_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("MO"))
+        mo_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mo_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("MO")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MO")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MO").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mo_df = mo_df.filter(col("loaded_at") > max_loaded_at)
@@ -444,14 +392,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Montana
     if state_allowlist is None or "MT" in state_allowlist:
-        mt_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_mt_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("MT"))
+        mt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mt_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("MT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "MT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "MT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 mt_df = mt_df.filter(col("loaded_at") > max_loaded_at)
@@ -459,14 +405,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Nebraska
     if state_allowlist is None or "NE" in state_allowlist:
-        ne_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ne_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("NE"))
+        ne_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ne_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("NE")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NE")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NE").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ne_df = ne_df.filter(col("loaded_at") > max_loaded_at)
@@ -474,14 +418,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Nevada
     if state_allowlist is None or "NV" in state_allowlist:
-        nv_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nv_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("NV"))
+        nv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nv_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("NV")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NV")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NV").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nv_df = nv_df.filter(col("loaded_at") > max_loaded_at)
@@ -489,14 +431,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New Hampshire
     if state_allowlist is None or "NH" in state_allowlist:
-        nh_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nh_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("NH"))
+        nh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nh_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("NH")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NH")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NH").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nh_df = nh_df.filter(col("loaded_at") > max_loaded_at)
@@ -504,14 +444,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New Jersey
     if state_allowlist is None or "NJ" in state_allowlist:
-        nj_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nj_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("NJ"))
+        nj_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nj_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("NJ")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NJ")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NJ").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nj_df = nj_df.filter(col("loaded_at") > max_loaded_at)
@@ -519,14 +457,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New Mexico
     if state_allowlist is None or "NM" in state_allowlist:
-        nm_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nm_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("NM"))
+        nm_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nm_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("NM")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NM")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NM").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nm_df = nm_df.filter(col("loaded_at") > max_loaded_at)
@@ -534,14 +470,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # New York
     if state_allowlist is None or "NY" in state_allowlist:
-        ny_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ny_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("NY"))
+        ny_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ny_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("NY")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NY")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NY").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ny_df = ny_df.filter(col("loaded_at") > max_loaded_at)
@@ -549,14 +483,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # North Carolina
     if state_allowlist is None or "NC" in state_allowlist:
-        nc_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nc_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("NC"))
+        nc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nc_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("NC")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "NC")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "NC").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nc_df = nc_df.filter(col("loaded_at") > max_loaded_at)
@@ -564,14 +496,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # North Dakota
     if state_allowlist is None or "ND" in state_allowlist:
-        nd_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_nd_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("ND"))
+        nd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nd_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("ND")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "ND")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "ND").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 nd_df = nd_df.filter(col("loaded_at") > max_loaded_at)
@@ -579,14 +509,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Ohio
     if state_allowlist is None or "OH" in state_allowlist:
-        oh_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_oh_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("OH"))
+        oh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_oh_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("OH")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "OH")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "OH").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 oh_df = oh_df.filter(col("loaded_at") > max_loaded_at)
@@ -594,14 +522,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Oklahoma
     if state_allowlist is None or "OK" in state_allowlist:
-        ok_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ok_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("OK"))
+        ok_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ok_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("OK")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "OK")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "OK").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ok_df = ok_df.filter(col("loaded_at") > max_loaded_at)
@@ -609,14 +535,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Oregon
     if state_allowlist is None or "OR" in state_allowlist:
-        or_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_or_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("OR"))
+        or_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_or_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("OR")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "OR")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "OR").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 or_df = or_df.filter(col("loaded_at") > max_loaded_at)
@@ -624,14 +548,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Pennsylvania
     if state_allowlist is None or "PA" in state_allowlist:
-        pa_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_pa_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("PA"))
+        pa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_pa_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("PA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "PA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "PA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 pa_df = pa_df.filter(col("loaded_at") > max_loaded_at)
@@ -639,14 +561,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Rhode Island
     if state_allowlist is None or "RI" in state_allowlist:
-        ri_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ri_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("RI"))
+        ri_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ri_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("RI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "RI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "RI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ri_df = ri_df.filter(col("loaded_at") > max_loaded_at)
@@ -654,14 +574,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # South Carolina
     if state_allowlist is None or "SC" in state_allowlist:
-        sc_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_sc_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("SC"))
+        sc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sc_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("SC")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "SC")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "SC").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 sc_df = sc_df.filter(col("loaded_at") > max_loaded_at)
@@ -669,14 +587,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # South Dakota
     if state_allowlist is None or "SD" in state_allowlist:
-        sd_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_sd_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("SD"))
+        sd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sd_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("SD")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "SD")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "SD").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 sd_df = sd_df.filter(col("loaded_at") > max_loaded_at)
@@ -684,14 +600,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Tennessee
     if state_allowlist is None or "TN" in state_allowlist:
-        tn_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_tn_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("TN"))
+        tn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tn_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("TN")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "TN")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "TN").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 tn_df = tn_df.filter(col("loaded_at") > max_loaded_at)
@@ -699,14 +613,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Texas
     if state_allowlist is None or "TX" in state_allowlist:
-        tx_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_tx_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("TX"))
+        tx_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tx_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("TX")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "TX")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "TX").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 tx_df = tx_df.filter(col("loaded_at") > max_loaded_at)
@@ -714,14 +626,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Utah
     if state_allowlist is None or "UT" in state_allowlist:
-        ut_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_ut_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("UT"))
+        ut_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ut_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("UT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "UT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "UT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 ut_df = ut_df.filter(col("loaded_at") > max_loaded_at)
@@ -729,14 +639,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Vermont
     if state_allowlist is None or "VT" in state_allowlist:
-        vt_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_vt_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("VT"))
+        vt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_vt_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("VT")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "VT")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "VT").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 vt_df = vt_df.filter(col("loaded_at") > max_loaded_at)
@@ -744,14 +652,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Virginia
     if state_allowlist is None or "VA" in state_allowlist:
-        va_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_va_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("VA"))
+        va_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_va_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("VA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "VA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "VA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 va_df = va_df.filter(col("loaded_at") > max_loaded_at)
@@ -759,14 +665,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Washington
     if state_allowlist is None or "WA" in state_allowlist:
-        wa_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wa_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("WA"))
+        wa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wa_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("WA")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WA")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WA").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wa_df = wa_df.filter(col("loaded_at") > max_loaded_at)
@@ -774,14 +678,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # West Virginia
     if state_allowlist is None or "WV" in state_allowlist:
-        wv_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wv_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("WV"))
+        wv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wv_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("WV")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WV")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WV").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wv_df = wv_df.filter(col("loaded_at") > max_loaded_at)
@@ -789,14 +691,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Wisconsin
     if state_allowlist is None or "WI" in state_allowlist:
-        wi_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wi_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("WI"))
+        wi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wi_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("WI")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WI")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WI").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wi_df = wi_df.filter(col("loaded_at") > max_loaded_at)
@@ -804,14 +704,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Wyoming
     if state_allowlist is None or "WY" in state_allowlist:
-        wy_df: DataFrame = dbt.ref(
-            "stg_dbt_source__l2_s3_wy_haystaq_dna_scores"
-        ).withColumn("state_postal_code", lit("WY"))
+        wy_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wy_haystaq_dna_scores").withColumn(
+            "state_postal_code", lit("WY")
+        )
         if dbt.is_incremental and this_df is not None:
             max_loaded_at = (
-                this_df.filter(col("state_postal_code") == "WY")
-                .agg({"loaded_at": "max"})
-                .collect()[0][0]
+                this_df.filter(col("state_postal_code") == "WY").agg({"loaded_at": "max"}).collect()[0][0]
             )
             if max_loaded_at is not None:
                 wy_df = wy_df.filter(col("loaded_at") > max_loaded_at)

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
@@ -115,614 +115,410 @@ def model(dbt, session: SparkSession) -> DataFrame:
     # we need to use a manual loop to read in each state
 
     # Alabama
-    al_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_al_uniform").withColumn(
-        "state_postal_code", lit("AL")
-    )
+    al_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_al_uniform").withColumn("state_postal_code", lit("AL"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "AL")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "AL").agg({"loaded_at": "max"}).collect()[0][0]
         )
         al_df = al_df.filter(col("loaded_at") > max_loaded_at)
 
     # Alaska
-    ak_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ak_uniform").withColumn(
-        "state_postal_code", lit("AK")
-    )
+    ak_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ak_uniform").withColumn("state_postal_code", lit("AK"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "AK")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "AK").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ak_df = ak_df.filter(col("loaded_at") > max_loaded_at)
 
     # Arizona
-    az_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_az_uniform").withColumn(
-        "state_postal_code", lit("AZ")
-    )
+    az_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_az_uniform").withColumn("state_postal_code", lit("AZ"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "AZ")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "AZ").agg({"loaded_at": "max"}).collect()[0][0]
         )
         az_df = az_df.filter(col("loaded_at") > max_loaded_at)
 
     # Arkansas
-    ar_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ar_uniform").withColumn(
-        "state_postal_code", lit("AR")
-    )
+    ar_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ar_uniform").withColumn("state_postal_code", lit("AR"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "AR")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "AR").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ar_df = ar_df.filter(col("loaded_at") > max_loaded_at)
 
     # California
-    ca_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ca_uniform").withColumn(
-        "state_postal_code", lit("CA")
-    )
+    ca_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ca_uniform").withColumn("state_postal_code", lit("CA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "CA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "CA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ca_df = ca_df.filter(col("loaded_at") > max_loaded_at)
 
     # Colorado
-    co_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_co_uniform").withColumn(
-        "state_postal_code", lit("CO")
-    )
+    co_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_co_uniform").withColumn("state_postal_code", lit("CO"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "CO")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "CO").agg({"loaded_at": "max"}).collect()[0][0]
         )
         co_df = co_df.filter(col("loaded_at") > max_loaded_at)
 
     # Connecticut
-    ct_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ct_uniform").withColumn(
-        "state_postal_code", lit("CT")
-    )
+    ct_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ct_uniform").withColumn("state_postal_code", lit("CT"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "CT")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "CT").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ct_df = ct_df.filter(col("loaded_at") > max_loaded_at)
 
     # Delaware
-    de_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_de_uniform").withColumn(
-        "state_postal_code", lit("DE")
-    )
+    de_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_de_uniform").withColumn("state_postal_code", lit("DE"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "DE")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "DE").agg({"loaded_at": "max"}).collect()[0][0]
         )
         de_df = de_df.filter(col("loaded_at") > max_loaded_at)
 
     # District of Columbia
-    dc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_dc_uniform").withColumn(
-        "state_postal_code", lit("DC")
-    )
+    dc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_dc_uniform").withColumn("state_postal_code", lit("DC"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "DC")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "DC").agg({"loaded_at": "max"}).collect()[0][0]
         )
         dc_df = dc_df.filter(col("loaded_at") > max_loaded_at)
 
     # Florida
-    fl_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_fl_uniform").withColumn(
-        "state_postal_code", lit("FL")
-    )
+    fl_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_fl_uniform").withColumn("state_postal_code", lit("FL"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "FL")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "FL").agg({"loaded_at": "max"}).collect()[0][0]
         )
         fl_df = fl_df.filter(col("loaded_at") > max_loaded_at)
 
     # Georgia
-    ga_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ga_uniform").withColumn(
-        "state_postal_code", lit("GA")
-    )
+    ga_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ga_uniform").withColumn("state_postal_code", lit("GA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "GA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "GA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ga_df = ga_df.filter(col("loaded_at") > max_loaded_at)
 
     # Hawaii
-    hi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_hi_uniform").withColumn(
-        "state_postal_code", lit("HI")
-    )
+    hi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_hi_uniform").withColumn("state_postal_code", lit("HI"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "HI")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "HI").agg({"loaded_at": "max"}).collect()[0][0]
         )
         hi_df = hi_df.filter(col("loaded_at") > max_loaded_at)
 
     # Idaho
-    id_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_id_uniform").withColumn(
-        "state_postal_code", lit("ID")
-    )
+    id_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_id_uniform").withColumn("state_postal_code", lit("ID"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "ID")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "ID").agg({"loaded_at": "max"}).collect()[0][0]
         )
         id_df = id_df.filter(col("loaded_at") > max_loaded_at)
 
     # Illinois
-    il_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_il_uniform").withColumn(
-        "state_postal_code", lit("IL")
-    )
+    il_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_il_uniform").withColumn("state_postal_code", lit("IL"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "IL")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "IL").agg({"loaded_at": "max"}).collect()[0][0]
         )
         il_df = il_df.filter(col("loaded_at") > max_loaded_at)
 
     # Indiana
-    in_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_in_uniform").withColumn(
-        "state_postal_code", lit("IN")
-    )
+    in_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_in_uniform").withColumn("state_postal_code", lit("IN"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "IN")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "IN").agg({"loaded_at": "max"}).collect()[0][0]
         )
         in_df = in_df.filter(col("loaded_at") > max_loaded_at)
 
     # Iowa
-    ia_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ia_uniform").withColumn(
-        "state_postal_code", lit("IA")
-    )
+    ia_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ia_uniform").withColumn("state_postal_code", lit("IA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "IA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "IA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ia_df = ia_df.filter(col("loaded_at") > max_loaded_at)
 
     # Kansas
-    ks_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ks_uniform").withColumn(
-        "state_postal_code", lit("KS")
-    )
+    ks_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ks_uniform").withColumn("state_postal_code", lit("KS"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "KS")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "KS").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ks_df = ks_df.filter(col("loaded_at") > max_loaded_at)
 
     # Kentucky
-    ky_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ky_uniform").withColumn(
-        "state_postal_code", lit("KY")
-    )
+    ky_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ky_uniform").withColumn("state_postal_code", lit("KY"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "KY")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "KY").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ky_df = ky_df.filter(col("loaded_at") > max_loaded_at)
 
     # Louisiana
-    la_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_la_uniform").withColumn(
-        "state_postal_code", lit("LA")
-    )
+    la_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_la_uniform").withColumn("state_postal_code", lit("LA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "LA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "LA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         la_df = la_df.filter(col("loaded_at") > max_loaded_at)
 
     # Maine
-    me_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_me_uniform").withColumn(
-        "state_postal_code", lit("ME")
-    )
+    me_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_me_uniform").withColumn("state_postal_code", lit("ME"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "ME")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "ME").agg({"loaded_at": "max"}).collect()[0][0]
         )
         me_df = me_df.filter(col("loaded_at") > max_loaded_at)
 
     # Maryland
-    md_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_md_uniform").withColumn(
-        "state_postal_code", lit("MD")
-    )
+    md_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_md_uniform").withColumn("state_postal_code", lit("MD"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "MD")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "MD").agg({"loaded_at": "max"}).collect()[0][0]
         )
         md_df = md_df.filter(col("loaded_at") > max_loaded_at)
 
     # Massachusetts
-    ma_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ma_uniform").withColumn(
-        "state_postal_code", lit("MA")
-    )
+    ma_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ma_uniform").withColumn("state_postal_code", lit("MA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "MA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "MA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ma_df = ma_df.filter(col("loaded_at") > max_loaded_at)
 
     # Michigan
-    mi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mi_uniform").withColumn(
-        "state_postal_code", lit("MI")
-    )
+    mi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mi_uniform").withColumn("state_postal_code", lit("MI"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "MI")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "MI").agg({"loaded_at": "max"}).collect()[0][0]
         )
         mi_df = mi_df.filter(col("loaded_at") > max_loaded_at)
 
     # Minnesota
-    mn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mn_uniform").withColumn(
-        "state_postal_code", lit("MN")
-    )
+    mn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mn_uniform").withColumn("state_postal_code", lit("MN"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "MN")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "MN").agg({"loaded_at": "max"}).collect()[0][0]
         )
         mn_df = mn_df.filter(col("loaded_at") > max_loaded_at)
 
     # Mississippi
-    ms_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ms_uniform").withColumn(
-        "state_postal_code", lit("MS")
-    )
+    ms_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ms_uniform").withColumn("state_postal_code", lit("MS"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "MS")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "MS").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ms_df = ms_df.filter(col("loaded_at") > max_loaded_at)
 
     # Missouri
-    mo_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mo_uniform").withColumn(
-        "state_postal_code", lit("MO")
-    )
+    mo_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mo_uniform").withColumn("state_postal_code", lit("MO"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "MO")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "MO").agg({"loaded_at": "max"}).collect()[0][0]
         )
         mo_df = mo_df.filter(col("loaded_at") > max_loaded_at)
 
     # Montana
-    mt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mt_uniform").withColumn(
-        "state_postal_code", lit("MT")
-    )
+    mt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_mt_uniform").withColumn("state_postal_code", lit("MT"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "MT")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "MT").agg({"loaded_at": "max"}).collect()[0][0]
         )
         mt_df = mt_df.filter(col("loaded_at") > max_loaded_at)
 
     # Nebraska
-    ne_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ne_uniform").withColumn(
-        "state_postal_code", lit("NE")
-    )
+    ne_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ne_uniform").withColumn("state_postal_code", lit("NE"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "NE")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "NE").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ne_df = ne_df.filter(col("loaded_at") > max_loaded_at)
 
     # Nevada
-    nv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nv_uniform").withColumn(
-        "state_postal_code", lit("NV")
-    )
+    nv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nv_uniform").withColumn("state_postal_code", lit("NV"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "NV")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "NV").agg({"loaded_at": "max"}).collect()[0][0]
         )
         nv_df = nv_df.filter(col("loaded_at") > max_loaded_at)
 
     # New Hampshire
-    nh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nh_uniform").withColumn(
-        "state_postal_code", lit("NH")
-    )
+    nh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nh_uniform").withColumn("state_postal_code", lit("NH"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "NH")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "NH").agg({"loaded_at": "max"}).collect()[0][0]
         )
         nh_df = nh_df.filter(col("loaded_at") > max_loaded_at)
 
     # New Jersey
-    nj_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nj_uniform").withColumn(
-        "state_postal_code", lit("NJ")
-    )
+    nj_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nj_uniform").withColumn("state_postal_code", lit("NJ"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "NJ")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "NJ").agg({"loaded_at": "max"}).collect()[0][0]
         )
         nj_df = nj_df.filter(col("loaded_at") > max_loaded_at)
 
     # New Mexico
-    nm_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nm_uniform").withColumn(
-        "state_postal_code", lit("NM")
-    )
+    nm_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nm_uniform").withColumn("state_postal_code", lit("NM"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "NM")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "NM").agg({"loaded_at": "max"}).collect()[0][0]
         )
         nm_df = nm_df.filter(col("loaded_at") > max_loaded_at)
 
     # New York
-    ny_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ny_uniform").withColumn(
-        "state_postal_code", lit("NY")
-    )
+    ny_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ny_uniform").withColumn("state_postal_code", lit("NY"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "NY")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "NY").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ny_df = ny_df.filter(col("loaded_at") > max_loaded_at)
 
     # North Carolina
-    nc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nc_uniform").withColumn(
-        "state_postal_code", lit("NC")
-    )
+    nc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nc_uniform").withColumn("state_postal_code", lit("NC"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "NC")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "NC").agg({"loaded_at": "max"}).collect()[0][0]
         )
         nc_df = nc_df.filter(col("loaded_at") > max_loaded_at)
 
     # North Dakota
-    nd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nd_uniform").withColumn(
-        "state_postal_code", lit("ND")
-    )
+    nd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_nd_uniform").withColumn("state_postal_code", lit("ND"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "ND")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "ND").agg({"loaded_at": "max"}).collect()[0][0]
         )
         nd_df = nd_df.filter(col("loaded_at") > max_loaded_at)
 
     # Ohio
-    oh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_oh_uniform").withColumn(
-        "state_postal_code", lit("OH")
-    )
+    oh_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_oh_uniform").withColumn("state_postal_code", lit("OH"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "OH")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "OH").agg({"loaded_at": "max"}).collect()[0][0]
         )
         oh_df = oh_df.filter(col("loaded_at") > max_loaded_at)
 
     # Oklahoma
-    ok_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ok_uniform").withColumn(
-        "state_postal_code", lit("OK")
-    )
+    ok_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ok_uniform").withColumn("state_postal_code", lit("OK"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "OK")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "OK").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ok_df = ok_df.filter(col("loaded_at") > max_loaded_at)
 
     # Oregon
-    or_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_or_uniform").withColumn(
-        "state_postal_code", lit("OR")
-    )
+    or_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_or_uniform").withColumn("state_postal_code", lit("OR"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "OR")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "OR").agg({"loaded_at": "max"}).collect()[0][0]
         )
         or_df = or_df.filter(col("loaded_at") > max_loaded_at)
 
     # Pennsylvania
-    pa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_pa_uniform").withColumn(
-        "state_postal_code", lit("PA")
-    )
+    pa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_pa_uniform").withColumn("state_postal_code", lit("PA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "PA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "PA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         pa_df = pa_df.filter(col("loaded_at") > max_loaded_at)
 
     # Rhode Island
-    ri_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ri_uniform").withColumn(
-        "state_postal_code", lit("RI")
-    )
+    ri_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ri_uniform").withColumn("state_postal_code", lit("RI"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "RI")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "RI").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ri_df = ri_df.filter(col("loaded_at") > max_loaded_at)
 
     # South Carolina
-    sc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sc_uniform").withColumn(
-        "state_postal_code", lit("SC")
-    )
+    sc_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sc_uniform").withColumn("state_postal_code", lit("SC"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "SC")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "SC").agg({"loaded_at": "max"}).collect()[0][0]
         )
         sc_df = sc_df.filter(col("loaded_at") > max_loaded_at)
 
     # South Dakota
-    sd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sd_uniform").withColumn(
-        "state_postal_code", lit("SD")
-    )
+    sd_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_sd_uniform").withColumn("state_postal_code", lit("SD"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "SD")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "SD").agg({"loaded_at": "max"}).collect()[0][0]
         )
         sd_df = sd_df.filter(col("loaded_at") > max_loaded_at)
 
     # Tennessee
-    tn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tn_uniform").withColumn(
-        "state_postal_code", lit("TN")
-    )
+    tn_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tn_uniform").withColumn("state_postal_code", lit("TN"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "TN")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "TN").agg({"loaded_at": "max"}).collect()[0][0]
         )
         tn_df = tn_df.filter(col("loaded_at") > max_loaded_at)
 
     # Texas
-    tx_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tx_uniform").withColumn(
-        "state_postal_code", lit("TX")
-    )
+    tx_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_tx_uniform").withColumn("state_postal_code", lit("TX"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "TX")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "TX").agg({"loaded_at": "max"}).collect()[0][0]
         )
         tx_df = tx_df.filter(col("loaded_at") > max_loaded_at)
 
     # Utah
-    ut_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ut_uniform").withColumn(
-        "state_postal_code", lit("UT")
-    )
+    ut_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_ut_uniform").withColumn("state_postal_code", lit("UT"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "UT")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "UT").agg({"loaded_at": "max"}).collect()[0][0]
         )
         ut_df = ut_df.filter(col("loaded_at") > max_loaded_at)
 
     # Vermont
-    vt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_vt_uniform").withColumn(
-        "state_postal_code", lit("VT")
-    )
+    vt_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_vt_uniform").withColumn("state_postal_code", lit("VT"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "VT")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "VT").agg({"loaded_at": "max"}).collect()[0][0]
         )
         vt_df = vt_df.filter(col("loaded_at") > max_loaded_at)
 
     # Virginia
-    va_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_va_uniform").withColumn(
-        "state_postal_code", lit("VA")
-    )
+    va_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_va_uniform").withColumn("state_postal_code", lit("VA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "VA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "VA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         va_df = va_df.filter(col("loaded_at") > max_loaded_at)
 
     # Washington
-    wa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wa_uniform").withColumn(
-        "state_postal_code", lit("WA")
-    )
+    wa_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wa_uniform").withColumn("state_postal_code", lit("WA"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "WA")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "WA").agg({"loaded_at": "max"}).collect()[0][0]
         )
         wa_df = wa_df.filter(col("loaded_at") > max_loaded_at)
 
     # West Virginia
-    wv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wv_uniform").withColumn(
-        "state_postal_code", lit("WV")
-    )
+    wv_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wv_uniform").withColumn("state_postal_code", lit("WV"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "WV")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "WV").agg({"loaded_at": "max"}).collect()[0][0]
         )
         wv_df = wv_df.filter(col("loaded_at") > max_loaded_at)
 
     # Wisconsin
-    wi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wi_uniform").withColumn(
-        "state_postal_code", lit("WI")
-    )
+    wi_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wi_uniform").withColumn("state_postal_code", lit("WI"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "WI")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "WI").agg({"loaded_at": "max"}).collect()[0][0]
         )
         wi_df = wi_df.filter(col("loaded_at") > max_loaded_at)
 
     # Wyoming
-    wy_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wy_uniform").withColumn(
-        "state_postal_code", lit("WY")
-    )
+    wy_df: DataFrame = dbt.ref("stg_dbt_source__l2_s3_wy_uniform").withColumn("state_postal_code", lit("WY"))
     if dbt.is_incremental:
         max_loaded_at = (
-            this_df.filter(col("state_postal_code") == "WY")
-            .agg({"loaded_at": "max"})
-            .collect()[0][0]
+            this_df.filter(col("state_postal_code") == "WY").agg({"loaded_at": "max"}).collect()[0][0]
         )
         wy_df = wy_df.filter(col("loaded_at") > max_loaded_at)
 

--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
@@ -88,32 +88,21 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
         uniform_updates = (
             uniform_df.join(thresholds, on="state_postal_code", how="left")
-            .filter(
-                col("max_uniform_loaded_at").isNull()
-                | (col("loaded_at") > col("max_uniform_loaded_at"))
-            )
+            .filter(col("max_uniform_loaded_at").isNull() | (col("loaded_at") > col("max_uniform_loaded_at")))
             .select("LALVOTERID")
         )
         flags_updates = (
             flags_df.join(thresholds, on="state_postal_code", how="left")
-            .filter(
-                col("max_flags_loaded_at").isNull()
-                | (col("loaded_at") > col("max_flags_loaded_at"))
-            )
+            .filter(col("max_flags_loaded_at").isNull() | (col("loaded_at") > col("max_flags_loaded_at")))
             .select("LALVOTERID")
         )
         scores_updates = (
             scores_df.join(thresholds, on="state_postal_code", how="left")
-            .filter(
-                col("max_scores_loaded_at").isNull()
-                | (col("loaded_at") > col("max_scores_loaded_at"))
-            )
+            .filter(col("max_scores_loaded_at").isNull() | (col("loaded_at") > col("max_scores_loaded_at")))
             .select("LALVOTERID")
         )
 
-        changed_ids = (
-            uniform_updates.union(flags_updates).union(scores_updates).distinct()
-        )
+        changed_ids = uniform_updates.union(flags_updates).union(scores_updates).distinct()
 
         if not changed_ids.take(1):
             return (
@@ -124,9 +113,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
         uniform_df = uniform_df.join(changed_ids, on="LALVOTERID", how="inner")
         flags_selected = flags_selected.join(changed_ids, on="LALVOTERID", how="inner")
-        scores_selected = scores_selected.join(
-            changed_ids, on="LALVOTERID", how="inner"
-        )
+        scores_selected = scores_selected.join(changed_ids, on="LALVOTERID", how="inner")
 
     return uniform_df.join(flags_selected, on="LALVOTERID", how="left").join(
         scores_selected, on="LALVOTERID", how="left"

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -8,11 +8,9 @@ from pyspark.sql.functions import (
     count,
     length,
     lit,
-)
-from pyspark.sql.functions import sum as spark_sum
-from pyspark.sql.functions import (
     when,
 )
+from pyspark.sql.functions import sum as spark_sum
 from pyspark.sql.types import (
     LongType,
     StringType,
@@ -104,14 +102,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         )
 
     district_type_from_columns = (
-        dbt.ref("int__model_prediction_voter_turnout")
-        .select(col("district_type"))
-        .distinct()
-        .collect()
+        dbt.ref("int__model_prediction_voter_turnout").select(col("district_type")).distinct().collect()
     )
-    district_type_from_columns = [
-        district_type.district_type for district_type in district_type_from_columns
-    ]
+    district_type_from_columns = [district_type.district_type for district_type in district_type_from_columns]
 
     district_type_from_columns = [
         district_type
@@ -136,9 +129,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         # if zipcode is 4 characters, pad with a 0
         district_df = district_df.withColumn(
             "zip_code",
-            when(
-                length(col("zip_code")) == 4, concat(lit("0"), col("zip_code"))
-            ).otherwise(col("zip_code")),
+            when(length(col("zip_code")) == 4, concat(lit("0"), col("zip_code"))).otherwise(col("zip_code")),
         )
 
         district_df = (

--- a/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_candidates_fuzzy_deduped.py
+++ b/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_candidates_fuzzy_deduped.py
@@ -61,9 +61,7 @@ def wrap_perform_fuzzy_matching(
 
         # Prepare HubSpot data for fuzzy matching
         hubspot_codes = (
-            hubspot_df[hubspot_df["hubspot_candidate_code"].notna()][
-                "hubspot_candidate_code"
-            ]
+            hubspot_df[hubspot_df["hubspot_candidate_code"].notna()]["hubspot_candidate_code"]
             .unique()
             .tolist()
         )
@@ -82,14 +80,11 @@ def wrap_perform_fuzzy_matching(
         # for _, row in techspeed_codes.iterrows():
         #     techspeed_code = row.get("techspeed_candidate_code")
         for techspeed_code in techspeed_codes:
-
             if pd.isna(techspeed_code):
                 continue
 
             # Find fuzzy matches
-            matches = process.extract(
-                techspeed_code, hubspot_codes, scorer=fuzz.ratio, limit=top_n
-            )
+            matches = process.extract(techspeed_code, hubspot_codes, scorer=fuzz.ratio, limit=top_n)
 
             # Filter by threshold and add to results
             for rank, (matched_code, score, _idx) in enumerate(matches, 1):
@@ -102,19 +97,11 @@ def wrap_perform_fuzzy_matching(
                             "fuzzy_matched_hubspot_candidate_code": matched_code,
                             "fuzzy_match_score": score,
                             "fuzzy_match_rank": rank,
-                            "fuzzy_matched_hubspot_contact_id": hubspot_data.get(
-                                "hubspot_contact_id"
-                            ),
-                            "fuzzy_matched_first_name": hubspot_data.get(
-                                "properties_firstname"
-                            ),
-                            "fuzzy_matched_last_name": hubspot_data.get(
-                                "properties_lastname"
-                            ),
+                            "fuzzy_matched_hubspot_contact_id": hubspot_data.get("hubspot_contact_id"),
+                            "fuzzy_matched_first_name": hubspot_data.get("properties_firstname"),
+                            "fuzzy_matched_last_name": hubspot_data.get("properties_lastname"),
                             "fuzzy_matched_state": hubspot_data.get("properties_state"),
-                            "fuzzy_matched_office_type": hubspot_data.get(
-                                "properties_office_type"
-                            ),
+                            "fuzzy_matched_office_type": hubspot_data.get("properties_office_type"),
                         }
                     )
                 else:
@@ -146,9 +133,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         tags=["intermediate", "techspeed", "hubspot", "fuzzy_deduped"],
     )
 
-    techspeed_candidates_w_hubspot: DataFrame = dbt.ref(
-        "int__techspeed_candidates_w_hubspot"
-    )
+    techspeed_candidates_w_hubspot: DataFrame = dbt.ref("int__techspeed_candidates_w_hubspot")
     hubspot_ytd_candidacies: DataFrame = dbt.ref("int__hubspot_ytd_candidacies")
     # Filter to valid candidate codes and rename id field
     hubspot_candidate_codes: DataFrame = hubspot_ytd_candidacies.filter(
@@ -172,23 +157,17 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     fuzzy_results = fuzzy_results.select(
         *[col(c) for c in base_columns],
-        col("fuzzy_results.techspeed_candidate_code").alias(
-            "fuzzy_results_techspeed_candidate_code"
-        ),
+        col("fuzzy_results.techspeed_candidate_code").alias("fuzzy_results_techspeed_candidate_code"),
         col("fuzzy_results.fuzzy_matched_hubspot_candidate_code").alias(
             "fuzzy_matched_hubspot_candidate_code"
         ),
         col("fuzzy_results.fuzzy_match_score").alias("fuzzy_match_score"),
         col("fuzzy_results.fuzzy_match_rank").alias("fuzzy_match_rank"),
-        col("fuzzy_results.fuzzy_matched_hubspot_contact_id").alias(
-            "fuzzy_matched_hubspot_contact_id"
-        ),
+        col("fuzzy_results.fuzzy_matched_hubspot_contact_id").alias("fuzzy_matched_hubspot_contact_id"),
         col("fuzzy_results.fuzzy_matched_first_name").alias("fuzzy_matched_first_name"),
         col("fuzzy_results.fuzzy_matched_last_name").alias("fuzzy_matched_last_name"),
         col("fuzzy_results.fuzzy_matched_state").alias("fuzzy_matched_state"),
-        col("fuzzy_results.fuzzy_matched_office_type").alias(
-            "fuzzy_matched_office_type"
-        ),
+        col("fuzzy_results.fuzzy_matched_office_type").alias("fuzzy_matched_office_type"),
     )
 
     return fuzzy_results

--- a/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_viability_scoring.py
+++ b/dbt/project/models/intermediate/techspeed_to_hubspot/int__techspeed_viability_scoring.py
@@ -21,9 +21,7 @@ from pyspark.sql.functions import (
 from us import states
 
 
-def _score_using_model(
-    df: pd.DataFrame, modelname: str, score_col: str
-) -> pd.DataFrame:
+def _score_using_model(df: pd.DataFrame, modelname: str, score_col: str) -> pd.DataFrame:
     """
     Score candidates using the latest version of the viability model.
 
@@ -37,9 +35,7 @@ def _score_using_model(
     """
     client = mlflow.tracking.MlflowClient()
     latest_model_version = max(
-        client.search_model_versions(
-            f"name='goodparty_data_catalog.model_predictions.{modelname}'"
-        ),
+        client.search_model_versions(f"name='goodparty_data_catalog.model_predictions.{modelname}'"),
         key=lambda x: x.version,
     ).version
     model = mlflow.sklearn.load_model(
@@ -52,9 +48,7 @@ def _score_using_model(
     # Score only complete rows
     valid_rows = df[model.feature_names_in_].notnull().all(axis=1)
     if valid_rows.sum() > 0:
-        df.loc[valid_rows, score_col] = model.predict_proba(
-            df.loc[valid_rows, model.feature_names_in_]
-        )[:, 1]
+        df.loc[valid_rows, score_col] = model.predict_proba(df.loc[valid_rows, model.feature_names_in_])[:, 1]
 
     return df
 
@@ -71,14 +65,10 @@ def _join_woe(df: DataFrame, col_name: str, spark: SparkSession) -> DataFrame:
     Returns:
         DataFrame with WoE values joined for the specified column
     """
-    woe_df = spark.table(
-        f"goodparty_data_catalog.model_predictions.viability_br_{col_name}_woe"
-    )
+    woe_df = spark.table(f"goodparty_data_catalog.model_predictions.viability_br_{col_name}_woe")
 
     # Get valid categories
-    valid_cats = [
-        row["cat_grouped"] for row in woe_df.select("cat_grouped").distinct().collect()
-    ]
+    valid_cats = [row["cat_grouped"] for row in woe_df.select("cat_grouped").distinct().collect()]
     df = df.withColumn(
         "grouped_col",
         when(col(col_name).isin(valid_cats), col(col_name)).otherwise(lit("Other")),
@@ -115,17 +105,13 @@ def model(dbt, session: SparkSession) -> DataFrame:
     df_candidates = dbt.ref("int__techspeed_candidates_fuzzy_deduped")
 
     # Add viability_id for tracking
-    df_candidates = df_candidates.withColumn(
-        "viability_id", monotonically_increasing_id()
-    )
+    df_candidates = df_candidates.withColumn("viability_id", monotonically_increasing_id())
 
     # Select and transform columns to match viability model expectations
     df_hs = df_candidates.select(
         col("viability_id"),
         col("techspeed_candidate_code"),
-        concat(col("first_name"), lit(" "), col("last_name")).alias(
-            "properties_candidate_name"
-        ),
+        concat(col("first_name"), lit(" "), col("last_name")).alias("properties_candidate_name"),
         col("city").alias("properties_city"),
         col("state").alias("properties_candidate_state"),
         col("election_date").alias("properties_election_date"),
@@ -141,9 +127,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         .when(col("number_of_candidates") == "", None)
         .otherwise(col("number_of_candidates").cast("int") - 1)
         .alias("properties_number_of_opponents"),
-        when(col("uncontested") == "Uncontested", "Yes")
-        .otherwise("No")
-        .alias("properties_open_seat_"),
+        when(col("uncontested") == "Uncontested", "Yes").otherwise("No").alias("properties_open_seat_"),
         col("party").alias("properties_candidate_party"),
         col("official_office_name").alias("properties_official_office_name"),
         col("candidate_office").alias("properties_candidate_office"),
@@ -160,9 +144,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
     df_hs = df_hs.withColumn("office_type_new", col("properties_office_type"))
 
     # Create state lookup table
-    state_lookup_data = [
-        {"state_key": s.name.lower(), "state": s.abbr} for s in states.STATES
-    ] + [{"state_key": s.abbr, "state": s.abbr} for s in states.STATES]
+    state_lookup_data = [{"state_key": s.name.lower(), "state": s.abbr} for s in states.STATES] + [
+        {"state_key": s.abbr, "state": s.abbr} for s in states.STATES
+    ]
     state_lookup = spark.createDataFrame(pd.DataFrame(state_lookup_data))
 
     # Transform variables to match HubSpot format for viability model
@@ -190,9 +174,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         )
         .withColumn(
             "multi_seat",
-            when(col("n_seats") > 1, 1)
-            .when(col("n_seats").isNull(), None)
-            .otherwise(0),
+            when(col("n_seats") > 1, 1).when(col("n_seats").isNull(), None).otherwise(0),
         )
         .withColumn(
             "partisan_contest",
@@ -237,9 +219,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     ]
 
     # Convert to pandas for ML model scoring
-    df_toscore = df_hs.select(
-        ["id", "techspeed_candidate_code"] + all_features
-    ).toPandas()
+    df_toscore = df_hs.select(["id", "techspeed_candidate_code"] + all_features).toPandas()
     df_toscore[all_features] = df_toscore[all_features].astype(float)
 
     # Score using MLflow model
@@ -260,7 +240,8 @@ def model(dbt, session: SparkSession) -> DataFrame:
             when(col("y_score0a").isNull() | col("y_score0a").isNaN(), None).otherwise(
                 round(5 * col("y_score0a"), 2)
             ),
-        ).withColumn(
+        )
+        .withColumn(
             "score_viability_automated",
             when(col("viability_rating_2_0").isNull(), None)
             .when(col("viability_rating_2_0") < 1, "No Chance")

--- a/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
@@ -23,14 +23,8 @@ def _filter_latest_loaded_files(df: DataFrame) -> DataFrame:
         .otherwise(None),
     )
 
-    window_spec = Window.partitionBy("source_file_type").orderBy(
-        col("loaded_at").desc()
-    )
-    return (
-        df.withColumn("rn", row_number().over(window_spec))
-        .filter(col("rn") == 1)
-        .drop("rn")
-    )
+    window_spec = Window.partitionBy("source_file_type").orderBy(col("loaded_at").desc())
+    return df.withColumn("rn", row_number().over(window_spec)).filter(col("rn") == 1).drop("rn")
 
 
 def _extract_table_name(source_file_type: str, state_id: str) -> str:
@@ -60,9 +54,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         databricks_schema = f"{dbt.this.schema}_source"
 
     s3_files_loaded: DataFrame = dbt.ref("load__l2_haystaq_sftp_to_s3")
-    state_list = [
-        row.state_id for row in s3_files_loaded.select("state_id").distinct().collect()
-    ]
+    state_list = [row.state_id for row in s3_files_loaded.select("state_id").distinct().collect()]
 
     load_id = str(uuid4())
     load_details: List[Dict[str, Any]] = []
@@ -76,12 +68,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         if dbt.is_incremental:
             this_table = session.table(f"{dbt.this}")
             this_table_state_files = this_table.filter(col("state_id") == state_id)
-            this_table_latest_files = _filter_latest_loaded_files(
-                this_table_state_files
-            )
+            this_table_latest_files = _filter_latest_loaded_files(this_table_state_files)
             this_table_latest_files_names = [
-                file.source_file_name
-                for file in this_table_latest_files.toLocalIterator()
+                file.source_file_name for file in this_table_latest_files.toLocalIterator()
             ]
 
             files_to_load_list: List[
@@ -94,9 +83,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
             for s3_file in latest_s3_files.toLocalIterator():
                 if s3_file.source_file_name in this_table_latest_files_names:
                     prior = (
-                        this_table_latest_files.filter(
-                            col("source_file_name") == s3_file.source_file_name
-                        )
+                        this_table_latest_files.filter(col("source_file_name") == s3_file.source_file_name)
                         .first()
                         .loaded_at
                     )
@@ -128,9 +115,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
                 ),
             )
         else:
-            files_to_load = latest_s3_files.select(
-                "source_file_name", "source_file_type", "s3_state_prefix"
-            )
+            files_to_load = latest_s3_files.select("source_file_name", "source_file_type", "s3_state_prefix")
 
         for file in files_to_load.toLocalIterator():
             source_file_name = file.source_file_name

--- a/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
@@ -56,9 +56,7 @@ def _create_sftp_connection(
     raise Exception("Failed to establish SFTP connection after all retries")
 
 
-def _select_latest_zip_file(
-    file_list: List[str], file_pattern: re.Pattern
-) -> Optional[str]:
+def _select_latest_zip_file(file_list: List[str], file_pattern: re.Pattern) -> Optional[str]:
     """
     Select the latest zip file from a list using a regex with a single (YYYYMMDD) capture group.
     """
@@ -114,18 +112,14 @@ def _extract_and_load_w_params(
 
             # Files look like: ak_haystaqdnaflags_20251005.tab.zip
             state_lower = state_id.lower()
-            suffix = (
-                "haystaqdnaflags" if haystaq_kind == "flags" else "haystaqdnascores"
-            )
+            suffix = "haystaqdnaflags" if haystaq_kind == "flags" else "haystaqdnascores"
             zip_pattern_str = "^" + state_lower + "_" + suffix + r"_(\d{8})\.tab\.zip$"
             zip_pattern = re.compile(zip_pattern_str, flags=re.IGNORECASE)
 
             try:
                 file_list = sftp_client.listdir(remote_dir)
             except FileNotFoundError:
-                logging.error(
-                    f"SFTP directory not found: {remote_dir}. Skipping {state_id}."
-                )
+                logging.error(f"SFTP directory not found: {remote_dir}. Skipping {state_id}.")
                 return EMPTY_LOAD_DETAILS
 
             source_zip_file_name = _select_latest_zip_file(
@@ -133,23 +127,17 @@ def _extract_and_load_w_params(
                 file_pattern=zip_pattern,
             )
             if source_zip_file_name is None:
-                logging.warning(
-                    f"No Haystaq {haystaq_kind} zip found for state {state_id} in {remote_dir}"
-                )
+                logging.warning(f"No Haystaq {haystaq_kind} zip found for state {state_id} in {remote_dir}")
                 return EMPTY_LOAD_DETAILS
 
             # We upload the extracted `.tab` to S3 (not the zip).
             tab_file_name = re.sub(r"\.zip$", "", source_zip_file_name, flags=re.I)
 
             s3_state_prefix = f"{s3_prefix}/{state_id.upper()}/{haystaq_kind}/"
-            s3_file_list = s3_client.list_objects_v2(
-                Bucket=s3_bucket, Prefix=s3_state_prefix
-            )
+            s3_file_list = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_state_prefix)
             s3_keys = [f["Key"] for f in s3_file_list.get("Contents", [])]
             if any(key.endswith(f"/{tab_file_name}") for key in s3_keys):
-                logging.info(
-                    f"{haystaq_kind} file already exists in S3 for {state_id}: {tab_file_name}"
-                )
+                logging.info(f"{haystaq_kind} file already exists in S3 for {state_id}: {tab_file_name}")
                 return EMPTY_LOAD_DETAILS
 
             full_zip_path = os.path.join(remote_dir, source_zip_file_name)
@@ -165,9 +153,7 @@ def _extract_and_load_w_params(
                 logging.warning(
                     f"Permission denied for temp dir {databricks_volume_directory}; falling back to default temp directory."
                 )
-                temp_dir_ctx = TemporaryDirectory(
-                    prefix=f"temp_{state_id}_{haystaq_kind}_"
-                )
+                temp_dir_ctx = TemporaryDirectory(prefix=f"temp_{state_id}_{haystaq_kind}_")
 
             with temp_dir_ctx as temp_dir:
                 local_zip_path = os.path.join(temp_dir, source_zip_file_name)
@@ -179,9 +165,7 @@ def _extract_and_load_w_params(
                         max_concurrent_prefetch_requests=64,
                     )
                 except OSError as e:
-                    logging.error(
-                        f"Source zip {full_zip_path} locked: {str(e)}. Skipping for now."
-                    )
+                    logging.error(f"Source zip {full_zip_path} locked: {str(e)}. Skipping for now.")
                     return EMPTY_LOAD_DETAILS
 
                 try:
@@ -189,15 +173,11 @@ def _extract_and_load_w_params(
                         extracted_names = zip_file.namelist()
                         zip_file.extractall(path=temp_dir)
                 except Exception:
-                    logging.error(
-                        f"Failed to extract {local_zip_path}. Skipping for now."
-                    )
+                    logging.error(f"Failed to extract {local_zip_path}. Skipping for now.")
                     return EMPTY_LOAD_DETAILS
 
                 # Expect exactly one .tab file
-                tab_names = [
-                    name for name in extracted_names if name.lower().endswith(".tab")
-                ]
+                tab_names = [name for name in extracted_names if name.lower().endswith(".tab")]
                 if len(tab_names) != 1:
                     raise ValueError(
                         f"Expected 1 .tab in {source_zip_file_name}, got {len(tab_names)}: {tab_names}"
@@ -215,24 +195,17 @@ def _extract_and_load_w_params(
                 # extracted file may not live at the root of `temp_dir`.
                 local_tab_path = os.path.join(temp_dir, extracted_tab_member)
                 if not os.path.isfile(local_tab_path):
-                    raise FileNotFoundError(
-                        f"Extracted tab file not found at {local_tab_path}"
-                    )
+                    raise FileNotFoundError(f"Extracted tab file not found at {local_tab_path}")
 
                 s3_key = f"{s3_state_prefix}{tab_file_name}"
-                s3_client.upload_file(
-                    Filename=local_tab_path, Bucket=s3_bucket, Key=s3_key
-                )
+                s3_client.upload_file(Filename=local_tab_path, Bucket=s3_bucket, Key=s3_key)
 
                 # Delete older versions for this state/type (keep only the latest by filename)
                 tab_pattern_str = "^" + state_lower + "_" + suffix + r"_(\d{8})\.tab$"
                 tab_pattern = re.compile(tab_pattern_str, flags=re.IGNORECASE)
                 for key in s3_keys:
                     key_basename = os.path.basename(key)
-                    if (
-                        re.match(tab_pattern, key_basename)
-                        and key_basename.lower() != tab_file_name.lower()
-                    ):
+                    if re.match(tab_pattern, key_basename) and key_basename.lower() != tab_file_name.lower():
                         s3_client.delete_object(Bucket=s3_bucket, Key=key)
 
             return {
@@ -244,9 +217,7 @@ def _extract_and_load_w_params(
             }
 
         except Exception as e:
-            logging.error(
-                f"Error processing state {state_id} ({haystaq_kind}): {str(e)}"
-            )
+            logging.error(f"Error processing state {state_id} ({haystaq_kind}): {str(e)}")
             error_details = traceback.format_exc()
             logging.error(f"Full exception details:\n{error_details}")
             raise Exception(
@@ -284,9 +255,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     flags_remote_dir = dbt.config.meta_get(
         "l2_haystaq_flags_sftp_dir", "/L2-Haystaq Issue Model Flags for Voters"
     )
-    scores_remote_dir = dbt.config.meta_get(
-        "l2_haystaq_scores_sftp_dir", "/L2-Haystaq Issue Model Scores"
-    )
+    scores_remote_dir = dbt.config.meta_get("l2_haystaq_scores_sftp_dir", "/L2-Haystaq Issue Model Scores")
     state_allowlist_raw = dbt.config.meta_get("l2_state_allowlist")
 
     # S3 configuration
@@ -297,15 +266,11 @@ def model(dbt, session: SparkSession) -> DataFrame:
     )
     l2_haystaq_prefix = f"l2_data/from_sftp_server/Haystaq/{dbt_env_name}"
 
-    databricks_volume_directory = (
-        f"/Volumes/goodparty_data_catalog/{dbt.this.schema}/object_storage/l2_temp"
-    )
+    databricks_volume_directory = f"/Volumes/goodparty_data_catalog/{dbt.this.schema}/object_storage/l2_temp"
 
     # get list of states
     states: DataFrame = (
-        dbt.ref("stg_airbyte_source__ballotready_s3_uscities_v1_77")
-        .select("state_id")
-        .distinct()
+        dbt.ref("stg_airbyte_source__ballotready_s3_uscities_v1_77").select("state_id").distinct()
     )
     states = states.withColumn("state_id", upper(col("state_id").cast(StringType())))
 
@@ -313,9 +278,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     states = states.filter(~col("state_id").isin(["VI", "PR"]))
     if state_allowlist_raw:
         allowlist = [
-            token.strip().upper()
-            for token in re.split(r"[,\s]+", state_allowlist_raw)
-            if token.strip()
+            token.strip().upper() for token in re.split(r"[,\s]+", state_allowlist_raw) if token.strip()
         ]
         logging.info(f"Filtering to states in allowlist: {allowlist}")
         states = states.filter(col("state_id").isin(allowlist))
@@ -354,15 +317,11 @@ def model(dbt, session: SparkSession) -> DataFrame:
     for state_id in state_list:
         flags_result = extract_flags(state_id)
         if flags_result["state_id"] is not None:
-            all_load_details.append(
-                {"state_id": state_id, "load_details": flags_result}
-            )
+            all_load_details.append({"state_id": state_id, "load_details": flags_result})
 
         scores_result = extract_scores(state_id)
         if scores_result["state_id"] is not None:
-            all_load_details.append(
-                {"state_id": state_id, "load_details": scores_result}
-            )
+            all_load_details.append({"state_id": state_id, "load_details": scores_result})
 
     # schema matches `load__l2_sftp_to_s3`
     load_details_schema = StructType(
@@ -372,9 +331,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
                 name="load_details",
                 dataType=StructType(
                     [
-                        StructField(
-                            name="state_id", dataType=StringType(), nullable=True
-                        ),
+                        StructField(name="state_id", dataType=StringType(), nullable=True),
                         StructField("source_file_names", ArrayType(StringType()), True),
                         StructField("source_zip_file", StringType(), True),
                         StructField("loaded_at", TimestampType(), True),
@@ -393,12 +350,8 @@ def model(dbt, session: SparkSession) -> DataFrame:
     states_loaded.cache()
     states_loaded.count()
     states_loaded = states_loaded.filter(col("load_details.state_id").isNotNull())
-    states_loaded = states_loaded.filter(
-        col("load_details.source_file_names").isNotNull()
-    )
-    states_loaded = states_loaded.filter(
-        col("load_details.source_zip_file").isNotNull()
-    )
+    states_loaded = states_loaded.filter(col("load_details.source_file_names").isNotNull())
+    states_loaded = states_loaded.filter(col("load_details.source_zip_file").isNotNull())
 
     exploded_states = states_loaded.select(
         col("load_id"),

--- a/dbt/project/models/load/load__l2_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_s3_to_databricks.py
@@ -39,16 +39,10 @@ def _filter_latest_loaded_files(df: DataFrame) -> DataFrame:
     )
 
     # define window to partition by source_file_type and order by loaded_at descending
-    window_spec = Window.partitionBy("source_file_type").orderBy(
-        col("loaded_at").desc()
-    )
+    window_spec = Window.partitionBy("source_file_type").orderBy(col("loaded_at").desc())
 
     # add row number and select only most recent record (row_number = 1)
-    df = (
-        df.withColumn("rn", row_number().over(window_spec))
-        .filter(col("rn") == 1)
-        .drop("rn")
-    )
+    df = df.withColumn("rn", row_number().over(window_spec)).filter(col("rn") == 1).drop("rn")
 
     return df
 
@@ -84,9 +78,7 @@ def _extract_table_name(source_file_name: str, state_id: str) -> str:
         file_type = file_type.split("-")[-1]
 
     # Construct the table name based on file type and whether it's a data dictionary
-    table_name = f"l2_s3_{state_id.lower()}_{file_type}".replace(
-        "datadictionary", "data_dictionary"
-    )
+    table_name = f"l2_s3_{state_id.lower()}_{file_type}".replace("datadictionary", "data_dictionary")
     table_name = table_name.replace("votehistory", "vote_history")
 
     return table_name
@@ -114,17 +106,13 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # get files loaded from sftp server into s3
     s3_files_loaded: DataFrame = dbt.ref("load__l2_sftp_to_s3")
-    state_list = [
-        row.state_id for row in s3_files_loaded.select("state_id").distinct().collect()
-    ]
+    state_list = [row.state_id for row in s3_files_loaded.select("state_id").distinct().collect()]
 
     # initialize list to capture metadata about data loads
     load_details = []
 
     # Ensure the schema exists
-    session.sql(
-        f"CREATE SCHEMA IF NOT EXISTS goodparty_data_catalog.{databricks_schema}"
-    )
+    session.sql(f"CREATE SCHEMA IF NOT EXISTS goodparty_data_catalog.{databricks_schema}")
     for state_id in state_list:
         state_files_loaded = s3_files_loaded.filter(col("state_id") == state_id)
 
@@ -135,12 +123,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         if dbt.is_incremental:
             this_table = session.table(f"{dbt.this}")
             this_table_state_files = this_table.filter(col("state_id") == state_id)
-            this_table_latest_files = _filter_latest_loaded_files(
-                this_table_state_files
-            )
+            this_table_latest_files = _filter_latest_loaded_files(this_table_state_files)
             this_table_latest_files_names = [
-                file.source_file_name
-                for file in this_table_latest_files.toLocalIterator()
+                file.source_file_name for file in this_table_latest_files.toLocalIterator()
             ]
 
             files_to_load_list: List[
@@ -151,14 +136,11 @@ def model(dbt, session: SparkSession) -> DataFrame:
             ] = []
             # Add file to load list if it's new or has newer loaded_at timestamp
             for s3_file in latest_s3_files.toLocalIterator():
-
                 if s3_file.source_file_name in this_table_latest_files_names:
                     # the file has been loaded to databricks before; check if the last s3 loaded file is newer
                     if (
                         s3_file.loaded_at
-                        > this_table_latest_files.filter(
-                            col("source_file_name") == s3_file.source_file_name
-                        )
+                        > this_table_latest_files.filter(col("source_file_name") == s3_file.source_file_name)
                         .first()
                         .loaded_at
                     ):

--- a/dbt/project/models/load/load__l2_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_sftp_to_s3.py
@@ -158,18 +158,11 @@ def _extract_and_load_w_params(
             source_zip_file_name = file_list[0]
             source_zip_file_base_name = source_zip_file_name.split(".")[0]
             s3_state_prefix = f"{s3_prefix}/{state_id.upper()}/"
-            s3_file_list = s3_client.list_objects_v2(
-                Bucket=s3_bucket, Prefix=s3_state_prefix
-            )
+            s3_file_list = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_state_prefix)
             s3_file_list = [f["Key"] for f in s3_file_list.get("Contents", [])]
-            s3_file_exists = any(
-                source_zip_file_base_name in s3_file_name
-                for s3_file_name in s3_file_list
-            )
+            s3_file_exists = any(source_zip_file_base_name in s3_file_name for s3_file_name in s3_file_list)
             if s3_file_exists:
-                logging.info(
-                    f"File with base name {source_zip_file_base_name} already exists in S3"
-                )
+                logging.info(f"File with base name {source_zip_file_base_name} already exists in S3")
                 return EMPTY_LOAD_DETAILS
 
             # download the file from the sftp server and extract it
@@ -224,8 +217,7 @@ def _extract_and_load_w_params(
 
                 # get list of files to upload
                 file_name_paths = [
-                    os.path.join(temp_extract_dir, file_name)
-                    for file_name in extracted_file_names
+                    os.path.join(temp_extract_dir, file_name) for file_name in extracted_file_names
                 ]
                 file_names_to_upload = []
                 if is_uniform:
@@ -253,16 +245,10 @@ def _extract_and_load_w_params(
                             extension = match.group(2)  # _DataDictionary.csv or .tab
 
                         # headers and footers must be removed from data dictionary files
-                        if (
-                            file_type in ["DEMOGRAPHIC", "UNIFORM"]
-                            and extension == "_DataDictionary.csv"
-                        ):
+                        if file_type in ["DEMOGRAPHIC", "UNIFORM"] and extension == "_DataDictionary.csv":
                             df = pd.read_csv(file_path, skiprows=15, skipfooter=24)
                             df.to_csv(file_path, index=False)
-                        elif (
-                            file_type == "VOTEHISTORY"
-                            and extension == "_DataDictionary.csv"
-                        ):
+                        elif file_type == "VOTEHISTORY" and extension == "_DataDictionary.csv":
                             df = pd.read_csv(file_path, skiprows=15, skipfooter=4)
                             df.to_csv(file_path, index=False)
                     else:
@@ -272,9 +258,7 @@ def _extract_and_load_w_params(
                     s3_key = f"{s3_state_prefix}{filename}"
 
                     if os.path.isfile(local_file_path):
-                        s3_client.upload_file(
-                            Filename=local_file_path, Bucket=s3_bucket, Key=s3_key
-                        )
+                        s3_client.upload_file(Filename=local_file_path, Bucket=s3_bucket, Key=s3_key)
                         # delete locally extracted files
                         os.remove(local_file_path)
 
@@ -282,17 +266,13 @@ def _extract_and_load_w_params(
                         for existing_s3_file in s3_file_list:
                             s3_regexp_match = re.match(pattern, existing_s3_file)
                             if s3_regexp_match and existing_s3_file != filename:
-                                s3_client.delete_object(
-                                    Bucket=s3_bucket, Key=existing_s3_file
-                                )
+                                s3_client.delete_object(Bucket=s3_bucket, Key=existing_s3_file)
 
         except Exception as e:
             logging.error(f"Error processing state {state_id}: {str(e)}")
             error_details = traceback.format_exc()
             logging.error(f"Full exception details:\n{error_details}")
-            raise Exception(
-                f"Error processing state {state_id}: {str(e)}\nFull traceback:\n{error_details}"
-            )
+            raise Exception(f"Error processing state {state_id}: {str(e)}\nFull traceback:\n{error_details}")
         finally:
             # Close SFTP connection
             if sftp_client is not None:
@@ -340,15 +320,11 @@ def model(dbt, session: SparkSession):
     )
     l2_vmfiles_prefix = f"l2_data/from_sftp_server/VMFiles/{dbt_env_name}"
 
-    databricks_volume_directory = (
-        f"/Volumes/goodparty_data_catalog/{dbt.this.schema}/object_storage/l2_temp"
-    )
+    databricks_volume_directory = f"/Volumes/goodparty_data_catalog/{dbt.this.schema}/object_storage/l2_temp"
 
     # get list of states
     states: DataFrame = (
-        dbt.ref("stg_airbyte_source__ballotready_s3_uscities_v1_77")
-        .select("state_id")
-        .distinct()
+        dbt.ref("stg_airbyte_source__ballotready_s3_uscities_v1_77").select("state_id").distinct()
     )
     states = states.withColumn("state_id", upper(col("state_id").cast(StringType())))
 
@@ -397,18 +373,12 @@ def model(dbt, session: SparkSession):
         # Process uniform load
         uniform_result = extract_and_load_uniform(state_id)
         if uniform_result["state_id"] is not None:  # Only add if load was successful
-            all_load_details.append(
-                {"state_id": state_id, "load_details": uniform_result}
-            )
+            all_load_details.append({"state_id": state_id, "load_details": uniform_result})
 
         # Process non-uniform load
         non_uniform_result = extract_and_load_non_uniform(state_id)
-        if (
-            non_uniform_result["state_id"] is not None
-        ):  # Only add if load was successful
-            all_load_details.append(
-                {"state_id": state_id, "load_details": non_uniform_result}
-            )
+        if non_uniform_result["state_id"] is not None:  # Only add if load was successful
+            all_load_details.append({"state_id": state_id, "load_details": non_uniform_result})
 
     states_loaded_pd = pd.DataFrame(all_load_details)
 
@@ -420,9 +390,7 @@ def model(dbt, session: SparkSession):
                 name="load_details",
                 dataType=StructType(
                     [
-                        StructField(
-                            name="state_id", dataType=StringType(), nullable=True
-                        ),
+                        StructField(name="state_id", dataType=StringType(), nullable=True),
                         StructField("source_file_names", ArrayType(StringType()), True),
                         StructField("source_zip_file", StringType(), True),
                         StructField("loaded_at", TimestampType(), True),

--- a/dbt/project/models/marts/people_api/m_people_api__districtstats_py.py
+++ b/dbt/project/models/marts/people_api/m_people_api__districtstats_py.py
@@ -67,9 +67,7 @@ OUTPUT_SCHEMA = StructType(
 )
 
 
-def _aggregate_buckets(
-    df: DataFrame, district_col: str, category_col: str
-) -> DataFrame:
+def _aggregate_buckets(df: DataFrame, district_col: str, category_col: str) -> DataFrame:
     """
     Aggregate counts per category for each district.
     Returns DataFrame with district_id, label, count columns.
@@ -171,9 +169,7 @@ def _get_income_bucket_label(income_int_col):
     )
 
 
-def _process_age_buckets(
-    voters_with_buckets: DataFrame, district_totals: DataFrame
-) -> DataFrame:
+def _process_age_buckets(voters_with_buckets: DataFrame, district_totals: DataFrame) -> DataFrame:
     """Process age bucket aggregation."""
     age_counts = _aggregate_buckets(voters_with_buckets, "district_id", "age_bucket")
     age_counts_with_total = age_counts.join(
@@ -184,16 +180,12 @@ def _process_age_buckets(
     return _buckets_to_array(age_counts_with_total, "age")
 
 
-def _process_homeowner_buckets(
-    voters_with_buckets: DataFrame, district_totals: DataFrame
-) -> DataFrame:
+def _process_homeowner_buckets(voters_with_buckets: DataFrame, district_totals: DataFrame) -> DataFrame:
     """
     Process homeowner bucket aggregation with label mapping:
     "Home Owner" / "Probable Home Owner" -> "Yes", "Renter" -> "No", else -> "Unknown"
     """
-    homeowner_counts = _aggregate_buckets(
-        voters_with_buckets, "district_id", "Homeowner_Probability_Model"
-    )
+    homeowner_counts = _aggregate_buckets(voters_with_buckets, "district_id", "Homeowner_Probability_Model")
     # Map labels to simplified categories
     homeowner_counts = homeowner_counts.withColumn(
         "label",
@@ -202,9 +194,7 @@ def _process_homeowner_buckets(
         .otherwise(F.lit("Unknown")),
     )
     # Re-aggregate to combine mapped labels
-    homeowner_counts = homeowner_counts.groupBy("district_id", "label").agg(
-        F.sum("count").alias("count")
-    )
+    homeowner_counts = homeowner_counts.groupBy("district_id", "label").agg(F.sum("count").alias("count"))
     homeowner_counts_with_total = homeowner_counts.join(
         district_totals.select("district_id", "total_constituents"),
         on="district_id",
@@ -213,9 +203,7 @@ def _process_homeowner_buckets(
     return _buckets_to_array(homeowner_counts_with_total, "homeowner")
 
 
-def _process_education_buckets(
-    voters_with_buckets: DataFrame, district_totals: DataFrame
-) -> DataFrame:
+def _process_education_buckets(voters_with_buckets: DataFrame, district_totals: DataFrame) -> DataFrame:
     """
     Process education bucket aggregation with label mapping:
     - "Did Not Complete High School Likely" -> "None"
@@ -227,9 +215,7 @@ def _process_education_buckets(
     - "Attended But Did Not Complete College Likely" -> "Some College"
     - else -> "Unknown"
     """
-    education_counts = _aggregate_buckets(
-        voters_with_buckets, "district_id", "Education_Of_Person"
-    )
+    education_counts = _aggregate_buckets(voters_with_buckets, "district_id", "Education_Of_Person")
     # Map labels to human-readable categories
     education_counts = education_counts.withColumn(
         "label",
@@ -255,9 +241,7 @@ def _process_education_buckets(
         .otherwise(F.lit("Unknown")),
     )
     # Re-aggregate to combine mapped labels
-    education_counts = education_counts.groupBy("district_id", "label").agg(
-        F.sum("count").alias("count")
-    )
+    education_counts = education_counts.groupBy("district_id", "label").agg(F.sum("count").alias("count"))
     education_counts_with_total = education_counts.join(
         district_totals.select("district_id", "total_constituents"),
         on="district_id",
@@ -273,9 +257,7 @@ def _process_presence_of_children_buckets(
     Process presence of children bucket aggregation with label mapping:
     "Y" -> "Yes", "N" -> "No", else -> "Unknown"
     """
-    children_counts = _aggregate_buckets(
-        voters_with_buckets, "district_id", "Presence_Of_Children"
-    )
+    children_counts = _aggregate_buckets(voters_with_buckets, "district_id", "Presence_Of_Children")
     # Map labels to human-readable categories
     children_counts = children_counts.withColumn(
         "label",
@@ -284,9 +266,7 @@ def _process_presence_of_children_buckets(
         .otherwise(F.lit("Unknown")),
     )
     # Re-aggregate to combine mapped labels
-    children_counts = children_counts.groupBy("district_id", "label").agg(
-        F.sum("count").alias("count")
-    )
+    children_counts = children_counts.groupBy("district_id", "label").agg(F.sum("count").alias("count"))
     children_counts_with_total = children_counts.join(
         district_totals.select("district_id", "total_constituents"),
         on="district_id",
@@ -295,13 +275,9 @@ def _process_presence_of_children_buckets(
     return _buckets_to_array(children_counts_with_total, "presenceOfChildren")
 
 
-def _process_income_buckets(
-    voters_with_buckets: DataFrame, district_totals: DataFrame
-) -> DataFrame:
+def _process_income_buckets(voters_with_buckets: DataFrame, district_totals: DataFrame) -> DataFrame:
     """Process estimated income range bucket aggregation."""
-    income_counts = _aggregate_buckets(
-        voters_with_buckets, "district_id", "income_bucket"
-    )
+    income_counts = _aggregate_buckets(voters_with_buckets, "district_id", "income_bucket")
     income_counts_with_total = income_counts.join(
         district_totals.select("district_id", "total_constituents"),
         on="district_id",
@@ -336,11 +312,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         max_updated_at = this_df.agg({"updated_at": "max"}).collect()[0][0]
         if max_updated_at:
             # Get districts with updated voters
-            updated_voter_ids = (
-                voter_df.filter(F.col("updated_at") > max_updated_at)
-                .select("id")
-                .distinct()
-            )
+            updated_voter_ids = voter_df.filter(F.col("updated_at") > max_updated_at).select("id").distinct()
             # Get distinct district IDs for updated voters
             updated_district_ids = (
                 districtvoter_df.join(
@@ -382,9 +354,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     # Add age and income bucket label columns
     voters_with_buckets = voters_with_districts.withColumn(
         "age_bucket", _get_age_bucket_label("Age_Int")
-    ).withColumn(
-        "income_bucket", _get_income_bucket_label("Estimated_Income_Amount_Int")
-    )
+    ).withColumn("income_bucket", _get_income_bucket_label("Estimated_Income_Amount_Int"))
 
     # Compute total constituents per district and max updated_at from voters
     district_totals = voters_with_buckets.groupBy("district_id").agg(
@@ -401,15 +371,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Compute all bucket aggregations using helper functions
     age_buckets_df = _process_age_buckets(voters_with_buckets, district_totals)
-    homeowner_buckets_df = _process_homeowner_buckets(
-        voters_with_buckets, district_totals
-    )
-    education_buckets_df = _process_education_buckets(
-        voters_with_buckets, district_totals
-    )
-    children_buckets_df = _process_presence_of_children_buckets(
-        voters_with_buckets, district_totals
-    )
+    homeowner_buckets_df = _process_homeowner_buckets(voters_with_buckets, district_totals)
+    education_buckets_df = _process_education_buckets(voters_with_buckets, district_totals)
+    children_buckets_df = _process_presence_of_children_buckets(voters_with_buckets, district_totals)
     income_buckets_df = _process_income_buckets(voters_with_buckets, district_totals)
 
     # Join all bucket dataframes together

--- a/dbt/project/models/marts/people_api/m_people_api__districtvoter.py
+++ b/dbt/project/models/marts/people_api/m_people_api__districtvoter.py
@@ -343,9 +343,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     # Join with district table to get district_id
     result_df = (
         districts_from_voters.join(
-            district__mart_df.select(
-                col("id").alias("district_id"), col("state"), col("type"), col("name")
-            ),
+            district__mart_df.select(col("id").alias("district_id"), col("state"), col("type"), col("name")),
             on=["state", "type", "name"],
             how="left",
         )

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -433,14 +433,9 @@ WRITE_TABLE_SCHEMA = StructType(
 )
 
 
-def _execute_sql_query(
-    query: str, host: str, port: int, user: str, password: str, database: str
-) -> None:
-
+def _execute_sql_query(query: str, host: str, port: int, user: str, password: str, database: str) -> None:
     try:
-        conn = psycopg2.connect(
-            dbname=database, user=user, password=password, host=host, port=port
-        )
+        conn = psycopg2.connect(dbname=database, user=user, password=password, host=host, port=port)
         cursor = conn.cursor()
         cursor.execute(query)
         conn.commit()
@@ -491,9 +486,7 @@ def _load_data_to_postgres(
     # Write data directly using JDBC
     df.write.format("jdbc").option("url", jdbc_url).option(
         "dbtable", f'{staging_schema}."{table_name}"'
-    ).option("user", db_user).option("password", db_pw).option(
-        "driver", "org.postgresql.Driver"
-    ).mode(
+    ).option("user", db_user).option("password", db_pw).option("driver", "org.postgresql.Driver").mode(
         "overwrite"
     ).save()
 
@@ -611,14 +604,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
             ],
         )
         for table, df in to_load:
-            query = (
-                f'SELECT MAX(updated_at) AS max_updated_at FROM {db_schema}."{table}"'
-            )
+            query = f'SELECT MAX(updated_at) AS max_updated_at FROM {db_schema}."{table}"'
             max_updated_at_df = (
-                session.read.format("jdbc")
-                .options(**jdbc_props)
-                .option("query", query)
-                .load()
+                session.read.format("jdbc").options(**jdbc_props).option("query", query).load()
             )
             max_updated_at[table] = max_updated_at_df.collect()[0]["max_updated_at"]
 

--- a/dbt/project/models/write/write__l2_databricks_to_gp_api.py
+++ b/dbt/project/models/write/write__l2_databricks_to_gp_api.py
@@ -398,25 +398,17 @@ PROTECTED_VOTER_COLUMN_LIST = [f'"{col}"' for col in VOTER_COLUMN_LIST]
 PROTECTED_REMOVED_COLUMNS = [f'"{col}"' for col in REMOVED_COLUMNS]
 PROTECTED_INTEGER_COLUMNS = [f'"{col}"' for col in INTEGER_COLUMNS]
 PROTECTED_NONREMOVED_NONINTEGER_COLUMNS = [
-    f'"{col}"'
-    for col in VOTER_COLUMN_LIST
-    if col not in REMOVED_COLUMNS + INTEGER_COLUMNS
+    f'"{col}"' for col in VOTER_COLUMN_LIST if col not in REMOVED_COLUMNS + INTEGER_COLUMNS
 ]
 
 
 # build upsert query
 voter_column_list_str = ",".join(PROTECTED_VOTER_COLUMN_LIST)
-nonremoved_noninteger_column_list_str = ",".join(
-    PROTECTED_NONREMOVED_NONINTEGER_COLUMNS
-)
+nonremoved_noninteger_column_list_str = ",".join(PROTECTED_NONREMOVED_NONINTEGER_COLUMNS)
 removed_column_null_list_str = "NULL AS " + ", NULL AS ".join(PROTECTED_REMOVED_COLUMNS)
 integer_column_list_str = "::INT, ".join(PROTECTED_INTEGER_COLUMNS) + "::INT"
 update_columns_list_str = " " + ", ".join(
-    [
-        f"{col} = EXCLUDED.{col}"
-        for col in PROTECTED_VOTER_COLUMN_LIST
-        if col != "LALVOTERID"
-    ]
+    [f"{col} = EXCLUDED.{col}" for col in PROTECTED_VOTER_COLUMN_LIST if col != "LALVOTERID"]
 )
 
 # Note that the value list under `INSERT` and `SELECT` must be in the same order, so a
@@ -859,9 +851,7 @@ def _execute_sql_query(
     Execute a SQL query and return the results. Not that the results should be None if no results are returned.
     """
     try:
-        conn = psycopg2.connect(
-            dbname=database, user=user, password=password, host=host, port=port
-        )
+        conn = psycopg2.connect(dbname=database, user=user, password=password, host=host, port=port)
         cursor = conn.cursor()
         cursor.execute(query)
         if return_results:
@@ -931,9 +921,7 @@ def _load_data_to_postgres(
 
     df.write.format("jdbc").option("url", jdbc_url).option(
         "dbtable", f'{staging_schema}."{table_name}"'
-    ).option("user", db_user).option("password", db_pw).option(
-        "driver", "org.postgresql.Driver"
-    ).mode(
+    ).option("user", db_user).option("password", db_pw).option("driver", "org.postgresql.Driver").mode(
         "overwrite"
     ).save()
 
@@ -942,9 +930,7 @@ def _load_data_to_postgres(
         "SET synchronous_commit = off; "
         "SET work_mem = '128MB'; "
         "SET max_parallel_workers_per_gather = 8; "
-        + upsert_query.format(
-            db_schema=db_schema, staging_schema=staging_schema, table_name=table_name
-        )
+        + upsert_query.format(db_schema=db_schema, staging_schema=staging_schema, table_name=table_name)
         + ";"
     )
     _execute_sql_query(
@@ -1036,10 +1022,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     loaded_to_databricks.count()
 
     # get the list of states to load
-    state_list = [
-        row.state_id
-        for row in loaded_to_databricks.select("state_id").distinct().collect()
-    ]
+    state_list = [row.state_id for row in loaded_to_databricks.select("state_id").distinct().collect()]
 
     # initialize list to capture metadata about data loads
     load_details: List[Dict[str, Any]] = []
@@ -1065,16 +1048,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
             SELECT COUNT(*) FROM {db_schema}."VoterFile"
             WHERE "Filename" = '{latest_file.source_file_name}'
         """
-        results = _execute_sql_query(
-            query, db_host, db_port, db_user, db_pw, db_name, return_results=True
-        )
+        results = _execute_sql_query(query, db_host, db_port, db_user, db_pw, db_name, return_results=True)
         if results[0][0] > 0:
             continue
 
         # write to destination postgres table
-        voter_column_list = [
-            col for col in VOTER_COLUMN_LIST if col not in REMOVED_COLUMNS
-        ]
+        voter_column_list = [col for col in VOTER_COLUMN_LIST if col not in REMOVED_COLUMNS]
 
         df = session.read.table(latest_file.table_path).select(voter_column_list)
 

--- a/dbt/project/models/write/write__people_api_db.py
+++ b/dbt/project/models/write/write__people_api_db.py
@@ -377,14 +377,8 @@ VOTER_COLUMN_LIST: list = [
 
 # protect case with double quotes for building SQL strings
 protected_voter_column_list = [f'"{col}"' for col in VOTER_COLUMN_LIST]
-voter_column_list_str = ",".join(
-    [col for col in protected_voter_column_list if col != '"id"']
-)
-update_set_query = [
-    f"{col} = EXCLUDED.{col}"
-    for col in protected_voter_column_list
-    if col != '"LALVOTERID"'
-]
+voter_column_list_str = ",".join([col for col in protected_voter_column_list if col != '"id"'])
+update_set_query = [f"{col} = EXCLUDED.{col}" for col in protected_voter_column_list if col != '"LALVOTERID"']
 update_set_query_str = ", ".join(update_set_query)
 
 # Note that the value list under `INSERT` and `SELECT` must be in the same order
@@ -586,9 +580,7 @@ def _load_data_to_postgres(
 
         df.write.format("jdbc").option("url", jdbc_url).option(
             "dbtable", f'{staging_schema}."{staging_table_name}"'
-        ).option("user", db_user).option("password", db_pw).option(
-            "driver", "org.postgresql.Driver"
-        ).mode(
+        ).option("user", db_user).option("password", db_pw).option("driver", "org.postgresql.Driver").mode(
             "overwrite"
         ).save()
 
@@ -614,9 +606,7 @@ def _load_data_to_postgres(
                 staging_schema=staging_schema,
             )
 
-        upsert_query_w_config = (
-            " ".join(config_parts) + " " + formatted_upsert_query + ";"
-        )
+        upsert_query_w_config = " ".join(config_parts) + " " + formatted_upsert_query + ";"
 
         _execute_sql_query(
             query=upsert_query_w_config,
@@ -674,9 +664,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     district_stats_table: DataFrame = dbt.ref("m_people_api__districtstats")
 
     # Convert buckets struct to JSON string for PostgreSQL JSONB storage
-    district_stats_table = district_stats_table.withColumn(
-        "buckets", to_json(col("buckets"))
-    )
+    district_stats_table = district_stats_table.withColumn("buckets", to_json(col("buckets")))
 
     # downsample for non-prod environment with low-population states
     # TODO: downsample based on on dbt cloud account. current env vars listed in docs are not available
@@ -684,16 +672,12 @@ def model(dbt, session: SparkSession) -> DataFrame:
     filter_list = ["WY", "ND", "VT", "DC", "AK", "SD"]  # 17.6 MM rows in DistrictVoter
     if dbt_env_name != "prod":
         voter_table = voter_table.filter(col("State").isin(filter_list))
-        district_voter_table = district_voter_table.filter(
-            col("state").isin(filter_list)
-        )
+        district_voter_table = district_voter_table.filter(col("state").isin(filter_list))
         # Filter district_stats_table to only include districts from filtered district_voter_table
         # This ensures data consistency: DistrictStats should only exist for districts
         # that have corresponding DistrictVoter records in non-prod environments
         filtered_district_ids = district_voter_table.select("district_id").distinct()
-        district_stats_table = district_stats_table.join(
-            filtered_district_ids, on="district_id", how="inner"
-        )
+        district_stats_table = district_stats_table.join(filtered_district_ids, on="district_id", how="inner")
 
     # initialize list to capture metadata about data loads
     load_id = str(uuid4())
@@ -751,9 +735,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
             db_host=db_host,
             db_port=db_port,
         )
-        max_updated_at_voter = _execute_sql_query(query, conn, return_results=True)[0][
-            0
-        ]
+        max_updated_at_voter = _execute_sql_query(query, conn, return_results=True)[0][0]
         conn.close()
         if max_updated_at_voter:
             # postgres rounds down microseconds, so add 2 seconds as a safe buffer
@@ -810,15 +792,8 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     for table_name, df, upsert_query in table_configs:
         # Get the max updated_at value from the existing data
-        query = (
-            f'SELECT MAX(updated_at) AS max_updated_at FROM {db_schema}."{table_name}"'
-        )
-        max_updated_at_df = (
-            session.read.format("jdbc")
-            .options(**jdbc_props)
-            .option("query", query)
-            .load()
-        )
+        query = f'SELECT MAX(updated_at) AS max_updated_at FROM {db_schema}."{table_name}"'
+        max_updated_at_df = session.read.format("jdbc").options(**jdbc_props).option("query", query).load()
 
         # Handle empty table case
         try:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,15 @@
+# Repo-wide ruff config. Conservative lint set (E,F,I) only; the opinionated
+# rules (UP,B,SIM,RUF) are ratcheted in per-directory as each gets its CI
+# workflow. people-api-loader/ overrides this with its own fuller [tool.ruff]
+# in pyproject.toml (ruff applies the nearest config per file).
+line-length = 110
+target-version = "py312"
+
+[lint]
+select = ["E", "F", "I"]
+ignore = ["E501"]
+
+[lint.per-file-ignores]
+# dbt model scripts run on Databricks where `dbutils` is an injected runtime
+# global; the previous flake8 config ignored F821 for the same reason.
+"dbt/project/models/**/*.py" = ["F821"]

--- a/tests/airflow/conftest.py
+++ b/tests/airflow/conftest.py
@@ -4,6 +4,4 @@ import os
 import sys
 
 # Add astro dir to path so tests can import include.custom_functions
-sys.path.insert(
-    0, os.path.join(os.path.dirname(__file__), "..", "..", "airflow", "astro")
-)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "airflow", "astro"))

--- a/tests/airflow/test_databricks_utils.py
+++ b/tests/airflow/test_databricks_utils.py
@@ -85,9 +85,7 @@ class TestGetProcessedFiles:
         cursor.fetchone.return_value = (1,)
         # Each row is a DAG run's comma-joined source_file_keys
         cursor.fetchall.return_value = [
-            (
-                "file1.tab|2026-01-15T10:00:00+00:00, file2.tab|2026-01-16T10:00:00+00:00",
-            ),
+            ("file1.tab|2026-01-15T10:00:00+00:00, file2.tab|2026-01-16T10:00:00+00:00",),
         ]
 
         result = get_processed_files(conn, catalog="cat", schema="sch")
@@ -205,9 +203,7 @@ class TestStageExpiredVoterIds:
             file_timestamps={"file1.tab": "2026-01-15T10:00:00+00:00"},
         )
 
-        merge_sql = [
-            c[0][0] for c in cursor.execute.call_args_list if "MERGE INTO" in c[0][0]
-        ][0]
+        merge_sql = [c[0][0] for c in cursor.execute.call_args_list if "MERGE INTO" in c[0][0]][0]
         assert "2026-01-15T10:00:00+00:00" in merge_sql
         # source_file_keys stores composite "filename|mtime" for idempotency
         assert "file1.tab|2026-01-15T10:00:00+00:00" in merge_sql
@@ -226,9 +222,7 @@ class TestStageExpiredVoterIds:
             dag_run_id="run_123",
         )
 
-        merge_sql = [
-            c[0][0] for c in cursor.execute.call_args_list if "MERGE INTO" in c[0][0]
-        ][0]
+        merge_sql = [c[0][0] for c in cursor.execute.call_args_list if "MERGE INTO" in c[0][0]][0]
         assert "NULL" in merge_sql
 
     def test_dag_run_id_escaped(self, mock_connection):
@@ -245,15 +239,11 @@ class TestStageExpiredVoterIds:
         )
 
         # Loads table DELETE has escaped dag_run_id
-        delete_calls = [
-            c[0][0] for c in cursor.execute.call_args_list if "DELETE FROM" in c[0][0]
-        ]
+        delete_calls = [c[0][0] for c in cursor.execute.call_args_list if "DELETE FROM" in c[0][0]]
         assert len(delete_calls) == 1
         assert "run_with\\'quote" in delete_calls[0]
         # MERGE also has escaped dag_run_id
-        merge_sql = [
-            c[0][0] for c in cursor.execute.call_args_list if "MERGE INTO" in c[0][0]
-        ][0]
+        merge_sql = [c[0][0] for c in cursor.execute.call_args_list if "MERGE INTO" in c[0][0]][0]
         assert "run_with\\'quote" in merge_sql
 
     def test_loads_record_is_last_execute(self, mock_connection):
@@ -337,9 +327,10 @@ class TestGetDatabricksConnection:
     def test_fails_fast_on_auth_error_without_retrying(self):
         """An invalid_client error raises immediately with no retry sleeps."""
         auth_error = Exception("invalid_client: Client authentication failed")
-        with patch.object(
-            databricks_utils.databricks_sql, "connect", side_effect=auth_error
-        ) as mock_connect, patch.object(databricks_utils.time, "sleep") as mock_sleep:
+        with (
+            patch.object(databricks_utils.databricks_sql, "connect", side_effect=auth_error) as mock_connect,
+            patch.object(databricks_utils.time, "sleep") as mock_sleep,
+        ):
             with pytest.raises(Exception, match="invalid_client"):
                 get_databricks_connection(**self._kwargs(max_retries=20))
 
@@ -349,11 +340,14 @@ class TestGetDatabricksConnection:
     def test_retries_transient_errors_then_succeeds(self):
         """A transient error is retried and the eventual connection returned."""
         conn = MagicMock()
-        with patch.object(
-            databricks_utils.databricks_sql,
-            "connect",
-            side_effect=[Exception("warehouse may be starting"), conn],
-        ) as mock_connect, patch.object(databricks_utils.time, "sleep") as mock_sleep:
+        with (
+            patch.object(
+                databricks_utils.databricks_sql,
+                "connect",
+                side_effect=[Exception("warehouse may be starting"), conn],
+            ) as mock_connect,
+            patch.object(databricks_utils.time, "sleep") as mock_sleep,
+        ):
             result = get_databricks_connection(**self._kwargs(max_retries=5))
 
         assert result is conn
@@ -362,11 +356,14 @@ class TestGetDatabricksConnection:
 
     def test_raises_after_exhausting_retries_on_transient_errors(self):
         """Persistent transient errors raise after exhausting max_retries."""
-        with patch.object(
-            databricks_utils.databricks_sql,
-            "connect",
-            side_effect=Exception("warehouse may be starting"),
-        ) as mock_connect, patch.object(databricks_utils.time, "sleep"):
+        with (
+            patch.object(
+                databricks_utils.databricks_sql,
+                "connect",
+                side_effect=Exception("warehouse may be starting"),
+            ) as mock_connect,
+            patch.object(databricks_utils.time, "sleep"),
+        ):
             with pytest.raises(Exception, match="warehouse"):
                 get_databricks_connection(**self._kwargs(max_retries=3))
 

--- a/tests/airflow/test_l2_sftp.py
+++ b/tests/airflow/test_l2_sftp.py
@@ -23,10 +23,7 @@ MANUAL_ID_OMITS_CONTENT = (
 )
 
 UPPERCASE_HEADER_CONTENT = (
-    "LALVOTERID\tstate_postal_code\n"
-    "LALWY0001\tWY\n"
-    "LALNC0002\tNC\n"
-    "LALCA0003\tCA\n"
+    "LALVOTERID\tstate_postal_code\n" "LALWY0001\tWY\n" "LALNC0002\tNC\n" "LALCA0003\tCA\n"
 )
 
 

--- a/tests/analytics/test_win_analysis.py
+++ b/tests/analytics/test_win_analysis.py
@@ -71,17 +71,13 @@ def test_win_event_predicate_rejects_bad_cutoff(bad):
 
 
 def test_build_working_set_beyond_signup_boundary():
-    df_in = pd.DataFrame(
-        {"user_id": [1, 2], "cohort": ["c", "c"], "core_distinct_types": [1, 2]}
-    )
+    df_in = pd.DataFrame({"user_id": [1, 2], "cohort": ["c", "c"], "core_distinct_types": [1, 2]})
     out = wa.build_win_working_set(_stub(df_in), COHORTS)
     assert list(out["beyond_signup"]) == [0, 1]
 
 
 def test_build_working_set_keeps_zero_event_user():
-    df_in = pd.DataFrame(
-        {"user_id": [1], "cohort": ["c"], "core_distinct_types": [0], "any_core": [0]}
-    )
+    df_in = pd.DataFrame({"user_id": [1], "cohort": ["c"], "core_distinct_types": [0], "any_core": [0]})
     out = wa.build_win_working_set(_stub(df_in), COHORTS)
     assert len(out) == 1
     assert out.loc[0, "beyond_signup"] == 0

--- a/tests/apps/genie_slack_bot/test_slack_bot.py
+++ b/tests/apps/genie_slack_bot/test_slack_bot.py
@@ -407,10 +407,7 @@ def test_feedback_without_mapping_updates_with_failure_message():
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": (
-                            "⚠️ _Unable to submit feedback. Please try asking a new "
-                            "question._"
-                        ),
+                        "text": ("⚠️ _Unable to submit feedback. Please try asking a new " "question._"),
                     },
                 }
             ],
@@ -458,10 +455,7 @@ def test_genie_error_updates_thinking_message_with_apology():
         {
             "channel": "D123",
             "ts": "1001",
-            "text": (
-                "Sorry, I encountered an error processing your request. "
-                "Please try again."
-            ),
+            "text": ("Sorry, I encountered an error processing your request. " "Please try again."),
         }
     ]
 

--- a/tests/apps/genie_tools/__init__.py
+++ b/tests/apps/genie_tools/__init__.py
@@ -5,8 +5,6 @@ from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)
 
-APP_PACKAGE = (
-    Path(__file__).resolve().parents[3] / "apps" / "genie-tools" / "src" / "genie_tools"
-)
+APP_PACKAGE = Path(__file__).resolve().parents[3] / "apps" / "genie-tools" / "src" / "genie_tools"
 if str(APP_PACKAGE) not in __path__:
     __path__.append(str(APP_PACKAGE))

--- a/tests/apps/genie_tools/test_genie_tools.py
+++ b/tests/apps/genie_tools/test_genie_tools.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+
 from genie_tools import cli
 from genie_tools.export_space import FetchedSpace, export_space_bundle
 from genie_tools.normalize_space import normalize_space_config
@@ -146,9 +147,7 @@ def test_export_space_bundle_writes_expected_files(tmp_path):
         )
 
     raw_payload = json.loads(artifacts.raw_path.read_text(encoding="utf-8"))
-    normalized_payload = json.loads(
-        artifacts.normalized_path.read_text(encoding="utf-8")
-    )
+    normalized_payload = json.loads(artifacts.normalized_path.read_text(encoding="utf-8"))
     redacted_payload = json.loads(artifacts.redacted_path.read_text(encoding="utf-8"))
     metadata_payload = json.loads(artifacts.metadata_path.read_text(encoding="utf-8"))
 
@@ -166,9 +165,7 @@ def test_cli_export_command_writes_files_and_reports_paths(tmp_path, capsys):
 
     with patch(
         "genie_tools.export_space.fetch_space_record",
-        return_value=FetchedSpace(
-            payload=payload, metadata={"requested_space_id": "s"}
-        ),
+        return_value=FetchedSpace(payload=payload, metadata={"requested_space_id": "s"}),
     ):
         exit_code = cli.main(
             [


### PR DESCRIPTION
Step 1 of `docs/superpowers/specs/2026-06-04-monorepo-per-directory-ci-design.md`.

## What
- Adds a root `ruff.toml`: line length 110, conservative lint set `E,F,I`, `ignore = ["E501"]`, and a per-file `F821` ignore for the dbt Databricks model scripts (the `dbutils` runtime global, which the old flake8 also ignored).
- Swaps the pre-commit `black`/`isort`/`flake8` hooks for `ruff` + `ruff-format`. Keeps `mypy` and `sqlfmt`. Drops the redundant local `pytest` hook (`python_tests.yml` still runs the tests).
- One-time mechanical reformat of the existing Python (55 files). The 3 lint auto-fixes are all I001 import-consolidation (behavior-preserving). `people-api-loader/` is unchanged: it keeps its own fuller ruff config via `pyproject.toml`, applied hierarchically.

## Scope
Conservative by design. The opinionated rules (`UP,B,SIM,RUF`) and per-directory workflows + test colocation are later steps that ratchet in per directory. `mypy` is retired per-directory later, not here (avoids a type-check gap).

## Verification
`pre-commit run --all-files` passes all hooks (ruff, ruff-format, mypy, sqlfmt, generic). `ruff check` / `ruff format --check` clean. Reviewed for spec compliance and that the reformat is purely mechanical (no logic/string/literal changes).

The large diff is the one-time reformat.