### PR TITLE
[DATA-1975] Expose ICP win/serve flags at Position level

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -224,6 +224,24 @@ models:
                   - REGIONAL
                   - STATE
                   - TOWNSHIP
+      - name: is_win_icp
+        description: >
+          ICP-Office-Win flag from int__icp_offices (icp_office_win). True when
+          the office is Win-ICP eligible, false when ineligible, null when the
+          office's voter_count is unknown. Ungated office-level flag.
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: is_serve_icp
+        description: >
+          ICP-Office-Serve flag from int__icp_offices (icp_office_serve). True
+          when the office is Serve-ICP eligible, false when ineligible, null
+          when the office's voter_count is unknown.
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
 
   - name: m_election_api__projected_turnout
     description: Turnout projections data load from model predictions

--- a/dbt/project/models/marts/election_api/m_election_api__position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__position.sql
@@ -117,40 +117,63 @@ with
             {% if is_incremental() %}
                 and tbl_position.updated_at > (select max(updated_at) from {{ this }})
             {% endif %}
+    ),
+
+    all_positions as (
+        select
+            id,
+            br_database_id,
+            br_position_id,
+            name,
+            state,
+            level,
+            district_id,
+            created_at,
+            updated_at
+        from matched_positions
+        union all
+        select
+            id,
+            br_database_id,
+            br_position_id,
+            name,
+            state,
+            level,
+            district_id,
+            created_at,
+            updated_at
+        from override_injected_positions
+        union all
+        select
+            id,
+            br_database_id,
+            br_position_id,
+            name,
+            state,
+            level,
+            district_id,
+            created_at,
+            updated_at
+        from unmatched_br_positions
     )
 
+-- ICP win/serve are office-eligibility flags joined from int__icp_offices on
+-- the BallotReady position id. Intentionally nullable (null = the office's
+-- voter_count is unknown). Not date-gated: a position is not tied to a single
+-- election, so consumers gate per-race if they need that.
 select
-    id,
-    br_database_id,
-    br_position_id,
-    name,
-    state,
-    level,
-    district_id,
-    created_at,
-    updated_at
-from matched_positions
-union all
-select
-    id,
-    br_database_id,
-    br_position_id,
-    name,
-    state,
-    level,
-    district_id,
-    created_at,
-    updated_at
-from override_injected_positions
-union all
-select
-    id,
-    br_database_id,
-    br_position_id,
-    name,
-    state,
-    level,
-    district_id,
-    created_at,
-    updated_at
-from unmatched_br_positions
+    all_positions.id,
+    all_positions.br_database_id,
+    all_positions.br_position_id,
+    all_positions.name,
+    all_positions.state,
+    all_positions.level,
+    all_positions.district_id,
+    all_positions.created_at,
+    all_positions.updated_at,
+    icp.icp_office_win as is_win_icp,
+    icp.icp_office_serve as is_serve_icp
+from all_positions
+left join
+    {{ ref("int__icp_offices") }} as icp
+    on all_positions.br_database_id = icp.br_database_position_id

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -132,7 +132,9 @@ POSITION_UPSERT_QUERY = """
         name,
         state,
         level,
-        district_id
+        district_id,
+        is_win_icp,
+        is_serve_icp
     )
     SELECT
         id::uuid,
@@ -141,7 +143,9 @@ POSITION_UPSERT_QUERY = """
         name,
         state,
         level::\"PositionLevel\",
-        district_id::uuid
+        district_id::uuid,
+        is_win_icp,
+        is_serve_icp
     FROM {staging_schema}."Position"
     ON CONFLICT (id) DO UPDATE SET
         br_database_id = EXCLUDED.br_database_id,
@@ -149,7 +153,9 @@ POSITION_UPSERT_QUERY = """
         name = EXCLUDED.name,
         state = EXCLUDED.state,
         level = EXCLUDED.level,
-        district_id = EXCLUDED.district_id
+        district_id = EXCLUDED.district_id,
+        is_win_icp = EXCLUDED.is_win_icp,
+        is_serve_icp = EXCLUDED.is_serve_icp
 """
 ISSUE_UPSERT_QUERY = """
     INSERT INTO {db_schema}."Issue" (


### PR DESCRIPTION
## What

Expose office-level ICP eligibility at the Position grain so the election-api can serve `is_win_icp` / `is_serve_icp`.

- `m_election_api__position.sql`: wrap the existing three-way union in an `all_positions` CTE and left join `int__icp_offices` on `br_database_id = br_database_position_id`, projecting `icp_office_win as is_win_icp` and `icp_office_serve as is_serve_icp`.
- `write__election_api_db.py`: add both columns to `POSITION_UPSERT_QUERY` (insert list, select, and `ON CONFLICT DO UPDATE`).
- `m_election_api.yaml`: document both columns and add `accepted_values: [true, false]` tests.

## Decisions

- **Nullable** flags. Null = the office's `voter_count` is unknown, matching `int__icp_offices` and the civics mart. We preserve the true/false/unknown distinction rather than collapsing null to false.
- **Ungated** win flag. Positions have no election dates, so the position-level `is_win_icp` is the raw office-eligibility flag (not the date-gated candidacy-level flag in the civics mart). Consumers gate per-race if needed.

## Notes

- The mart is incremental on `position.updated_at`. An ICP change driven only by upstream district `voter_count` or the `icp_normalized_position_names` seed (no position update) will not re-emit the row until that position next updates. Acceptable for now; flagging so it's a conscious choice.
- Paired change in election-api adds the `isWinIcp` / `isServeIcp` columns + migration. The election-api migration must deploy before this write model runs with the new upsert.

`dbt compile --select m_election_api__position` passes (refs resolve, join is valid).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the election-api Postgres load path and requires schema migration ordering; changes are additive but affect a core API entity.
> 
> **Overview**
> Adds **office-level ICP Win/Serve eligibility** to the election-api **Position** mart and syncs those fields into Postgres.
> 
> `m_election_api__position` now unions the three existing position sources into an `all_positions` CTE, then **left joins** `int__icp_offices` on BallotReady position id to expose **`is_win_icp`** and **`is_serve_icp`** (mapped from `icp_office_win` / `icp_office_serve`). Both stay **nullable** when office `voter_count` is unknown, and the win flag is **ungated** at the position grain (no election-date logic—callers gate per race if needed).
> 
> `write__election_api_db.py` extends **`POSITION_UPSERT_QUERY`** so inserts and `ON CONFLICT` updates include the new columns. Schema docs add column descriptions and `accepted_values` tests for true/false (nulls allowed).
> 
> **Deploy note:** the paired election-api DB migration must land **before** this write job runs with the expanded upsert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dbc537c7a5b5e054201ae6ab645a21930b0a316. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->