### PR TITLE
Point clustered_candidacy_stages source at unsuffixed table

### DIFF
--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -1530,11 +1530,6 @@ sources:
 
     tables:
       - name: clustered_candidacy_stages
-        # Date-suffixed snapshot from the 2026-05-27 matcha run, promoted
-        # as part of DATA-1523 (Phase 3) to use cluster assignments derived
-        # from the post-Phase-2 parsed candidate codes. Update the identifier
-        # when promoting a new run; staging models stay unchanged.
-        identifier: clustered_candidacy_stages20260527
         description: >
           Cluster assignments produced by Splink's connected-components clustering
           (threshold: 0.95 match probability). Each row is a single candidacy-stage record


### PR DESCRIPTION
## Problem

\`stg_er_source__clustered_candidacy_stages\` was resolving to \`er_source.clustered_candidacy_stages20260527\` in Databricks instead of \`er_source.clustered_candidacy_stages\`.

The source's logical name is \`clustered_candidacy_stages\`, but its definition in \`__sources.yaml\` carried an \`identifier: clustered_candidacy_stages20260527\` override. dbt resolves a source to its \`identifier\`, so \`source("er_source", "clustered_candidacy_stages")\` physically read the date-suffixed snapshot. The override was added to pin to a specific matcha run.

## Fix

Remove the \`identifier\` override so the source resolves to the rolling \`er_source.clustered_candidacy_stages\` table.

## Verification

- Target table exists and is newer/larger: 130,508 rows / 106,215 clusters vs 122,022 / 101,956 in the pinned snapshot.
- All 23 columns selected by the staging model exist in the target table.
- \`dbt build --select stg_er_source__clustered_candidacy_stages\` passes: 1 model + 8 tests, 0 warnings, 0 errors.
- Compiled SQL confirmed to read \`er_source.clustered_candidacy_stages\`.

Note: the sibling \`pairwise_candidacy_stages\` source still carries the same \`...20260527\` identifier pin. Left unchanged here since it was out of scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches entity-resolution cluster input for downstream civics canonical-ID logic; behavior is intentional but cluster assignments can differ from the old pinned snapshot.
> 
> **Overview**
> **Points the `er_source.clustered_candidacy_stages` dbt source at the rolling Databricks table** instead of the pinned `clustered_candidacy_stages20260527` snapshot.
> 
> The PR removes the `identifier` override (and the inline comment about promoting dated matcha runs) from `__sources.yaml`, so `source('er_source', 'clustered_candidacy_stages')` and `stg_er_source__clustered_candidacy_stages` compile to `er_source.clustered_candidacy_stages` with no staging SQL changes. **`pairwise_candidacy_stages` is unchanged** and still uses `pairwise_candidacy_stages20260527`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a1bfb0fd285826440596966c86303534c7eeee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->