### PR TITLE
[DATA-1994] district_census_stats (the civics district population reference)

### DIFF
--- a/dbt/project/models/marts/civics/district_census_stats.sql
+++ b/dbt/project/models/marts/civics/district_census_stats.sql
@@ -1,0 +1,116 @@
+-- Civics mart district_census_stats: the universal district population reference
+-- (DATA-1994). One row per district -- (state_postal_code, district_type,
+-- district_name) -- for every district of the 22 v1 major office-bearing types
+-- nationwide, PLUS one clearly-flagged statewide row per state (50 + DC).
+--
+-- Rolls up int__district_census_allocation (THE SUBSTRATE). The substrate already
+-- conserves mass (allocations sum to block population per (block, type)), so
+-- district_population = sum(allocated_population) is the block-population-weighted
+-- district total. It is FRACTIONAL by design (exact mass conservation; round for
+-- display downstream) and cast to double to pin the mart's column type across the
+-- UNION with the integer-valued statewide branch.
+--
+-- TWO POPULATION BASES live in district_population, distinguished by district_type:
+-- * local rows (the 22 types): voter-block-ALLOCATED population -- inferred from
+-- blocks that carry >=1 L2 voter, so they carry the documented ~2.4%
+-- zero-voter-block undercount (TDD App B.1).
+-- * statewide rows (district_type='State'): EXACT whole-state 2020 census
+-- population (sum over ALL blocks incl. zero-voter), computed directly from
+-- census -- a genuinely statewide official represents the whole state
+-- (TDD 4.5). Reproduces the official 2020 frame to the person.
+-- Consumers wanting only local districts filter WHERE district_type <> 'State'
+-- (people_served excludes statewide from the North Star; the substrate-binding
+-- test is likewise scoped to non-statewide rows).
+--
+-- This table is read ONE district_type at a time: summing district_population
+-- across types double-counts (each type independently tiles the country), and
+-- summing local + statewide mixes the two bases. That is inherent to a universal
+-- district reference, not specific to the statewide rows.
+--
+-- v1 = population columns only. ACS demographics + the validated (block-group)
+-- non-exact-assignment share land in the demographic layer (phase 2, DATA-1991).
+with
+    substrate as (select * from {{ ref("int__district_census_allocation") }}),
+
+    -- the 22-type local districts: a pure rollup of the substrate. Exact-binds to
+    -- the substrate (assert_district_census_stats_binds_substrate).
+    local_districts as (
+        select
+            state_postal_code,
+            district_type,
+            district_name,
+            cast(sum(allocated_population) as double) as district_population,
+            -- count(distinct): unambiguously "distinct census blocks". The
+            -- substrate's tested (block, type, name) key makes this == count(*),
+            -- but distinct is self-documenting.
+            count(distinct block_geoid) as n_census_blocks,
+            sum(voters_in_block_district) as registered_voters
+        from substrate
+        group by state_postal_code, district_type, district_name
+    ),
+
+    -- statewide population: EXACT whole-state 2020 census total via the SAME
+    -- geoid-FIPS -> fips_codes derivation the substrate uses for state_postal_code,
+    -- so the postal-code domain matches the local rows exactly. The inner join to
+    -- the (50 + DC) fips_codes state seed excludes Puerto Rico (no L2 coverage,
+    -- TDD 8) and every territory.
+    statewide_pop as (
+        select
+            sf.place_name as state_postal_code,
+            cast(sum(p.population) as double) as district_population,
+            count(distinct p.block_geoid) as n_census_blocks
+        from {{ ref("stg_census__block_population") }} p
+        join
+            {{ ref("fips_codes") }} sf
+            on left(p.block_geoid, 2) = sf.fips_code
+            and sf.level = 'state'
+        group by sf.place_name
+    ),
+
+    -- state registered-voter total: per block take the max voter count across the
+    -- 22 types, then sum per state. Verified to equal the universal-County voter
+    -- total to the voter (County covers every voter block), so this is the state's
+    -- L2 voter count, robust for DC / independent cities that lack a County row.
+    statewide_voters as (
+        select state_postal_code, sum(block_voters) as registered_voters
+        from
+            (
+                select
+                    state_postal_code, block_geoid, max(voters_in_block) as block_voters
+                from substrate
+                group by state_postal_code, block_geoid
+            )
+        group by state_postal_code
+    ),
+
+    statewide as (
+        select
+            sp.state_postal_code,
+            'State' as district_type,
+            sp.state_postal_code as district_name,
+            sp.district_population,
+            sp.n_census_blocks,
+            coalesce(sv.registered_voters, 0) as registered_voters
+        from statewide_pop sp
+        left join statewide_voters sv using (state_postal_code)
+    )
+
+select
+    state_postal_code,
+    district_type,
+    district_name,
+    district_population,
+    n_census_blocks,
+    registered_voters
+from local_districts
+
+union all
+
+select
+    state_postal_code,
+    district_type,
+    district_name,
+    district_population,
+    n_census_blocks,
+    registered_voters
+from statewide

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -2653,3 +2653,102 @@ models:
         description: Timestamp when the BallotReady position record was last updated.
         data_tests:
           - not_null
