### PR TITLE
[DATA-1972] Position-keyed office_type crosswalk

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -2486,6 +2486,41 @@ models:
         data_tests:
           - not_null
 
+  - name: int__civics_position_office_type
+    description: >
+      One row per BallotReady position with the canonical office_type, derived
+      from the normalized position name (DATA-1972). Source of office_type for
+      positioned candidacies in the civics marts.
+    columns:
+      - name: br_position_database_id
+        description: BallotReady position database id (grain).
+        data_tests:
+          - not_null
+          - unique
+      - name: office_type
+        description: Canonical office_type for the position (map_office_type output).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Alderman
+                  - Attorney
+                  - City Council
+                  - Clerk/Treasurer
+                  - Congressional
+                  - County Supervisor
+                  - Judge
+                  - Mayor
+                  - President
+                  - School Board
+                  - Sheriff
+                  - State House
+                  - State Senate
+                  - Statewide/Governor
+                  - Town Council
+                  - Other
+
   - name: int__civics_candidate_gp_api
     description: >
       Product Database (gp_api_db) users transformed into the civics mart

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -2520,6 +2520,23 @@ models:
                   - Statewide/Governor
                   - Town Council
                   - Other
+      - name: is_office_type_fallback
+        description: >
+          True when no candidate_office could be derived for the position (no
+          normalized position name available and no position-name pattern
+          matched), making office_type the NULL-input fallback 'Other' rather
+          than a real classification. True rows mean the incremental
+          normalized-position model is lagging the position universe; the mart
+          coalesce already prevents fallback 'Other' from overriding per-source
+          values.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - false
+              config:
+                severity: warn
 
   - name: int__civics_candidate_gp_api
     description: >

--- a/dbt/project/models/intermediate/civics/int__civics_position_office_type.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_position_office_type.sql
@@ -1,0 +1,40 @@
+{{ config(materialized="table", tags=["civics"]) }}
+
+-- One row per BallotReady position (br_position_database_id) carrying the
+-- canonical office_type for that position. office_type is derived from
+-- BallotReady's normalized position name through the same two-stage transform
+-- the BR candidacy path uses:
+-- map_office_type(generate_candidate_office_from_position(name, normalized_name))
+-- so every source can inherit a single, position-stable office_type by joining
+-- on br_position_database_id (DATA-1972), instead of deriving office_type from
+-- its own free-text office string. Mirrors how int__icp_offices keys on the
+-- position. Built from the position universe (every BR position), not from BR
+-- candidacies, so positions where only a product or TechSpeed candidate ran are
+-- still covered.
+with
+    position as (
+        select database_id, name, normalized_position
+        from {{ ref("stg_airbyte_source__ballotready_api_position") }}
+    ),
+
+    normalized_position as (
+        select database_id, name from {{ ref("int__ballotready_normalized_position") }}
+    ),
+
+    with_candidate_office as (
+        select
+            position.database_id as br_position_database_id,
+            {{
+                generate_candidate_office_from_position(
+                    "position.name", "normalized_position.name"
+                )
+            }} as candidate_office
+        from position
+        left join
+            normalized_position
+            on position.normalized_position.databaseid = normalized_position.database_id
+    )
+
+select br_position_database_id, {{ map_office_type("candidate_office") }} as office_type
+from with_candidate_office
+where br_position_database_id is not null

--- a/dbt/project/models/intermediate/civics/int__civics_position_office_type.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_position_office_type.sql
@@ -35,6 +35,14 @@ with
             on position.normalized_position.databaseid = normalized_position.database_id
     )
 
-select br_position_database_id, {{ map_office_type("candidate_office") }} as office_type
+select
+    br_position_database_id,
+    {{ map_office_type("candidate_office") }} as office_type,
+    -- True when no candidate_office could be derived for the position (the
+    -- normalized-position model has no row for it and no position-name pattern
+    -- matched), making office_type the NULL-input fallback 'Other' rather than
+    -- a real classification. Expected all-false; true rows mean the incremental
+    -- normalized-position model is lagging the position universe.
+    candidate_office is null as is_office_type_fallback
 from with_candidate_office
 where br_position_database_id is not null

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -330,7 +330,17 @@ select
     deduplicated.candidate_office,
     deduplicated.official_office_name,
     deduplicated.office_level,
-    deduplicated.office_type,
+    -- DATA-1972: positioned rows inherit the canonical office_type from the
+    -- position crosswalk whenever it classifies the position (non-Other).
+    -- A per-source value survives when the crosswalk can only say 'Other',
+    -- so a clean source value is never downgraded; rows without a position
+    -- (e.g. 2025 HubSpot archive, TS-without-position) keep the per-source
+    -- value; remaining blanks fill with the crosswalk's 'Other'.
+    coalesce(
+        nullif(pos_ot.office_type, 'Other'),
+        deduplicated.office_type,
+        pos_ot.office_type
+    ) as office_type,
     deduplicated.candidacy_result,
     case
         when
@@ -383,6 +393,9 @@ from deduplicated
 left join
     {{ ref("int__icp_offices") }} as icp
     on deduplicated.br_position_database_id = icp.br_database_position_id
