### PR TITLE
[DATA-1986] Add statewide positions to zip→office mapping

### DIFF
--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -238,7 +238,10 @@ models:
               arguments:
                 value_set: "{{ get_us_states_list(include_DC=true, include_US=false) }}"
       - name: district_type
-        description: "L2 district column name (e.g. City, US_Congressional_District)"
+        description: >
+          L2 district column name (e.g. City, US_Congressional_District), plus
+          the synthetic value 'State' (one row per in-state zip, district_name =
+          state_postal_code) used to give statewide positions zip coverage.
         tests:
           - not_null
       - name: district_name

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_br_office.sql
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_br_office.sql
@@ -79,6 +79,20 @@ with
         left join
             {{ ref("stg_airbyte_source__ballotready_api_race") }} as tbl_br_race
             on tbl_br_position.database_id = tbl_br_race.position.databaseid
+        -- DATA-1986: the LLM BR Office <-> L2 District matcher uses
+        -- l2_district_type='State' as a fallback bucket, so non-statewide
+        -- positions also land there (district/circuit/appellate judges,
+        -- state-legislative districts, water/community special districts).
+        -- Restrict statewide coverage to positions whose BR geography is the
+        -- whole state (mtfcc='G4000') and that are contestable (exclude
+        -- judicial retention seats). Non-'State' district types are unaffected;
+        -- curated statewide exceptions flow through override_zip_to_br_office.
+        where
+            tbl_zip.district_type <> 'State'
+            or (
+                tbl_br_position.mtfcc = 'G4000'
+                and not coalesce(tbl_br_position.is_retention, false)
+            )
         -- dedup to the latest race per BR position per zip+district
         qualify
             row_number() over (

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_l2_district.py
@@ -144,6 +144,46 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
         district_dataframes.append(district_df)
 
+    # Synthetic statewide district (DATA-1986). 'State' is excluded from the
+    # per-column loop above (EXCLUDED_DISTRICT_TYPES) because it is not a real
+    # L2 district column, but statewide BR positions (Governor, U.S. Senate,
+    # etc.) are matched to l2_district_type='State', l2_district_name=<state>
+    # by the LLM BR Office <-> L2 District matcher, the override seed, and
+    # int__l2_district_aggregations.
+    # Without these bridge rows those positions get zero zip coverage and never
+    # appear in the zip-scoped officepicker. Every voter in a zip is in the
+    # state, so the state is the district and voters_in_zip_district equals
+    # voters_in_zip (pct_districtzip_to_zip == 1.0 downstream).
+    state_df = l2_uniform_data.select(
+        col("state_postal_code"),
+        col("Residence_Addresses_Zip").alias("zip_code"),
+    ).filter(col("Residence_Addresses_Zip").isNotNull())
+
+    state_df = state_df.withColumn(
+        "zip_code",
+        when(length(col("zip_code")) == 4, concat(lit("0"), col("zip_code"))).otherwise(col("zip_code")),
+    )
+
+    state_df = (
+        state_df.groupBy("state_postal_code", "zip_code")
+        .agg(count("*").alias("voters_in_zip_district"))
+        .withColumn("voters_in_zip", spark_sum("voters_in_zip_district").over(zip_window))
+        .withColumn("district_name", col("state_postal_code"))
+        .withColumn("district_type", lit("State"))
+        # Match the column order of the per-district frames above so the
+        # positional union below aligns correctly.
+        .select(
+            "state_postal_code",
+            "zip_code",
+            "district_name",
+            "voters_in_zip_district",
+            "voters_in_zip",
+            "district_type",
+        )
+    )
+
+    district_dataframes.append(state_df)
+
     if district_dataframes:
         zip_code_to_l2_district = district_dataframes[0]
         for df in district_dataframes[1:]:

--- a/dbt/project/tests/assert_statewide_coverage_is_genuinely_statewide.sql
+++ b/dbt/project/tests/assert_statewide_coverage_is_genuinely_statewide.sql
@@ -1,0 +1,25 @@
+-- DATA-1986: statewide (district_type='State') coverage must be limited to
+-- genuinely statewide, contestable offices — positions whose BR geography is
+-- the whole state (mtfcc='G4000') and that are not judicial retention seats.
+--
+-- The LLM BR Office <-> L2 District matcher over-assigns l2_district_type='State'
+-- to non-statewide positions (district/circuit/appellate judges, state
+-- legislative districts, water/community districts); the gate in
+-- int__zip_code_to_br_office drops those. Human-curated statewide exceptions in
+-- the override seed are exempt (they carry their own intentional State mapping).
+--
+-- Each row returned is a matcher-path 'State' position that should have been
+-- gated out.
+select z.br_database_id, pos.name, pos.mtfcc, pos.is_retention
+from {{ ref("int__zip_code_to_br_office") }} as z
+inner join
+    {{ ref("stg_airbyte_source__ballotready_api_position") }} as pos
+    on z.br_database_id = pos.database_id
+where
+    z.district_type = 'State'
+    and z.br_database_id not in (
+        select br_database_id
+        from {{ ref("l2_br_match_overrides") }}
+        where br_database_id is not null
+    )
+    and (pos.mtfcc <> 'G4000' or coalesce(pos.is_retention, false))

--- a/dbt/project/tests/assert_zip_to_l2_state_coverage.sql
+++ b/dbt/project/tests/assert_zip_to_l2_state_coverage.sql
@@ -1,0 +1,27 @@
+-- DATA-1986: every (zip, state) in int__zip_code_to_l2_district must have a
+-- synthetic 'State' district row. Statewide positions (Governor, U.S. Senate,
+-- etc.) are matched to l2_district_type='State' by the LLM BR Office <-> L2
+-- District matcher, so without a (zip, 'State', <state>) bridge row per
+-- in-state zip they get zero zip->office coverage and never appear in the
+-- zip-scoped officepicker.
+--
+-- This guards the bridge rows this change adds, independent of which dated
+-- matcher model the pipeline currently references. Each row returned is a
+-- (zip, state) that has district rows but no 'State' row.
+with
+    zip_states as (
+        select distinct zip_code, state_postal_code
+        from {{ ref("int__zip_code_to_l2_district") }}
+    ),
+    state_coverage as (
+        select distinct zip_code, state_postal_code
+        from {{ ref("int__zip_code_to_l2_district") }}
+        where district_type = 'State'
+    )
+select z.zip_code, z.state_postal_code
+from zip_states as z
+left join
+    state_coverage as s
+    on z.zip_code = s.zip_code
+    and z.state_postal_code = s.state_postal_code
+where s.zip_code is null


### PR DESCRIPTION
## Why

Statewide offices (Governor, U.S. Senate, and other state-level seats) never appeared in the signup office picker — surfaced by a candidate who couldn't find the OR Governor race, and tracked alongside OH U.S. Senate (DATA-1949) and OK Labor Commissioner (DATA-1962).

Two issues, both fixed here:

1. **Missing zip bridge.** Statewide positions are matched to the synthetic `l2_district_type='State'` by the LLM BR Office ↔ L2 District matcher (and the override seed and `int__l2_district_aggregations` assume it), but `int__zip_code_to_l2_district` excluded `State` from its district types (`EXCLUDED_DISTRICT_TYPES`). So matched statewide positions had **zero** zip rows, `m_election_api__zip_to_position` left-joined them with `zip_code = NULL`, and the zip-scoped picker never surfaced them.

2. **Polluted `State` label.** The matcher uses `l2_district_type='State'` as a *fallback bucket* for positions whose true district it can't resolve, so ~39% of its `State`-labeled positions are not statewide (circuit/appellate-by-district judges, state-legislative districts, water/community special districts). Naively bridging all of them would surface ~200 bogus "statewide" offices per ZIP in the picker.

## What

1. Add a synthetic `State` block to `int__zip_code_to_l2_district.py`: one row per in-state ZIP with `district_type='State'`, `district_name=state_postal_code`, `voters_in_zip_district = voters_in_zip` (whole ZIP is in the state, so `pct_districtzip_to_zip = 1.0`). Mirrors the state-level aggregation in `int__l2_district_aggregations.sql`.

2. Gate statewide coverage in `int__zip_code_to_br_office.sql` (matcher path) on the BR position's own geography — `mtfcc='G4000'` (the whole-state Census geography) and `not is_retention` (exclude judicial "keep-the-judge" retention votes, which aren't contestable races). Non-`State` district types are untouched, and the human-curated override seed stays ungated so statewide-elected/district-resident exceptions (e.g. GA Public Service Commission) are preserved.