+
+  - name: district_census_stats
+    description: >
+      The universal district population reference: one row per district for every
+      district of the 22 v1 major office-bearing types nationwide, plus one
+      clearly-flagged statewide row per state (district_type='State'). A rollup of
+      int__district_census_allocation (the substrate). The first consumer of the
+      Constituents Served substrate (DATA-1359); read by official_constituents.
+
+      Grain: One row per (state_postal_code, district_type, district_name).
+
+      Population basis differs by district_type. Local rows (the 22 types) carry
+      voter-block-ALLOCATED population (inferred from blocks with >=1 L2 voter; carry
+      the ~2.4% zero-voter-block undercount). Statewide rows carry EXACT whole-state
+      2020 census population. Read one district_type at a time: summing
+      district_population across types double-counts, and summing local + statewide
+      mixes the two bases -- consumers wanting only local districts filter
+      WHERE district_type <> 'State'. v1 is population only; ACS demographics and the
+      validated non-exact-assignment share are phase 2 (DATA-1991).
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [state_postal_code, district_type, district_name]
+    columns:
+      - name: state_postal_code
+        description: Two-letter state postal code, derived from the census geoid FIPS prefix (authoritative).
+        data_tests:
+          - not_null
+      - name: district_type
+        description: >
+          L2 district-column type (one of the 22 v1 major office-bearing types), or
+          'State' for the synthetic statewide rows.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - County
+                  - US_Congressional_District
+                  - State_Senate_District
+                  - State_House_District
+                  - State_Legislative_District
+                  - City
+                  - Township
+                  - Town_District
+                  - Village
+                  - Borough
+                  - City_Council_Commissioner_District
+                  - City_Ward
+                  - County_Commissioner_District
+                  - County_Supervisorial_District
+                  - School_District
+                  - Unified_School_District
+                  - School_Board_District
+                  - Board_of_Education_District
+                  - City_School_District
+                  - Elementary_School_District
+                  - High_School_District
+                  - Fire_District
+                  - State
+      - name: district_name
+        description: >
+          Normalized L2 district name (normalize_l2_district_name). NOT unique across
+          states (e.g. Congressional District '1' exists in many states) -- the key is
+          the full (state, type, name). For statewide rows this is the state postal code.
+        data_tests:
+          - not_null
+      - name: district_population
+        description: >
+          2020 census population of the district. Local rows: sum of the substrate's
+          block-population-weighted allocated_population (FRACTIONAL by design; round for
+          display). Statewide rows: exact whole-state census population.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+      - name: n_census_blocks
+        description: >
+          Census blocks composing the district. Local rows: voter-bearing blocks from the
+          substrate. Statewide rows: all census blocks in the state.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+      - name: registered_voters
+        description: >
+          L2 registered voters in the district (the voters-vs-constituents contrast Serve
+          shows). Local rows: sum of substrate voters_in_block_district. Statewide rows:
+          per-state sum of the per-block max voter count across types (equals the state's
+          universal-County voter total).
+        data_tests:
+          - not_null
+          # min 1 (not 0): every district/state has >=1 voter by construction. Also catches
+          # a statewide voter-join key mismatch silently zeroing voters.
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1

