### PR TITLE
ci: reusable uv-subproject workflow + best-practice fixes

### DIFF
--- a/.github/workflows/airflow.yml
+++ b/.github/workflows/airflow.yml
@@ -1,25 +1,13 @@
 name: airflow
 on:
   pull_request:
-    paths: ['airflow/**', '.github/workflows/airflow.yml']
+    paths: ['airflow/**', '.github/workflows/airflow.yml', '.github/workflows/uv-subproject.yml']
   push:
     branches: [main]
-    paths: ['airflow/**', '.github/workflows/airflow.yml']
+    paths: ['airflow/**', '.github/workflows/airflow.yml', '.github/workflows/uv-subproject.yml']
 jobs:
   test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: airflow
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: airflow/uv.lock
-      - name: Install
-        run: uv sync --frozen
-      - name: Pytest
-        run: uv run pytest -ra
-      - name: Type check
-        run: uv run mypy astro/dags astro/tests astro/include/custom_functions
+    uses: ./.github/workflows/uv-subproject.yml
+    with:
+      directory: airflow
+      mypy-targets: astro/dags astro/tests astro/include/custom_functions

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -1,25 +1,13 @@
 name: analytics
 on:
   pull_request:
-    paths: ['analytics/**', '.github/workflows/analytics.yml']
+    paths: ['analytics/**', '.github/workflows/analytics.yml', '.github/workflows/uv-subproject.yml']
   push:
     branches: [main]
-    paths: ['analytics/**', '.github/workflows/analytics.yml']
+    paths: ['analytics/**', '.github/workflows/analytics.yml', '.github/workflows/uv-subproject.yml']
 jobs:
   test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: analytics
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: analytics/uv.lock
-      - name: Install
-        run: uv sync --frozen
-      - name: Pytest
-        run: uv run pytest -ra
-      - name: Type check
-        run: uv run mypy lib tests
+    uses: ./.github/workflows/uv-subproject.yml
+    with:
+      directory: analytics
+      mypy-targets: lib tests

--- a/.github/workflows/dbt.yml
+++ b/.github/workflows/dbt.yml
@@ -1,25 +1,13 @@
 name: dbt
 on:
   pull_request:
-    paths: ['dbt/**', '.github/workflows/dbt.yml']
+    paths: ['dbt/**', '.github/workflows/dbt.yml', '.github/workflows/uv-subproject.yml']
   push:
     branches: [main]
-    paths: ['dbt/**', '.github/workflows/dbt.yml']
+    paths: ['dbt/**', '.github/workflows/dbt.yml', '.github/workflows/uv-subproject.yml']
 jobs:
   test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: dbt
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: dbt/uv.lock
-      - name: Install
-        run: uv sync --frozen
-      - name: Pytest
-        run: uv run pytest -ra
-      - name: Type check
-        run: uv run mypy tests
+    uses: ./.github/workflows/uv-subproject.yml
+    with:
+      directory: dbt
+      mypy-targets: tests

--- a/.github/workflows/genie-slack-bot.yml
+++ b/.github/workflows/genie-slack-bot.yml
@@ -1,25 +1,13 @@
 name: genie-slack-bot
 on:
   pull_request:
-    paths: ['apps/genie-slack-bot/**', '.github/workflows/genie-slack-bot.yml']
+    paths: ['apps/genie-slack-bot/**', '.github/workflows/genie-slack-bot.yml', '.github/workflows/uv-subproject.yml']
   push:
     branches: [main]
-    paths: ['apps/genie-slack-bot/**', '.github/workflows/genie-slack-bot.yml']
+    paths: ['apps/genie-slack-bot/**', '.github/workflows/genie-slack-bot.yml', '.github/workflows/uv-subproject.yml']
 jobs:
   test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/genie-slack-bot
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: apps/genie-slack-bot/uv.lock
-      - name: Install
-        run: uv sync --frozen
-      - name: Pytest
-        run: uv run pytest -ra
-      - name: Type check
-        run: uv run mypy app.py config.py databricks_genie_client.py slack_bot.py tests
+    uses: ./.github/workflows/uv-subproject.yml
+    with:
+      directory: apps/genie-slack-bot
+      mypy-targets: app.py config.py databricks_genie_client.py slack_bot.py tests

--- a/.github/workflows/genie-tools.yml
+++ b/.github/workflows/genie-tools.yml
@@ -1,25 +1,13 @@
 name: genie-tools
 on:
   pull_request:
-    paths: ['apps/genie-tools/**', '.github/workflows/genie-tools.yml']
+    paths: ['apps/genie-tools/**', '.github/workflows/genie-tools.yml', '.github/workflows/uv-subproject.yml']
   push:
     branches: [main]
-    paths: ['apps/genie-tools/**', '.github/workflows/genie-tools.yml']
+    paths: ['apps/genie-tools/**', '.github/workflows/genie-tools.yml', '.github/workflows/uv-subproject.yml']
 jobs:
   test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/genie-tools
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: apps/genie-tools/uv.lock
-      - name: Install
-        run: uv sync --frozen
-      - name: Pytest
-        run: uv run pytest -ra
-      - name: Type check
-        run: uv run mypy src
+    uses: ./.github/workflows/uv-subproject.yml
+    with:
+      directory: apps/genie-tools
+      mypy-targets: src

--- a/.github/workflows/matcha.yml
+++ b/.github/workflows/matcha.yml
@@ -2,33 +2,17 @@ name: matcha
 
 # Lint/format for matcha/ is handled repo-wide by pre-commit.yml (ruff). This
 # workflow only runs the matcha unit tests, scoped so it fires solely on
-# changes under matcha/.
+# changes under matcha/. Integration tests require a live Databricks connection
+# and self-skip when DATABRICKS_HTTP_PATH is unset; they are excluded here too.
 on:
   pull_request:
-    paths:
-      - 'matcha/**'
-      - '.github/workflows/matcha.yml'
+    paths: ['matcha/**', '.github/workflows/matcha.yml', '.github/workflows/uv-subproject.yml']
   push:
     branches: [main]
-    paths:
-      - 'matcha/**'
-      - '.github/workflows/matcha.yml'
-
+    paths: ['matcha/**', '.github/workflows/matcha.yml', '.github/workflows/uv-subproject.yml']
 jobs:
   test:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: matcha
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: matcha/uv.lock
-      - name: Install
-        run: uv sync --frozen
-      - name: Pytest
-        # Integration tests require a live Databricks connection and self-skip
-        # when DATABRICKS_HTTP_PATH is unset; exclude them here explicitly.
-        run: uv run pytest -ra -m "not integration"
+    uses: ./.github/workflows/uv-subproject.yml
+    with:
+      directory: matcha
+      pytest-args: -ra -m "not integration"

--- a/.github/workflows/people-api-loader.yml
+++ b/.github/workflows/people-api-loader.yml
@@ -1,5 +1,8 @@
 name: people-api-loader
 
+# Standalone (not via uv-subproject.yml): this project uses the Astral type
+# checker `ty` instead of mypy, and keeps its dev deps in an optional-deps
+# extra, so it needs `--extra dev`. Ruff is covered repo-wide by pre-commit.yml.
 on:
   pull_request:
     paths:
@@ -11,6 +14,13 @@ on:
       - 'people-api-loader/**'
       - '.github/workflows/people-api-loader.yml'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -19,16 +29,12 @@ jobs:
         working-directory: people-api-loader
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: people-api-loader/uv.lock
       - name: Install
-        run: uv sync --extra dev
-      - name: Ruff check
-        run: uv run ruff check src tests
-      - name: Ruff format check
-        run: uv run ruff format --check src tests
+        run: uv sync --frozen --extra dev
       - name: Type check (ty)
         run: uv run ty check
       - name: Pytest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -14,7 +21,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'  # must match version in prod airflow
+          # Repo-wide Python standard. Only affects version-independent hooks
+          # here (ruff, sqlfmt); mypy runs in its own isolated hook env.
+          python-version: '3.14'
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/uv-subproject.yml
+++ b/.github/workflows/uv-subproject.yml
@@ -1,0 +1,49 @@
+name: uv-subproject
+
+# Reusable CI body for a uv-managed subproject: install from the lockfile, run
+# pytest, and (optionally) mypy. Callers supply the directory and type-check
+# targets; triggers and path filters stay in each caller workflow.
+on:
+  workflow_call:
+    inputs:
+      directory:
+        description: Subproject directory (also used as the cache key and working dir).
+        required: true
+        type: string
+      mypy-targets:
+        description: Paths to type-check with mypy. Empty skips the mypy step.
+        required: false
+        type: string
+        default: ''
+      pytest-args:
+        description: Arguments passed to pytest.
+        required: false
+        type: string
+        default: '-ra'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.directory }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: ${{ inputs.directory }}/uv.lock
+      - name: Install
+        run: uv sync --frozen
+      - name: Pytest
+        run: uv run pytest ${{ inputs.pytest-args }}
+      - name: Type check
+        if: inputs.mypy-targets != ''
+        run: uv run mypy ${{ inputs.mypy-targets }}

--- a/analytics/diagnostics/pipeline_profiler.py
+++ b/analytics/diagnostics/pipeline_profiler.py
@@ -211,10 +211,7 @@ def segment_stages(records: list[dict]) -> tuple[dict, str]:
     else:
         review = (exec_end, exec_end)  # empty
     # calibration
-    if calib is not None:
-        calibration = (calib, _first_human_after(records, calib))
-    else:
-        calibration = (n, n)  # empty
+    calibration = (calib, _first_human_after(records, calib)) if calib is not None else (n, n)
 
     spans = {"framing": framing, "execution": execution, "review": review, "calibration": calibration}
     # Markers are assumed to occur in pipeline order. If they don't (e.g. a

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -26,7 +26,7 @@ target-version = "py313"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
-ignore = ["E501", "RUF002"]
+ignore = ["E501", "RUF002", "RUF001"]
 
 [tool.mypy]
 python_version = "3.14"


### PR DESCRIPTION
Follow-up to the uv-standardization PRs (#464, #466, #467, #468), which left six per-subproject CI workflows with byte-identical job bodies. Dedups them and applies a few CI best practices.

- Adds `.github/workflows/uv-subproject.yml` (`workflow_call`) with the shared job: checkout, `setup-uv`, `uv sync --frozen`, pytest, optional mypy. Inputs: `directory`, `mypy-targets`, `pytest-args`.
- `airflow`, `analytics`, `dbt`, `genie-slack-bot`, `genie-tools`, `matcha` collapse to triggers plus a one-line call. Triggers/path filters stay per-caller (the part that differs); each caller adds `uv-subproject.yml` to its `paths`.
- `permissions: contents: read` and a `concurrency` group (cancels superseded PR runs, never main) folded into the reusable workflow; all six callers inherit them.
- `pre-commit.yml`: runner Python 3.11 -> 3.14 (the old `must match prod airflow` pin was stale; prod airflow is on 3.14). Same permissions/concurrency added.
- `people-api-loader.yml`: `setup-uv` v3 -> v6, drop `ruff check`/`format` steps already covered repo-wide, sync `--frozen --extra dev`, add permissions/concurrency. Stays standalone (uses `ty`, not mypy).

`pre-commit` was already red on main from ruff debt in the analytics profiler (#480). Cleared it: ignore `RUF001` in analytics (matching dbt) for the `×` glyphs, and collapse one `SIM108` if/else to a ternary.
