### PR TITLE
[DATA-1993] People Served metrics + per-official constituents

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3413,3 +3413,57 @@ models:
             expression: >
               length(block_geoid) = 15 and length(block_group_geoid) = 12
               and length(tract_geoid) = 11
+
+  - name: int__serve_block_coverage
+    description: >
+      The count-once engine (DATA-1993, epic DATA-1359). One row per (census block,
+      served_set) with the count of DISTINCT cohort-served voters and the block's total
+      voters; people_served reads it as count-once(set) = sum(served_voters /
+      total_voters * block_population) over served blocks. Count-once is a
+      distinct-PERSON union across overlapping district types, which the counts-only
+      substrate cannot produce (cross-type voter dedup needs voter IDs), so this model
+      scans int__l2_nationwide_uniform once -- the "scanned, never surfaced" node from
+      TDD 7.1 -- and emits only block-grain counts (PII-free). Scoped to the same 22
+      district types as the substrate (get_l2_major_district_columns), so count-once <=
+      count-multiple holds. served_set is 'all' (served by any cohort district) or one
+      of the 22 L2 district types; statewide officials are read from the exact T5
+      'State' rows in people_served, not here.
+    columns:
+      - name: block_geoid
+        description: 15-char zero-padded 2020 census block GEOID
+        data_tests:
+          - not_null
+      - name: served_set
+        description: >
+          'all' (voters served by any cohort district) or an L2 district_type (voters
+          served by a cohort district of that type)
+        data_tests:
+          - not_null
+      - name: served_voters
+        description: Distinct cohort-served voters in this block for this served_set
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: total_voters
+        description: >
+          Distinct voters in this block carrying >=1 of the 22 major district values
+          (the count-once denominator; ~= the block's total voters since County covers
+          essentially all)
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+                inclusive: true
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          name: serve_block_coverage_unique_key
+          arguments:
+            combination_of_columns: [block_geoid, served_set]
+      - dbt_utils.expression_is_true:
+          name: serve_block_coverage_served_le_total
+          arguments:
+            expression: "served_voters <= total_voters"