+left join
+    {{ ref("int__civics_position_office_type") }} as pos_ot
+    on deduplicated.br_position_database_id = pos_ot.br_position_database_id
 left join
     latest_stage_per_candidacy as latest
     on deduplicated.gp_candidacy_id = latest.gp_candidacy_id

--- a/dbt/project/models/marts/civics/election.sql
+++ b/dbt/project/models/marts/civics/election.sql
@@ -157,7 +157,16 @@ select
     deduplicated.official_office_name,
     deduplicated.candidate_office,
     deduplicated.office_level,
-    deduplicated.office_type,
+    -- DATA-1972: positioned elections inherit the canonical office_type from
+    -- the position crosswalk whenever it classifies the position (non-Other),
+    -- keeping candidacy and election marts consistent; per-source values
+    -- survive when the crosswalk can only say 'Other'; rows without a
+    -- position keep the per-source value.
+    coalesce(
+        nullif(pos_ot.office_type, 'Other'),
+        deduplicated.office_type,
+        pos_ot.office_type
+    ) as office_type,
     deduplicated.state,
     deduplicated.city,
     deduplicated.district,
@@ -218,5 +227,8 @@ from deduplicated
 left join
     {{ ref("int__icp_offices") }} as icp
     on deduplicated.br_position_database_id = icp.br_database_position_id
+left join
+    {{ ref("int__civics_position_office_type") }} as pos_ot
+    on deduplicated.br_position_database_id = pos_ot.br_position_database_id
 left join stage_dates on deduplicated.gp_election_id = stage_dates.gp_election_id
 left join gp_api_membership as gp on deduplicated.gp_election_id = gp.gp_election_id

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -510,9 +510,11 @@ models:
       - name: office_type
         description: >
           Standardized office classification (map_office_type buckets).
-          Reconciled across sources with BallotReady preferred over gp_api over
-          DDHQ; BallotReady derives it from the normalized position name, while
-          gp_api derives it from raw onboarding free-text (DATA-1972).
+          Positioned rows inherit the canonical value from
+          int__civics_position_office_type (one office_type per BallotReady
+          position, derived from the normalized position name) whenever the
+          crosswalk classifies the position; otherwise the per-source value
+          (BallotReady preferred, then gp_api, then DDHQ) is kept (DATA-1972).
 
       - name: candidacy_result
         description: >
@@ -1167,7 +1169,13 @@ models:
           may have a subset of these values.
 
       - name: office_type
-        description: Type of office (executive, legislative, judicial, etc.)
+        description: >
+          Standardized office classification (map_office_type buckets).
+          Positioned rows inherit the canonical value from
+          int__civics_position_office_type (one office_type per BallotReady
+          position, derived from the normalized position name) whenever the
+          crosswalk classifies the position; otherwise the per-source value
+          (BallotReady preferred, then gp_api, then DDHQ) is kept (DATA-1972).
 
       - name: state
         description: U.S. state for the election


### PR DESCRIPTION
Second of two PRs for DATA-1972. Adds int__civics_position_office_type (one office_type per BR position, derived from the normalized position name via the existing two-stage macro). The candidacy AND election marts inherit office_type from it by br_position_database_id via a hybrid coalesce, falling back to the per-source value when there is no position or the crosswalk can only say 'Other'. See DATA-1972.

Verified against the dbt Cloud CI preview schema (full plan battery, re-checked after the review-driven fallback-flag commit):

Crosswalk (int__civics_position_office_type)
- 285,394 rows, exactly one per BallotReady position; 0 NULL office_type; 0 fallback rows (every position currently resolves a normalized name).
- Reproduces the BallotReady candidacy derivation on 31,087 of 31,087 shared positions (0 disagreements), so BR-sourced rows are unchanged by construction.

candidacy mart, preview vs prod baseline
- gp_api candidacies 'Other': 93.2% before -> 8.2% after. The remaining 908 are all at positions whose normalized name genuinely maps to Other.
- TechSpeed-with-position NULL office_type: 13,493 before -> 0 after.
- Positions carrying 2+ distinct office_types across their candidacies: 3,455 before -> 1 after (the residual is a crosswalk-Other position where per-source values survive by design).
- Marquee races (US Senate TX/NC/IL; Governor CA/FL/GA/TX/CO): 502 candidacies, every one now Congressional or Statewide/Governor, zero 'Other' remaining.
- Safety: 0 rows that had a clean office_type became 'Other'; row count exactly equals prod; is_win_icp / is_serve_icp identical row-for-row; 48 positioned rows reference positions absent from the API position table and keep per-source values (expected, plan anticipated ~51).

election mart
- Wiring verified active (all 396,244 positioned rows join the crosswalk) with zero rows changed: the mart was already fully consistent with the crosswalk because its positioned rows derive from the same BR position path. The join is a consistency guard so candidacy and election stay aligned for the election-api surfaces if non-BR election sources appear.

Context: PR1 (#475), already in prod, fixed the 576 merged product candidacies (568 'Other' -> 3) and its downstream surfaces; this PR fixes the gp_api-only and TechSpeed populations and makes office_type position-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)