### PR TITLE
calib(data): one-and-done engagement facts + try_cast join gotcha

### DIFF
--- a/.claude/skills/win-analytics-knowledge/references/engagement.md
+++ b/.claude/skills/win-analytics-knowledge/references/engagement.md
@@ -49,6 +49,8 @@ Both are recomputed from durable, version-agnostic events; do NOT use the stored
 
 Raw "any Win-product Amplitude evidence" (≥1 candidate-attributed event) reads high (~79% for Nov-2025) but is heavily padded by the one-off registration event `Onboarding - User Created`: ~45% of that cohort had *only* that single event and nothing else. When characterizing engagement, report **"engaged beyond account creation"** (≥2 distinct candidate-attributed events, ~34% for Nov-2025) alongside raw any-evidence — the former is the meaningful floor, the latter is barely above "registered."
 
+The signup-anchored, forward-window analog is **"one-and-done"**: signed up but produced zero candidate-attributed activity on any calendar day *after* the signup day (anchor `users_win_candidacy.user_created_at`, version-agnostic). For the 2026 signup cohort (≥14d tenure, N=4,123, *verified 2026-06-09; drifts*): **one-and-done = 67.6%** under the hygiene filter, **73.1%** under `is_win`-only attribution; only ~3% have zero events at all (so it is behavioral, not a coverage gap). The complement — "returned after signup day" — is ~32%, vs ~97% on any-evidence: a registered / has-any-activity count overstates real adoption by roughly 3x. This is population-wide across acquisition channels, not a paid-signup composition artifact.
+
 ## Amplitude event landscape
 
 ### The modeling layers

--- a/.claude/skills/win-analytics-knowledge/references/joins.md
+++ b/.claude/skills/win-analytics-knowledge/references/joins.md
@@ -20,7 +20,7 @@ Part of the **win-analytics-knowledge** skill. The ID landscape and canonical jo
 
 | Concept | Field | Where it lives | Notes |
 |---|---|---|---|
-| **Win user (product)** | `user_id` (BIGINT) | `users.user_id`, `users_win_*.user_id`, `int__amplitude_*.user_id` | Cast from Amplitude string `user_id` at the staging→intermediate boundary; non-numeric or empty IDs excluded. |
+| **Win user (product)** | `user_id` (BIGINT) | `users.user_id`, `users_win_*.user_id`, `int__amplitude_*.user_id` | Cast from Amplitude string `user_id` at the staging→intermediate boundary; non-numeric or empty IDs excluded. When querying raw `stg_airbyte_source__amplitude_api_events` directly (ad-hoc, BIGINT marts), use `try_cast(user_id as bigint) is not null` — **not** `where user_id rlike '^[0-9]+$' ... cast(user_id as bigint)`, which Spark can reorder so the cast runs before the regex filter and raises `CAST_INVALID_INPUT` on Firebase-style ids. |
 | **Win campaign (product)** | `campaign_id` (string) | `campaigns.campaign_id`, `users_win_candidacy.campaign_id`, `candidacy.product_campaign_id` | A campaign can have multiple historical versions (`campaign_version_id`) if the user reused it across cycles. |
 | **Campaign version** | `campaign_version_id` (string) | `users_win_candidacy.campaign_version_id` | Grain of `users_win_candidacy`. Pre-filter to `is_latest_version` for canonical rows. |
 | **Candidacy (GP-internal)** | `gp_candidacy_id` (uuid) | `candidacy.gp_candidacy_id`, `candidacy_stage.gp_candidacy_id` | Hashed UUID. Stable across providers via ER crosswalk in `int__civics_er_canonical_ids`. |


### PR DESCRIPTION
Data-calibration edits from the 2026-06-09 calibration log (2026 signup one-and-done analysis). Track: data.

## Findings

- **T1-b (data-state) — engagement.md.** Add the signup-anchored, forward-window "one-and-done" metric to the "any evidence vs engaged beyond account creation" section. 2026 signup cohort (≥14d tenure, N=4,123): 67.6% under the hygiene filter, 73.1% under `is_win`-only; ~3% coverage floor (so behavioral). Hedged with verification date since it drifts.
- **T1-a (universal) — joins.md.** Sharpen the Win `user_id` row: when querying raw `stg_airbyte_source__amplitude_api_events` directly, use `try_cast(user_id as bigint) is not null` rather than `rlike '^[0-9]+$'` then `cast`, which Spark can reorder into a `CAST_INVALID_INPUT` on non-numeric ids.

## Files
- `.claude/skills/win-analytics-knowledge/references/engagement.md`
- `.claude/skills/win-analytics-knowledge/references/joins.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill reference updates; no runtime, SQL, or pipeline changes.
> 
> **Overview**
> Documentation-only calibration for the **win-analytics-knowledge** skill from the 2026-06-09 data log.
> 
> **engagement.md** extends the “any evidence vs engaged beyond account creation” section with the signup-anchored **one-and-done** metric (no candidate-attributed activity after signup day, anchored on `users_win_candidacy.user_created_at`). It documents 2026 signup cohort rates (~67.6% / 73.1% by attribution), notes the ~3% zero-event floor, and warns that “any evidence” overstates adoption vs “returned after signup day” by ~3x.
> 
> **joins.md** adds a Spark-safe pattern for filtering numeric Win `user_id` on raw `stg_airbyte_source__amplitude_api_events`: prefer **`try_cast(user_id as bigint) is not null`** instead of regex-then-`cast`, which Spark can reorder and break on Firebase-style ids with `CAST_INVALID_INPUT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cb519ac01da316c94eed97b3520f03f7a12049. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->