--- a/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
@@ -1,0 +1,129 @@
+{{ config(materialized="table", tags=["intermediate", "civics", "serve"]) }}
+
+-- int__serve_block_coverage (DATA-1993): the count-once engine. One row per
+-- (census block, served_set) carrying the count of DISTINCT served voters and the
+-- block's total voters. people_served reads it: count-once for a set =
+-- sum(served_voters / total_voters * block_population) over served blocks.
+--
+-- WHY a voter scan (and not the substrate): count-once is a distinct-PERSON union
+-- across overlapping district types. Within one type the cohort districts partition a
+-- block's voters, but a voter served by BOTH their city and their county cannot be
+-- de-duplicated across types from counts alone -- that cross-type overlap is exactly
+-- the "represented by 2+ officials" gap. So the union needs voter IDs, which the
+-- counts-only substrate (and int__l2_block_district_map) dropped at the
+-- count(distinct lalvoterid) step. This model scans int__l2_nationwide_uniform once --
+-- the "scanned, never surfaced" node from TDD 7.1 -- and emits ONLY block-grain counts
+-- (PII-free). It is a model, not an inline CTE, because the ~230M-row unpivot is heavy
+-- (Dan's "break out only if it grows complex" clause); it restores the original TDD
+-- DAG.
+--
+-- Scoped to the SAME 22 district types as the substrate
+-- (get_l2_major_district_columns),
+-- so count-once <= count-multiple holds while the substrate is at 22 types. state is
+-- derived from the block's geoid FIPS prefix (the substrate's rule), matching the
+-- substrate block-for-block; the '06'=6 numeric coercion is proven (the merged
+-- substrate
+-- has all 51 states, 0 null state). served_set: 'all' (any cohort district) or one of
+-- the
+-- 22 l2 types. Statewide officials are NOT here -- they are read from the exact T5
+-- 'State'
+-- rows in people_served and reported separately (TDD 4.5), avoiding a basis mix.
+with
+    cohort_districts as (
+        select distinct
+            state,
+            l2_district_type as district_type,
+            normalized_district_name as district_name
+        from {{ ref("int__serve_district_resolution") }}
+        where resolution_path != 'unresolved' and not is_statewide
+    ),
+
+    state_fips as (
+        select fips_code, place_name as state_postal_code
+        from {{ ref("fips_codes") }}
+        where level = 'state'
+    ),
+
+    l2 as (
+        select
+            lpad(
+                cast(residence_addresses_complete_census_geocode as string), 15, '0'
+            ) as block_geoid,
+            lalvoterid,
+            {{ get_l2_major_district_columns(use_backticks=true, cast_to_string=true) }}
+        from {{ ref("int__l2_nationwide_uniform") }}
+        where residence_addresses_complete_census_geocode is not null
+    ),
+
+    unpivoted as (
+        select
+            block_geoid,
+            lalvoterid,
+            district_column_name as district_type,
+            {{ normalize_l2_district_name("district_value") }} as district_name
+        from
+            l2 unpivot (
+                district_value for district_column_name
+                in ({{ get_l2_major_district_columns(use_backticks=false) }})
+            )
+        where district_value is not null and trim(district_value) != ''
+    ),
+
+    -- per (block, voter, type): is this voter in a cohort district of this type?
+    voter_type as (
+        select
+            u.block_geoid,
+            u.lalvoterid,
+            u.district_type,
+            max(
+                case when c.district_type is not null then 1 else 0 end
+            ) as served_this_type
+        from unpivoted u
+        join state_fips sf on left(u.block_geoid, 2) = sf.fips_code
+        left join
+            cohort_districts c
+            on c.state = sf.state_postal_code
+            and c.district_type = u.district_type
+            and c.district_name = u.district_name
+        group by u.block_geoid, u.lalvoterid, u.district_type
+    ),
+
+    -- per (block, voter): served by ANY cohort district (the cross-type union)
+    voter_any as (
+        select block_geoid, lalvoterid, max(served_this_type) as served_any
+        from voter_type
+        group by block_geoid, lalvoterid
+    ),
+
+    -- block denominator + the cohort-wide served-voter union
+    block_all as (
+        select block_geoid, count(*) as total_voters, sum(served_any) as served_voters
+        from voter_any
+        group by block_geoid
+    ),
+
+    -- per (block, type): voters served by a cohort district of that type
+    block_by_type as (
+        select
+            block_geoid,
+            district_type as served_set,
+            sum(served_this_type) as served_voters
+        from voter_type
+        group by block_geoid, district_type
+        having sum(served_this_type) > 0
+    ),
+
+    coverage as (
+        select block_geoid, 'all' as served_set, served_voters, total_voters
+        from block_all
+        where served_voters > 0
+
+        union all
+
+        select t.block_geoid, t.served_set, t.served_voters, b.total_voters
+        from block_by_type t
+        join block_all b on t.block_geoid = b.block_geoid
+    )
+
+select block_geoid, served_set, served_voters, total_voters
+from coverage

--- a/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
@@ -66,7 +66,13 @@ with
                 district_value for district_column_name
                 in ({{ get_l2_major_district_columns(use_backticks=false) }})
             )
-        where district_value is not null and trim(district_value) != ''
+        where
+            district_value is not null
+            and trim(district_value) != ''
+            -- drop values that normalize to empty (e.g. a bare "(EST.)"), mirroring
+            -- int__l2_block_district_map so the voter grain (and thus total_voters)
+            -- stays identical to the substrate across refreshes (verified 0-diff today)
+            and trim({{ normalize_l2_district_name("district_value") }}) != ''
     ),
 
     -- per (block, voter, type): is this voter in a cohort district of this type?

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1456,3 +1456,137 @@ models:
         data_tests:
           - not_null
           - unique
