### PR TITLE
Restore .tickets/ to .gitignore (inadvertently dropped by #432)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ analytics/ad_hoc/
 # itself. See the win-analytics-process skill's references/calibration.md for the convention.
 analytics/runbook/CALIBRATION_*.md
 
+# Per-ticket working notes (plans, prompts, validation outputs) — personal
+# local scratch, never tracked.
+.tickets/
+
 # Entity resolution local data and results
 entity_resolution/data/
 entity_resolution/results/*.csv


### PR DESCRIPTION
## Summary
`.tickets/` is the per-ticket local working-notes convention (plans, prompts, validation outputs) — personal scratch that should never be tracked. It was ignored on `main` (added in #147) until **#432 (ER first-name preprocessing) inadvertently removed the rule** from `.gitignore`. That PR's purpose was unrelated to ignores, so this was almost certainly a stray revert during a merge/rebase.

Effect of the regression on current `main`: everyone now sees their local `.tickets/` contents as untracked — cluttering Source Control and exposed to a stray `git add -A`. This restores the one-line rule, with an intent comment matching the file's existing style (alongside `analytics/ad_hoc/`, `CALIBRATION_*.md`).

## Test plan
- [x] Rule present in committed tree: `git show HEAD:.gitignore | grep tickets` → `.tickets/`
- [x] Resolves as ignored; `.tickets/` no longer appears in `git status`
- [x] Pure ignore restore — `git ls-files .tickets/` was already empty, so no tracked files are affected
- [x] pre-commit hooks pass (trailing-whitespace, end-of-files, mixed-line-ending, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore-only change with no tracked files under `.tickets/`; no runtime or deployment impact.
> 
> **Overview**
> Restores the **`.tickets/`** ignore rule (and matching comment) that was dropped in #432. That directory holds per-ticket local working notes and should stay untracked so Source Control stays clean and accidental `git add` is less likely.
> 
> No application or build behavior changes—only ignore policy aligned with existing conventions like `analytics/ad_hoc/` and `CALIBRATION_*.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9601ccd2317e1a039fd98906b32f4d61ff4e54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->