### PR TITLE
fix(analytics): unblock repo-wide pre-commit (RUF001/SIM108 in pipeline_profiler)

### DIFF
--- a/analytics/diagnostics/pipeline_profiler.py
+++ b/analytics/diagnostics/pipeline_profiler.py
@@ -210,8 +210,8 @@ def segment_stages(records: list[dict]) -> tuple[dict, str]:
         review = (reviewer, max(reviewer, rev_end))
     else:
         review = (exec_end, exec_end)  # empty
-    # calibration
-    if calib is not None:
+    # calibration  (kept as an if/else to parallel the `review` block above)
+    if calib is not None:  # noqa: SIM108
         calibration = (calib, _first_human_after(records, calib))
     else:
         calibration = (n, n)  # empty
@@ -377,12 +377,12 @@ def format_report(profiles: list[RunProfile]) -> str:
         )
         d = prof.decisions
         if d is not None:
-            revs = ", ".join(f"{k}×{v}" for k, v in sorted(d.reviewer_counts.items())) or "none"
+            revs = ", ".join(f"{k}×{v}" for k, v in sorted(d.reviewer_counts.items())) or "none"  # noqa: RUF001
             proc = ", ".join(sorted(set(d.process_design_edits))) or "none"
             lines.append("")
             lines.append(
-                f"**Decisions:** deliverable — notebook ×{d.notebook_writes} · "
-                f"analysis-script ×{d.analysis_script_writes} · nb-build ×{d.notebook_build_writes}  |  "
+                f"**Decisions:** deliverable — notebook ×{d.notebook_writes} · "  # noqa: RUF001
+                f"analysis-script ×{d.analysis_script_writes} · nb-build ×{d.notebook_build_writes}  |  "  # noqa: RUF001
                 f"reviewers — {revs}  |  process-design edits — {proc}"
             )
         lines.append("")

--- a/analytics/tests/test_pipeline_profiler.py
+++ b/analytics/tests/test_pipeline_profiler.py
@@ -471,8 +471,8 @@ def test_format_report_renders_decisions_line():
     )
     report = pp.format_report([prof])
     assert "Decisions" in report
-    assert "analysis-script ×3" in report
-    assert "nb-build ×1" in report
+    assert "analysis-script ×3" in report  # noqa: RUF001
+    assert "nb-build ×1" in report  # noqa: RUF001
     assert "framing.md" in report
     assert report.count("pipeline.md") == 1  # process edits deduped in render
 


### PR DESCRIPTION
## Summary

#480 (`analytics: pipeline cost profiler`) landed with lint violations that fail CI's repo-wide `pre-commit run --all-files`, so **every open PR is currently red** (the failure shows up on unrelated PRs because pre-commit lints the whole tree on the merge ref). This clears them:

- 6× **RUF001** — ambiguous `×` (MULTIPLICATION SIGN) in the diagnostic report strings (`notebook ×3`, etc.).
- 1× **SIM108** — an `if/else` ruff wants as a ternary.

## Approach

Targeted `# noqa` rather than changing behavior or output:
- `# noqa: RUF001` keeps the intentional `×N` ("N times") glyph in the report — readable and deliberate; `× → x` would give `alicex2`.
- `# noqa: SIM108` keeps the `calibration` block as an `if/else`, parallel to the structurally identical `review` block right above it (which ruff doesn't flag only because its ternary would be too long).

No logic or output changes — comment-only.

## Test Plan
- [x] `pre-commit run ruff --files <both files>` → Passed
- [x] `pre-commit run ruff-format --files <both files>` → Passed

cc @ the #480 author — happy to switch to `× → x` instead of noqa if you'd prefer the ASCII glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)