### PR TITLE
analytics: profile-based Databricks auth, drop PAT and gp-ai-projects shim

### DIFF
--- a/.claude/skills/win-analytics-knowledge/references/engagement.md
+++ b/.claude/skills/win-analytics-knowledge/references/engagement.md
@@ -109,7 +109,7 @@ UTM lives only in the `user_properties` JSON on `stg_airbyte_source__amplitude_a
 
 The pattern: read raw events from `stg_airbyte_source__amplitude_api_events`, filter to the relevant family + window, aggregate to `user_id × time bucket` or `user_id × funnel step`. Mirror the structure of `int__amplitude_user_milestones` (user-grain milestones) or `int__amplitude_win_activity` (per-month aggregates).
 
-Reusable Python pull-script template at `analytics/projects/win_outcomes_scout/notebooks/_pull_amplitude_universe.py` (uses `databricks-sql-connector` via the global env vars — see user-level CLAUDE.md). The reusable build-once-slice-many helper is `analytics/lib/win_analysis.py` (see the process skill's `methodology.md`).
+Reusable Python pull-script template at `analytics/projects/win_outcomes_scout/notebooks/_pull_amplitude_universe.py`. Connect via the profile-auth helper `analytics/lib/databricks_conn.py` (`run_query`, authenticates via the `~/.databrickscfg` profile). The reusable build-once-slice-many helper is `analytics/lib/win_analysis.py` (see the process skill's `methodology.md`).
 
 ## Cross-references
 

--- a/.claude/skills/win-analytics-process/references/methodology.md
+++ b/.claude/skills/win-analytics-process/references/methodology.md
@@ -108,7 +108,7 @@ dbt show --inline "SELECT ... FROM goodparty_data_catalog.<schema>.<table> WHERE
 
 Per project memory: hit `goodparty_data_catalog.*` directly. `ref()` can resolve to stale dev artifacts. Prod schemas: `dbt` (staging + intermediates; the legacy `dbt_staging` schema is being retired, everything is consolidating into `dbt`), `mart_analytics` / `mart_civics` (marts), `model_predictions` (MLflow outputs).
 
-For larger query results that exceed `dbt show` truncation, use the `databricks-sql-connector` Python client via the global env vars (see user-level CLAUDE.md). Pattern in `analytics/projects/win_outcomes_scout/notebooks/_pull_amplitude_universe.py`.
+For larger query results that exceed `dbt show` truncation, run SQL through the profile-auth helper `analytics/lib/databricks_conn.py` (`run_query(sql) -> DataFrame`, authenticates via the `~/.databrickscfg` profile, set up with `databricks auth login`). Pull-script pattern in `analytics/projects/win_outcomes_scout/notebooks/_pull_amplitude_universe.py`.
 
 ## Binning conventions
 

--- a/analytics/lib/README.md
+++ b/analytics/lib/README.md
@@ -32,14 +32,16 @@ shared by the dbt models and notebooks. See the win-analytics-knowledge skill's
 ## Usage from a notebook
 
 This module is connection-agnostic: you inject a `run_query(sql) -> DataFrame`
-callable. With the gp-ai-projects shared client:
+callable. The repo-standard connection is the profile-auth helper
+`databricks_conn.py`, which authenticates via the `~/.databrickscfg` profile
+(`databricks auth login`) with no PAT and no cross-repo dependency:
 
 ```python
 import sys; sys.path.insert(0, "analytics/lib")   # adjust to repo-relative path
-from shared.databricks_client import DatabricksClient   # via uv run --project ../gp-ai-projects
+import databricks_conn as dbc
 import win_analysis as wa
 
