### PR TITLE
Fix sync_election_api OOM: chunk mart reads per partition (state / issue)

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -279,6 +279,10 @@ def sync_election_api():
                     source_query=query,
                     target_columns=ZTP_TARGET_COLUMNS,
                     transform_row=_ztp_transform_row,
+                    # Statewide coverage (DATA-1986) added ~260k rows; read one
+                    # state at a time so the worker's peak memory stays bounded
+                    # as the mart grows, instead of buffering the full result.
+                    partition_column="state",
                 )
 
         @task

--- a/airflow/astro/include/custom_functions/election_api_utils.py
+++ b/airflow/astro/include/custom_functions/election_api_utils.py
@@ -90,6 +90,40 @@ def create_staging_table(conn, spec: TableSyncSpec) -> None:
         cur.close()
 
 
+def _partition_queries(
+    source_query: str,
+    partition_column: str | None,
+    batch_size: int,
+) -> list[str]:
+    """Split `source_query` into one query per distinct `partition_column` value.
+
+    Each partition's result set is read independently, so the worker's peak
+    memory is bounded by a single partition rather than the whole mart (the
+    Databricks connector buffers a result set client-side, so an ever-growing
+    mart eventually OOMs the worker). Without a `partition_column`, the source
+    query is returned unchanged.
+    """
+    if partition_column is None:
+        return [source_query]
+
+    distinct_query = f"SELECT DISTINCT {partition_column} AS _pv FROM ({source_query}) AS _src"
+    _cols, batches = read_databricks_table(distinct_query, batch_size=batch_size)
+    try:
+        values = [row[0] for batch in batches for row in batch]
+    finally:
+        batches.close()
+
+    queries = []
+    for value in values:
+        if value is None:
+            predicate = f"_src.{partition_column} IS NULL"
+        else:
+            escaped = str(value).replace("'", "''")
+            predicate = f"_src.{partition_column} = '{escaped}'"
+        queries.append(f"SELECT * FROM ({source_query}) AS _src WHERE {predicate}")
+    return queries
+
+
 def bulk_insert_from_databricks(
     conn,
     spec: TableSyncSpec,
@@ -97,36 +131,50 @@ def bulk_insert_from_databricks(
     target_columns: Sequence[str],
     transform_row: Callable[[tuple], tuple] | None = None,
     batch_size: int = 5000,
+    partition_column: str | None = None,
 ) -> int:
     """Stream `source_query` from Databricks into `staging.<table>_new` in batches.
 
     `transform_row` runs once per source row; if provided, the returned tuple
     must align with `target_columns`. If absent, source rows pass through
     unchanged (must already match `target_columns`).
-    """
-    logger.info("Reading from Databricks: %s", source_query)
-    _col_names, batches = read_databricks_table(source_query, batch_size=batch_size)
 
+    `partition_column`, if set, splits the read into one Databricks query per
+    distinct value so peak worker memory stays bounded to a single partition
+    instead of the whole result set (see `_partition_queries`). The single
+    commit still lands after all partitions, so a mid-load failure rolls the
+    whole staging load back and a retry starts from a clean `<table>_new`.
+    """
     col_list = ", ".join(f'"{c}"' for c in target_columns)
     insert_sql = f'INSERT INTO "{spec.staging_schema}"."{spec.new_table}" ' f"({col_list}) VALUES %s"
 
+    queries = _partition_queries(source_query, partition_column, batch_size)
+
     total = 0
+    cur = conn.cursor()
     try:
-        cur = conn.cursor()
-        try:
-            for batch in batches:
-                rows = [transform_row(r) if transform_row else tuple(r) for r in batch]
-                if not rows:
-                    continue
-                psycopg2.extras.execute_values(cur, insert_sql, rows, page_size=batch_size)
-                total += len(rows)
-                if total % 50_000 < batch_size:
-                    logger.info("Inserted %d rows so far", total)
-            conn.commit()
-        finally:
-            cur.close()
+        for query in queries:
+            logger.info("Reading from Databricks: %s", query)
+            _col_names, batches = read_databricks_table(query, batch_size=batch_size)
+            try:
+                for batch in batches:
+                    rows = [transform_row(r) if transform_row else tuple(r) for r in batch]
+                    if not rows:
+                        continue
+                    psycopg2.extras.execute_values(cur, insert_sql, rows, page_size=batch_size)
+                    total += len(rows)
+                    if total % 50_000 < batch_size:
+                        logger.info("Inserted %d rows so far", total)
+            finally:
+                batches.close()
+        conn.commit()
+    except Exception:
+        # Discard partial inserts so a retry starts from a clean <table>_new
+        # (and the connection isn't left in an aborted-transaction state).
+        conn.rollback()
+        raise
     finally:
-        batches.close()
+        cur.close()
 
     logger.info("Loaded %d rows into %s.%s", total, spec.staging_schema, spec.new_table)
     return total

--- a/airflow/astro/tests/test_election_api_utils.py
+++ b/airflow/astro/tests/test_election_api_utils.py
@@ -1,0 +1,184 @@
+"""Tests for election-api sync utilities (bulk_insert_from_databricks)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from include.custom_functions import election_api_utils
+from include.custom_functions.election_api_utils import bulk_insert_from_databricks
+
+
+def _spec():
+    return SimpleNamespace(staging_schema="staging", new_table="ZipToPosition_new")
+
+
+def _gen(batches):
+    """A real generator (supports .close(), which the loader calls)."""
+
+    def g():
+        yield from batches
+
+    return g()
+
+
+class TestBulkInsertPartitioning:
+    """Partitioned reads keep peak memory bounded by one partition, not the
+    full mart, while preserving single-commit retry-safety."""
+
+    def test_no_partition_runs_single_query(self):
+        """Without partition_column, the source query runs once (unchanged)."""
+        conn = MagicMock()
+        conn.cursor.return_value = MagicMock()
+        reads = []
+
+        def fake_read(query, batch_size=5000):
+            reads.append(query)
+            return (["a"], _gen([[(1,), (2,)]]))
+
+        with (
+            patch.object(election_api_utils, "read_databricks_table", side_effect=fake_read),
+            patch.object(election_api_utils.psycopg2.extras, "execute_values") as ev,
+        ):
+            total = bulk_insert_from_databricks(conn, _spec(), "SELECT a FROM t", ["a"])
+
+        assert total == 2
+        assert reads == ["SELECT a FROM t"]
+        assert ev.call_count == 1
+        conn.commit.assert_called_once()
+
+    def test_partition_chunks_by_distinct_value(self):
+        """With partition_column, one DISTINCT query + one query per value, and
+        every partition's rows are inserted under a single end-of-load commit."""
+        conn = MagicMock()
+        conn.cursor.return_value = MagicMock()
+        reads = []
+
+        def fake_read(query, batch_size=5000):
+            reads.append(query)
+            if "DISTINCT" in query:
+                return (["_pv"], _gen([[("CA",), ("OR",)]]))
+            if "'CA'" in query:
+                return (["a"], _gen([[(1,)]]))
+            if "'OR'" in query:
+                return (["a"], _gen([[(2,), (3,)]]))
+            raise AssertionError(f"unexpected query: {query}")
+
+        with (
+            patch.object(election_api_utils, "read_databricks_table", side_effect=fake_read),
+            patch.object(election_api_utils.psycopg2.extras, "execute_values"),
+        ):
+            total = bulk_insert_from_databricks(
+                conn,
+                _spec(),
+                "SELECT a, state FROM t",
+                ["a"],
+                partition_column="state",
+            )
+
+        assert total == 3
+        assert sum("DISTINCT" in q for q in reads) == 1
+        assert any("'CA'" in q for q in reads)
+        assert any("'OR'" in q for q in reads)
+        # Single commit after all partitions: a mid-load failure rolls back the
+        # whole staging load so a retry starts clean.
+        conn.commit.assert_called_once()
+
+    def test_partition_handles_null_value(self):
+        """A NULL partition value is loaded via an IS NULL predicate (no row loss)."""
+        conn = MagicMock()
+        conn.cursor.return_value = MagicMock()
+        reads = []
+
+        def fake_read(query, batch_size=5000):
+            reads.append(query)
+            if "DISTINCT" in query:
+                return (["_pv"], _gen([[(None,)]]))
+            return (["a"], _gen([[(9,)]]))
+
+        with (
+            patch.object(election_api_utils, "read_databricks_table", side_effect=fake_read),
+            patch.object(election_api_utils.psycopg2.extras, "execute_values"),
+        ):
+            total = bulk_insert_from_databricks(
+                conn,
+                _spec(),
+                "SELECT a, state FROM t",
+                ["a"],
+                partition_column="state",
+            )
+
+        assert total == 1
+        assert any("IS NULL" in q for q in reads)
+
+    def test_load_failure_rolls_back(self):
+        """A mid-load error rolls the staging transaction back (so a retry starts
+        clean) and does not commit, matching the documented guarantee."""
+        conn = MagicMock()
+        conn.cursor.return_value = MagicMock()
+
+        def fake_read(query, batch_size=5000):
+            return (["a"], _gen([[(1,)]]))
+
+        with (
+            patch.object(election_api_utils, "read_databricks_table", side_effect=fake_read),
+            patch.object(
+                election_api_utils.psycopg2.extras,
+                "execute_values",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            bulk_insert_from_databricks(conn, _spec(), "SELECT a FROM t", ["a"])
+
+        conn.rollback.assert_called_once()
+        conn.commit.assert_not_called()
+
+    def test_distinct_read_closed_on_consumer_error(self):
+        """If consuming the distinct-values result raises, the batches generator
+        is still closed (no leaked Databricks connection)."""
+        closed = {"v": False}
+
+        def gen():
+            try:
+                yield [()]  # empty row -> row[0] raises IndexError in the caller
+            finally:
+                closed["v"] = True
+
+        batches = gen()
+
+        def fake_read(query, batch_size=5000):
+            return (["_pv"], batches)
+
+        with (
+            patch.object(election_api_utils, "read_databricks_table", side_effect=fake_read),
+            pytest.raises(IndexError),
+        ):
+            election_api_utils._partition_queries("SELECT a, state FROM t", "state", 5000)
+
+        assert closed["v"] is True
+
+    def test_partition_escapes_single_quotes(self):
+        """Single quotes in a partition value are escaped in the predicate."""
+        conn = MagicMock()
+        conn.cursor.return_value = MagicMock()
+        reads = []
+
+        def fake_read(query, batch_size=5000):
+            reads.append(query)
+            if "DISTINCT" in query:
+                return (["_pv"], _gen([[("O'Brien",)]]))
+            return (["a"], _gen([[(1,)]]))
+
+        with (
+            patch.object(election_api_utils, "read_databricks_table", side_effect=fake_read),
+            patch.object(election_api_utils.psycopg2.extras, "execute_values"),
+        ):
+            bulk_insert_from_databricks(
+                conn,
+                _spec(),
+                "SELECT a, county FROM t",
+                ["a"],
+                partition_column="county",
+            )
+
+        assert any("O''Brien" in q for q in reads)


### PR DESCRIPTION
## Why

`sync_election_api` → `zip_to_position.load_staging` is OOMing in prod (`SIGKILL`/-9, the kernel OOM-killer) while reading the `m_election_api__zip_to_position` mart from Databricks.

Root cause: DATA-1986 (#490) added statewide office coverage — ~260k rows, growing the mart ~23% to ~1.36M. `bulk_insert_from_databricks` reads via `read_databricks_table`, which intends to stream (`fetchmany`, CloudFetch off), but with CloudFetch disabled the databricks-sql connector buffers the result set client-side, so the worker's peak memory scales with total result size. The growth pushed it past the worker's memory ceiling (the OOM hits ~18s in, during result fetching, before much is inserted).

## What

Add an optional `partition_column` to `bulk_insert_from_databricks`. When set, it reads one distinct partition value at a time (`SELECT DISTINCT <col>` then one filtered query per value), so peak worker memory is bounded by a single partition rather than the whole mart. `zip_to_position` partitions by `state` → ~51 reads of ~26k rows each instead of one 1.36M-row buffer.

Preserved behavior:
- **Single end-of-load commit** (after all partitions), so a mid-load failure rolls back the whole staging load and a retry starts from a clean `<table>_new` — `build_staging` recreates it anyway.
- NULL partition values are loaded via an `IS NULL` predicate (no row loss).
- Single quotes in partition values are escaped.
- Callers that don't pass `partition_column` are unchanged.

## Tests

New `test_election_api_utils.py` (4 cases): no-partition single query, chunk-by-distinct-value with single commit, NULL-value handling, quote escaping. All pass; existing `test_sync_election_api` / `test_databricks_utils` / DAG-integrity suites still pass.

## Notes

- This targets the failing `zip_to_position` load. `district_top_issues` also showed failures in the same run; if it OOMs independently it can adopt the same `partition_column` (it's now a one-line change for any mart with a suitable partition column) — left out here to keep scope tight.
- Alternative considered: enabling CloudFetch (`use_cloud_fetch=True`). Rejected for now — it was deliberately disabled in `read_databricks_table`, and partition-chunking bounds memory independent of connector internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)