### PR TITLE
[DATA-1984] Expose positions in civics mart

### DIFF
--- a/dbt/project/models/marts/civics/README.md
+++ b/dbt/project/models/marts/civics/README.md
@@ -15,6 +15,7 @@ All models materialize as tables in the `mart_civics` schema.
 | `candidate` | gp_candidate_id | Unique persons, deduped across BallotReady and HubSpot |
 | `candidacy_stage` | gp_candidacy_stage_id | Per-stage election results (primary, general, runoff) |
 | `election` | gp_election_id | Full election cycles with pivoted stage dates |
+| `positions` | br_position_database_id | Every BallotReady position (office) with L2 district match and ICP flags |
 | `election_stage` | gp_election_stage_id | Individual election stages with vendor IDs |
 | `elected_officials` | gp_elected_official_id | Person-grain merge of BR + TS + gp-api elected officials |
 | `elected_official_terms` | gp_elected_official_term_id | Term-grain BR fact table with TS provenance and gp-api bridge |
@@ -36,6 +37,7 @@ What are you looking for?
 +-- What office they ran for, election dates     --> candidacy
 +-- Did they win or lose? Vote counts?           --> candidacy_stage
 +-- Election details (office, district, dates)   --> election / election_stage
++-- An office/position and its ICP eligibility    --> positions
 +-- Officeholder (current/past)                  --> elected_officials
 +-- A specific term served                       --> elected_official_terms
 +-- GP app user data (signup, Win/Serve status)  --> users

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -2323,3 +2323,161 @@ models:
           name: person_mart_source_systems_known_values
           config:
             severity: error
+
+  - name: positions
+    description: >
+      Every BallotReady position (office) we know about, with its L2 district
+      match, voter count, and ICP eligibility flags. Mostly pass-through over
+      int__icp_offices, with standardized office_type joined from
+      int__civics_position_office_type on br_position_database_id.
+
+      Grain: One row per BallotReady position (br_position_database_id).
+
+      ICP flags (is_win_icp, is_serve_icp, is_win_supersize_icp) are
+      position-level and NOT date-gated: they reflect whether the office type
+      and district size qualify for the Win / Serve / Supersize ICP. The
+      election and candidacy marts apply an additional effective-date gate on
+      top of the win flags; this model does not, because a position has no
+      election dates. The flags are NULL when the position has no matched L2
+      district (icp_voter_count is NULL), since size eligibility is unknown.
+
+    columns:
+      - name: br_position_database_id
+        description: >
+          Primary key. The numeric identifier for the position (office) in
+          BallotReady's database. Joins to election.br_position_database_id and
+          stg_airbyte_source__ballotready_api_position.database_id.
+        data_tests:
+          - unique
+          - not_null
+
+      - name: br_position_id
+        description: BallotReady's GraphQL (base64-encoded) position identifier.
+        data_tests:
+          - not_null
+
+      - name: state
+        description: U.S. state for the position.
+        data_tests:
+          - is_state_abbreviation
+
+      - name: position_name
+        description: BallotReady's position name (e.g. "Apple Valley City Council").
+
+      - name: office_type
+        description: >
+          Standardized office classification (map_office_type buckets),
+          inherited from int__civics_position_office_type so positions,
+          election, and candidacy marts share one office_type per BallotReady
+          position. 'Other' when no classification could be derived.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - City Council
+                  - Other
+                  - School Board
+                  - Clerk/Treasurer
+                  - Judge
+                  - County Supervisor
+                  - Mayor
+                  - Town Council
+                  - Sheriff
+                  - State House
+                  - Attorney
+                  - State Senate
+                  - Congressional
+                  - Statewide/Governor
+
+      - name: br_normalized_position_type
+        description: >
+          BallotReady's standardized position category (e.g. "City Council",
+          "Mayor", "School Board"). Used for cross-office comparison and ICP
+          classification regardless of how individual jurisdictions name the
+          office.
+
+      - name: is_judicial
+        description: Whether the office is a judicial position (from BallotReady).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_appointed
+        description: Whether the office is an appointed position (from BallotReady).
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: l2_district_name
+        description: >
+          Name of the matched L2 voter-file district. NULL when no L2 district
+          matched this position.
+
+      - name: l2_district_type
+        description: >
+          Type of the matched L2 voter-file district (e.g. City, City_Ward,
+          County_Commissioner_District). NULL when no L2 district matched.
+
+      - name: is_l2_matched
+        description: >
+          Whether this position matched an L2 voter-file district. NULL when
+          the position has no L2 match record.
+
+      - name: icp_voter_count
+        description: >
+          L2 voter count for the matched district, used to determine ICP
+          eligibility. Thresholds are defined in int__icp_offices and may change
+          over time. NULL for positions without a matched L2 district.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+              config:
+                where: "icp_voter_count is not null"
+
+      - name: is_win_icp
+        description: >
+          Whether this position meets the Win ICP criteria (office type and
+          voter count). Position-level, not date-gated. NULL when the position
+          has no matched L2 district (size eligibility unknown).
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_serve_icp
+        description: >
+          Whether this position meets the Serve ICP criteria (office type and
+          voter count). Position-level. NULL when the position has no matched
+          L2 district.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: is_win_supersize_icp
+        description: >
+          Whether this position exceeds the upper voter-count threshold for the
+          standard Win process, requiring separate consideration. Position-level.
+          NULL when the position has no matched L2 district.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
+      - name: icp_win_effective_date
+        description: >
+          Date from which the Win ICP designation is effective for this
+          position's normalized type. Used by the election/candidacy marts to
+          date-gate the win flag. NULL when the normalized type has no effective
+          date configured.
+
+      - name: updated_at
+        description: Timestamp when the BallotReady position record was last updated.
+        data_tests:
+          - not_null

