### PR TITLE
calib(data): consolidation-2026-06-15

### DIFF
--- a/.claude/skills/win-analytics-knowledge/references/engagement.md
+++ b/.claude/skills/win-analytics-knowledge/references/engagement.md
@@ -30,7 +30,7 @@ caveats and deprecations the one-line registry definitions don't carry.
 - **`is_post_amplitude_registration`** (`user_created_at >= 2023-12-10`, the documented Amplitude tracking start) is **too loose** for engagement analyses — Win-product event instrumentation actually started ~2025-05-28.
 - **`has_completed_onboarding_flow`** (`onboarding_completed_at IS NOT NULL`, event `onboarding_complete`) and **`is_onboarded`** (US user, dashboard viewed within 14d of *Amplitude registration*) are both **⚠ NEW-FLOW-BLIND** across the 2026-05-07 cutover. Deprecated as cohort filters — use the canonical **Onboarded** metric instead.
 - **`is_active_candidate_7d/_30d/_90d`** are computed against `current_date`; recompute against an anchor date for retrospective analyses.
-- **`is_activated`** is a lifetime flag (true if the user *ever* sent an outreach campaign); anchor it to `first_campaign_sent_at <= election_date` for forward/recent cohorts so post-election sends don't leak. Do not conflate with the colloquial "activated."
+- **`is_activated`** is a lifetime flag (true if the user *ever* sent an outreach campaign) — anchor it before the election cutoff for forward/recent cohorts so post-election sends don't leak (mechanism in the point-in-time caveat below). Do not conflate with the colloquial "activated."
 - **Onboarding completed (pledge)** is version-agnostic across both eras but first-seen 2025-09, so it under-counts pre-2025-09 cohorts.
 
 ### Terminology
@@ -39,11 +39,11 @@ Two distinct onboarding concepts — keep them named separately so they stop dri
 - **"onboarding dashboard viewed"** (canonical **Onboarded**) = viewed the candidate dashboard within 14 days of account creation (the broad cohort filter).
 - **"onboarding completed (pledge)"** = fired `Onboarding - Candidate Pledge Completed` within 14 days (the strict funnel metric).
 
-Both are recomputed from durable, version-agnostic events; do NOT use the stored `is_onboarded` / `has_completed_onboarding_flow` flags across the 2026-05-07 cutover (both new-flow-blind, see Onboarding flow versions below).
+Both are recomputed from durable, version-agnostic events, not the stored `is_onboarded` / `has_completed_onboarding_flow` flags (new-flow-blind across the cutover; see Onboarding flow versions below).
 
 ### Point-in-time caveat for retrospective cohorts
 
-`has_completed_onboarding_flow` and `is_activated` are lifetime-to-now flags (true if the user *ever* hit the milestone), like `is_active_candidate_*`. For a retrospective cohort analysis anchored to a past election, recompute them from the raw stream restricted to events before the anchor, so post-anchor activity doesn't leak into the funnel. (2026-06-01: the magnitude was immaterial for the Nov-2025 cohort — 21.2% as-of-today vs 20.9% anchored — but the principle holds and matters more for recent cohorts whose anchor is close to today.)
+`has_completed_onboarding_flow` and `is_activated` are lifetime-to-now flags (true if the user *ever* hit the milestone), like `is_active_candidate_*`. For a retrospective cohort analysis anchored to a past election, recompute them from the raw stream restricted to events before the anchor (for `is_activated`, `first_campaign_sent_at <= election_date`), so post-anchor activity doesn't leak into the funnel. (2026-06-01: the magnitude was immaterial for the Nov-2025 cohort — 21.2% as-of-today vs 20.9% anchored — but the principle holds and matters more for recent cohorts whose anchor is close to today.)
 
 ### "Any evidence" vs "engaged beyond account creation"
 

--- a/analytics/runbook/CANDIDATES.md
+++ b/analytics/runbook/CANDIDATES.md
@@ -1,6 +1,6 @@
 # Calibration candidates ledger
 
-Last consolidation pass: **none yet** (treat as past the nudge threshold once the ledger has entries)
+Last consolidation pass: **2026-06-15** (engagement.md dedup)
 
 Shared and committed, unlike the personal, gitignored `CALIBRATION_*.md` logs. Decouples observing
 something from proposing a doc edit: a run appends a line here instead of proposing an edit when an


### PR DESCRIPTION
## What this is

First **consolidation pass** of the win-analytics-process calibration step (the pruning mode added in #501), run manually over the win-analytics-knowledge reference docs. **Data-track**, single-ownership cleanup only — no data facts changed.

## Candidates reviewed (per-item approval gate)

Three candidates surfaced; each was approved or rejected individually, nothing on bulk approval.

1. **Applied — `engagement.md`, `is_activated` anchoring recipe stated once.** The `first_campaign_sent_at <= election_date` recipe was duplicated in the per-flag caveat (line 33) and the point-in-time caveat section (line 46). Moved it to its owning section (line 46); the per-flag bullet now points there.
2. **Applied — `engagement.md`, trim the new-flow-blind restatement (line 42).** The warning appears in the routing trigger, the per-flag caveat, the terminology block, and the onboarding-flow-versions section (the owner). Trimmed the terminology-block restatement to a pointer; the other three still carry it.
3. **Kept separate — `gotchas.md`, Pro vs ICP win-rate-inversion rows.** Considered for merge, rejected: they share a symptom but have distinct mechanisms and mitigations, so merging would lose detail.

## Ledger

Records the `2026-06-15` consolidation-pass date at the top of `analytics/runbook/CANDIDATES.md`, per the consolidation convention.

## Notes

- Net: 4 insertions / 4 deletions across two files. No metric definitions or facts altered.
- Process observation from the run (not blocking): with `CANDIDATES.md` still empty, the ledger-driven pruning lever ("data-state claims that never reached confirmation") can't fire yet, so this first pass was inspection-only. That's expected for an empty ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reference-doc wording and ledger metadata only; no runtime code, pipelines, or metric logic.
> 
> **Overview**
> First **calibration consolidation pass** (2026-06-15): documentation-only cleanup in win-analytics knowledge, with no metric definitions or data facts changed.
> 
> **`engagement.md`** deduplicates guidance analysts were seeing in multiple places. The **`is_activated`** per-flag bullet no longer repeats the `first_campaign_sent_at <= election_date` recipe; it points to the **Point-in-time caveat** section, where that mechanism is spelled out once. The **Terminology** block’s new-flow-blind warning is shortened to a pointer instead of restating the full “do not use stored flags” paragraph.
> 
> **`analytics/runbook/CANDIDATES.md`** records the consolidation date at the top of the calibration candidates ledger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 855cdfcb5f78733bf68efdd3bbbcfb905a756478. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->