### PR TITLE
[DATA-2000] Fix 2025 BR position linkage (HubSpot cutover artifact)

### DIFF
--- a/dbt/project/models/intermediate/civics/int__hubspot_companies_w_contacts_2025.sql
+++ b/dbt/project/models/intermediate/civics/int__hubspot_companies_w_contacts_2025.sql
@@ -206,18 +206,25 @@ with
                 tbl_contacts.is_pledged
             ) as is_pledged,
             tbl_gp_db_campaign.id as product_campaign_id,
-            -- BallotReady Position Database ID (decoded from base64 positionId in
-            -- campaign details)
-            cast(
-                regexp_extract(
-                    cast(
-                        unbase64(
-                            tbl_gp_db_campaign.details:positionid::string
-                        ) as string
-                    ),
-                    '/([0-9]+)$',
-                    1
-                ) as bigint
+            -- BallotReady Position Database ID. Live source: the campaign's
+            -- organization (organization.position_id -> enhanced_position.id ->
+            -- br_database_id). The legacy base64 decode of
+            -- campaign.details:positionid is kept as a fallback but is now empty
+            -- (~4/62k) -- the gp-api data-flow cutover moved the position FK onto
+            -- the organization, so the old field went dark.
+            coalesce(
+                tbl_enhanced_position.br_database_id,
+                cast(
+                    regexp_extract(
+                        cast(
+                            unbase64(
+                                tbl_gp_db_campaign.details:positionid::string
+                            ) as string
+                        ),
+                        '/([0-9]+)$',
+                        1
+                    ) as bigint
+                )
             ) as br_position_database_id,
             -- assessments (coalesce HubSpot win_number with GP DB path_to_victory)
             coalesce(
@@ -243,6 +250,13 @@ with
         left join
             {{ ref("stg_airbyte_source__gp_api_db_path_to_victory") }} as tbl_gp_db_ptv
             on tbl_gp_db_campaign.id = tbl_gp_db_ptv.campaign_id
+        -- Resolve the BR position from the campaign's organization (live source).
+        left join
+            {{ ref("stg_airbyte_source__gp_api_db_organization") }} as tbl_org
+            on tbl_gp_db_campaign.organization_slug = tbl_org.slug
+        left join
+            {{ ref("int__enhanced_position") }} as tbl_enhanced_position
+            on tbl_org.position_id = tbl_enhanced_position.id
     ),
 
     -- Companies without contacts - create rows with null contact data
@@ -361,16 +375,22 @@ with
             nullif(cwoc.properties_verified_candidates, '') as verified_candidate,
             {{ cast_to_boolean("cwoc.properties_pledge_status") }} as is_pledged,
             tbl_gp_db_campaign.id as product_campaign_id,
-            cast(
-                regexp_extract(
-                    cast(
-                        unbase64(
-                            tbl_gp_db_campaign.details:positionid::string
-                        ) as string
-                    ),
-                    '/([0-9]+)$',
-                    1
-                ) as bigint
+            -- BR Position Database ID from the campaign's organization (live
+            -- source); legacy campaign.details:positionid decode kept as an
+            -- empty fallback. See the companies_joined_contacts branch.
+            coalesce(
+                tbl_enhanced_position.br_database_id,
+                cast(
+                    regexp_extract(
+                        cast(
+                            unbase64(
+                                tbl_gp_db_campaign.details:positionid::string
+                            ) as string
+                        ),
+                        '/([0-9]+)$',
+                        1
+                    ) as bigint
+                )
             ) as br_position_database_id,
             coalesce(
                 cast(cwoc.properties_win_number as string),
@@ -388,6 +408,12 @@ with
         left join
             {{ ref("stg_airbyte_source__gp_api_db_path_to_victory") }} as tbl_gp_db_ptv
             on tbl_gp_db_campaign.id = tbl_gp_db_ptv.campaign_id
+        left join
+            {{ ref("stg_airbyte_source__gp_api_db_organization") }} as tbl_org
+            on tbl_gp_db_campaign.organization_slug = tbl_org.slug
+        left join
+            {{ ref("int__enhanced_position") }} as tbl_enhanced_position
+            on tbl_org.position_id = tbl_enhanced_position.id
     ),
 
     -- Contacts without associated companies


### PR DESCRIPTION
## What

The HubSpot-era 2025 archive path decoded `br_position_database_id` from `campaign.details:positionid`. That field went empty after the gp-api data-flow cutover moved the position FK onto the **organization** (only ~4 of 62k campaigns still carry it). So the entire 2025 chain had a null BR position, cascading to `int__civics_candidacy_2025`, `int__civics_election_stage_2025`, and the `candidacy`/`election` stage marts — 2025 elected officials had elections but no resolvable position.

Fix: resolve the BR position from the live source —
`campaign.organization_slug → organization.position_id → int__enhanced_position.id → br_database_id` — keeping the legacy base64 decode as a (now-empty) fallback. Join keys are unique (verified: no fan-out).

## Effect

`br_position_database_id` populated:
- `int__hubspot_companies_w_contacts_2025`: 0 → 34,606
- `int__civics_candidacy_2025`: 0 → 24,170
- 2025 `election_stage` rows: 0 → 12,732

## Scope note

This is the broad correctness fix for 2025 BR-position linkage. It does **not** by itself surface 2025 results to the elected-official support score: the vote-bearing DDHQ-matched candidacies sit on a separate `election_stage` grain with no org link, so that case is handled by the name-matched 2025 supplement in the election-api support model (PR for DATA-2000). Reconciling those grains was evaluated and deferred (large rework, ceiling already reached by the supplement).

## Testing

- `dbt build --select int__hubspot_companies_w_contacts_2025`: pass; column populates as above.
- No fan-out: `organization.slug`, `int__enhanced_position.id`, and `int__civics_candidacy_2025.gp_candidacy_id` all have 0 duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)