### PR TITLE
[DATA-1972] office_type quick win: prefer BR in mart coalesce

### DIFF
--- a/dbt/project/macros/variable_standardization/office_standardizations.sql
+++ b/dbt/project/macros/variable_standardization/office_standardizations.sql
@@ -6,7 +6,10 @@
     - BR: generate_candidate_office_from_position (ballotready_standardizations.sql)
     - DDHQ: parse_ddhq_candidate_office (ddhq_standardizations.sql)
     - TS: pre-populated in upstream model
-    - GP API: generate_candidate_office_from_position via campaigns mart
+    - GP API: candidate_office is the product DB campaign_office (raw onboarding
+      free-text), mapped here by map_office_type. NOTE: this free-text input is
+      why gp_api office_type is mostly 'Other'; DATA-1972 routes positioned rows
+      through int__civics_position_office_type instead.
 
   This macro normalizes those values into a consistent office_type.
   All comparisons use lower() so casing differences (e.g. from initcap

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -128,9 +128,15 @@ with
             -- TS wins for is_incumbent (TS: 51k populated, BR: 0); gp_api/DDHQ
             -- excluded.
             coalesce(ts.is_incumbent, br.is_incumbent) as is_incumbent,
-            -- office_type: gp_api > BR > DDHQ (TS doesn't carry it at this grain).
+            -- office_type: BR > gp_api > DDHQ. BR derives office_type from
+            -- BallotReady's normalized position name (low Other rate); gp_api
+            -- derives it from raw onboarding free-text (high Other rate), so
+            -- prefer BR when a matched BR row exists. TS carries none at this grain.
+            -- DATA-1972: PR2 supersedes this for positioned rows via the
+            -- int__civics_position_office_type crosswalk; this ordering remains
+            -- the fallback when br_position_database_id is null.
             coalesce(
-                gp_api.office_type, br.office_type, ddhq.office_type
+                br.office_type, gp_api.office_type, ddhq.office_type
             ) as office_type,
             -- br_position_database_id: gp_api > BR > TS. DDHQ doesn't carry it.
             coalesce(

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -509,11 +509,10 @@ models:
 
       - name: office_type
         description: >
-          Standardized type of office sourced from HubSpot properties.
-          Common values include School Board, City Council, Town Council,
-          Mayor, Judge, State House, State Senate, Congressional,
-          Statewide/Governor, Sheriff, Alderman, Attorney, Clerk/Treasurer,
-          County Supervisor, President, and Other.
+          Standardized office classification (map_office_type buckets).
+          Reconciled across sources with BallotReady preferred over gp_api over
+          DDHQ; BallotReady derives it from the normalized position name, while
+          gp_api derives it from raw onboarding free-text (DATA-1972).
 
       - name: candidacy_result
         description: >


### PR DESCRIPTION
First of two PRs for DATA-1972. Reorders the candidacy mart office_type coalesce to prefer BallotReady over gp_api, so matched product candidacies stop showing as 'Other'. Fixes a stale comment in office_standardizations.sql. PR2 (#478) adds the position-keyed crosswalk. See DATA-1972.

Measured impact in prod (Delta time travel, before vs after the on-merge build):

- Target population, the 576 product candidacies Splink-merged with a BallotReady row: 'Other' 568 -> 3. Redistribution: County Supervisor 0 -> 217, City Council 0 -> 214, School Board 0 -> 82, Mayor 0 -> 35, Judge 8 -> 9, Sheriff 0 -> 7, Clerk/Treasurer 0 -> 5, Town Council 0 -> 4.
- Correctness: every changed value equals the BallotReady classification derived from the official position name (0 mismatches against the BR intermediate; e.g. City Legislature -> City Council, Local School Board -> School Board, City Executive//Mayor -> Mayor).
- Safety: 0 rows lost a clean value; NULL count and total row count flat; ICP flags identical row-for-row.
- Downstream: users_win_candidacy 'Other' 23,569 -> 22,477 (-1,092 rows at campaign-version grain); leads_win_candidacy 'Other' 37,205 -> 36,642 (-563); m_election_api__race flipped 51 races from 'Other' to specific office types (26 County Supervisor, 13 City Council, 10 Clerk/Treasurer, 1 School Board, 1 Mayor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)