### PR TITLE
[DATA-1987] NHGIS block population staging model

### DIFF
--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -1583,3 +1583,22 @@ sources:
           after post-prediction filters. Each row is a pair of election-stage records with
           match weights, match probabilities, and per-comparison gamma levels. For auditing
           election-stage match quality.
+
+  - name: nhgis
+    schema: sandbox
+    description: >
+      NHGIS extracts of the 2020 decennial census, staged by the research team. The 2020
+      frame is static: these tables are a one-time load, not a refreshing feed, so
+      downstream tests pin exact totals.
+    tables:
+      - name: blocks_to_pop_a
+        description: >
+          First of the two files of the 2020 census block population extract. The a/b
+          split is by row count, not state boundary (Missouri spans both files), so both
+          tables are required for a complete national frame. All columns are strings, and
+          the first data row is an embedded descriptive header that must be filtered out.
+      - name: blocks_to_pop_b
+        description: >
+          Second of the two files of the 2020 census block population extract. Columns
+          are typed; GEOCODE is stored as a number, which drops leading zeros, so always
+          zero-pad to the 15-character block GEOID on read.

--- a/dbt/project/models/staging/nhgis_source/stg_nhgis.yaml
+++ b/dbt/project/models/staging/nhgis_source/stg_nhgis.yaml
@@ -1,0 +1,36 @@
+version: 2
+
+models:
+  - name: stg_nhgis__block_population
+    description: >
+      2020 decennial census population per census block, unioned from the two
+      research-staged NHGIS extracts. The file split is by row count, not state,
+      so both tables are required for a complete national frame (Missouri spans
+      both). Covers all states, DC, and Puerto Rico. The 2020 frame is static, so
+      singular tests pin the exact national totals and Missouri's block count as
+      union regressions.
+    columns:
+      - name: block_geoid
+        description: >
+          Census block GEOID, zero-padded to the canonical 15 characters
+          (state + county + tract + block). Numeric upstream storage drops
+          leading zeros, so consumers should always join on this padded form.
+        data_tests:
+          - not_null
+          - unique
+      - name: state_fips
+        description: Two-character zero-padded state FIPS code (includes DC and Puerto Rico).
+        data_tests:
+          - not_null
+      - name: population
+        description: Total 2020 decennial census population of the block (NHGIS variable U7H001).
+        data_tests:
+          - not_null
+      - name: tract_geoid
+        description: Census tract GEOID, the first 11 characters of block_geoid.
+        data_tests:
+          - not_null
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "length(block_geoid) = 15 and length(state_fips) = 2 and length(tract_geoid) = 11"

