### PR TITLE
analytics(profiler): decompose headline arm + active-first combined view

### DIFF
--- a/analytics/diagnostics/baseline_question.md
+++ b/analytics/diagnostics/baseline_question.md
@@ -30,12 +30,27 @@ held constant and the arms stay comparable.
 
 - **"total users" (the percentage denominator):** per month, does it mean Win
   users who signed up that month, who were active that month, or cumulative as
-  of that month? (resolved by first full run: _____)
-- **"activated users":** the governed activation definition. (resolved: _____)
+  of that month? (resolved by first full run: **cumulative** registered Win users
+  as of each month-end, restricted to an upcoming/live election: per-user
+  `MAX(election_date)` **bounded to `[2020-01-01, 2050-01-01]`** `>= the measured
+  month's start`, using `users_win_candidacy.election_date` (the per-stage field,
+  NOT the leaky `users_win_base.election_date`), deduped to distinct `user_id`
+  (MIN `user_created_at`), `is_latest_version AND NOT is_demo`. The bound removes
+  corrupt far-future dates (e.g. year 20021) that would otherwise read as
+  perpetually upcoming — see win-analytics-knowledge `gotchas.md`. Reproducible
+  base: Jan 9,877 / Feb 10,690 / Mar 11,207 / Apr 11,259 / May 10,853. The filter
+  drops past-election candidates whose candidacy is over.)
+- **"activated users":** the governed activation definition. (resolved: anchored
+  point-in-time via `first_campaign_sent_at <= month-end`, NOT the lifetime
+  `is_activated` flag, so post-month activations don't leak into earlier months.)
 - **"completed onboarding":** spans the May-2026 onboarding-flow cutover
   (`onboarding_complete` vs `Onboarding - Candidate Pledge Completed`); needs the
-  unified definition. (resolved: _____)
-- **"viewed dashboard":** the dashboard-view event. (resolved: _____)
+  unified definition. (resolved: the version-agnostic raw event
+  `Onboarding - Candidate Pledge Completed` fired within 14 days of signup, with
+  `event_time <= month-end`.)
+- **"viewed dashboard":** the dashboard-view event. (resolved: the raw event
+  `Dashboard - Candidate Dashboard Viewed` fired within 14 days of signup, with
+  `event_time <= month-end`.)
 
 ## Runnable arms
 

--- a/analytics/diagnostics/pipeline_profiler.py
+++ b/analytics/diagnostics/pipeline_profiler.py
@@ -9,15 +9,21 @@ See analytics/planning/2026-06-09-pipeline-profiler-design.md.
 Stage definitions (these four map 1:1 to the pipeline stages in the
 win-analytics-process skill's references/pipeline.md, which is the authority):
 
-  framing      Pipeline stage 1 (Frame). From the win-analytics skill load to
-               the `_brief.yaml` write. Includes the scoping conversation and the
-               framing-approval gate: the human-idle here is largely you
-               answering scoping questions and approving the brief.
+  framing      Pipeline stage 1 (Frame). From the win-analytics skill load to the
+               framing->execution boundary: the `_brief.yaml` write, or, when an
+               express run skips the brief file, the first deliverable artifact
+               write. Includes the scoping conversation and the framing-approval
+               gate: the human-idle here is largely you answering scoping
+               questions and approving the brief. When neither a brief nor a
+               deliverable exists (a fully-inline run) framing and execution
+               cannot be separated and are reported as one `framing+execution`
+               span (RunProfile.framing_merged; flagged confidence: low).
   execution    Pipeline stage 2 (Execute) plus the stage-G results checkpoint.
-               From the brief write to the first reviewer dispatch. Includes
-               building the analysis artifact AND the results-checkpoint gate,
-               which has no artifact marker, so the idle spent waiting for
-               results approval is attributed here, not to a separate stage.
+               From the framing->execution boundary to the first reviewer
+               dispatch. Includes building the analysis artifact AND the
+               results-checkpoint gate, which has no artifact marker, so the idle
+               spent waiting for results approval is attributed here, not to a
+               separate stage.
   review       Pipeline stages 3 and + (the product-data-scientist and
                product-manager reviewers). From the first reviewer dispatch to
                the last reviewer result. Reviewers run in parallel, so this is a
@@ -148,6 +154,27 @@ def _first_of(*vals: int | None, default: int) -> int:
     return next((v for v in vals if v is not None), default)
 
 
+def _is_deliverable_path(path: str) -> bool:
+    """True when a written/edited file is an analysis deliverable artifact
+    (notebook, headless notebook-build script, or an ad-hoc/projects/notebooks .py)."""
+    base = os.path.basename(path)
+    if path.endswith(".ipynb"):
+        return True
+    if base.startswith("build_") and base.endswith(".py"):
+        return True
+    return path.endswith(".py") and any(seg in path for seg in ("/ad_hoc/", "/projects/", "/notebooks/"))
+
+
+def _first_deliverable_index(records: list[dict]) -> int | None:
+    """Index of the first Write/Edit of a deliverable artifact, else None.
+    Used as the framing->execution boundary when an express run skips the brief file."""
+    for i, rec in enumerate(records):
+        for name, tool_input, _tid in _iter_tool_uses(rec):
+            if name in ("Write", "Edit") and _is_deliverable_path(str(tool_input.get("file_path", ""))):
+                return i
+    return None
+
+
 def _first_human_after(records: list[dict], start: int) -> int:
     """Index of the first human message strictly after `start`, else len(records)."""
     for i in range(start + 1, len(records)):
@@ -196,11 +223,16 @@ def segment_stages(records: list[dict]) -> tuple[dict, str]:
 
     confidence = "ok" if ("skill_load" in idx and brief is not None) else "low"
 
+    # framing->execution boundary: the brief file (the clean handoff), or, when an
+    # express run skips it, the first deliverable artifact write. When neither
+    # exists (a fully-inline run), framing and execution cannot be separated and
+    # are reported as one merged span (see RunProfile.framing_merged).
+    handoff = brief if brief is not None else _first_deliverable_index(records)
     # framing
-    framing_end = _first_of(brief, reviewer, calib, default=n)
+    framing_end = _first_of(handoff, reviewer, calib, default=n)
     framing = (skill, framing_end)
     # execution
-    exec_start = brief if brief is not None else framing_end
+    exec_start = handoff if handoff is not None else framing_end
     exec_end = _first_of(reviewer, calib, default=n)
     execution = (exec_start, max(exec_start, exec_end))
     # review
@@ -210,7 +242,7 @@ def segment_stages(records: list[dict]) -> tuple[dict, str]:
         review = (reviewer, max(reviewer, rev_end))
     else:
         review = (exec_end, exec_end)  # empty
-    # calibration
+    # calibration (empty span when no calibration file was written)
     calibration = (calib, _first_human_after(records, calib)) if calib is not None else (n, n)
 
     spans = {"framing": framing, "execution": execution, "review": review, "calibration": calibration}
@@ -299,6 +331,9 @@ class RunProfile:
     confidence: str
     stages: dict[str, StageMetrics] = field(default_factory=dict)
     decisions: RunDecisions | None = None
+    # True when neither a brief nor a deliverable artifact exists, so framing and
+    # execution could not be separated and are reported as one merged span.
+    framing_merged: bool = False
 
 
 def load_records(path: str) -> list[dict]:
@@ -354,17 +389,23 @@ def format_report(profiles: list[RunProfile]) -> str:
             cache = m.cache_creation_input_tokens + m.cache_read_input_tokens
             wall = m.model_active_seconds + m.human_idle_seconds
             stage_total_tokens = m.input_tokens + m.output_tokens + cache
-            lines.append(
-                f"| {stage} | {_min(m.model_active_seconds)} | {_min(m.human_idle_seconds)} | "
-                f"{_min(wall)} | {_pct(m.model_active_seconds, total_active)} | "
-                f"{m.input_tokens} | {m.output_tokens} | {cache} | "
-                f"{_pct(stage_total_tokens, run_total_tokens)} |"
-            )
+            # totals always accumulate, even for a row we fold away below
             tot.model_active_seconds += m.model_active_seconds
             tot.human_idle_seconds += m.human_idle_seconds
             tot.input_tokens += m.input_tokens
             tot.output_tokens += m.output_tokens
             tot_cache += cache
+            # when framing and execution could not be separated, fold the empty
+            # execution row into a single "framing+execution" row.
+            if prof.framing_merged and stage == "execution":
+                continue
+            label = "framing+execution" if (prof.framing_merged and stage == "framing") else stage
+            lines.append(
+                f"| {label} | {_min(m.model_active_seconds)} | {_min(m.human_idle_seconds)} | "
+                f"{_min(wall)} | {_pct(m.model_active_seconds, total_active)} | "
+                f"{m.input_tokens} | {m.output_tokens} | {cache} | "
+                f"{_pct(stage_total_tokens, run_total_tokens)} |"
+            )
         tot_wall = tot.model_active_seconds + tot.human_idle_seconds
         tot_token_pct = 100 if run_total_tokens else 0
         lines.append(
@@ -383,23 +424,30 @@ def format_report(profiles: list[RunProfile]) -> str:
                 f"reviewers — {revs}  |  process-design edits — {proc}"
             )
         lines.append("")
-    # combined summary
+    # combined summary — model-active is the comparison metric; wall-clock is
+    # dropped here because human-idle (time the human stepped away) dominates it
+    # and is not pipeline cost.
     n = len(profiles) or 1
     lines += [
         "## Combined (mean across runs)",
         "",
-        "| stage | mean_model_active_min | mean_human_idle_min | mean_wall_clock_min |",
-        "|---|---|---|---|",
+        "| stage | mean_model_active_min |",
+        "|---|---|",
     ]
     for stage in STAGES:
         active = sum(p.stages.get(stage, StageMetrics()).model_active_seconds for p in profiles) / n
-        idle = sum(p.stages.get(stage, StageMetrics()).human_idle_seconds for p in profiles) / n
-        lines.append(f"| {stage} | {_min(active)} | {_min(idle)} | {_min(active + idle)} |")
+        lines.append(f"| {stage} | {_min(active)} |")
+    mean_active_total = sum(s.model_active_seconds for p in profiles for s in p.stages.values()) / n
+    mean_idle_total = sum(s.human_idle_seconds for p in profiles for s in p.stages.values()) / n
     lines += [
         "",
-        "> Note: reviewer internal tokens are not in the transcript (sub-agent sidechains "
-        "are not recorded), so review-stage token counts reflect only the parent context. "
-        "Review wall-clock is the parallel max-span (dispatch to last reviewer result).",
+        f"> Model-active is the comparison metric: mean total {_min(mean_active_total)} min/run. "
+        f"Mean human-idle is {_min(mean_idle_total)} min/run, **excluded** from the active "
+        "columns above — it is mostly time the human stepped away between turns, not pipeline "
+        "cost, and it swamps wall-clock, so wall-clock is not meaned here.",
+        "> Reviewer internal tokens are not in the transcript (sub-agent sidechains are not "
+        "recorded), so review-stage token counts reflect only the parent context. Review "
+        "wall-clock is the parallel max-span (dispatch to last reviewer result).",
     ]
     return "\n".join(lines)
 
@@ -414,7 +462,14 @@ def profile_run(path: str) -> RunProfile:
         tokens = _token_totals(sl)
         active, idle = _split_time(sl)
         stages[stage] = StageMetrics(model_active_seconds=active, human_idle_seconds=idle, **tokens)
-    return RunProfile(path=path, confidence=confidence, stages=stages, decisions=_collect_decisions(records))
+    merged = ("brief_write" not in _marker_indices(records)) and (_first_deliverable_index(records) is None)
+    return RunProfile(
+        path=path,
+        confidence=confidence,
+        stages=stages,
+        decisions=_collect_decisions(records),
+        framing_merged=merged,
+    )
 
 
 def _resolve_paths(patterns: list[str]) -> list[str]:

--- a/analytics/tests/test_pipeline_profiler.py
+++ b/analytics/tests/test_pipeline_profiler.py
@@ -477,6 +477,105 @@ def test_format_report_renders_decisions_line():
     assert report.count("pipeline.md") == 1  # process edits deduped in render
 
 
+def test_segment_stages_uses_deliverable_boundary_without_brief():
+    # express run skips the brief file but writes a .py deliverable; framing should
+    # end at the deliverable write rather than swallowing the whole run.
+    records = [
+        _tool_use_rec("2026-06-08T19:00:00Z", "Skill", "s1", skill="win-analytics-process"),  # 0
+        {"type": "user", "timestamp": "2026-06-08T19:02:00Z", "message": {"content": "answers"}},  # 1
+        _tool_use_rec("2026-06-08T19:05:00Z", "Write", "w1", file_path="/x/ad_hoc/q.py"),  # 2 deliverable
+        {"type": "assistant", "timestamp": "2026-06-08T19:06:00Z", "message": {"content": "ran"}},  # 3
+        _tool_use_rec("2026-06-08T19:06:30Z", "Agent", "a1", subagent_type="product-data-scientist"),  # 4
+        _tool_result_rec("2026-06-08T19:08:00Z", "a1"),  # 5
+    ]
+    spans, confidence = pp.segment_stages(records)
+    assert spans["framing"] == (0, 2)  # framing ends at the deliverable write
+    assert spans["execution"] == (2, 4)  # deliverable .. reviewer
+    assert confidence == "low"  # no brief -> approximate split, still flagged
+
+
+def test_segment_stages_merges_framing_execution_when_no_brief_or_deliverable():
+    # fully-inline headline arm: no brief, no artifact, no reviewer, no calibration.
+    records = [
+        _tool_use_rec("2026-06-08T19:00:00Z", "Skill", "s1", skill="win-analytics-process"),  # 0
+        {"type": "user", "timestamp": "2026-06-08T19:02:00Z", "message": {"content": "answers"}},  # 1
+        {"type": "assistant", "timestamp": "2026-06-08T19:05:00Z", "message": {"content": "computed"}},  # 2
+        {"type": "assistant", "timestamp": "2026-06-08T19:06:00Z", "message": {"content": "answer"}},  # 3
+    ]
+    spans, confidence = pp.segment_stages(records)
+    assert spans["framing"] == (0, 4)  # spans the whole run (merged)
+    assert spans["execution"][0] == spans["execution"][1]  # empty execution
+    assert confidence == "low"
+
+
+def test_profile_run_flags_framing_merged_for_inline_run(tmp_path):
+    records = [
+        _tool_use_rec("2026-06-08T19:00:00Z", "Skill", "s1", skill="win-analytics-process"),
+        {"type": "assistant", "timestamp": "2026-06-08T19:05:00Z", "message": {"content": "answer"}},
+    ]
+    f = tmp_path / "inline.jsonl"
+    f.write_text("\n".join(_json.dumps(r) for r in records))
+    prof = pp.profile_run(str(f))
+    assert prof.framing_merged is True
+
+
+def test_profile_run_not_merged_with_brief(tmp_path):
+    records = [
+        _tool_use_rec("2026-06-08T19:00:00Z", "Skill", "s1", skill="win-analytics-process"),
+        _tool_use_rec("2026-06-08T19:05:00Z", "Write", "w1", file_path="/x/q_brief.yaml"),
+        {"type": "assistant", "timestamp": "2026-06-08T19:06:00Z", "message": {"content": "y"}},
+    ]
+    f = tmp_path / "brief.jsonl"
+    f.write_text("\n".join(_json.dumps(r) for r in records))
+    prof = pp.profile_run(str(f))
+    assert prof.framing_merged is False
+
+
+def test_profile_run_not_merged_with_deliverable_only(tmp_path):
+    records = [
+        _tool_use_rec("2026-06-08T19:00:00Z", "Skill", "s1", skill="win-analytics-process"),
+        _tool_use_rec("2026-06-08T19:05:00Z", "Write", "w1", file_path="/x/ad_hoc/q.py"),
+        {"type": "assistant", "timestamp": "2026-06-08T19:06:00Z", "message": {"content": "y"}},
+    ]
+    f = tmp_path / "deliv.jsonl"
+    f.write_text("\n".join(_json.dumps(r) for r in records))
+    prof = pp.profile_run(str(f))
+    assert prof.framing_merged is False
+
+
+def test_format_report_labels_merged_framing_execution():
+    prof = pp.RunProfile(
+        path="/tmp/inline.jsonl",
+        confidence="low",
+        framing_merged=True,
+        stages={
+            "framing": pp.StageMetrics(input_tokens=1000, model_active_seconds=300),
+            "execution": pp.StageMetrics(),  # empty / folded in
+            "review": pp.StageMetrics(),
+            "calibration": pp.StageMetrics(),
+        },
+    )
+    report = pp.format_report([prof])
+    assert "framing+execution" in report
+
+
+def test_format_report_combined_drops_wall_clock_and_excludes_idle():
+    p1 = pp.RunProfile(
+        path="/a.jsonl",
+        confidence="ok",
+        stages={"framing": pp.StageMetrics(model_active_seconds=120, human_idle_seconds=600)},
+    )
+    p2 = pp.RunProfile(
+        path="/b.jsonl",
+        confidence="ok",
+        stages={"framing": pp.StageMetrics(model_active_seconds=240, human_idle_seconds=0)},
+    )
+    report = pp.format_report([p1, p2])
+    assert "mean_wall_clock_min" not in report  # misleading wall-clock mean dropped
+    assert "human-idle" in report.lower()
+    assert "excluded" in report.lower()  # idle surfaced as excluded from the active comparison
+
+
 def test_write_log_appends_to_single_file(tmp_path):
     p1 = pp._write_log("REPORT ONE", ["/x/a.jsonl"], tmp_path, datetime(2026, 6, 10, 14, 30, 5))
     p2 = pp._write_log("REPORT TWO", ["/x/b.jsonl"], tmp_path, datetime(2026, 6, 11, 9, 0, 0))


### PR DESCRIPTION
## Summary

Follow-up to #480 (the profiler PR merged before these changes were committed, so they need their own PR onto `main`). Two things, both surfaced by the DATA-1959 arm-profiling runs:

### Profiler patch (`pipeline_profiler.py`)
The headline (fully-inline) arm collapsed into a single mislabeled "framing" stage because it writes no brief and no artifact, so the segmenter had no framing→execution boundary, and `confidence: low` was the only signal.

- **Boundary fallback:** framing→execution now ends at the first of `{brief write, deliverable artifact write}`, so express runs that skip the brief file still decompose (script/notebook arms).
- **Honest inline span:** when neither a brief nor a deliverable exists, framing and execution can't be separated, so the run reports one `framing+execution` span (new `RunProfile.framing_merged`) instead of pretending everything was framing. Still flagged `confidence: low`.
- **Combined view:** leads with mean model-active, **drops the misleading wall-clock mean** (human-idle — time the user stepped away — dominated it, up to 51 min in one arm), and surfaces mean human-idle separately as excluded.

### Benchmark fixture (`baseline_question.md`)
The "total users" answer-key resolution is pinned to the reproducible rule from the calibration PR (#481): per-user `MAX(election_date)` bounded to `[2020-01-01, 2050-01-01]` `>= month start`, using `users_win_candidacy.election_date`, with the reproducible per-month base (Jan 9,877 … May 10,853).

## Tests
7 new tests (49 profiler / 80 analytics total), all passing. Ruff + ruff-format clean.

## Related
- #480 (merged) — the profiler this extends.
- #481 (open) — the Track-1 calibration that defines the bounded election-date rule referenced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only profiler and benchmark documentation changes with broad test coverage; no production runtime or data-pipeline behavior.
> 
> **Overview**
> Extends the pipeline profiler so **express** and **fully-inline** benchmark arms segment honestly instead of lumping everything into framing.
> 
> **Profiler:** The framing→execution handoff is now the first **`_brief.yaml` write** or, when express skips the brief, the first **deliverable** write (`.ipynb`, `build_*_nb.py`, or `.py` under ad_hoc/projects/notebooks). Runs with **no brief and no deliverable** set `RunProfile.framing_merged` and report one **`framing+execution`** row (still `confidence: low`). The **combined** summary mean only **model-active** time, drops misleading mean wall-clock, and calls out mean human-idle as excluded from pipeline cost.
> 
> **Benchmark fixture:** `baseline_question.md` pins the scoping answer key (total users with bounded `users_win_candidacy.election_date`, point-in-time activation, onboarding/dashboard events) so arms stay comparable after the first full run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ba27c4b072fdafa438e839e332ca7c57061599. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->