--- a/dbt/project/models/marts/civics/positions.sql
+++ b/dbt/project/models/marts/civics/positions.sql
@@ -1,0 +1,50 @@
+-- Civics mart positions table.
+-- Mostly pass-through over int__icp_offices: every BallotReady position we know
+-- about, with its L2 district match, voter count, and ICP eligibility flags.
+-- Standardized office_type is joined from int__civics_position_office_type,
+-- keyed on the same br_position_database_id, so positions, election, and
+-- candidacy marts share one office classification.
+--
+-- ICP flags here are position-level (un-gated): they reflect whether the office
+-- type and district size qualify for the Win / Serve / Supersize ICP. The
+-- election and candidacy marts apply an additional effective-date gate on top
+-- of is_win_icp / is_win_supersize_icp; this model does not, since a position
+-- has no election dates.
+with
+    icp as (select * from {{ ref("int__icp_offices") }}),
+
+    position_office_type as (
+        select * from {{ ref("int__civics_position_office_type") }}
+    )
+
+select
+    icp.br_database_position_id as br_position_database_id,
+    icp.br_position_id,
+    icp.state,
+    icp.br_position_name as position_name,
+
+    -- Standardized office naming, shared with the election/candidacy marts
+    position_office_type.office_type,
+    icp.normalized_position_type as br_normalized_position_type,
+
+    icp.is_judicial,
+    icp.is_appointed,
+
+    -- L2 district match
+    icp.l2_district_name,
+    icp.l2_district_type,
+    icp.is_matched as is_l2_matched,
+    icp.voter_count as icp_voter_count,
+
+    -- ICP eligibility flags (position-level, not date-gated)
+    icp.icp_office_win as is_win_icp,
+    icp.icp_office_serve as is_serve_icp,
+    icp.icp_win_supersize as is_win_supersize_icp,
+    icp.icp_win_effective_date,
+
+    icp.updated_at
+
+from icp
+left join
+    position_office_type
+    on icp.br_database_position_id = position_office_type.br_position_database_id