--- a/dbt/project/models/staging/nhgis_source/stg_nhgis__block_population.sql
+++ b/dbt/project/models/staging/nhgis_source/stg_nhgis__block_population.sql
@@ -7,7 +7,9 @@
 with
     pop_a as (
         select
-            lpad(cast(geocode as string), 15, '0') as block_geoid,
+            -- the inner bigint cast pins decimal string output even if a
+            -- re-staged source lands with a float-inferred geocode
+            lpad(cast(cast(geocode as bigint) as string), 15, '0') as block_geoid,
             lpad(cast(statea as string), 2, '0') as state_fips,
             cast(u7h001 as bigint) as population
         from {{ source("nhgis", "blocks_to_pop_a") }}
@@ -18,7 +20,7 @@ with
 
     pop_b as (
         select
-            lpad(cast(geocode as string), 15, '0') as block_geoid,
+            lpad(cast(cast(geocode as bigint) as string), 15, '0') as block_geoid,
             lpad(cast(statea as string), 2, '0') as state_fips,
             cast(u7h001 as bigint) as population
         from {{ source("nhgis", "blocks_to_pop_b") }}

--- a/dbt/project/models/staging/nhgis_source/stg_nhgis__block_population.sql
+++ b/dbt/project/models/staging/nhgis_source/stg_nhgis__block_population.sql
@@ -7,10 +7,10 @@
 with
     pop_a as (
         select
-            -- the inner bigint cast pins decimal string output even if a
-            -- re-staged source lands with a float-inferred geocode
+            -- the inner bigint casts pin decimal string output even if a
+            -- re-staged source lands with float-inferred numeric columns
             lpad(cast(cast(geocode as bigint) as string), 15, '0') as block_geoid,
-            lpad(cast(statea as string), 2, '0') as state_fips,
+            lpad(cast(cast(statea as bigint) as string), 2, '0') as state_fips,
             cast(u7h001 as bigint) as population
         from {{ source("nhgis", "blocks_to_pop_a") }}
         -- this table is all-string and embeds a descriptive header as its
@@ -21,7 +21,7 @@ with
     pop_b as (
         select
             lpad(cast(cast(geocode as bigint) as string), 15, '0') as block_geoid,
-            lpad(cast(statea as string), 2, '0') as state_fips,
+            lpad(cast(cast(statea as bigint) as string), 2, '0') as state_fips,
             cast(u7h001 as bigint) as population
         from {{ source("nhgis", "blocks_to_pop_b") }}
     ),

--- a/dbt/project/models/staging/nhgis_source/stg_nhgis__block_population.sql
+++ b/dbt/project/models/staging/nhgis_source/stg_nhgis__block_population.sql
@@ -1,0 +1,38 @@
+-- 2020 decennial census population per census block, unioned from the two
+-- research-staged NHGIS extracts. The a/b file split is by row count, not
+-- state (Missouri spans both files), so both sources are required for a
+-- complete national frame. Block GEOIDs are zero-padded to the canonical
+-- 15 characters: numeric storage drops leading zeros, and downstream joins
+-- (e.g. to L2's numeric census geocode) assume the padded form.
+with
+    pop_a as (
+        select
+            lpad(cast(geocode as string), 15, '0') as block_geoid,
+            lpad(cast(statea as string), 2, '0') as state_fips,
+            cast(u7h001 as bigint) as population
+        from {{ source("nhgis", "blocks_to_pop_a") }}
+        -- this table is all-string and embeds a descriptive header as its
+        -- first data row; keep only rows whose state code is numeric
+        where try_cast(statea as int) is not null
+    ),
+
+    pop_b as (
+        select
+            lpad(cast(geocode as string), 15, '0') as block_geoid,
+            lpad(cast(statea as string), 2, '0') as state_fips,
+            cast(u7h001 as bigint) as population
+        from {{ source("nhgis", "blocks_to_pop_b") }}
+    ),
+
+    unioned as (
+        select *
+        from pop_a
+        union all
+        select *
+        from pop_b
+    ),
+
+    final as (select *, left(block_geoid, 11) as tract_geoid from unioned)
+
+select *
+from final

--- a/dbt/project/tests/assert_nhgis_block_population_2020_frame_totals.sql
+++ b/dbt/project/tests/assert_nhgis_block_population_2020_frame_totals.sql
@@ -1,0 +1,15 @@
+{{ config(severity="error") }}
+
+-- The 2020 decennial census frame is static: the national block count and
+-- total population (including Puerto Rico) are exact, stable targets, so a
+-- fixed-count test is appropriate here, and only here; do not copy this
+-- pattern to refreshing sources. Validated against official 2020 census
+-- tallies (DATA-1359 TDD, appendix D.1).
+with
+    totals as (
+        select count(*) as total_blocks, sum(population) as total_population
+        from {{ ref("stg_nhgis__block_population") }}
+    )
+select *
+from totals
+where total_blocks != 8174955 or total_population != 334735155

--- a/dbt/project/tests/assert_nhgis_block_population_missouri_union_coverage.sql
+++ b/dbt/project/tests/assert_nhgis_block_population_missouri_union_coverage.sql
@@ -1,0 +1,16 @@
+{{ config(severity="error") }}
+
+-- Missouri spans BOTH NHGIS source files: the a/b split is by row count, not
+-- state, so a union that silently drops either source corrupts Missouri
+-- first. The 2020 decennial frame is static, which makes the exact official
+-- block count a stable regression target (validated against the official
+-- 2020 census tally; DATA-1359 TDD, appendix D.1).
+with
+    missouri as (
+        select count(*) as mo_blocks
+        from {{ ref("stg_nhgis__block_population") }}
+        where state_fips = '29'
+    )
+select *
+from missouri
+where mo_blocks != 253632


### PR DESCRIPTION
## Summary

Adds `stg_nhgis__block_population`, a tested staging model over the research-staged NHGIS 2020 decennial census block population tables (`sandbox.blocks_to_pop_a` / `_b`), per the DATA-1359 constituents-served TDD (sections 6-7, appendix D.1). This is the population side of the district-to-block bridge; the downstream intermediates land in later tickets.

What it does:

- Unions both NHGIS files. The a/b split is by row count, not state: Missouri spans both files, so a broken union silently drops part of MO.
- Filters table a's embedded descriptive header row (`try_cast(statea as int) is not null`); table a is all-string, table b is typed with `GEOCODE` as BIGINT.
- Zero-pads block GEOIDs to the canonical 15 characters (numeric storage drops leading zeros) and derives `state_fips` and `tract_geoid`.

## Tests

| Test | Guards against |
|---|---|
| `unique` + `not_null` on `block_geoid`, `not_null` on the other columns | duplicate or missing keys |
| `assert_nhgis_block_population_missouri_union_coverage` (MO rows = 253,632) | a broken union; MO splits 36,262 (file a) + 217,370 (file b) |
| `assert_nhgis_block_population_2020_frame_totals` (8,174,955 rows, total population 334,735,155) | dropped rows, a kept header row, double counting |
| `dbt_utils.expression_is_true` on geoid lengths (15/2/11) | a skipped zero-pad |

Fixed counts are appropriate because the 2020 decennial frame is static; the totals tie out exactly to official 2020 census tallies (US 331,449,281 plus PR 3,285,874). This pattern should not be copied to refreshing sources.

## Verification

Local dbt cannot parse this project (Fusion preview), so the logic was verified read-only against the warehouse on 2026-06-11:

- Union: 8,174,955 rows, population 334,735,155, MO 253,632 (matches TDD appendix D.1 exactly)
- `block_geoid`: fully unique, 0 nulls, all 15 characters; STATEA-derived and GEOCODE-derived state agree on every row
- Red-phase checks: dropping either file or keeping the header row makes the singular tests fire (MO 36,262 or 217,370; row count 8,174,956)

After CI builds, I will re-verify the three reconciliation numbers on the CI preview schema and post the results here.

Ticket: DATA-1987 (epic DATA-1359)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect union, header handling, or GEOID padding would skew population used for downstream district-to-block work; tests mitigate but the frame is foundational for constituents-served metrics.
> 
> **Overview**
> Adds a **new dbt source** (`nhgis` in `sandbox`) for the research-staged 2020 NHGIS block population extracts (`blocks_to_pop_a` / `blocks_to_pop_b`) and a staging model **`stg_nhgis__block_population`** that unions both files into one national block-level frame.
> 
> The model **normalizes keys and types**: 15-digit `block_geoid` and 2-digit `state_fips` via `lpad`, drops file **a**’s embedded header row (`try_cast(statea as int) is not null`), casts population from `u7h001`, and derives **`tract_geoid`** from `block_geoid`.
> 
> **Tests** guard data quality and the fragile union: column `not_null` / `unique` on `block_geoid`, GEOID length checks, plus singular regressions for **national** block count and population (8,174,955 / 334,735,155) and **Missouri** block count (253,632) because MO spans both a/b files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b8ec5eb6452e15067e162fc931bb66653462f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->