--- a/dbt/project/tests/assert_district_census_stats_binds_substrate.sql
+++ b/dbt/project/tests/assert_district_census_stats_binds_substrate.sql
@@ -1,0 +1,49 @@
+-- Binding contract (DATA-1994): every NON-statewide district_census_stats row must
+-- equal the direct substrate rollup -- population within float tolerance; voters and
+-- distinct-block count exactly -- AND the non-statewide row-set must match the
+-- substrate's distinct districts (full outer catches either side missing). Statewide
+-- (district_type='State') rows are census-derived, not from the substrate, so they
+-- are excluded. A structural drift guard (the mart and this query are the same
+-- rollup); conceptual correctness is verified by the Claude reconciliation. Returns
+-- offending rows; empty = pass.
+with
+    substrate_rollup as (
+        select
+            state_postal_code,
+            district_type,
+            district_name,
+            sum(allocated_population) as substrate_pop,
+            sum(voters_in_block_district) as substrate_voters,
+            count(distinct block_geoid) as substrate_blocks
+        from {{ ref("int__district_census_allocation") }}
+        group by state_postal_code, district_type, district_name
+    ),
+
+    mart as (
+        select
+            state_postal_code,
+            district_type,
+            district_name,
+            district_population,
+            registered_voters,
+            n_census_blocks
+        from {{ ref("district_census_stats") }}
+        where district_type <> 'State'
+    )
+
+select
+    coalesce(m.state_postal_code, s.state_postal_code) as state_postal_code,
+    coalesce(m.district_type, s.district_type) as district_type,
+    coalesce(m.district_name, s.district_name) as district_name
+from mart m
+full outer join
+    substrate_rollup s
+    on m.state_postal_code = s.state_postal_code
+    and m.district_type = s.district_type
+    and m.district_name = s.district_name
+where
+    m.state_postal_code is null
+    or s.state_postal_code is null
+    or abs(m.district_population - s.substrate_pop) > 1e-6
+    or m.registered_voters <> s.substrate_voters
+    or m.n_census_blocks <> s.substrate_blocks

--- a/dbt/project/tests/assert_district_census_stats_statewide_binds_census.sql
+++ b/dbt/project/tests/assert_district_census_stats_statewide_binds_census.sql
@@ -1,0 +1,34 @@
+-- Statewide binding (DATA-1994): each statewide (district_type='State') row's
+-- district_population and n_census_blocks must equal the direct census rollup over
+-- the 50 + DC fips_codes states (Puerto Rico excluded by the inner join). The 2020
+-- census frame is static, so this is a fixed binding (TDD 7.3 -- fixed tests on the
+-- immutable census frame). Catches FIPS-mapping errors, PR leakage, and dropped or
+-- duplicated blocks in the statewide branch. Returns offending rows; empty = pass.
+with
+    census_rollup as (
+        select
+            sf.place_name as state_postal_code,
+            cast(sum(p.population) as double) as census_pop,
+            count(distinct p.block_geoid) as census_blocks
+        from {{ ref("stg_census__block_population") }} p
+        join
+            {{ ref("fips_codes") }} sf
+            on left(p.block_geoid, 2) = sf.fips_code
+            and sf.level = 'state'
+        group by sf.place_name
+    ),
+
+    statewide as (
+        select state_postal_code, district_population, n_census_blocks
+        from {{ ref("district_census_stats") }}
+        where district_type = 'State'
+    )
+
+select coalesce(s.state_postal_code, c.state_postal_code) as state_postal_code
+from statewide s
+full outer join census_rollup c on s.state_postal_code = c.state_postal_code
+where
+    s.state_postal_code is null
+    or c.state_postal_code is null
+    or abs(s.district_population - c.census_pop) > 1e-6
+    or s.n_census_blocks <> c.census_blocks

--- a/dbt/project/tests/assert_district_census_stats_statewide_complete.sql
+++ b/dbt/project/tests/assert_district_census_stats_statewide_complete.sql
@@ -1,0 +1,13 @@
+-- Statewide completeness (DATA-1994): one statewide row per US state + DC, matching
+-- the fips_codes state seed (50 + DC = 51; no Puerto Rico -- no L2 coverage).
+-- Self-references the seed rather than hardcoding 51. Returns a row (fails) iff the
+-- statewide count differs from the seed's state count.
+select m.n as statewide_rows, s.n as fips_state_rows
+from
+    (
+        select count(*) as n
+        from {{ ref("district_census_stats") }}
+        where district_type = 'State'
+    ) m
+cross join (select count(*) as n from {{ ref("fips_codes") }} where level = 'state') s
+where m.n <> s.n


