### PR TITLE
[DATA-1582] Enrich election_stage mart for DDHQ coverage-gap analysis

### DIFF
--- a/dbt/project/analyses/ddhq_election_stage_coverage_gaps.sql
+++ b/dbt/project/analyses/ddhq_election_stage_coverage_gaps.sql
@@ -1,0 +1,44 @@
+-- DDHQ vs BallotReady local election coverage gaps.
+--
+-- This is a dbt *analysis*: it is compiled (refs resolved, validated against the
+-- schema) but never materialized. Run the compiled SQL ad hoc to inspect which
+-- BallotReady local races DDHQ has not matched.
+--
+-- Definition of a gap: BallotReady has the race (`ballotready` in source_systems)
+-- but DDHQ does not (`ddhq` not in source_systems). Scoped to be a fair,
+-- actionable comparison:
+-- - bounded to DDHQ's data horizon (max DDHQ election_date) so far-future BR
+-- races DDHQ has not loaded yet are not counted as gaps;
+-- - local only (office_level not in State/Federal);
+-- - partisan primaries excluded (out of scope for the DDHQ coverage agreement:
+-- independent / 3rd-party candidates are ineligible);
+-- - real races only (br_candidate_count > 0) -- races with no filed candidates
+-- are largely uncontested or BR implied-future races that never reach DDHQ.
+-- has_techspeed_match flags the highest-confidence subset: a second source
+-- independently confirms the race exists.
+with
+    ddhq_horizon as (
+        select max(election_date) as last_ddhq_election_date
+        from {{ ref("int__civics_election_stage_ddhq") }}
+    )
+
+select
+    e.gp_election_stage_id,
+    -- 2-letter state prefix of race_name (reliable for 2026+ rows).
+    upper(substring(e.race_name, 1, 2)) as state,
+    e.race_name,
+    e.office_level,
+    e.election_date,
+    e.stage_type,
+    e.br_candidate_count,
+    array_contains(e.source_systems, 'techspeed') as has_techspeed_match
+from {{ ref("election_stage") }} as e
+cross join ddhq_horizon as h
+where
+    not array_contains(e.source_systems, 'ddhq')
+    and array_contains(e.source_systems, 'ballotready')
+    and e.election_date between date '2026-01-01' and h.last_ddhq_election_date
+    and e.office_level not in ('State', 'Federal')
+    and not coalesce(e.partisan_type = 'partisan' and e.is_primary, false)
+    and e.br_candidate_count > 0
+order by state, e.election_date, e.race_name

--- a/dbt/project/models/marts/civics/election_stage.sql
+++ b/dbt/project/models/marts/civics/election_stage.sql
@@ -15,6 +15,8 @@
     "election_date",
     "election_name",
     "race_name",
+    "office_level",
+    "office_type",
     "is_primary",
     "is_runoff",
     "is_retention",
@@ -35,6 +37,10 @@ with
             ddhq_election_stage_date as election_date,
             cast(null as string) as election_name,
             ddhq_race_name as race_name,
+            -- 2025 archive carries no office taxonomy; null to match
+            -- merged_since_2026 column order (br_wins_cols loop).
+            cast(null as string) as office_level,
+            cast(null as string) as office_type,
             election_stage in (
                 'primary', 'primary runoff', 'primary special', 'primary special runoff'
             ) as is_primary,
@@ -138,6 +144,19 @@ with
         select distinct gp_election_stage_id
         from {{ ref("int__civics_candidacy_stage_gp_api") }}
         where gp_election_stage_id is not null
+    ),
+
+    -- BR candidacies per race (BR-side candidate count). Sourced from the
+    -- race-grain S3 candidacies so every stage's br_race_id gets its own count;
+    -- the rolled-up candidacy model collapses stages onto one any_value
+    -- br_race_id and would zero-out the non-selected stages.
+    br_candidacy_counts as (
+        select
+            cast(br_race_id as string) as br_race_id,
+            count(distinct cast(br_candidate_id as string)) as br_candidate_count
+        from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
+        where br_race_id is not null
+        group by br_race_id
     )
 
 select
@@ -151,11 +170,14 @@ select
     deduplicated.election_date,
     deduplicated.election_name,
     deduplicated.race_name,
+    deduplicated.office_level,
+    deduplicated.office_type,
     deduplicated.is_primary,
     deduplicated.is_runoff,
     deduplicated.is_retention,
     deduplicated.number_of_seats,
     deduplicated.total_votes_cast,
