### PR TITLE
[DATA-1988] Serve district resolution model (int__serve_district_resolution)

### DIFF
--- a/dbt/project/macros/normalize_l2_district_name.sql
+++ b/dbt/project/macros/normalize_l2_district_name.sql
@@ -1,0 +1,15 @@
+-- Normalized join key for L2 district names. L2 names drift between
+-- snapshots: the " (EST.)" suffix appears and disappears, and doubled
+-- internal spaces show up in some vintages. Joining cohort districts to
+-- L2-derived tables on the raw name silently zeroes those districts, so
+-- every cross-snapshot district-name join must normalize BOTH sides with
+-- this macro (collapse whitespace, strip a trailing " (EST.)", upper-case).
+{% macro normalize_l2_district_name(column_expr) %}
+    upper(
+        regexp_replace(
+            trim(regexp_replace({{ column_expr }}, '\\s+', ' ')),
+            '\\s*\\(EST\\.\\)$',
+            ''
+        )
+    )
+{% endmacro %}

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3159,3 +3159,149 @@ models:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns: [source_name, gp_election_stage_id]
+
+  - name: int__serve_district_resolution
+    description: >
+      Resolves each serve org to its L2 district: the serve-cohort entry point
+      onto the District/Census substrate (a downstream consumer; election-api
+      quarantined here, not in the substrate). Part of the Constituents Served
+      pipeline
+      (DATA-1988, epic DATA-1359). One row per serve org (organizations mart,
+      organization_type = 'serve'), resolved to the L2 district the official
+      serves: override-first through the org's election-api district record
+      (coalesce(override_district_id, district_id), which bakes in the manual
+      override corrections), with the LLM position->district crosswalk as
+      fallback. Carries the snapshot-stable normalized district join key (L2
+      names drift between snapshots), the resolution path, and guardrail
+      flags: requires_review (deterministic container-mismatch rules),
+      is_geo_seat (the jurisdiction-vs-electoral-seat semantics question),
+      is_statewide (reported separately downstream), and is_internal_email.
+      Rows are never excluded here; pending cohort decisions are var-driven
+      filters plus flags, and flagged rows flow through for downstream review.
+    columns:
+      - name: organization_slug
+        description: Serve org identifier (primary key)
+        data_tests:
+          - unique
+          - not_null
+      - name: user_id
+        description: Owning user of the serve org
+        data_tests:
+          - not_null
+      - name: elected_office_id
+        description: >
+          The org's elected office record (its existence is what makes the
+          org a serve org)
+        data_tests:
+          - not_null
+      - name: ballotready_position_id
+        description: BallotReady position id, when the org has a linked position
+      - name: position_name
+        description: Position title from the linked election-api position
+      - name: custom_position_name
+        description: Free-text position title entered in the product
+      - name: district_id
+        description: >
+          The election-api district id the org resolves through
+          (override_district_id when present, else the position's district)
+      - name: resolution_path
+        description: Which leg resolved the org to a district
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["district_mart", "crosswalk", "unresolved"]
+      - name: state
+        description: >
+          Two-letter state code of the resolved district. Sourced from the
+          district row (or crosswalk row), never from the org's
+          position_state, which is null for override-only orgs.
+        data_tests:
+          - not_null:
+              config:
+                where: "resolution_path != 'unresolved'"
+      - name: l2_district_type
+        description: >
+          L2 district-type column name. 'State' is a synthetic type for
+          statewide offices; every other value, including 'Other', is a real
+          L2 column.
+        data_tests:
+          - not_null:
+              config:
+                where: "resolution_path != 'unresolved'"
+      - name: l2_district_name
+        description: Raw L2 district name as carried by the resolving source
+        data_tests:
+          - not_null:
+              config:
+                where: "resolution_path != 'unresolved'"
+      - name: normalized_district_name
+        description: >
+          Snapshot-stable district join key (normalize_l2_district_name
+          macro: collapse whitespace, strip the drifting " (EST.)" suffix,
+          upper-case). Downstream joins to L2-derived tables must use this
+          key, normalized on both sides.
+        data_tests:
+          - not_null:
+              config:
+                where: "resolution_path != 'unresolved'"
+      - name: is_statewide
+        description: >
+          Resolved to the synthetic statewide district; statewide orgs are
+          reported separately downstream, never mixed into the local headline
+        data_tests:
+          - not_null
+      - name: review_rule_statewide_container
+        description: >
+          Deterministic rule (a) - matched to the synthetic statewide
+          district but the title is not a statewide office
+        data_tests:
+          - not_null
+      - name: review_rule_county_container
+        description: >
+          Deterministic rule (b) - matched to a whole county but the title
+          carries no county/borough/parish term (county-equivalent
+          independent cities, stored by L2 in the County column with a
+          ' CITY' suffix, are excluded as correct matches)
+        data_tests:
+          - not_null
+      - name: review_rule_subscope_marker
+        description: >
+          Deterministic rule (c) - title names a sub-jurisdiction (subarea
+          seat, community education council) while the match is a whole
+          county, city, or school district
+        data_tests:
+          - not_null
+      - name: requires_review
+        description: >
+          Any container-mismatch rule fired: the resolved district likely
+          contains, but is larger than, the office's real jurisdiction.
+          Flagged rows still flow through; the review queue consumes them.
+        data_tests:
+          - not_null
+      - name: review_reason
+        description: Human-readable list of the rules that fired; null when none
+      - name: is_geo_seat
+        description: >
+          Title carries a geographic seat designation (Ward 3, District F,
+          Zone 1) while the matched district is the whole jurisdiction.
+          Correct under whole-jurisdiction semantics (the v1 default),
+          overcounts under electoral-district semantics. Flag only - the
+          semantics decision is pending.
+        data_tests:
+          - not_null
+      - name: is_internal_email
+        description: >
+          Owner email matches the internal/test pattern. Whether these orgs
+          count toward the public metric is a pending product decision, so
+          flag, never exclude (the serve_cohort_exclude_internal_email_orgs
+          var flips the filter).
+        data_tests:
+          - not_null
+    data_tests:
+      - dbt_utils.expression_is_true:
+          name: serve_district_resolution_review_reason_consistency
+          arguments:
+            expression: >
+              (requires_review and review_reason is not null)
+              or (not requires_review and review_reason is null)

--- a/dbt/project/models/intermediate/civics/int__serve_district_resolution.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_district_resolution.sql
@@ -1,0 +1,196 @@
+{{ config(materialized="table", tags=["civics", "serve"]) }}
+
+-- int__serve_district_resolution: resolves each serve org to its L2 district
+-- (override-first via election-api, crosswalk fallback). The serve-cohort
+-- entry point onto the District/Census substrate: a downstream consumer of the
+-- substrate, not part of it, so the election-api dependency is quarantined here
+-- and never pulls into the substrate build.
+--
+-- One row per serve org (organizations mart, organization_type = 'serve'),
+-- resolving each org to the L2 district its official serves (DATA-1988, epic
+-- DATA-1359): downstream models join the resolved (state, l2_district_type,
+-- normalized_district_name) tuple to L2-derived tables to count the people
+-- who live in each official's jurisdiction.
+--
+-- Resolution is override-first: the org's own election-api district record
+-- (coalesce(override_district_id, district_id), which bakes in the manual
+-- override corrections made through the product) wins; the LLM
+-- position->district crosswalk is the fallback for orgs with a BallotReady
+-- position but no district row. Orgs resolving through neither path carry
+-- resolution_path = 'unresolved' (mostly custom free-text positions - a
+-- product fix, not a pipeline fix).
+--
+-- Rows are never excluded here. Pending product decisions (ever-serve vs
+-- currently-active cohort, internal-email orgs in or out) surface as flag
+-- columns plus var-driven filters so a decision is a parameter flip, not a
+-- rewrite. requires_review marks deterministic container-mismatch rules (a
+-- local office resolved to a too-large containing district); is_geo_seat
+-- marks the jurisdiction-vs-electoral-seat semantics question. Flagged rows
+-- flow through; downstream consumers decide what to do with them.
+with
+    serve_orgs as (
+        -- the cohort predicate lives here and only here: "ever-serve" by
+        -- default. A future ever-vs-active decision lands as one more
+        -- predicate in this CTE.
+        select * from {{ ref("organizations") }} where organization_type = 'serve'
+    ),
+
+    districts as (select * from {{ ref("m_election_api__district") }}),
+
+    crosswalk as (
+        select *
+        from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
+        where is_matched
+    ),
+
+    resolved as (
+        select
+            o.organization_slug,
+            o.user_id,
+            o.elected_office_id,
+            o.ballotready_position_id,
+            o.position_name,
+            o.custom_position_name,
+            coalesce(o.override_district_id, o.district_id) as district_id,
+            case
+                when d.id is not null
+                then 'district_mart'
+                when x.br_database_id is not null
+                then 'crosswalk'
+                else 'unresolved'
+            end as resolution_path,
+            -- override-only orgs have no position, hence a null
+            -- position_state: the district row is the authoritative state
+            -- source on both paths
+            coalesce(d.state, x.state) as state,
+            coalesce(d.l2_district_type, x.l2_district_type) as l2_district_type,
+            coalesce(d.l2_district_name, x.l2_district_name) as l2_district_name,
+            -- combined searchable office title for the deterministic flag
+            -- rules below (position titles and custom titles both carry
+            -- scope markers)
+            lower(
+                concat_ws(
+                    ' ',
+                    coalesce(o.position_name, ''),
+                    coalesce(o.custom_position_name, '')
+                )
+            ) as title_text,
+            o.user_email
+        from serve_orgs o
+        left join districts d on coalesce(o.override_district_id, o.district_id) = d.id
+        left join crosswalk x on o.ballotready_position_id = x.br_database_id
+    ),
+
+    final as (
+        select
+            organization_slug,
+            user_id,
+            elected_office_id,
+            ballotready_position_id,
+            position_name,
+            custom_position_name,
+            district_id,
+            resolution_path,
+            state,
+            l2_district_type,
+            l2_district_name,
+            {{ normalize_l2_district_name("l2_district_name") }}
+            as normalized_district_name,
+
+            -- 'State' is a synthetic L2 district type for statewide offices
+            -- (every other type, including 'Other', is a real L2 column).
+            -- Statewide orgs are reported separately downstream, never mixed
+            -- into the local headline.
+            coalesce(l2_district_type = 'State', false) as is_statewide,
+
+            -- requires_review rules: deterministic, no discretion. Each rule
+            -- targets the container-fallback failure mode (an office matched
+            -- to a district that contains, but is larger than, its real
+            -- jurisdiction), which validation found to be the dominant
+            -- precision risk on both resolution paths.
+            -- (a) matched to the synthetic statewide district but the title
+            -- is not a statewide office
+            coalesce(
+                l2_district_type = 'State'
+                and not title_text
+                rlike 'u\\.?s\\.? senate|united states senate|governor|secretary of state|attorney general|treasurer|auditor|comptroller|superintendent of public instruction',
+                false
+            ) as review_rule_statewide_container,
+
+            -- (b) matched to a whole county but nothing in the title says
+            -- county-level office. Virginia-style independent cities are
+            -- county-equivalents that L2 stores in the County column with a
+            -- ' CITY' name suffix; a city office matched to one of those is
+            -- correct, so they are excluded.
+            coalesce(
+                l2_district_type = 'County'
+                and not title_text rlike 'county|borough|parish'
+                and not normalized_district_name like '% CITY',
+                false
+            ) as review_rule_county_container,
+
+            -- (c) title names a sub-jurisdiction (a subarea seat or a
+            -- community education council, whose office governs less than
+            -- the matched district) while the match is a whole county,
+            -- city, or school district
+            coalesce(
+                title_text rlike 'subarea|community education council'
+                and l2_district_type
+                in ('County', 'City', 'School_District', 'Unified_School_District'),
+                false
+            ) as review_rule_subscope_marker,
+
+            review_rule_statewide_container
+            or review_rule_county_container
+            or review_rule_subscope_marker as requires_review,
+
+            nullif(
+                concat_ws(
+                    '; ',
+                    case
+                        when review_rule_statewide_container
+                        then 'non-statewide office matched to the statewide district'
+                    end,
+                    case
+                        when review_rule_county_container
+                        then
+                            'matched to a whole county but title has no county/borough/parish term'
+                    end,
+                    case
+                        when review_rule_subscope_marker
+                        then
+                            'title names a sub-jurisdiction but matched to a whole district'
+                    end
+                ),
+                ''
+            ) as review_reason,
+
+            -- the title carries a geographic seat designation (Ward 3,
+            -- District F, Zone 1) while the matched district is the whole
+            -- jurisdiction: under "whole governed jurisdiction" semantics
+            -- (the v1 default) these are correct; under electoral-district
+            -- semantics they overcount. Flag only - the semantics decision
+            -- is pending. Seat/place/position numbering is at-large, not
+            -- geographic, and is deliberately not matched.
+            coalesce(
+                title_text
+                rlike '(ward|district|zone|area|division|subdistrict|precinct|region)[ .#-]*([0-9]+|[a-h])\\b'
+                and not (
+                    l2_district_type
+                    rlike 'Ward|Subdistrict|SubDistrict|Commissioner|Supervisorial|Legislative|Congressional|State_House|State_Senate|Precinct|School_Board|Board_of_Education_District|Council_District|Judicial'
+                    or l2_district_type in ('State', 'Other')
+                ),
+                false
+            ) as is_geo_seat,
+
+            -- internal/test accounts; whether they count toward the public
+            -- metric is a pending product decision, so flag, never exclude
+            coalesce(user_email ilike '%goodparty%', false) as is_internal_email
+        from resolved
+    )
+
+select *
+from final
+{% if var("serve_cohort_exclude_internal_email_orgs", false) %}
+    where not is_internal_email
+{% endif %}

--- a/dbt/project/tests/assert_serve_district_resolution_bind_l2_voters_warn.sql
+++ b/dbt/project/tests/assert_serve_district_resolution_bind_l2_voters_warn.sql
@@ -1,0 +1,46 @@
+{{ config(severity="warn") }}
+
+-- Name-drift guard for the serve cohort (DATA-1988). Every resolved,
+-- non-statewide cohort district must match at least one row in
+-- int__l2_district_aggregations on the normalized
+-- (state, district_type, district_name) key - normalized on BOTH sides,
+-- because L2 names drift between snapshots. A district that fails here
+-- would silently report zero constituents downstream, so the failing rows
+-- ARE the re-match queue: each one needs a corrected override or a
+-- crosswalk re-match. Severity is warn (not error) while the known drift
+-- backlog is worked off; flip to error once the queue is empty.
+--
+-- Caveat: int__l2_district_aggregations is incremental and never deletes,
+-- so a district renamed in the newest L2 snapshot can still bind to a
+-- stale row here. The post-refresh newly-unbound check (review-ops ticket
+-- of the epic) covers that window.
+with
+    cohort_districts as (
+        select state, l2_district_type, normalized_district_name, count(*) as n_orgs
+        from {{ ref("int__serve_district_resolution") }}
+        where resolution_path != 'unresolved' and not is_statewide
+        group by state, l2_district_type, normalized_district_name
+    ),
+
+    l2_districts as (
+        select distinct
+            state_postal_code as state,
+            district_type as l2_district_type,
+            {{ normalize_l2_district_name("district_name") }}
+            as normalized_district_name
+        from {{ ref("int__l2_district_aggregations") }}
+    )
+
+select
+    cohort_districts.state,
+    cohort_districts.l2_district_type,
+    cohort_districts.normalized_district_name,
+    cohort_districts.n_orgs
+from cohort_districts
+left join
+    l2_districts
+    on cohort_districts.state = l2_districts.state
+    and cohort_districts.l2_district_type = l2_districts.l2_district_type
+    and cohort_districts.normalized_district_name
+    = l2_districts.normalized_district_name
+where l2_districts.state is null

--- a/dbt/project/tests/assert_serve_district_resolution_coverage_floor.sql
+++ b/dbt/project/tests/assert_serve_district_resolution_coverage_floor.sql
@@ -1,10 +1,18 @@
 -- Alerting guard on the serve-cohort district resolution rate (DATA-1988).
--- Fails when the share of serve orgs resolving to a district drops below
--- 95%. A share floor rather than a fixed count, so cohort growth alone
--- never trips it; a real drop means an upstream break (district mart,
--- crosswalk vintage, or organizations mart joins).
+-- Fails when the resolved share drops below 95%, or when the model is empty
+-- (count(*) = 0, a total upstream break). A share floor, not a fixed count,
+-- so cohort growth alone never trips it; a real drop means an upstream break
+-- (district mart, crosswalk vintage, or organizations mart joins). The
+-- `* 1.0` keeps the ratio an explicit float per the sibling coverage tests
+-- (Databricks `/` is already float division, not integer-truncating), and
+-- nullif(count(*), 0) guards the empty model from an ANSI divide-by-zero.
 select
     count(*) as total_orgs,
     count(case when resolution_path != 'unresolved' then 1 end) as resolved_orgs
 from {{ ref("int__serve_district_resolution") }}
-having count(case when resolution_path != 'unresolved' then 1 end) / count(*) < 0.95
+having
+    count(*) = 0
+    or count(case when resolution_path != 'unresolved' then 1 end)
+    * 1.0
+    / nullif(count(*), 0)
+    < 0.95

--- a/dbt/project/tests/assert_serve_district_resolution_coverage_floor.sql
+++ b/dbt/project/tests/assert_serve_district_resolution_coverage_floor.sql
@@ -1,0 +1,10 @@
+-- Alerting guard on the serve-cohort district resolution rate (DATA-1988).
+-- Fails when the share of serve orgs resolving to a district drops below
+-- 95%. A share floor rather than a fixed count, so cohort growth alone
+-- never trips it; a real drop means an upstream break (district mart,
+-- crosswalk vintage, or organizations mart joins).
+select
+    count(*) as total_orgs,
+    count(case when resolution_path != 'unresolved' then 1 end) as resolved_orgs
+from {{ ref("int__serve_district_resolution") }}
+having count(case when resolution_path != 'unresolved' then 1 end) / count(*) < 0.95


### PR DESCRIPTION
## What

`int__serve_district_resolution`: the serve-org to L2-district resolution leg of the Constituents Served pipeline (DATA-1988, epic DATA-1359). Grain: one row per serve org. Each org is resolved to the L2 district its official serves:

1. **Primary (override-first):** the org's own election-api district record, `coalesce(override_district_id, district_id)` joined to `m_election_api__district`, which bakes in the manual override corrections made through the product.
2. **Fallback:** the LLM position-to-district crosswalk (`stg_model_predictions__llm_l2_br_match_20260126`, `is_matched`) on `ballotready_position_id`.

This is the **serve-cohort entry point onto the District/Census substrate**: a downstream *consumer* of the substrate, not part of it, so the election-api dependency is quarantined here and never pulls into the (heavier) substrate build.

Also adds `normalize_l2_district_name` (macro): the snapshot-stable district-name join key (collapse whitespace, strip the drifting `" (EST.)"` suffix, upper-case). All downstream joins to L2-derived tables must normalize both sides with it.

Rows are never excluded. Pending product decisions surface as flags plus a var-driven filter (`serve_cohort_exclude_internal_email_orgs`):

- `is_statewide`: synthetic `State` matches, reported separately downstream.
- `requires_review` + `review_reason`: deterministic container-mismatch rules.
- `is_geo_seat`: geographic seat title matched to the whole jurisdiction (flag only; seat semantics is a pending decision).
- `is_internal_email`: internal/test-pattern owner emails (flag only).

## This revision (T2 rework of the prior PR)

- **Rebased on main.** The earlier apparent deletions were a branch-behind-main artifact; this branch is now on top of current main with the clean 5-file diff (0 deletions).
- **Renamed** `int__serve_cohort_district` to `int__serve_district_resolution` (the old name did not convey what the model does). The two singular tests and the inline review-reason test were renamed to match; the `normalize_l2_district_name` macro and the cohort-membership var keep their names. **Logic is byte-for-byte unchanged** (git reports 95% file similarity; only the header comment expanded).
- Aligns with the signed-off TDD v2 §7.1.

## Tests

- Schema: unique/not_null grain, accepted_values on `resolution_path`, not_null on resolution columns where resolved, flag not_nulls, review_reason vs requires_review consistency.
- `assert_serve_district_resolution_coverage_floor`: resolved share >= 95% (share floor, not a fixed count).
- `assert_serve_district_resolution_bind_l2_voters_warn`: every resolved non-statewide district must bind at least one row in `int__l2_district_aggregations` on the normalized key (both sides normalized). **Warn severity: the failure rows ARE the re-match queue.**

## Verification (re-confirmed 2026-06-16 against prod via the read-only databricks-query helper)

Reconciliation of the resolution logic against current prod upstreams, exact match to the validated design targets:

| Metric | Target | Got |
|---|---|---|
| serve orgs (grain) | 1,854 | 1,854 (1,854 distinct slugs, no fan-out) |
| resolved (district mart + crosswalk) | 1,788 = 1,783 + 5 | 1,788 = 1,783 + 5 |
| unresolved | 66 | 66 |
| statewide | 2 | 2 |
| coverage floor | pass (>= 95%) | 0.9644 |

## Notes

- The election-api dependency stays here by design (quarantined from the substrate, which depends only on L2 + decennial population).
- Caveat in the binding-test header: `int__l2_district_aggregations` is incremental-merge and never deletes, so a freshly renamed district can still bind a stale row; the post-refresh newly-unbound check is the epic's review-ops follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cohort-resolution logic ties serve orgs to L2 voter geography; wrong matches would skew constituent counts, but override-first design, quarantined election-api dependency, and binding/coverage tests limit blast radius.
> 
> **Overview**
> Adds **`int__serve_district_resolution`**, one row per serve org, mapping each org to the L2 district its official serves for the Constituents Served pipeline. Resolution is **override-first** via `m_election_api__district` on `coalesce(override_district_id, district_id)`, with the LLM position→district crosswalk as fallback; election-api stays on this model so the District/Census substrate build is not pulled in.
> 
> Introduces **`normalize_l2_district_name`** so L2 district joins use a stable key (whitespace collapse, strip trailing ` (EST.)`, upper-case) on both sides of downstream L2 joins.
> 
> The model emits **`resolution_path`**, **`normalized_district_name`**, and review flags (`requires_review` / `review_reason` for container mismatches, `is_geo_seat`, `is_statewide`, `is_internal_email`) without dropping rows; optional cohort filtering uses **`serve_cohort_exclude_internal_email_orgs`**.
> 
> Schema tests plus **`assert_serve_district_resolution_coverage_floor`** (≥95% resolved) and **`assert_serve_district_resolution_bind_l2_voters_warn`** (resolved non-statewide districts must bind `int__l2_district_aggregations` on the normalized key, warn severity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e8b9c459d59c8be844487a17f7a364828a9074. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->