Tests: `assert_zip_to_l2_state_coverage.sql` (every ZIP has a `State` bridge row) and `assert_statewide_coverage_is_genuinely_statewide.sql` (no matcher-path `State` coverage for non-G4000 or retention positions). Both are matcher-independent.

## Data validation (before → after, dbt cloud)

Before = current production (`goodparty_data_catalog.dbt`); after = full-refresh of this branch.

| Metric | Before | After |
|---|---:|---:|
| `int__zip_code_to_l2_district` `State` rows | 0 | 39,647 |
| `int__zip_code_to_br_office` `State` rows | 0 | 581,276 |
| `int__zip_code_to_br_office` total rows | 2,224,830 | 2,838,351 |
| Distinct statewide positions with coverage | 0 | 778 |
| **Statewide positions reaching the picker** (mart, future elections) | 0 | **334** (~6.5/state, max 16) |

The gate matters: without it the matcher's raw `State` label yields 1,639,835 statewide rows / 1,724 positions, ~39% of which are non-statewide. Gating on `mtfcc='G4000'` + `not is_retention` drops those to 581,276 rows / 778 positions while keeping every genuinely statewide office.

Per-race ZIP coverage in `m_election_api__zip_to_position` (all `pct=1.0`):

| Race | Level / office_type | Before | After |
|---|---|---:|---:|
| Oregon Governor (165277) | State / Statewide-Governor | 0 | 433 |
| U.S. Senate - Ohio (46218) | Federal / Congressional | 0 | 1,246 |
| Oklahoma Labor Commissioner (162113) | State / Other | 0 | 681 |

38/38 tests on the three affected models pass, including the `voters_in_zip` invariant, `one_district_type_per_br`, `assert_override_positions_have_zip_coverage`, and the two new tests above.

## Consumer confirmation (omni)

Traced the election-api → gp-api → webapp picker path; no product code change needed. `ZipToPosition.search()` filters by `zipCode` (now populated) and `pct >= 0.005` (ours is 1.0), and gp-api's `expandLevelToDisplayLevels` maps `STATE → ['State']` / `FEDERAL → ['Federal']`, matching the mart's `display_office_level`.

## Deployment note

The model is incremental, so the production deploy needs a one-time `--full-refresh` of `int__zip_code_to_l2_district` to backfill `State` rows for all existing ZIPs. The mart → election-api sync must run afterward for the change to reach the product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)