+    coalesce(bcc.br_candidate_count, 0) as br_candidate_count,
     deduplicated.partisan_type,
     deduplicated.filing_period_start_on,
     deduplicated.filing_period_end_on,
@@ -199,3 +221,4 @@ left join
 left join
     gp_api_membership as gp
     on deduplicated.gp_election_stage_id = gp.gp_election_stage_id
+left join br_candidacy_counts as bcc on deduplicated.br_race_id = bcc.br_race_id

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -1522,6 +1522,16 @@ models:
           fields (e.g. "IL Franklin County Board - Full Term"). Not directly
           comparable across eras due to the format difference.
 
+      - name: office_level
+        description: >
+          Office level (City, County, Township, Local, Regional, State,
+          Federal). BR-first precedence, then TechSpeed, then DDHQ. NULL for
+          2025 archive records.
+      - name: office_type
+        description: >
+          Office type. BR-first precedence, then TechSpeed, then DDHQ. NULL for
+          2025 archive records.
+
       - name: is_primary
         description: Whether this stage is a primary election
         data_tests:
@@ -1552,6 +1562,12 @@ models:
           column because it may contain the value "uncontested" for races
           without competitive vote tallies, not just numeric values. Cast
           to integer only after filtering out non-numeric entries.
+
+      - name: br_candidate_count
+        description: >
+          Count of BallotReady candidacies on the race, from the race-grain S3
+          candidacies source. 0 when BR has no candidacies (e.g. DDHQ/TS-only
+          rows, or uncontested / future races with no filed candidates).
 
       - name: partisan_type
         description: >


### PR DESCRIPTION
## Summary

Enriches the `election_stage` civics mart with `office_level`, `office_type`, and `br_candidate_count` so DDHQ-vs-BR election coverage-gap analysis can be expressed as a **filter over the mart** — the mart's `source_systems` already reflects DDHQ coverage — rather than a standalone crosswalk-joining model.

This **supersedes #446** (the standalone `int__civics_ddhq_election_stage_coverage_gaps` model), per review feedback that the mart + a filter is the cleaner home.

- `office_level` / `office_type`: BR-first coalesce from the per-source election_stage models.
- `br_candidate_count`: distinct BR candidacies per race from the race-grain S3 candidacies source (avoids the `any_value(br_race_id)` collapse in the rolled-up candidacy model).
- All additive; grain unchanged (one row per `gp_election_stage_id`).

## Why the mart is the right (and more accurate) source

The mart's `source_systems` is built from the per-source `gp_election_stage_id` alignment, which turns out to be **more complete than the Splink ER crosswalk for DDHQ**: it identifies **260 real DDHQ matches** (all with a `ddhq_race_id`) within the actionable subset that the crosswalk missed (the crosswalk caught 64 the mart missed). So the gap count drops and gets more trustworthy.

## The coverage-gap query

DDHQ-vs-BR local coverage gaps, bounded to DDHQ's data horizon and scoped to the agreement (partisan primaries excluded):

```sql
with ddhq_horizon as (
    select max(election_date) as last_ddhq_election_date
    from mart_civics.election_stage  -- or the int model: int__civics_election_stage_ddhq
    where array_contains(source_systems, 'ddhq')
)
select
    e.gp_election_stage_id,
    upper(substring(e.race_name, 1, 2)) as state,  -- 2-letter race_name prefix
    e.race_name,
    e.office_level,
    e.election_date,
    e.stage_type,
    e.br_candidate_count,
    array_contains(e.source_systems, 'techspeed') as has_techspeed_match
from mart_civics.election_stage e, ddhq_horizon h
where not array_contains(e.source_systems, 'ddhq')      -- DDHQ has no match
  and array_contains(e.source_systems, 'ballotready')   -- BR has the race
  and e.election_date between date '2026-01-01' and h.last_ddhq_election_date
  and e.office_level not in ('State', 'Federal')         -- local
  and not coalesce(e.partisan_type = 'partisan' and e.is_primary, false)  -- agreement scope
  and e.br_candidate_count > 0                            -- real races only
order by state, e.election_date, e.race_name;
```

## Funnel (current data)

- **13,433** scoped local gaps (within DDHQ window, agreement-scoped)
- → **813** with BR candidates (real races)
- → **364** also TS-confirmed (a second source confirms the race exists; highest-confidence "DDHQ missed a real race")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