### PR DESCRIPTION
## What

Adds `district_census_stats` (mart, `mart_civics`): the universal district population reference. One row per
district `(state_postal_code, district_type, district_name)` for every district of the 22 v1 major
office-bearing types nationwide, plus one clearly-flagged statewide row per state. A rollup of
`int__district_census_allocation` (the substrate, DATA-1992). This is T5 of the Constituents Served epic
(DATA-1359), built before T4 so `official_constituents` can read it.

## Columns (v1 is population only)

- `district_population`: 2020 census population. Local rows are the block-population-weighted
  `sum(allocated_population)` from the substrate (fractional by design; voter-block-allocated, so they carry the
  documented ~2.4% zero-voter-block undercount). Statewide rows are the exact whole-state census population.
- `n_census_blocks`, `registered_voters`.

ACS demographics and the validated non-exact-assignment share are phase 2 (DATA-1991).

## Design decisions

- **Statewide as clearly-flagged `district_type='State'` rows** (50 states + DC; no Puerto Rico, no L2 coverage).
  Population is computed directly from census (the whole state), not the voter-block allocation, because a
  genuinely statewide official represents the whole state. This centralizes statewide population in one table so
  consumers stay DRY; they filter `WHERE district_type <> 'State'` for the local reading (people_served excludes
  statewide from the North Star). Two population bases live in one column, discriminated by `district_type` and
  documented in the model and YAML.
- **`non_exact_share` deferred to phase 2.** The substrate's block-grain `is_non_exact` is mostly geocoding
  noise; the validated accuracy measure is block-group grain and lands with the demographic layer. The v1 column
  set stays population-only.

## Tests

- Schema: unique key `(state_postal_code, district_type, district_name)`; not_null on all columns;
  accepted_values on `district_type` (the 22 types plus `State`); ranges (`district_population >= 0`,
  `n_census_blocks >= 1`, `registered_voters >= 1`).
- Singular: `binds_substrate` (every non-statewide row equals the direct substrate rollup, row-set plus values);
  `statewide_complete` (statewide row count equals the `fips_codes` state seed); `statewide_binds_census`
  (statewide population and block counts equal the direct census rollup).

## Verification

Independent reconciliation (run in Claude against the prod substrate plus census frame; full reconciliation on
the CI preview schema follows in a comment once it builds): 90,552 local rows plus 51 statewide rows; statewide
population reproduces the official 2020 census frame to the person (331,449,281 for 50 states plus DC); 435
congressional districts; 3,149 counties; the per-block-max statewide voter total equals the universal-County
voter total exactly.

Plan and independent plan review: `.tickets/constituents_served/28-implementation-plan.md`,
`29-T5-codex-plan-review.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New foundational mart for constituents/population metrics with two population bases in one column; misuse (summing across types or mixing local/statewide) would skew downstream analytics, though tests and docs mitigate structural drift.
> 
> **Overview**
> Adds **`district_census_stats`**, a civics mart that is the universal district population reference for Constituents Served (DATA-1994): one row per `(state_postal_code, district_type, district_name)` for the 22 v1 L2 district types, plus synthetic **`district_type='State'`** rows for 50 states + DC.
> 
> **Local districts** roll up `int__district_census_allocation` into `district_population` (fractional allocated census), `n_census_blocks`, and `registered_voters`. **Statewide rows** use exact 2020 block census totals and a per-block max voter count across types; consumers must filter `district_type <> 'State'` when they only want local districts and must not sum across types.
> 
> Documents the model in **`m_civics.yaml`** (grain, column semantics, uniqueness, accepted `district_type` values, range tests). Adds three singular tests: non-statewide rows bind to the substrate rollup, statewide rows bind to direct census, and statewide row count matches the `fips_codes` state seed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05b780006a309e8dd8b592d57627590089a61da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->