--- a/dbt/project/models/marts/civics/positions.sql
+++ b/dbt/project/models/marts/civics/positions.sql
@@ -1,15 +1,3 @@
--- Civics mart positions table.
--- Mostly pass-through over int__icp_offices: every BallotReady position we know
--- about, with its L2 district match, voter count, and ICP eligibility flags.
--- Standardized office_type is joined from int__civics_position_office_type,
--- keyed on the same br_position_database_id, so positions, election, and
--- candidacy marts share one office classification.
---
--- ICP flags here are position-level (un-gated): they reflect whether the office
--- type and district size qualify for the Win / Serve / Supersize ICP. The
--- election and candidacy marts apply an additional effective-date gate on top
--- of is_win_icp / is_win_supersize_icp; this model does not, since a position
--- has no election dates.
 with
     icp as (select * from {{ ref("int__icp_offices") }}),
 


### PR DESCRIPTION
Adds a `positions` model to the civics mart (`mart_civics.positions`), one row per BallotReady position. It's mostly pass-through over `int__icp_offices`, exposing every office we know about along with its ICP eligibility flags.

This is the data-platform half of DATA-1984: exposing ICP/positions data as a governed civics mart table so the HubSpot ICP-flagging automation can look up flags by office using true L2 voter counts. The service-principal access (terraform: add the SP to the civics mart reader group) is a separate change in `gp-terraform-dataplatform`.

Mostly a pass-through for now:

- Identifiers: `br_position_database_id` (PK), `br_position_id`, `state`, `position_name`
- Standardized naming: `office_type` (from `int__civics_position_office_type`, shared with the election/candidacy marts), `br_normalized_position_type`
- Office attributes: `is_judicial`, `is_appointed`
- L2 match: `l2_district_name`, `l2_district_type`, `is_l2_matched`, `icp_voter_count`
- ICP flags: `is_win_icp`, `is_serve_icp`, `is_win_supersize_icp`, `icp_win_effective_date`
- `updated_at`

## Notes

- ICP flags here are position-level and **not** date-gated. The election/candidacy marts apply an effective-date gate on top of the win flags; a position has no election dates, so this model exposes the raw eligibility. Flags are NULL when a position has no matched L2 district.
- Flag names follow the civics mart convention (`is_win_icp`, etc.) used in the election and candidacy marts.

## Testing

- Grain verified unique on `br_position_database_id` (285,394 rows).
- `dbt build --select positions` succeeds; `dbt test --select positions` passes (15 tests: unique/not_null on PK, not_null on flags/ids/office_type/updated_at, accepted_values on `office_type` and the boolean flags, `is_state_abbreviation`, `accepted_range >= 0` on `icp_voter_count`).
- pre-commit (sqlfmt, yaml, generic hooks) passes.

Ref: DATA-1984

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only mart built from existing intermediates with documented semantics and dbt tests; no changes to merge logic in election or candidacy models.
> 
> **Overview**
> Adds a governed **`mart_civics.positions`** table (one row per `br_position_database_id`) so consumers can look up BallotReady offices with L2 district match, **`icp_voter_count`**, and Win/Serve/Supersize ICP flags without going through election- or candidacy-grain marts.
> 
> The model is mostly a pass-through from `int__icp_offices`, with **`office_type`** left-joined from `int__civics_position_office_type` so it aligns with the election and candidacy marts. ICP columns use the same naming (`is_win_icp`, etc.) but expose **position-level, un-gated** eligibility; election/candidacy still apply **`icp_win_effective_date`** on top. Flags stay **NULL** when there is no L2 match.
> 
> Docs and tests are added in `m_civics.yaml` (grain, column descriptions, ~15 data tests) and the civics README is updated so **`positions`** is listed in the model table and the “which table?” guide for office/ICP lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d77e53e95c80b80f11119cf30734007e183c2c02. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->