-run_query = DatabricksClient().execute_query
+run_query = dbc.run_query
 cohorts = {
     "nov2025_general": {
         "filter": "general_election_date BETWEEN '2025-11-01' AND '2025-11-30'",

--- a/analytics/lib/databricks_conn.py
+++ b/analytics/lib/databricks_conn.py
@@ -1,0 +1,129 @@
+"""Profile-based Databricks connection for analytics notebooks and scripts.
+
+Provides a ``run_query(sql) -> pandas.DataFrame`` callable to inject into the
+connection-agnostic helpers in ``win_analysis.py``. It is the analytics
+counterpart of ``matcha/scripts/databricks_io.py`` and
+``airflow/.../databricks_utils.py``: SQL runs through ``databricks-sql-connector``
+and auth is resolved by the Databricks SDK ``Config`` via ``credentials_provider``,
+so there is no personal access token and no cross-repo dependency on the
+gp-ai-projects ``DatabricksClient``.
+
+Auth mirrors matcha: if the SDK ``Config`` carries a service-principal
+``client_id`` / ``client_secret`` (e.g. CI), it uses OAuth M2M; otherwise it uses
+the ``~/.databrickscfg`` CLI / SDK default profile (``databricks auth login``,
+honoring ``DATABRICKS_CONFIG_PROFILE``). The connector and SDK imports are lazy so
+the pure helpers import with only pandas present.
+
+Usage from a notebook::
+
+    import sys; sys.path.insert(0, "analytics/lib")
+    import databricks_conn as dbc
+    import win_analysis as wa
+
+    df = wa.build_win_working_set(dbc.run_query, cohorts)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Callable, Sequence
+
+import pandas as pd
+
+
+def _server_hostname(host: str | None) -> str:
+    """Return the bare ``server_hostname`` the sql-connector expects.
+
+    The SDK ``Config.host`` is a full URL (``https://<host>``); the connector
+    wants the host with no scheme and no trailing slash.
+    """
+    if not host:
+        raise ValueError("Databricks profile resolved an empty host. Run `databricks auth login`.")
+    return host.removeprefix("https://").removeprefix("http://").rstrip("/")
+
+
+def _build_connect_kwargs(config: Any, http_path: str, *, oauth_m2m: Callable[[Any], Any]) -> dict:
+    """Return kwargs for ``databricks_sql.connect()``.
+
+    Mirrors ``matcha/scripts/databricks_io.py``: scheme-stripped host, the SQL
+    warehouse ``http_path``, and a ``credentials_provider`` chosen by auth mode.
+    With a service-principal ``client_id`` / ``client_secret`` it uses OAuth M2M;
+    otherwise the SDK default (``~/.databrickscfg`` profile).
+    """
+    if not http_path:
+        raise ValueError("DATABRICKS_HTTP_PATH is not set (expected /sql/1.0/warehouses/<id>).")
+
+    if config.client_id and config.client_secret:
+
+        def credentials():
+            return oauth_m2m(config)
+    else:
+
+        def credentials():
+            return config.authenticate
+
+    return {
+        "server_hostname": _server_hostname(config.host),
+        "http_path": http_path,
+        "credentials_provider": credentials,
+    }
+
+
+def _connect_with_retry(
+    connect_fn: Callable[..., Any],
+    kwargs: dict,
+    *,
+    max_retries: int = 5,
+    retry_delay: int = 10,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> Any:
+    """Open a connection, retrying on failure to absorb SQL-warehouse cold start.
+
+    Sleeps ``retry_delay`` seconds between attempts; re-raises the last error
+    after ``max_retries`` attempts.
+    """
+    for attempt in range(max_retries):
+        try:
+            return connect_fn(**kwargs)
+        except Exception:
+            if attempt == max_retries - 1:
+                raise
+            sleep_fn(retry_delay)
+    raise RuntimeError("unreachable")
+
+
+def _to_dataframe(description: Sequence[Any], rows: Sequence[Any]) -> pd.DataFrame:
+    """Build a DataFrame from a cursor ``description`` and fetched ``rows``.
+
+    Column names come from the first element of each ``description`` entry,
+    matching the DB-API shape the sql-connector cursor exposes.
+    """
+    columns = [col[0] for col in description]
+    return pd.DataFrame(list(rows), columns=columns)
+
+
+def run_query(sql: str, *, max_retries: int = 5, retry_delay: int = 10) -> pd.DataFrame:
+    """Execute ``sql`` against the profile's SQL warehouse, return a DataFrame.
+
+    Auth is resolved by the SDK ``Config`` (M2M service principal if configured,
+    else the ``~/.databrickscfg`` profile). The SQL warehouse comes from
+    ``DATABRICKS_HTTP_PATH`` (``/sql/1.0/warehouses/<id>``).
+    """
+    from databricks import sql as dbsql
+    from databricks.sdk.core import Config, oauth_service_principal
+
+    config = Config()
+    kwargs = _build_connect_kwargs(
+        config,
+        os.environ.get("DATABRICKS_HTTP_PATH", ""),
+        oauth_m2m=oauth_service_principal,
+    )
+    connection = _connect_with_retry(dbsql.connect, kwargs, max_retries=max_retries, retry_delay=retry_delay)
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            rows = cursor.fetchall()
+            return _to_dataframe(cursor.description, rows)
+    finally:
+        connection.close()

--- a/analytics/lib/win_analysis.py
+++ b/analytics/lib/win_analysis.py
@@ -10,8 +10,8 @@ split is retired in favor of that single date cutoff -- run with a different
 cutoff for a sensitivity check.
 
 This module is connection-agnostic: callers inject a ``run_query(sql) -> DataFrame``
-callable, so it works equally with the gp-ai-projects ``DatabricksClient`` or an
-inline ``databricks.sql.connect`` cursor.
+callable. The repo-standard one is ``databricks_conn.run_query`` (profile auth via
+``~/.databrickscfg``); any ``run_query(sql) -> DataFrame`` callable works.
 """
 
 from __future__ import annotations

--- a/analytics/tests/test_databricks_conn.py
+++ b/analytics/tests/test_databricks_conn.py
@@ -1,0 +1,137 @@
+"""Tests for analytics/lib/databricks_conn.py.
+
+Covers the testable units of the profile-auth connection helper: scheme
+stripping, the cursor description+rows to DataFrame mapping, the
+connect-kwargs builder (including the M2M vs U2M auth branch), and the
+cold-start retry. The actual network ``databricks.sql.connect`` call inside
+``run_query`` is thin glue and is not unit tested.
+"""
+
+from types import SimpleNamespace
+
+import databricks_conn as dc
+import pytest
+
+
+def test_server_hostname_strips_https_scheme():
+    assert dc._server_hostname("https://dbc-3d8ca484.cloud.databricks.com") == (
+        "dbc-3d8ca484.cloud.databricks.com"
+    )
+
+
+def test_server_hostname_strips_trailing_slash():
+    assert dc._server_hostname("https://dbc-x.cloud.databricks.com/") == ("dbc-x.cloud.databricks.com")
+
+
+def test_server_hostname_passes_through_bare_host():
+    assert dc._server_hostname("dbc-x.cloud.databricks.com") == ("dbc-x.cloud.databricks.com")
+
+
+def test_server_hostname_rejects_empty():
+    with pytest.raises(ValueError):
+        dc._server_hostname(None)
+
+
+def test_to_dataframe_uses_description_columns():
+    # sql-connector cursor.description is a list of 7-tuples; col name is [0].
+    description = [
+        ("user_id", None, None, None, None, None, None),
+        ("n_events", None, None, None, None, None, None),
+    ]
+    rows = [("u1", 3), ("u2", 7)]
+    df = dc._to_dataframe(description, rows)
+    assert list(df.columns) == ["user_id", "n_events"]
+    assert df.shape == (2, 2)
+    assert df.loc[1, "user_id"] == "u2"
+    assert df.loc[1, "n_events"] == 7
+
+
+def test_to_dataframe_empty_rows_keeps_columns():
+    description = [("a", None, None, None, None, None, None), ("b", None, None, None, None, None, None)]
+    df = dc._to_dataframe(description, [])
+    assert list(df.columns) == ["a", "b"]
+    assert df.empty
+
+
+def _fake_oauth(config):
+    return f"m2m-provider-for-{config.client_id}"
+
+
+def test_build_connect_kwargs_strips_host_and_passes_http_path():
+    config = SimpleNamespace(
+        host="https://dbc-x.cloud.databricks.com",
+        client_id=None,
+        client_secret=None,
+        authenticate="u2m-header-factory",
+    )
+    kwargs = dc._build_connect_kwargs(config, "/sql/1.0/warehouses/abc", oauth_m2m=_fake_oauth)
+    assert kwargs["server_hostname"] == "dbc-x.cloud.databricks.com"
+    assert kwargs["http_path"] == "/sql/1.0/warehouses/abc"
+    assert callable(kwargs["credentials_provider"])
+
+
+def test_build_connect_kwargs_rejects_empty_http_path():
+    config = SimpleNamespace(host="https://h", client_id=None, client_secret=None, authenticate="x")
+    with pytest.raises(ValueError):
+        dc._build_connect_kwargs(config, "", oauth_m2m=_fake_oauth)
+
+
+def test_build_connect_kwargs_u2m_uses_config_authenticate():
+    config = SimpleNamespace(
+        host="https://h",
+        client_id=None,
+        client_secret=None,
+        authenticate="u2m-header-factory",
+    )
+    kwargs = dc._build_connect_kwargs(config, "/p", oauth_m2m=_fake_oauth)
+    # U2M: the provider yields the SDK Config.authenticate header factory.
+    assert kwargs["credentials_provider"]() == "u2m-header-factory"
+
+
+def test_build_connect_kwargs_m2m_uses_oauth_service_principal():
+    config = SimpleNamespace(
+        host="https://h",
+        client_id="sp-client",
+        client_secret="sp-secret",
+        authenticate="should-not-be-used",
+    )
+    kwargs = dc._build_connect_kwargs(config, "/p", oauth_m2m=_fake_oauth)
+    # M2M: client_id + client_secret present, so the provider yields the
+    # service-principal OAuth provider, not config.authenticate.
+    assert kwargs["credentials_provider"]() == "m2m-provider-for-sp-client"
+
+
+def test_connect_with_retry_succeeds_after_transient_failures():
+    attempts = {"n": 0}
+    slept = []
+
+    def flaky_connect(**_kwargs):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise ConnectionError("warehouse cold start")
+        return "connection"
+
+    conn = dc._connect_with_retry(
+        flaky_connect,
+        {"server_hostname": "h"},
+        max_retries=5,
+        retry_delay=7,
+        sleep_fn=slept.append,
+    )
+    assert conn == "connection"
+    assert attempts["n"] == 3
+    assert slept == [7, 7]  # slept between the two failed attempts, not after success
+
+
+def test_connect_with_retry_raises_after_max_retries():
+    def always_fails(**_kwargs):
+        raise ConnectionError("down")
+
+    with pytest.raises(ConnectionError):
+        dc._connect_with_retry(
+            always_fails,
+            {},
+            max_retries=3,
+            retry_delay=0,
+            sleep_fn=lambda _d: None,
+        )


### PR DESCRIPTION
## Summary

Migrates the analytics pipeline's Databricks connection off the PAT env var and the cross-repo gp-ai-projects `DatabricksClient` onto the repo-standard profile-based SDK auth, matching `matcha` and `airflow`. Analytics was the last Databricks consumer still on a PAT.

## What changed

- New `analytics/lib/databricks_conn.py`: `run_query(sql) -> DataFrame` via `databricks-sql-connector` with SDK `Config` `credentials_provider`. Mirrors `matcha/scripts/databricks_io.py`, including the M2M (service principal, e.g. CI) vs U2M (`~/.databrickscfg` profile) auth branch and a cold-start retry. Keeps `fetchall` rather than matcha's arrow path because analytics ships no pyarrow. Local file (not a shared import) per the multi-venv rule.
- Repointed the injection points off the PAT patterns: `analytics/lib/README.md`, the `win_analysis.py` docstring, and the `win-analytics-process` / `win-analytics-knowledge` skill run-query guidance. `win_analysis.py` stays connection-agnostic.
- Tests in `analytics/tests/test_databricks_conn.py`: scheme stripping, cursor-to-DataFrame mapping, the M2M/U2M auth branch, and the retry loop.

## Verification

- `analytics` suite: 31 passed. ruff check + format clean. mypy clean (pre-commit).
- Live `SELECT 1` round-trip with `DATABRICKS_API_KEY` unset returns the correct row through profile OAuth, confirming the PAT is no longer used.

## Follow-up (not in this PR)

The user-level CLAUDE.md still documents the PAT env-var wiring as the Databricks standard, which is now stale for the analytics path. Flagged for a later personal-doc update; intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local analytics connectivity and documentation only; no production data pipeline or auth policy changes beyond dropping PAT for this path.
> 
> **Overview**
> **Adds profile-based Databricks SQL access for analytics** and removes the PAT / cross-repo `gp-ai-projects` `DatabricksClient` path from the documented workflow.
> 
> New **`analytics/lib/databricks_conn.py`** exposes `run_query(sql) -> DataFrame` via `databricks-sql-connector`, with SDK `Config` auth (service-principal OAuth M2M when `client_id`/`client_secret` are set, otherwise `~/.databrickscfg` from `databricks auth login`), `DATABRICKS_HTTP_PATH` for the warehouse, and retries for cold-start failures—aligned with matcha/airflow patterns.
> 
> **Docs and injection points** now steer notebooks and skills to `dbc.run_query` instead of global PAT env vars: `analytics/lib/README.md`, `win_analysis.py` docstring, and win-analytics **engagement** / **methodology** references. `win_analysis.py` remains connection-agnostic.
> 
> **`analytics/tests/test_databricks_conn.py`** unit-tests hostname normalization, cursor→DataFrame mapping, M2M vs user auth kwargs, and the retry loop (not live `connect`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67f48cf3c8931b0a667abf05db7d59ed61be6c5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->