+
+  - name: people_served
+    description: >
+      The People Served metrics (DATA-1993, epic DATA-1359): one row per
+      (metric_variant, office_type). count_once is the distinct-person union (from
+      int__serve_block_coverage); the count_multiple variants are sums off the substrate
+      via district_census_stats. Ordering holds within every office_type: count_once <=
+      count_multiple_per_district <= per_seat <= per_org. office_type is 'all' (the local
+      cohort-wide North Star headline) or one of the 22 L2 district types, PLUS 'State'
+      for statewide officials, which are read from the EXACT T5 'State' census totals and
+      reported SEPARATELY (TDD 4.5) -- never folded into 'all'. Filter office_type !=
+      'State' for the local reading, = 'State' for the statewide breakout. The live 'all'
+      numbers include population from a few known wrong-scope matches (requires_review,
+      pending the DATA-1989 upstream overrides) -- those officials are flagged on
+      official_constituents; the conservative reading excludes them. Thin by design;
+      variants may migrate to the dbt semantic layer.
+    columns:
+      - name: metric_variant
+        description: >
+          count_once (distinct people) or count_multiple_per_district / per_seat / per_org.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - count_once
+                  - count_multiple_per_district
+                  - count_multiple_per_seat
+                  - count_multiple_per_org
+      - name: office_type
+        description: >
+          'all' (local cohort-wide), an L2 district type, or 'State' (statewide officials,
+          reported separately).
+        data_tests:
+          - not_null
+      - name: people_served
+        description: The metric value (population; fractional, round for display).
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: n_cohort_districts
+        description: >
+          Count of cohort districts behind a count_multiple row; null for count_once.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          name: people_served_unique_key
+          arguments:
+            combination_of_columns: [metric_variant, office_type]
+      - dbt_utils.expression_is_true:
+          name: people_served_north_star_sanity_band
+          arguments:
+            expression: "people_served between 30000000 and 90000000"
+          config:
+            # wide catastrophic-breakage guard on the local North Star (currently ~56M);
+            # the ordering invariant (singular test) is the hard correctness check.
+            where: "metric_variant = 'count_once' and office_type = 'all'"
+            severity: warn
+
+  - name: official_constituents
+    description: >
+      The Serve per-official display surface (DATA-1993, epic DATA-1359): one row per
+      resolved serve official with the population of the jurisdiction they serve ("your
+      district has N constituents, M registered voters"). A clean read off
+      district_census_stats. Local officials join on (state, type, normalized name);
+      statewide officials (is_statewide) read the district_type='State' row by state.
+      Officials whose district is a deferred special-district type or whose name drifted
+      bind nothing -> has_census_match=false, null constituents (a documented v1-scope /
+      re-match gap, not a defect). requires_review is carried so the product can caveat
+      known wrong-scope matches (pending DATA-1989); flagged rows are never filtered. The
+      high-undercount flag is deferred to a follow-up; v1 ships constituents_minus_voters
+      (the honest raw gap).
+    columns:
+      - name: organization_slug
+        description: Serve org identifier (primary key; one row per official).
+        data_tests:
+          - unique
+          - not_null
+      - name: user_id
+        description: Owning user of the serve org.
+      - name: state
+        description: Two-letter state code of the resolved district.
+      - name: l2_district_type
+        description: L2 district type the official resolves to.
+      - name: normalized_district_name
+        description: Normalized L2 district name (the join key to district_census_stats).
+      - name: is_statewide
+        description: Resolved to a statewide office (reads the exact T5 'State' row).
+        data_tests:
+          - not_null
+      - name: resolution_path
+        description: How the org resolved (district_mart or crosswalk).
+      - name: requires_review
+        description: >
+          Carried from the resolver: the resolved district likely contains, but is larger
+          than, the office's real jurisdiction. For the product to caveat; not filtered.
+        data_tests:
+          - not_null
+      - name: is_geo_seat
+        description: Carried from the resolver (the jurisdiction-vs-electoral-seat flag).
+      - name: constituents
+        description: >
+          The district population the official serves
+          (district_census_stats.district_population; fractional for local rows, round for
+          display). Null when has_census_match is false.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+              config:
+                where: "has_census_match"
+      - name: registered_voters
+        description: >
+          The district's L2 registered-voter count. Null when has_census_match is false.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+              config:
+                where: "has_census_match"
+      - name: constituents_minus_voters
+        description: >
+          constituents - registered_voters: the voters-vs-constituents gap that motivates
+          outreach. Null when has_census_match is false.
+      - name: has_census_match
+        description: >
+          Whether the official's district bound a district_census_stats row. False for
+          deferred special-district types or name-drifted districts (the v1-scope gap).
+        data_tests:
+          - not_null

--- a/dbt/project/models/marts/analytics/official_constituents.sql
+++ b/dbt/project/models/marts/analytics/official_constituents.sql
@@ -1,0 +1,62 @@
+{{ config(materialized="view", tags=["marts", "analytics", "serve"]) }}
+
+-- official_constituents (DATA-1993): the Serve per-official display surface -- one row
+-- per resolved serve official with the population of the jurisdiction they serve
+-- ("your district has N constituents, M registered voters"). A clean read off
+-- district_census_stats; unaffected by the count-once dedup. Local officials join on
+-- (state, type, normalized name); statewide officials (is_statewide) read the
+-- district_type='State' row by state (T5 join contract). Each resolver row uses exactly
+-- one branch (the is_statewide guard), and district_census_stats is unique on its key
+-- with one 'State' row per state, so there is no fan-out: one row per official.
+--
+-- Officials whose district is a deferred special-district type or whose name drifted
+-- bind
+-- nothing -> has_census_match=false, null constituents (a documented v1-scope /
+-- re-match
+-- gap, not a defect). requires_review is carried through so the product can caveat the
+-- known wrong-scope matches (pending the DATA-1989 upstream overrides); flagged rows
+-- are
+-- NEVER filtered here. The high-undercount flag is deferred to a follow-up (a correct
+-- voterless/invisible-population measure needs geographic assignment of zero-voter
+-- blocks,
+-- out of v1 scope); v1 ships constituents_minus_voters, the honest raw gap. View
+-- materialization (a thin always-fresh lookup, like the sibling users_serve_activity).
+with
+    resolver as (
+        select *
+        from {{ ref("int__serve_district_resolution") }}
+        where resolution_path != 'unresolved'
+    ),
+
+    stats as (select * from {{ ref("district_census_stats") }})
+
+select
+    r.organization_slug,
+    r.user_id,
+    r.state,
+    r.l2_district_type,
+    r.normalized_district_name,
+    r.is_statewide,
+    r.resolution_path,
+    r.requires_review,
+    r.is_geo_seat,
+    coalesce(s.district_population, sw.district_population) as constituents,
+    coalesce(s.registered_voters, sw.registered_voters) as registered_voters,
+    coalesce(s.district_population, sw.district_population)
+    - coalesce(s.registered_voters, sw.registered_voters) as constituents_minus_voters,
+    (
+        s.state_postal_code is not null or sw.state_postal_code is not null
+    ) as has_census_match
+from resolver r
+left join
+    stats s
+    on not r.is_statewide
+    and r.state = s.state_postal_code
+    and r.l2_district_type = s.district_type
+    and r.normalized_district_name = s.district_name
+    and s.district_type != 'State'
+left join
+    stats sw
+    on r.is_statewide
+    and r.state = sw.state_postal_code
+    and sw.district_type = 'State'

--- a/dbt/project/models/marts/analytics/people_served.sql
+++ b/dbt/project/models/marts/analytics/people_served.sql
@@ -1,0 +1,166 @@
+{{ config(materialized="table", tags=["marts", "analytics", "serve"]) }}
+
+-- people_served (DATA-1993): the People Served metrics, one row per
+-- (metric_variant, office_type). count-once is the distinct-person union from
+-- int__serve_block_coverage; count-multiple variants are pure sums off the substrate
+-- via district_census_stats. Scoped to the 22 office-bearing district types, so
+-- count-once <= count_multiple_per_district <= per_seat <= per_org by construction
+-- (a distinct union is <= a sum; a per-district sum <= per-seat <= per-org because
+-- 1 <= n_seats <= n_orgs per district).
+--
+-- office_type: 'all' (the cohort-wide local rollup -- the North Star headline) or one
+-- of
+-- the 22 local types, PLUS 'State' for STATEWIDE officials. Statewide is read from T5's
+-- EXACT 'State' census rows and reported SEPARATELY (TDD 4.5): it is never folded
+-- into the
+-- local 'all' rollup (which would mix population bases and swamp the local story). The
+-- deduped local+statewide union is intentionally not a stored column (set-relative; a
+-- fresh
+-- query -- TDD 4.2).
+--
+-- The live 'all' numbers include population from a few known wrong-scope matches
+-- (requires_review, pending the DATA-1989 upstream overrides); the conservative reading
+-- excludes them. Those rows are carried + flagged on official_constituents for the
+-- product
+-- to caveat; they are NOT filtered here (fix upstream, not in the model -- TDD 7.3).
+-- seat =
+-- a distinct namespaced position/office id with an org_slug fallback, guaranteeing
+-- 1 <= n_seats <= n_orgs per district. Thin by design: variants may migrate to the dbt
+-- semantic layer.
+with
+    block_pop as (
+        select block_geoid, population from {{ ref("stg_census__block_population") }}
+    ),
+
+    coverage as (select * from {{ ref("int__serve_block_coverage") }}),
+
+    -- count-once per served_set (local: 'all' = the North Star, plus per type)
+    count_once_local as (
+        select
+            c.served_set as office_type,
+            sum(c.served_voters * 1.0 / c.total_voters * p.population) as people_served
+        from coverage c
+        join block_pop p on c.block_geoid = p.block_geoid
+        group by c.served_set
+    ),
+
+    -- one row per cohort district (local + statewide), with seat/org multipliers.
+    -- seat id is namespaced so a BallotReady id never collides with an office id; the
+    -- org_slug fallback guarantees every org contributes >=1 distinct seat.
+    district_level as (
+        select
+            co.l2_district_type as office_type,
+            s.district_population,
+            count(distinct co.organization_slug) as n_orgs,
+            count(
+                distinct coalesce(
+                    'br:' || cast(co.ballotready_position_id as string),
+                    'eo:' || cast(co.elected_office_id as string),
+                    'org:' || co.organization_slug
+                )
+            ) as n_seats
+        from {{ ref("int__serve_district_resolution") }} co
+        join
+            {{ ref("district_census_stats") }} s
+            on co.state = s.state_postal_code
+            and co.l2_district_type = s.district_type
+            and co.normalized_district_name = s.district_name
+            and s.district_type != 'State'
+        where co.resolution_path != 'unresolved' and not co.is_statewide
+        group by
+            co.l2_district_type,
+            s.state_postal_code,
+            s.district_name,
+            s.district_population
+
+        union all
+
+        select
+            'State' as office_type,
+            s.district_population,
+            count(distinct co.organization_slug) as n_orgs,
+            count(
+                distinct coalesce(
+                    'br:' || cast(co.ballotready_position_id as string),
+                    'eo:' || cast(co.elected_office_id as string),
+                    'org:' || co.organization_slug
+                )
+            ) as n_seats
+        from {{ ref("int__serve_district_resolution") }} co
+        join
+            {{ ref("district_census_stats") }} s
+            on co.state = s.state_postal_code
+            and s.district_type = 'State'
+        where co.resolution_path != 'unresolved' and co.is_statewide
+        group by s.state_postal_code, s.district_population
+    ),
+
+    -- count-multiple per office_type (the 22 types + 'State'), and a local-only 'all'
+    -- rollup
+    cm_by_type as (
+        select
+            office_type,
+            sum(district_population) as per_district,
+            sum(district_population * n_seats) as per_seat,
+            sum(district_population * n_orgs) as per_org,
+            count(*) as n_cohort_districts
+        from district_level
+        group by office_type
+    ),
+
+    cm_all as (
+        select
+            'all' as office_type,
+            sum(district_population) as per_district,
+            sum(district_population * n_seats) as per_seat,
+            sum(district_population * n_orgs) as per_org,
+            count(*) as n_cohort_districts
+        from district_level
+        where office_type != 'State'
+    ),
+
+    cm as (
+        select *
+        from cm_by_type
+        union all
+        select *
+        from cm_all
+    ),
+
+    -- statewide count-once = the distinct-state population sum (no inter-state
+    -- overlap),
+    -- which equals statewide per_district -> add it so 'State' has all four variants.
+    statewide_count_once as (
+        select 'State' as office_type, per_district as people_served
+        from cm_by_type
+        where office_type = 'State'
+    ),
+
+    final as (
+        select
+            'count_once' as metric_variant,
+            office_type,
+            people_served,
+            cast(null as bigint) as n_cohort_districts
+        from count_once_local
+
+        union all
+
+        select 'count_once', office_type, people_served, cast(null as bigint)
+        from statewide_count_once
+
+        union all
+
+        select
+            'count_multiple_per_district', office_type, per_district, n_cohort_districts
+        from cm
+        union all
+        select 'count_multiple_per_seat', office_type, per_seat, n_cohort_districts
+        from cm
+        union all
+        select 'count_multiple_per_org', office_type, per_org, n_cohort_districts
+        from cm
+    )
+
+select metric_variant, office_type, people_served, n_cohort_districts
+from final

--- a/dbt/project/tests/assert_people_served_ordering_invariant.sql
+++ b/dbt/project/tests/assert_people_served_ordering_invariant.sql
@@ -1,11 +1,12 @@
--- The People Served ordering invariant (DATA-1993): within every office_type,
--- count_once <= count_multiple_per_district <= per_seat <= per_org. count-once dedups
--- people; each count-multiple variant can only re-count them (a per-district sum >= a
--- distinct union; per-seat >= per-district and per-org >= per-seat because
--- 1 <= n_seats <= n_orgs per district). Returns offending office_types; empty = pass.
--- Null-tolerant so a legitimately-absent variant does not false-fail; the unique test
--- on
--- (metric_variant, office_type) guards against duplicate rows that max() would hide.
+-- The People Served invariant (DATA-1993): within every office_type, all four metric
+-- variants are PRESENT and count_once <= count_multiple_per_district <= per_seat <=
+-- per_org. count-once dedups people; each count-multiple variant can only re-count them
+-- (a per-district sum >= a distinct union; per-seat >= per-district and per-org >=
+-- per-seat because 1 <= n_seats <= n_orgs per district). Strict on presence too: every
+-- office_type ('all', each L2 type, and 'State') carries all four variants by
+-- construction, so a missing one is a build bug -- the null-tolerant form would hide
+-- it.
+-- Returns offending office_types; empty = pass.
 with
     p as (
         select
@@ -31,9 +32,19 @@ with
         group by office_type
     )
 
-select *
+select
+    *,
+    case
+        when co is null or cmd is null or cms is null or cmo is null
+        then 'missing_variant'
+        else 'ordering_violation'
+    end as failure
 from p
 where
-    (co is not null and cmd is not null and co > cmd + 1e-6)
-    or (cmd is not null and cms is not null and cmd > cms + 1e-6)
-    or (cms is not null and cmo is not null and cms > cmo + 1e-6)
+    co is null
+    or cmd is null
+    or cms is null
+    or cmo is null
+    or co > cmd + 1e-6
+    or cmd > cms + 1e-6
+    or cms > cmo + 1e-6

--- a/dbt/project/tests/assert_people_served_ordering_invariant.sql
+++ b/dbt/project/tests/assert_people_served_ordering_invariant.sql
@@ -1,0 +1,39 @@
+-- The People Served ordering invariant (DATA-1993): within every office_type,
+-- count_once <= count_multiple_per_district <= per_seat <= per_org. count-once dedups
+-- people; each count-multiple variant can only re-count them (a per-district sum >= a
+-- distinct union; per-seat >= per-district and per-org >= per-seat because
+-- 1 <= n_seats <= n_orgs per district). Returns offending office_types; empty = pass.
+-- Null-tolerant so a legitimately-absent variant does not false-fail; the unique test
+-- on
+-- (metric_variant, office_type) guards against duplicate rows that max() would hide.
+with
+    p as (
+        select
+            office_type,
+            max(case when metric_variant = 'count_once' then people_served end) as co,
+            max(
+                case
+                    when metric_variant = 'count_multiple_per_district'
+                    then people_served
+                end
+            ) as cmd,
+            max(
+                case
+                    when metric_variant = 'count_multiple_per_seat' then people_served
+                end
+            ) as cms,
+            max(
+                case
+                    when metric_variant = 'count_multiple_per_org' then people_served
+                end
+            ) as cmo
+        from {{ ref("people_served") }}
+        group by office_type
+    )
+
+select *
+from p
+where
+    (co is not null and cmd is not null and co > cmd + 1e-6)
+    or (cmd is not null and cms is not null and cmd > cms + 1e-6)
+    or (cms is not null and cmo is not null and cms > cmo + 1e-6)


### PR DESCRIPTION
## What

The first product-facing consumers of the district/census substrate (epic DATA-1359; this is the last v1 build):

- **`int__serve_block_coverage`** (intermediate/civics): the count-once engine. Scans the L2 voter file once to emit per-`(block, served_set)` distinct served-voter counts. Count-once is a distinct-person union across overlapping district types, which the counts-only substrate cannot produce (cross-type voter dedup needs voter IDs), so this is the "scanned, never surfaced" node from TDD 7.1. Counts-only output (PII-free). Scoped to the same 22 district types as the substrate, so the ordering invariant holds.
- **`people_served`** (mart/analytics): the People Served metrics, one row per `(metric_variant, office_type)`. count_once plus count_multiple per district / seat / org. Statewide officials read the exact T5 `State` rows and are reported separately (`office_type='State'`), never folded into the local `all` headline (TDD 4.5). Thin by design.
- **`official_constituents`** (mart/analytics): one row per resolved serve official with `constituents`, `registered_voters`, the gap, and `has_census_match`.

## Key decisions

- **count-once = voter-union** (the distinct-person North Star), not the whole-block reading. Whole-block breaks the ordering invariant: it sums a split block's full population while count-multiple is on the substrate's allocated basis. A spec inconsistency caught at plan time and resolved with two independent model reviews plus live data.
- **requires_review is carried through, never filtered.** Wrong-scope matches are fixed upstream (DATA-1989 overrides), not patched in the model (a blunt flag filter over-excludes legitimate districts). The flag rides on `official_constituents` for the product to caveat.
- **High-undercount flag deferred** to a follow-up (a correct voterless/invisible-population measure needs geographic assignment of zero-voter blocks, out of v1 scope); v1 ships the honest `constituents_minus_voters` gap.
- **Seat multiplier hardened** with an `organization_slug` fallback so `1 <= n_seats <= n_orgs` per district (guarantees per-district <= per-seat <= per-org).
- Codex plan-gate review: GO after revisions (statewide redesign, seat-id namespacing, unique test, reconciliation additions); 6 other findings verified as non-issues against data.

## Tests

- Ordering invariant (singular): count_once <= per_district <= per_seat <= per_org within every office_type.
- served_voters <= total_voters; unique keys on both marts; range checks; a wide North-Star sanity band. Bands, not fixed counts (the cohort is live and the L2 file refreshes).

## Verification

count-once and count-multiple were validated on prod data before commit (ordering holds for all 21 binding types; statewide join confirmed). Reconciliation on the CI preview schema will follow as a comment once the build completes. Local dbt is Fusion and cannot parse the project, so verification is on CI.

Not self-merged; opened for human review.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New heavy L2 nationwide materialization and population metrics that drive product OKRs; correctness is guarded by ordering and key tests but wrong-scope matches still flow into headline numbers until upstream fixes.
> 
> **Overview**
> Introduces the first **Serve analytics consumers** of the district/census substrate: headline People Served metrics and per-official constituent counts.
> 
> **`int__serve_block_coverage`** (new intermediate table) is the **count-once engine**: one scan of `int__l2_nationwide_uniform`, unpivot across the same 22 L2 district types as the substrate, join to cohort districts from `int__serve_district_resolution`, and emit PII-free `(block_geoid, served_set)` rows with `served_voters` / `total_voters` for `'all'` and per-type sets. Statewide offices stay out of this model.
> 
> **`people_served`** (new mart table) exposes one row per `(metric_variant, office_type)`: **count_once** from block coverage × census block population; **count_multiple** variants from `district_census_stats` with seat/org multipliers (namespaced seat ids + `organization_slug` fallback). Local **`office_type = 'all'`** is separate from **`State`** statewide totals (TDD 4.5).
> 
> **`official_constituents`** (new view) is one row per resolved Serve org with `constituents`, `registered_voters`, `constituents_minus_voters`, and `has_census_match`, joining local districts on normalized names or statewide on `district_type = 'State'`. **`requires_review`** is passed through, not filtered.
> 
> **Tests/docs:** YAML for the new models; singular **`assert_people_served_ordering_invariant`**; uniqueness, ranges, and a warn-level North Star sanity band on `count_once` / `all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7944a77ccebc63bb9719bd1244d5e61862d357a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->