### PR TITLE
feat(analytics): Amplitude event git-provenance backfill (DATA-2007)

### DIFF
--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -1,0 +1,791 @@
+"""One-time backfill: build the initial git-provenance table for Amplitude events (DATA-2007).
+
+Walks the omni git history ONCE over the instrumentation paths and writes one
+provenance row per Amplitude ``event_type`` to a Databricks landing table via an
+idempotent MERGE, plus a commit-SHA watermark so DATA-2006's incremental updater
+can resume with ``git log <lastSHA>..HEAD``.
+
+This is phase 1 extracted from DATA-2006; it builds nothing incremental and writes
+nothing back to Amplitude. DATA-2005 builds ``stg__amplitude_event_provenance`` over
+the table this produces.
+
+Cross-repo by nature: it READS the omni working tree's git history (``--repo`` /
+``OMNI_REPO``) and WRITES this repo's Databricks data layer (via the analytics
+``databricks_conn`` profile auth -- no PAT).
+
+Extraction note: ``trackEvent(...)`` in omni is called with *constant references*
+(``trackEvent(EVENTS.ServeOnboarding.SwornInCompleted)``), not string literals. The
+event-type strings live as VALUES in the ``EVENTS`` map
+(packages/gp-webapp/helpers/analyticsHelper.ts) and a few gp-api type/string files.
+So we do not parse ``trackEvent('...')``; instead we anchor on the authoritative event
+universe (``dbt.int__amplitude_event_taxonomy``, ~408 events) and match those literals
+against added/removed diff lines in a single ``git log -p`` pass.
+
+Deploy-ref anchored: the walk, the HEAD-presence grep, and PR attribution all target the
+deployed default branch (``origin/develop``, fetched first), so provenance reflects what
+shipped rather than whatever branch the local checkout is on.
+
+PR attribution is pure git, matching omni's merge-commit workflow: a commit's own subject
+rarely carries a PR ref, so for any gap we walk the ancestry path to the merge commit that
+introduced it (``Merge pull request #N from ...``) and parse that. (The GitHub
+``commits/{sha}/pulls`` REST endpoint was evaluated and returns nothing for this repo.)
+
+The landing schema is env-configurable (airflow_source in prod, --schema private_tristan for
+local dev; see ``resolve_schema``).
+
+Usage::
+
+    # prod (orchestrated, lands in airflow_source):
+    cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
+        --repo ~/Documents/0_goodparty/0_repos/omni
+    # local dev (writable schema):
+    cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
+        --repo ~/Documents/0_goodparty/0_repos/omni --schema private_tristan
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+# Instrumentation packages whose history defines when an event was added/removed.
+INSTRUMENTATION_PATHS = ["packages/gp-webapp", "packages/gp-api"]
+
+# Events came online in Amplitude ~2025-05; the EVENTS map + segment wiring landed
+# ~2025-02. Bounding the walk here skips the large pre-2024 scaffold-era diffs while
+# keeping an 8-month margin before real instrumentation. None walks full history.
+DEFAULT_SINCE = "2024-06-01"
+
+# Rows per multi-row INSERT. One round-trip per chunk; small enough to stay well under
+# any bound-parameter ceiling (chunk * ~12 cols params), large enough that the whole
+# ~400-row table writes in a couple of round-trips (minimizes warehouse-drop exposure).
+INSERT_CHUNK_ROWS = 200
+
+# Deployed default branch we attribute against. Provenance must reflect what shipped, so
+# the walk, the HEAD-presence grep, and the merge-walk all target this ref (fetched first),
+# not whatever branch the local omni checkout happens to be on.
+DEPLOY_REF = "origin/develop"
+
+DATABRICKS_CATALOG = "goodparty_data_catalog"
+TAXONOMY_TABLE = f"{DATABRICKS_CATALOG}.dbt.int__amplitude_event_taxonomy"
+
+# Landing schema is env-configurable, mirroring the airflow_source convention
+# (l2_expired_voters reads Variable `databricks_source_schema`: airflow_source in prod,
+# airflow_source_dev in dev). airflow_source is the repo's source for job-written tables and
+# is where DATA-2005 registers this as a dbt source; the state table sits beside it, like
+# l2_expired_voters + l2_expired_voters_loads. Local dev runs (whose creds can't write the
+# airflow_source* schemas) pass --schema private_tristan. The prod default is zero-config.
+DEFAULT_SOURCE_SCHEMA = "airflow_source"
+_PROVENANCE_BASENAME = "amplitude_event_provenance"
+JOB_NAME = "amplitude_event_provenance_backfill"
+
+
+def provenance_tables(schema: str, catalog: str = DATABRICKS_CATALOG) -> tuple[str, str]:
+    """``(landing_table, state_table)`` fully-qualified names for a landing schema."""
+    base = f"{catalog}.{schema}.{_PROVENANCE_BASENAME}"
+    return base, f"{base}_state"
+
+
+def resolve_schema(env: dict[str, str], override: str | None = None) -> str:
+    """Landing schema: explicit --schema, else env, else the prod default (airflow_source)."""
+    return (
+        override
+        or env.get("AMPLITUDE_PROVENANCE_SCHEMA")
+        or env.get("DBT_AIRFLOW_SOURCE_SCHEMA")
+        or DEFAULT_SOURCE_SCHEMA
+    )
+
+
+PROVENANCE_TABLE, STATE_TABLE = provenance_tables(DEFAULT_SOURCE_SCHEMA)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (self-contained; mirror the DATA-1952 monitor's git correlation)
+# --------------------------------------------------------------------------- #
+
+
+def parse_pr_number(subject: str | None) -> str | None:
+    """Pull a PR number from a commit subject, else None.
+
+    Handles both conventions: omni's dominant merge-commit form
+    ("Merge pull request #1892 from ...") and the squash suffix ("... (#1234)").
+    """
+    text = subject or ""
+    match = re.search(r"Merge pull request #(\d+)", text) or re.search(r"\(#(\d+)\)", text)
+    return match.group(1) if match else None
+
+
+def classify_code_status(present_in_head: bool | None, has_history: bool) -> str:
+    """Map (grep-at-HEAD result, whether the literal has any git history) to a status."""
+    if present_in_head is None:
+        return "unknown"  # git unavailable / errored
+    if present_in_head:
+        return "present"  # instrumentation still in the codebase
+    if has_history:
+        return "removed"  # was there, now gone -> deprecated/renamed in code
+    return "not_found_in_code"  # literal never appeared in the instrumentation paths
+
+
+# Quote-family chars dropped (not separated) when slugging, so "Can't" -> "cant".
+_QUOTE_CHARS = "'`’‘“”′″\""
+
+
+def slugify_event(name: str) -> str:
+    """Punctuation-robust key: lowercase, drop quotes/apostrophes, other non-alnum -> '_'.
+
+    Amplitude's stored ``event_type`` and the code literal sometimes differ only by an
+    apostrophe (e.g. "Click Can't See Office" vs "Click Cant See Office"); both slug to
+    the same value so downstream can join on the slug without punctuation drift. This is
+    a convenience join key alongside the verbatim ``event_type`` -- not the walk's match
+    key, which stays exact.
+    """
+    stripped = "".join(c for c in name.lower() if c not in _QUOTE_CHARS)
+    return re.sub(r"[^a-z0-9]+", "_", stripped).strip("_")
+
+
+# --------------------------------------------------------------------------- #
+# Event-literal extraction -- anchored on the known event universe
+# --------------------------------------------------------------------------- #
+
+
+def compile_event_pattern(events: Iterable[str]) -> re.Pattern[str]:
+    """Compile one alternation regex over the known event_type literals.
+
+    Sorted longest-first so a longer event name wins over a shorter one it
+    contains (regex alternation is ordered + non-overlapping left-to-right),
+    which stops a short literal from being double-counted inside a longer one.
+    """
+    ordered = sorted(set(events), key=len, reverse=True)
+    return re.compile("|".join(re.escape(e) for e in ordered))
+
+
+def find_events(text: str, pattern: re.Pattern[str]) -> set[str]:
+    """Set of known event literals appearing in ``text`` (a diff line or grep dump)."""
+    return set(pattern.findall(text))
+
+
+# --------------------------------------------------------------------------- #
+# Single-pass history walk
+# --------------------------------------------------------------------------- #
+
+# Header line emitted by: git log -p --date=short
+#   --format='%x00%H%x1f%h%x1f%ad%x1f%s'
+# A NUL marks the start of each commit; the remaining fields are 0x1f-separated.
+_HEADER_PREFIX = "\x00"
+_FIELD_SEP = "\x1f"
+_GIT_LOG_FORMAT = "--format=%x00%H%x1f%h%x1f%ad%x1f%s"
+
+Commit = dict[str, str | None]
+
+
+def _commit_from_header(line: str) -> Commit:
+    """Parse a NUL-prefixed header line into a commit dict (pr derived from subject)."""
+    full, short, cdate, subject = line[len(_HEADER_PREFIX) :].split(_FIELD_SEP, 3)
+    return {"commit": full, "short": short, "date": cdate, "subject": subject, "pr": parse_pr_number(subject)}
+
+
+def parse_git_log(lines: Iterable[str], pattern: re.Pattern[str]) -> dict[str, dict]:
+    """Single pass over a ``git log -p`` stream -> per-event provenance accumulator.
+
+    Returns ``{event_type: {'instrumented', 'retired', 'last_change'}}`` where each
+    value is a commit dict or None. Attribution is by COMMIT DATE, not stream order,
+    so it is robust to git's newest-first output and to non-monotonic dates:
+      - instrumented = earliest-dated commit that net-ADDED the literal
+      - retired      = latest-dated commit that net-REMOVED it
+      - last_change  = latest-dated commit that net-added OR net-removed it
+    Within a commit, a literal on both + and - lines (a move/reindent) nets to zero
+    and is ignored, so reformatting never looks like an add or a remove.
+    """
+    acc: dict[str, dict] = {}
+    cur: Commit | None = None
+    added: set[str] = set()
+    removed: set[str] = set()
+
+    def flush() -> None:
+        if cur is None:
+            return
+        net_added = added - removed
+        net_removed = removed - added
+        for ev in net_added:
+            _record(acc, ev, cur, "instrumented")
+        for ev in net_removed:
+            _record(acc, ev, cur, "retired")
+        for ev in net_added | net_removed:
+            _record(acc, ev, cur, "last_change")
+
+    for line in lines:
+        if line.startswith(_HEADER_PREFIX):
+            flush()
+            cur = _commit_from_header(line)
+            added, removed = set(), set()
+        elif cur is None:
+            continue
+        elif line.startswith("+") and not line.startswith("+++"):
+            added |= find_events(line[1:], pattern)
+        elif line.startswith("-") and not line.startswith("---"):
+            removed |= find_events(line[1:], pattern)
+    flush()
+    return acc
+
+
+def _record(acc: dict[str, dict], event: str, commit: Commit, slot: str) -> None:
+    """Keep the earliest commit for 'instrumented', the latest for 'retired'/'last_change'.
+
+    Dates are 'YYYY-MM-DD' strings, so lexical comparison is chronological.
+    """
+    entry = acc.setdefault(event, {"instrumented": None, "retired": None, "last_change": None})
+    current = entry[slot]
+    if current is None:
+        entry[slot] = commit
+    elif slot == "instrumented":
+        if commit["date"] < current["date"]:
+            entry[slot] = commit
+    elif commit["date"] > current["date"]:  # 'retired' / 'last_change'
+        entry[slot] = commit
+
+
+# --------------------------------------------------------------------------- #
+# Row assembly (schema shared with DATA-2005 staging and DATA-2006 incremental)
+# --------------------------------------------------------------------------- #
+
+# (column, Databricks type) in write order.
+PROVENANCE_SCHEMA = [
+    ("event_type", "STRING"),
+    ("event_type_slug", "STRING"),
+    ("instrumented_commit", "STRING"),
+    ("instrumented_pr", "STRING"),
+    ("instrumented_date", "DATE"),
+    ("retired_commit", "STRING"),
+    ("retired_pr", "STRING"),
+    ("retired_date", "DATE"),
+    ("code_status", "STRING"),
+    ("still_in_code", "BOOLEAN"),
+    ("last_code_change_date", "DATE"),
+    ("updated_at", "TIMESTAMP"),
+]
+PROVENANCE_COLUMNS = [c for c, _ in PROVENANCE_SCHEMA]
+
+
+def build_provenance_row(
+    event_type: str,
+    accum_entry: dict | None,
+    present_in_head: bool | None,
+    updated_at: str,
+) -> dict:
+    """Turn one accumulator entry + HEAD-presence into a provenance row dict.
+
+    ``accum_entry`` is None when the literal never net-changed inside the walked
+    window (either it does not exist in code, or it predates the ``--since`` bound).
+    We never guess provenance: instrumented/retired come only from observed commits.
+    ``retired_*`` is emitted only when the event is genuinely gone at HEAD.
+    """
+    instrumented = accum_entry["instrumented"] if accum_entry else None
+    retired = accum_entry["retired"] if accum_entry else None
+    last_change = accum_entry["last_change"] if accum_entry else None
+    has_history = bool(instrumented or retired or last_change)
+    code_status = classify_code_status(present_in_head, has_history)
+
+    row = {
+        "event_type": event_type,
+        "event_type_slug": slugify_event(event_type),
+        "instrumented_commit": instrumented["commit"] if instrumented else None,
+        "instrumented_pr": instrumented["pr"] if instrumented else None,
+        "instrumented_date": instrumented["date"] if instrumented else None,
+        "retired_commit": None,
+        "retired_pr": None,
+        "retired_date": None,
+        "code_status": code_status,
+        "still_in_code": present_in_head,
+        "last_code_change_date": last_change["date"] if last_change else None,
+        "updated_at": updated_at,
+    }
+    if code_status == "removed" and retired:
+        row["retired_commit"] = retired["commit"]
+        row["retired_pr"] = retired["pr"]
+        row["retired_date"] = retired["date"]
+    return row
+
+
+def collect_provenance(
+    events: Sequence[str],
+    git_log_lines: Iterable[str],
+    grep_text: str,
+    updated_at: str,
+) -> list[dict]:
+    """Full pure pipeline: walk -> HEAD presence -> one provenance row per event."""
+    pattern = compile_event_pattern(events)
+    acc = parse_git_log(git_log_lines, pattern)
+    present = present_at_head(events, grep_text)
+    return [build_provenance_row(e, acc.get(e), present.get(e), updated_at) for e in events]
+
+
+# --------------------------------------------------------------------------- #
+# PR resolution (pure): backfill *_pr gaps the squash-suffix heuristic misses
+# --------------------------------------------------------------------------- #
+
+# parse_pr_number reads a PR ref straight off a commit subject -- but the *feature* commits
+# that add/remove an event literal carry no ref; the PR number lives only on the merge commit
+# that brought them into the deployed branch. So for any commit still missing a PR we walk the
+# ancestry path to that introducing merge and parse its subject. Pure git, offline, and aligned
+# with omni's merge-commit workflow (commits/{sha}/pulls returns nothing for this repo).
+
+_PR_FIELDS = (("instrumented_commit", "instrumented_pr"), ("retired_commit", "retired_pr"))
+
+
+def _pick_introducing_merge(rev_list_output: str) -> str | None:
+    """From ``git rev-list --ancestry-path --merges <sha>..<ref>`` output, the introducing merge.
+
+    rev-list emits newest-first, so the merge that actually brought the commit into the ref
+    is the *oldest* on the ancestry path (later lines are subsequent merges on the mainline).
+    """
+    shas = rev_list_output.split()
+    return shas[-1] if shas else None
+
+
+def resolve_pr_gaps(
+    rows: Sequence[dict], resolver: Callable[[str], str | None] | None
+) -> tuple[Sequence[dict], int]:
+    """Fill null ``*_pr`` from ``resolver(sha)``; each distinct SHA resolved once.
+
+    Only touches a ``*_pr`` that is null and whose ``*_commit`` is set, so a PR already
+    found by parse_pr_number is never overwritten. ``resolver`` is None when offline (no
+    token, no gh CLI) -- a no-op, leaving whatever the subject heuristic found. Mutates the
+    rows in place and returns ``(rows, n_filled)``.
+    """
+    if resolver is None:
+        return rows, 0
+    cache: dict[str, str | None] = {}
+
+    def lookup(sha: str) -> str | None:
+        if sha not in cache:
+            cache[sha] = resolver(sha)
+        return cache[sha]
+
+    filled = 0
+    for row in rows:
+        for commit_key, pr_key in _PR_FIELDS:
+            if row.get(pr_key) is None and row.get(commit_key):
+                pr = lookup(row[commit_key])
+                if pr is not None:
+                    row[pr_key] = pr
+                    filled += 1
+    return rows, filled
+
+
+def present_at_head(events: Sequence[str], grep_text: str) -> dict[str, bool]:
+    """{event: bool} -- whether each known literal appears in a HEAD ``git grep`` dump."""
+    found = find_events(grep_text, compile_event_pattern(events))
+    return {e: e in found for e in events}
+
+
+# --------------------------------------------------------------------------- #
+# SQL builders (pure)
+# --------------------------------------------------------------------------- #
+
+
+def build_git_log_argv(
+    root: str, since: str | None, paths: Sequence[str], ref: str | None = None
+) -> list[str]:
+    """argv for the single ``git log -p`` pass over the instrumentation paths.
+
+    ``ref`` (e.g. ``origin/develop``) bounds the walk to a revision; placed before the ``--``
+    so git reads it as a rev, not a path. None walks HEAD (current checkout).
+    """
+    argv = ["git", "-C", root, "log", "-p", "--date=short", _GIT_LOG_FORMAT]
+    if since:
+        argv += ["--since", since]
+    if ref:
+        argv.append(ref)
+    return [*argv, "--", *paths]
+
+
+def build_create_table_sql(table: str, or_replace: bool = False) -> str:
+    """Typed Delta DDL for the shared provenance schema (CREATE [OR REPLACE] / IF NOT EXISTS)."""
+    cols = ",\n  ".join(f"{c} {t}" for c, t in PROVENANCE_SCHEMA)
+    verb = "CREATE OR REPLACE TABLE" if or_replace else "CREATE TABLE IF NOT EXISTS"
+    return f"{verb} {table} (\n  {cols}\n) USING DELTA"
+
+
+def build_merge_sql(target: str, staging: str, columns: Sequence[str], key: str = "event_type") -> str:
+    """Idempotent MERGE of ``staging`` into ``target`` keyed on ``key`` (UPDATE/INSERT)."""
+    non_key = [c for c in columns if c != key]
+    set_clause = ", ".join(f"t.{c} = s.{c}" for c in non_key)
+    insert_cols = ", ".join(columns)
+    insert_vals = ", ".join(f"s.{c}" for c in columns)
+    return (
+        f"MERGE INTO {target} AS t\n"
+        f"USING {staging} AS s\n"
+        f"ON t.{key} = s.{key}\n"
+        f"WHEN MATCHED THEN UPDATE SET {set_clause}\n"
+        f"WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})"
+    )
+
+
+def row_params(row: dict, columns: Sequence[str]) -> tuple:
+    """Row dict -> positional bind tuple in ``columns`` order (raw values, no escaping)."""
+    return tuple(row.get(c) for c in columns)
+
+
+def build_bulk_insert(table: str, columns: Sequence[str], rows: Sequence[dict]) -> tuple[str, list]:
+    """One multi-row parameterized INSERT + flattened (row-major) bind params.
+
+    Values are BOUND, never interpolated -- this is what makes event names with
+    apostrophes (e.g. "Click Can't See Office") store correctly. A single multi-row
+    INSERT is one network round-trip, far more robust than ``executemany`` (which
+    round-trips per row and holds the warehouse connection long enough to be dropped).
+    """
+    tuple_sql = "(" + ", ".join("?" for _ in columns) + ")"
+    sql = f"INSERT INTO {table} ({', '.join(columns)}) VALUES " + ", ".join(tuple_sql for _ in rows)
+    params = [v for row in rows for v in row_params(row, columns)]
+    return sql, params
+
+
+STATE_COLUMNS = ["job_name", "last_processed_sha", "head_ref", "commit_count", "last_run_at"]
+
+_CREATE_STATE_TABLE_SQL = (
+    "CREATE TABLE IF NOT EXISTS {table} (\n"
+    "  job_name STRING,\n"
+    "  last_processed_sha STRING,\n"
+    "  head_ref STRING,\n"
+    "  commit_count BIGINT,\n"
+    "  last_run_at TIMESTAMP\n"
+    ") USING DELTA"
+)
+
+
+def build_watermark_merge_sql(state_table: str) -> str:
+    """Parameterized single-row MERGE of the high-water mark, keyed on ``job_name``.
+
+    Five bound params, in ``STATE_COLUMNS`` order. ``commit_count`` / ``last_run_at``
+    are CAST to their column types so string/int binds land correctly.
+    """
+    return (
+        f"MERGE INTO {state_table} AS t\n"
+        f"USING (SELECT ? AS job_name, ? AS last_processed_sha, ? AS head_ref, "
+        f"CAST(? AS BIGINT) AS commit_count, CAST(? AS TIMESTAMP) AS last_run_at) AS s\n"
+        f"ON t.job_name = s.job_name\n"
+        f"WHEN MATCHED THEN UPDATE SET "
+        f"t.last_processed_sha = s.last_processed_sha, t.head_ref = s.head_ref, "
+        f"t.commit_count = s.commit_count, t.last_run_at = s.last_run_at\n"
+        f"WHEN NOT MATCHED THEN INSERT "
+        f"(job_name, last_processed_sha, head_ref, commit_count, last_run_at) "
+        f"VALUES (s.job_name, s.last_processed_sha, s.head_ref, s.commit_count, s.last_run_at)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Git IO (thin subprocess wrappers; injectable for tests)
+# --------------------------------------------------------------------------- #
+
+
+def run_git_log(root: str, since: str | None, paths: Sequence[str], ref: str | None = None) -> Iterator[str]:
+    """Stream the single ``git log -p`` pass line-by-line (the diff stream is large)."""
+    argv = build_git_log_argv(root, since, paths, ref)
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, text=True)
+    assert proc.stdout is not None
+    try:
+        yield from (line.rstrip("\n") for line in proc.stdout)
+    finally:
+        proc.stdout.close()
+        proc.wait()
+
+
+def git_grep_present_text(root: str, events: Sequence[str], paths: Sequence[str], ref: str = "HEAD") -> str:
+    """Dump of ``ref`` lines containing any known literal, via one fixed-string git grep.
+
+    ``-F`` treats each event as a literal; ``-h`` drops filenames. git grep exits 1
+    when nothing matches (an empty dump), which is not an error here.
+    """
+    patterns: list[str] = []
+    for e in events:
+        patterns += ["-e", e]
+    argv = ["git", "-C", root, "grep", "-F", "-h", "--no-color", *patterns, ref, "--", *paths]
+    proc = subprocess.run(argv, capture_output=True, text=True)
+    return proc.stdout
+
+
+def git_head_sha(root: str, ref: str = "HEAD") -> str:
+    return subprocess.run(
+        ["git", "-C", root, "rev-parse", ref], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def git_head_ref(root: str, ref: str | None = None) -> str:
+    """The ref name to record as the watermark's branch: the deploy ref, else current HEAD."""
+    if ref:
+        return ref
+    return subprocess.run(
+        ["git", "-C", root, "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def git_commit_count(root: str, since: str | None, paths: Sequence[str], ref: str = "HEAD") -> int:
+    argv = ["git", "-C", root, "rev-list", "--count", ref]
+    if since:
+        argv += ["--since", since]
+    out = subprocess.run([*argv, "--", *paths], capture_output=True, text=True, check=True).stdout
+    return int(out.strip() or "0")
+
+
+def git_fetch(root: str, ref: str) -> None:
+    """Update the deploy ref from its remote (``origin/develop`` -> ``git fetch origin develop``)."""
+    remote, _, branch = ref.partition("/")
+    argv = ["git", "-C", root, "fetch", "--quiet", remote]
+    if branch:
+        argv.append(branch)
+    subprocess.run(argv, capture_output=True, text=True)
+
+
+# --------------------------------------------------------------------------- #
+# Git PR resolution IO (merge-walk; no network, matches omni's merge-commit flow)
+# --------------------------------------------------------------------------- #
+
+
+def git_merge_pr(root: str, sha: str, deploy_ref: str) -> str | None:
+    """PR number for the merge commit that introduced ``sha`` into ``deploy_ref``, else None.
+
+    Walks the ancestry path from the commit to the deploy ref, takes the introducing merge,
+    and parses its subject. None when the commit reached the ref without a merge (e.g. a
+    direct push) or is not an ancestor of the ref.
+    """
+    rev_list = subprocess.run(
+        ["git", "-C", root, "rev-list", "--ancestry-path", "--merges", f"{sha}..{deploy_ref}"],
+        capture_output=True,
+        text=True,
+    )
+    if rev_list.returncode != 0:
+        return None
+    merge_sha = _pick_introducing_merge(rev_list.stdout)
+    if not merge_sha:
+        return None
+    subject = subprocess.run(
+        ["git", "-C", root, "log", "-1", "--format=%s", merge_sha], capture_output=True, text=True
+    ).stdout
+    return parse_pr_number(subject)
+
+
+def make_merge_walk_resolver(root: str, deploy_ref: str) -> Callable[[str], str | None]:
+    """A ``sha -> PR`` resolver bound to a checkout + deploy ref, for ``resolve_pr_gaps``."""
+    return lambda sha: git_merge_pr(root, sha, deploy_ref)
+
+
+# --------------------------------------------------------------------------- #
+# Databricks IO (cursor is injected -- a DB-API cursor from databricks_conn)
+# --------------------------------------------------------------------------- #
+
+
+def _missing_columns(existing: set[str], schema: Sequence[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Schema entries whose column is absent from ``existing`` (order preserved)."""
+    return [(c, t) for c, t in schema if c not in existing]
+
+
+def _ensure_columns(cursor: Any, table: str, schema: Sequence[tuple[str, str]]) -> None:
+    """Add any schema columns missing from an existing table (Delta schema evolution).
+
+    Needed because ``CREATE TABLE IF NOT EXISTS`` will not evolve a table that already
+    exists with an older schema -- e.g. when this shared table predates ``event_type_slug``.
+    """
+    cursor.execute(f"DESCRIBE TABLE {table}")
+    existing: set[str] = set()
+    for row in cursor.fetchall():
+        name = row[0]
+        if not name or name.startswith("#"):  # partition / detail section -> stop
+            break
+        existing.add(name)
+    missing = _missing_columns(existing, schema)
+    if missing:
+        adds = ", ".join(f"{c} {t}" for c, t in missing)
+        cursor.execute(f"ALTER TABLE {table} ADD COLUMNS ({adds})")
+
+
+def fetch_event_universe(cursor: Any, taxonomy_table: str = TAXONOMY_TABLE) -> list[str]:
+    """The authoritative ~408 distinct event_type values to attribute provenance for."""
+    cursor.execute(
+        f"SELECT DISTINCT event_type FROM {taxonomy_table} "
+        f"WHERE event_type IS NOT NULL ORDER BY event_type"
+    )
+    return [str(r[0]) for r in cursor.fetchall()]
+
+
+def write_provenance(cursor: Any, rows: Sequence[dict], table: str = PROVENANCE_TABLE) -> None:
+    """Create the table if needed and MERGE rows in via a staging table (idempotent).
+
+    Rows are bound via ``executemany`` -- no inline SQL -- so apostrophes/quotes in
+    event names survive intact.
+    """
+    staging = f"{table}__stage"
+    cursor.execute(build_create_table_sql(table))
+    _ensure_columns(cursor, table, PROVENANCE_SCHEMA)  # evolve a pre-existing older table
+    cursor.execute(build_create_table_sql(staging, or_replace=True))
+    for i in range(0, len(rows), INSERT_CHUNK_ROWS):
+        chunk = rows[i : i + INSERT_CHUNK_ROWS]
+        cursor.execute(*build_bulk_insert(staging, PROVENANCE_COLUMNS, chunk))
+    cursor.execute(build_merge_sql(table, staging, PROVENANCE_COLUMNS))
+    cursor.execute(f"DROP TABLE IF EXISTS {staging}")
+
+
+def write_watermark(
+    cursor: Any,
+    last_processed_sha: str,
+    head_ref: str,
+    commit_count: int,
+    last_run_at: str,
+    state_table: str = STATE_TABLE,
+) -> None:
+    """Upsert the SHA high-water mark so DATA-2006 can resume with git log <sha>..HEAD."""
+    cursor.execute(_CREATE_STATE_TABLE_SQL.format(table=state_table))
+    cursor.execute(
+        build_watermark_merge_sql(state_table),
+        (JOB_NAME, last_processed_sha, head_ref, commit_count, last_run_at),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def resolve_omni_repo(arg: str | None, env: dict[str, str]) -> str:
+    """The omni checkout to walk: --repo, else $OMNI_REPO. Must be an existing dir."""
+    root = arg or env.get("OMNI_REPO")
+    if not root:
+        raise SystemExit("ERROR: pass --repo or set OMNI_REPO to an omni checkout path.")
+    root = os.path.expanduser(root)
+    if not os.path.isdir(os.path.join(root, ".git")) and not os.path.exists(os.path.join(root, ".git")):
+        raise SystemExit(f"ERROR: {root} is not a git checkout (no .git).")
+    return root
+
+
+def run_backfill(
+    cursor: Any,
+    root: str,
+    since: str | None,
+    now: datetime,
+    table: str = PROVENANCE_TABLE,
+    state_table: str = STATE_TABLE,
+    ref: str = DEPLOY_REF,
+    pr_resolver: Callable[[str], str | None] | None = None,
+) -> list[dict]:
+    """Fetch the universe, walk git once, write the table + watermark. Returns the rows."""
+    updated_at = now.replace(tzinfo=None).isoformat(timespec="seconds")
+    events = fetch_event_universe(cursor)
+    print(f"Event universe: {len(events)} event_types", file=sys.stderr)
+
+    print(
+        f"Walking git log -p {ref} {' '.join(INSTRUMENTATION_PATHS)} (since {since or 'all history'}) ...",
+        file=sys.stderr,
+    )
+    lines = run_git_log(root, since, INSTRUMENTATION_PATHS, ref)
+    grep_text = git_grep_present_text(root, events, INSTRUMENTATION_PATHS, ref)
+    # parse_git_log consumes the stream; collect_provenance needs both, so materialize
+    # the (small) grep dump first and stream the (large) log into collect_provenance.
+    rows = collect_provenance(events, lines, grep_text, updated_at)
+
+    _, filled = resolve_pr_gaps(rows, pr_resolver)  # mutates rows in place
+    if pr_resolver is not None:
+        print(f"Merge-walk PR backfill: filled {filled} *_pr gaps", file=sys.stderr)
+
+    write_provenance(cursor, rows, table)
+    write_watermark(
+        cursor,
+        git_head_sha(root, ref),
+        git_head_ref(root, ref),
+        git_commit_count(root, since, INSTRUMENTATION_PATHS, ref),
+        updated_at,
+        state_table,
+    )
+    return rows
+
+
+def _summarize(rows: Sequence[dict]) -> str:
+    by_status: dict[str, int] = {}
+    for r in rows:
+        by_status[r["code_status"]] = by_status.get(r["code_status"], 0) + 1
+    parts = ", ".join(f"{k}={v}" for k, v in sorted(by_status.items()))
+    return f"{len(rows)} rows ({parts})"
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--repo", default=None, help="Path to an omni checkout (else $OMNI_REPO).")
+    p.add_argument(
+        "--since",
+        default=DEFAULT_SINCE,
+        help=f"Lower-bound git history (default {DEFAULT_SINCE}). 'all' walks full history.",
+    )
+    p.add_argument(
+        "--schema",
+        default=None,
+        help=(
+            f"Landing schema (default: $AMPLITUDE_PROVENANCE_SCHEMA / $DBT_AIRFLOW_SOURCE_SCHEMA "
+            f"/ {DEFAULT_SOURCE_SCHEMA}). Use --schema private_tristan for local dev."
+        ),
+    )
+    p.add_argument("--table", default=None, help="Full landing table name; overrides --schema.")
+    p.add_argument("--state-table", default=None, help="Full state table name; overrides --schema.")
+    p.add_argument(
+        "--ref",
+        default=DEPLOY_REF,
+        help=f"Deploy ref to attribute against (default {DEPLOY_REF}).",
+    )
+    p.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Skip the git fetch of the deploy ref (use the local checkout's current ref state).",
+    )
+    p.add_argument(
+        "--no-pr-resolve",
+        action="store_true",
+        help="Skip the merge-walk PR backfill; *_pr stays whatever the commit subject yielded.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    root = resolve_omni_repo(args.repo, dict(os.environ))
+    since = None if args.since == "all" else args.since
+
+    schema = resolve_schema(dict(os.environ), args.schema)
+    default_table, default_state = provenance_tables(schema)
+    table = args.table or default_table
+    state_table = args.state_table or default_state
+    print(f"Landing schema: {schema} -> {table}", file=sys.stderr)
+
+    if not args.no_fetch:
+        print(f"Fetching {args.ref} ...", file=sys.stderr)
+        git_fetch(root, args.ref)
+    pr_resolver = None if args.no_pr_resolve else make_merge_walk_resolver(root, args.ref)
+
+    from databricks_conn import get_connection  # lazy: pure logic imports without pandas/SDK
+
+    connection = get_connection()
+    try:
+        with connection.cursor() as cursor:
+            rows = run_backfill(
+                cursor,
+                root,
+                since,
+                datetime.now(UTC),
+                table=table,
+                state_table=state_table,
+                ref=args.ref,
+                pr_resolver=pr_resolver,
+            )
+    finally:
+        connection.close()
+    print(_summarize(rows), file=sys.stderr)
+    print(f"Wrote {table} and watermark {state_table}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -175,19 +175,28 @@ def find_events(text: str, pattern: re.Pattern[str]) -> set[str]:
 # --------------------------------------------------------------------------- #
 
 # Header line emitted by: git log -p --date=short
-#   --format='%x00%H%x1f%h%x1f%ad%x1f%s'
+#   --format='%x00%H%x1f%h%x1f%ad%x1f%at%x1f%s'
 # A NUL marks the start of each commit; the remaining fields are 0x1f-separated.
+# %ad (--date=short) is the human-readable date we store; %at (commit epoch) is the
+# precise ordering key, so same-day commits break ties by true time, not stream order.
 _HEADER_PREFIX = "\x00"
 _FIELD_SEP = "\x1f"
-_GIT_LOG_FORMAT = "--format=%x00%H%x1f%h%x1f%ad%x1f%s"
+_GIT_LOG_FORMAT = "--format=%x00%H%x1f%h%x1f%ad%x1f%at%x1f%s"
 
 Commit = dict[str, str | None]
 
 
 def _commit_from_header(line: str) -> Commit:
     """Parse a NUL-prefixed header line into a commit dict (pr derived from subject)."""
-    full, short, cdate, subject = line[len(_HEADER_PREFIX) :].split(_FIELD_SEP, 3)
-    return {"commit": full, "short": short, "date": cdate, "subject": subject, "pr": parse_pr_number(subject)}
+    full, short, cdate, ts, subject = line[len(_HEADER_PREFIX) :].split(_FIELD_SEP, 4)
+    return {
+        "commit": full,
+        "short": short,
+        "date": cdate,
+        "ts": ts,
+        "subject": subject,
+        "pr": parse_pr_number(subject),
+    }
 
 
 def parse_git_log(lines: Iterable[str], pattern: re.Pattern[str]) -> dict[str, dict]:
@@ -237,16 +246,17 @@ def parse_git_log(lines: Iterable[str], pattern: re.Pattern[str]) -> dict[str, d
 def _record(acc: dict[str, dict], event: str, commit: Commit, slot: str) -> None:
     """Keep the earliest commit for 'instrumented', the latest for 'retired'/'last_change'.
 
-    Dates are 'YYYY-MM-DD' strings, so lexical comparison is chronological.
+    Ordering is by commit epoch ('ts'), so two net-changes on the same calendar day
+    are disambiguated by their true time rather than by git's newest-first stream order.
     """
     entry = acc.setdefault(event, {"instrumented": None, "retired": None, "last_change": None})
     current = entry[slot]
     if current is None:
         entry[slot] = commit
     elif slot == "instrumented":
-        if commit["date"] < current["date"]:
+        if int(commit["ts"]) < int(current["ts"]):
             entry[slot] = commit
-    elif commit["date"] > current["date"]:  # 'retired' / 'last_change'
+    elif int(commit["ts"]) > int(current["ts"]):  # 'retired' / 'last_change'
         entry[slot] = commit
 
 
@@ -485,15 +495,22 @@ def build_watermark_merge_sql(state_table: str) -> str:
 
 
 def run_git_log(root: str, since: str | None, paths: Sequence[str], ref: str | None = None) -> Iterator[str]:
-    """Stream the single ``git log -p`` pass line-by-line (the diff stream is large)."""
+    """Stream the single ``git log -p`` pass line-by-line (the diff stream is large).
+
+    A non-zero exit (bad ref, corrupt repo) raises ``CalledProcessError`` once the stream
+    is exhausted: otherwise a failed log parses as an empty history and we would MERGE a
+    table of all-null provenance rows with no error signal.
+    """
     argv = build_git_log_argv(root, since, paths, ref)
-    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, text=True)
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     assert proc.stdout is not None
     try:
         yield from (line.rstrip("\n") for line in proc.stdout)
     finally:
         proc.stdout.close()
-        proc.wait()
+        _, stderr = proc.communicate()
+        if proc.returncode != 0:
+            raise subprocess.CalledProcessError(proc.returncode, argv, stderr=stderr)
 
 
 def git_grep_present_text(root: str, events: Sequence[str], paths: Sequence[str], ref: str = "HEAD") -> str:
@@ -537,12 +554,22 @@ def git_commit_count(root: str, since: str | None, paths: Sequence[str], ref: st
 
 
 def git_fetch(root: str, ref: str) -> None:
-    """Update the deploy ref from its remote (``origin/develop`` -> ``git fetch origin develop``)."""
+    """Update the deploy ref from its remote (``origin/develop`` -> ``git fetch origin develop``).
+
+    Aborts on a non-zero exit (network outage, missing remote, bad credentials) rather than
+    silently walking — and watermarking — stale local ``origin/develop`` state.
+    """
     remote, _, branch = ref.partition("/")
     argv = ["git", "-C", root, "fetch", "--quiet", remote]
     if branch:
         argv.append(branch)
-    subprocess.run(argv, capture_output=True, text=True)
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ERROR: git fetch {remote} {branch} failed (exit {result.returncode}).\n"
+            f"{result.stderr.strip()}\n"
+            "Use --no-fetch to skip the fetch and walk the local ref state."
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/analytics/lib/databricks_conn.py
+++ b/analytics/lib/databricks_conn.py
@@ -104,12 +104,15 @@ def _to_dataframe(description: Sequence[Any], rows: Sequence[Any]) -> pd.DataFra
     return pd.DataFrame(list(rows), columns=columns)
 
 
-def run_query(sql: str, *, max_retries: int = 5, retry_delay: int = 10) -> pd.DataFrame:
-    """Execute ``sql`` against the profile's SQL warehouse, return a DataFrame.
+def get_connection(*, max_retries: int = 5, retry_delay: int = 10) -> Any:
+    """Open an authenticated connection to the profile's SQL warehouse.
 
     Auth is resolved by the SDK ``Config`` (M2M service principal if configured,
     else the ``~/.databrickscfg`` profile). The SQL warehouse comes from
-    ``DATABRICKS_HTTP_PATH`` (``/sql/1.0/warehouses/<id>``).
+    ``DATABRICKS_HTTP_PATH`` (``/sql/1.0/warehouses/<id>``). The caller owns the
+    connection (use it as a context manager or ``close()`` it). Use this when you
+    need a cursor for writes / parameterized binding / executemany; for a one-shot
+    read use ``run_query``.
     """
     from databricks import sql as dbsql
     from databricks.sdk.core import Config, oauth_service_principal
@@ -120,7 +123,17 @@ def run_query(sql: str, *, max_retries: int = 5, retry_delay: int = 10) -> pd.Da
         os.environ.get("DATABRICKS_HTTP_PATH", ""),
         oauth_m2m=oauth_service_principal,
     )
-    connection = _connect_with_retry(dbsql.connect, kwargs, max_retries=max_retries, retry_delay=retry_delay)
+    return _connect_with_retry(dbsql.connect, kwargs, max_retries=max_retries, retry_delay=retry_delay)
+
+
+def run_query(sql: str, *, max_retries: int = 5, retry_delay: int = 10) -> pd.DataFrame:
+    """Execute ``sql`` against the profile's SQL warehouse, return a DataFrame.
+
+    Auth is resolved by the SDK ``Config`` (M2M service principal if configured,
+    else the ``~/.databrickscfg`` profile). The SQL warehouse comes from
+    ``DATABRICKS_HTTP_PATH`` (``/sql/1.0/warehouses/<id>``).
+    """
+    connection = get_connection(max_retries=max_retries, retry_delay=retry_delay)
     try:
         with connection.cursor() as cursor:
             cursor.execute(sql)

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -1,0 +1,677 @@
+import os
+from datetime import UTC, datetime
+
+import amplitude_event_provenance_backfill as bf
+from amplitude_event_provenance_backfill import (
+    PROVENANCE_COLUMNS,
+    PROVENANCE_SCHEMA,
+    _missing_columns,
+    build_bulk_insert,
+    build_create_table_sql,
+    build_git_log_argv,
+    build_merge_sql,
+    build_provenance_row,
+    build_watermark_merge_sql,
+    classify_code_status,
+    collect_provenance,
+    compile_event_pattern,
+    find_events,
+    parse_git_log,
+    parse_pr_number,
+    present_at_head,
+    resolve_omni_repo,
+    row_params,
+    slugify_event,
+)
+
+SEP = "\x1f"
+
+
+def _header(full, short, date, subject):
+    return "\x00" + SEP.join([full, short, date, subject])
+
+
+# --------------------------------------------------------------------------- #
+# parse_pr_number / classify_code_status
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_pr_number_pulls_squash_merge_suffix():
+    assert parse_pr_number("feat: add events (#1234)") == "1234"
+
+
+def test_parse_pr_number_pulls_merge_commit_form():
+    # omni's dominant convention is merge commits, not squash suffixes.
+    assert parse_pr_number("Merge pull request #1892 from thegoodparty/feat/briefings") == "1892"
+
+
+def test_parse_pr_number_none_when_no_suffix():
+    assert parse_pr_number("WEB-3658: fullstory events") is None
+    assert parse_pr_number("") is None
+    assert parse_pr_number(None) is None
+
+
+def test_classify_code_status_present_when_in_head():
+    assert classify_code_status(True, True) == "present"
+    assert classify_code_status(True, False) == "present"
+
+
+def test_classify_code_status_removed_when_absent_with_history():
+    assert classify_code_status(False, True) == "removed"
+
+
+def test_classify_code_status_not_found_when_absent_without_history():
+    assert classify_code_status(False, False) == "not_found_in_code"
+
+
+def test_classify_code_status_unknown_when_git_unavailable():
+    assert classify_code_status(None, True) == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# slugify_event -- punctuation-robust matching key
+# --------------------------------------------------------------------------- #
+
+
+def test_slugify_event_lowercases_and_separates_on_punctuation():
+    assert slugify_event("Polls - Poll Results Overview Viewed") == "polls_poll_results_overview_viewed"
+
+
+def test_slugify_event_apostrophe_variants_collapse_to_same_slug():
+    # The whole point: the Amplitude name and the code literal may differ only by
+    # an apostrophe; both must yield the same slug so they reconcile downstream.
+    with_apos = slugify_event("Onboarding - Office Step: Click Can't See Office")
+    without = slugify_event("Onboarding - Office Step: Click Cant See Office")
+    assert with_apos == without == "onboarding_office_step_click_cant_see_office"
+
+
+def test_slugify_event_handles_curly_quotes_and_trailing_punct():
+    assert slugify_event("Pro Upgrade - Guidance: Click let’s go!") == "pro_upgrade_guidance_click_lets_go"
+
+
+def test_slugify_event_already_snake_case_passthrough():
+    assert slugify_event("pro_upgrade_complete") == "pro_upgrade_complete"
+
+
+# --------------------------------------------------------------------------- #
+# find_events
+# --------------------------------------------------------------------------- #
+
+
+def test_find_events_matches_map_value_literal():
+    pattern = compile_event_pattern(["Polls - Create Poll Clicked", "Polls - Poll Question Completed"])
+    line = "  createPollClicked: 'Polls - Create Poll Clicked',"
+    assert find_events(line, pattern) == {"Polls - Create Poll Clicked"}
+
+
+def test_find_events_empty_when_no_known_literal():
+    pattern = compile_event_pattern(["Polls - Create Poll Clicked"])
+    assert find_events("  const x = doThing()", pattern) == set()
+
+
+def test_find_events_prefers_longest_to_avoid_substring_shadowing():
+    pattern = compile_event_pattern(["Completed", "Pledge Completed"])
+    line = "  pledge: 'Pledge Completed',"
+    assert find_events(line, pattern) == {"Pledge Completed"}
+
+
+def test_find_events_matches_double_quoted_and_multiple():
+    pattern = compile_event_pattern(["pro_upgrade_complete", "onboarding_complete"])
+    line = '  PRO: "pro_upgrade_complete", ONB: "onboarding_complete",'
+    assert find_events(line, pattern) == {"pro_upgrade_complete", "onboarding_complete"}
+
+
+# --------------------------------------------------------------------------- #
+# parse_git_log -- the single-pass history walk
+# --------------------------------------------------------------------------- #
+
+# Newest-first, as real `git log` emits. Commit 3 reindents Event A (a move:
+# it appears on both - and + lines, so it must net to no change).
+_STREAM = [
+    _header("cccc", "cccc", "2025-04-01", "refactor: reindent (#333)"),
+    "diff --git a/x.ts b/x.ts",
+    "--- a/x.ts",
+    "+++ b/x.ts",
+    "@@ -1,3 +1,3 @@",
+    "-  a: 'Event A',",
+    "+    a: 'Event A',",
+    _header("bbbb", "bbbb", "2025-03-01", "feat: tweak (#222)"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -1,2 +1,2 @@",
+    "-  b: 'Event B',",
+    "+  c: 'Event C',",
+    _header("aaaa", "aaaa", "2025-02-01", "WEB-1: add events"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -0,0 +1,2 @@",
+    "+  a: 'Event A',",
+    "+  b: 'Event B',",
+]
+
+
+def _parsed():
+    return parse_git_log(_STREAM, compile_event_pattern(["Event A", "Event B", "Event C"]))
+
+
+def test_parse_git_log_instrumented_is_earliest_add():
+    acc = _parsed()
+    assert acc["Event A"]["instrumented"]["commit"] == "aaaa"
+    assert acc["Event A"]["instrumented"]["date"] == "2025-02-01"
+    assert acc["Event A"]["instrumented"]["pr"] is None
+
+
+def test_parse_git_log_retire_is_latest_net_removal():
+    acc = _parsed()
+    assert acc["Event B"]["instrumented"]["commit"] == "aaaa"
+    assert acc["Event B"]["retired"]["commit"] == "bbbb"
+    assert acc["Event B"]["retired"]["pr"] == "222"
+
+
+def test_parse_git_log_reindent_move_is_not_a_change():
+    acc = _parsed()
+    assert acc["Event A"]["retired"] is None
+    assert acc["Event A"]["last_change"]["commit"] == "aaaa"
+
+
+def test_parse_git_log_event_added_later_has_no_retire():
+    acc = _parsed()
+    assert acc["Event C"]["instrumented"]["commit"] == "bbbb"
+    assert acc["Event C"]["retired"] is None
+
+
+def test_parse_git_log_omits_events_never_seen():
+    acc = parse_git_log(_STREAM, compile_event_pattern(["Event A", "Nonexistent Event"]))
+    assert "Nonexistent Event" not in acc
+
+
+# --------------------------------------------------------------------------- #
+# build_provenance_row
+# --------------------------------------------------------------------------- #
+
+UPDATED = "2026-06-17T00:00:00"
+COMMIT_A = {
+    "commit": "aaaa",
+    "short": "aaaa",
+    "date": "2025-02-01",
+    "subject": "WEB-1: add events",
+    "pr": None,
+}
+COMMIT_B = {
+    "commit": "bbbb",
+    "short": "bbbb",
+    "date": "2025-03-01",
+    "subject": "feat: remove (#222)",
+    "pr": "222",
+}
+
+
+def test_build_row_present_event_has_instrumented_and_no_retire():
+    acc = {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A}
+    row = build_provenance_row("Event A", acc, present_in_head=True, updated_at=UPDATED)
+    assert row["code_status"] == "present"
+    assert row["still_in_code"] is True
+    assert row["instrumented_commit"] == "aaaa"
+    assert row["instrumented_pr"] is None
+    assert row["instrumented_date"] == "2025-02-01"
+    assert row["retired_commit"] is None
+    assert row["last_code_change_date"] == "2025-02-01"
+    assert row["updated_at"] == UPDATED
+
+
+def test_build_row_includes_slug():
+    row = build_provenance_row("Polls - Create Poll Clicked", None, present_in_head=True, updated_at=UPDATED)
+    assert row["event_type"] == "Polls - Create Poll Clicked"
+    assert row["event_type_slug"] == "polls_create_poll_clicked"
+
+
+def test_build_row_removed_event_populates_retire():
+    acc = {"instrumented": COMMIT_A, "retired": COMMIT_B, "last_change": COMMIT_B}
+    row = build_provenance_row("Event B", acc, present_in_head=False, updated_at=UPDATED)
+    assert row["code_status"] == "removed"
+    assert row["still_in_code"] is False
+    assert row["retired_commit"] == "bbbb"
+    assert row["retired_pr"] == "222"
+    assert row["retired_date"] == "2025-03-01"
+
+
+def test_build_row_not_found_event_is_all_null():
+    row = build_provenance_row("Sign Up Clicked", None, present_in_head=False, updated_at=UPDATED)
+    assert row["code_status"] == "not_found_in_code"
+    assert row["instrumented_commit"] is None
+    assert row["retired_commit"] is None
+    assert row["last_code_change_date"] is None
+
+
+def test_build_row_present_but_predates_window_does_not_guess():
+    row = build_provenance_row("Old Event", None, present_in_head=True, updated_at=UPDATED)
+    assert row["code_status"] == "present"
+    assert row["still_in_code"] is True
+    assert row["instrumented_commit"] is None
+    assert row["last_code_change_date"] is None
+
+
+def test_build_row_event_type_preserved():
+    row = build_provenance_row("Event A", None, present_in_head=None, updated_at=UPDATED)
+    assert row["event_type"] == "Event A"
+    assert row["code_status"] == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# build_git_log_argv / present_at_head / collect_provenance
+# --------------------------------------------------------------------------- #
+
+
+def test_build_git_log_argv_single_pass_with_since():
+    argv = build_git_log_argv("/repo", "2024-06-01", ["packages/gp-webapp"])
+    assert argv[:4] == ["git", "-C", "/repo", "log"]
+    assert "-p" in argv
+    assert "--format=%x00%H%x1f%h%x1f%ad%x1f%s" in argv
+    assert argv[argv.index("--since") + 1] == "2024-06-01"
+    assert argv[argv.index("--") + 1 :] == ["packages/gp-webapp"]
+
+
+def test_build_git_log_argv_omits_since_when_none():
+    argv = build_git_log_argv("/repo", None, ["packages/gp-api"])
+    assert "--since" not in argv
+
+
+def test_build_git_log_argv_walks_the_deploy_ref():
+    argv = build_git_log_argv("/repo", "2024-06-01", ["packages/gp-webapp"], ref="origin/develop")
+    # the ref must precede the pathspec separator so git treats it as a revision, not a path
+    assert "origin/develop" in argv
+    assert argv.index("origin/develop") < argv.index("--")
+
+
+def test_present_at_head_marks_found_literals():
+    grep_text = "  a: 'Event A',\n  c: 'Event C',"
+    present = present_at_head(["Event A", "Event B", "Event C"], grep_text)
+    assert present == {"Event A": True, "Event B": False, "Event C": True}
+
+
+def test_collect_provenance_one_row_per_event_with_correct_status():
+    grep_text = "'Event A'\n'Event C'"  # B is gone at HEAD
+    rows = collect_provenance(["Event A", "Event B", "Event C"], _STREAM, grep_text, updated_at=UPDATED)
+    by_event = {r["event_type"]: r for r in rows}
+    assert len(rows) == 3
+    assert by_event["Event A"]["code_status"] == "present"
+    assert by_event["Event A"]["instrumented_commit"] == "aaaa"
+    assert by_event["Event B"]["code_status"] == "removed"
+    assert by_event["Event B"]["retired_commit"] == "bbbb"
+    assert by_event["Event C"]["code_status"] == "present"
+    assert by_event["Event C"]["instrumented_commit"] == "bbbb"
+
+
+# --------------------------------------------------------------------------- #
+# SQL builders (parameterized -- no hand-escaping)
+# --------------------------------------------------------------------------- #
+
+
+def test_build_create_table_sql_declares_typed_columns():
+    sql = build_create_table_sql("cat.sch.t")
+    assert "CREATE TABLE IF NOT EXISTS cat.sch.t" in sql
+    assert "event_type STRING" in sql
+    assert "event_type_slug STRING" in sql
+    assert "instrumented_date DATE" in sql
+    assert "still_in_code BOOLEAN" in sql
+    assert "updated_at TIMESTAMP" in sql
+
+
+def test_build_create_table_sql_or_replace():
+    assert build_create_table_sql("cat.sch.stage", or_replace=True).startswith(
+        "CREATE OR REPLACE TABLE cat.sch.stage"
+    )
+
+
+def test_missing_columns_returns_schema_entries_absent_from_table_in_order():
+    existing = {"event_type", "instrumented_commit", "updated_at"}
+    missing = _missing_columns(existing, PROVENANCE_SCHEMA)
+    names = [c for c, _ in missing]
+    assert "event_type_slug" in names  # the newly-added column is flagged
+    assert "event_type" not in names  # already present, not re-added
+    assert names == [c for c, _ in PROVENANCE_SCHEMA if c not in existing]  # order preserved
+
+
+def test_missing_columns_empty_when_all_present():
+    existing = {c for c, _ in PROVENANCE_SCHEMA}
+    assert _missing_columns(existing, PROVENANCE_SCHEMA) == []
+
+
+def test_build_bulk_insert_one_tuple_per_row_with_flattened_params():
+    rows = [
+        build_provenance_row(
+            "A", {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A}, True, UPDATED
+        ),
+        build_provenance_row("Can't B", None, False, UPDATED),
+    ]
+    sql, params = build_bulk_insert("cat.sch.stage", PROVENANCE_COLUMNS, rows)
+    assert sql.startswith("INSERT INTO cat.sch.stage (")
+    n = len(PROVENANCE_COLUMNS)
+    assert sql.count("?") == 2 * n  # 2 rows worth of placeholders
+    assert sql.count("), (") == 1  # two value tuples
+    assert len(params) == 2 * n  # flattened, row-major
+    assert params[0] == "A" and params[n] == "Can't B"  # row boundaries; apostrophe intact
+
+
+def test_row_params_orders_values_and_preserves_apostrophe():
+    row = build_provenance_row(
+        "Onboarding - Office Step: Click Can't See Office",
+        {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A},
+        present_in_head=True,
+        updated_at=UPDATED,
+    )
+    params = row_params(row, PROVENANCE_COLUMNS)
+    assert params[0] == "Onboarding - Office Step: Click Can't See Office"  # apostrophe intact
+    assert params[1] == "onboarding_office_step_click_cant_see_office"  # slug
+    assert params[PROVENANCE_COLUMNS.index("still_in_code")] is True
+    assert len(params) == len(PROVENANCE_COLUMNS)
+
+
+def test_build_merge_sql_keys_on_event_type_and_updates_non_key_columns():
+    sql = build_merge_sql("cat.sch.target", "cat.sch.stage", ["event_type", "code_status", "updated_at"])
+    assert "MERGE INTO cat.sch.target AS t" in sql
+    assert "USING cat.sch.stage AS s" in sql
+    assert "ON t.event_type = s.event_type" in sql
+    assert "t.code_status = s.code_status" in sql
+    set_block = sql.split("UPDATE SET", 1)[1].split("WHEN NOT MATCHED", 1)[0]
+    assert "t.event_type = s.event_type" not in set_block
+    assert "WHEN NOT MATCHED THEN INSERT" in sql
+
+
+def test_build_watermark_merge_sql_is_parameterized_and_keys_on_job_name():
+    sql = build_watermark_merge_sql("cat.sch.state")
+    assert "MERGE INTO cat.sch.state AS t" in sql
+    assert "ON t.job_name = s.job_name" in sql
+    assert "CAST(? AS BIGINT) AS commit_count" in sql
+    assert "CAST(? AS TIMESTAMP) AS last_run_at" in sql
+    assert sql.count("?") == 5  # job_name, sha, head_ref, commit_count, last_run_at
+
+
+# --------------------------------------------------------------------------- #
+# resolve_omni_repo
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_omni_repo_prefers_arg(tmp_path):
+    (tmp_path / ".git").mkdir()
+    assert resolve_omni_repo(str(tmp_path), {}) == str(tmp_path)
+
+
+def test_resolve_omni_repo_falls_back_to_env(tmp_path):
+    (tmp_path / ".git").mkdir()
+    assert resolve_omni_repo(None, {"OMNI_REPO": str(tmp_path)}) == str(tmp_path)
+
+
+def test_resolve_omni_repo_errors_when_unset():
+    import pytest
+
+    with pytest.raises(SystemExit):
+        resolve_omni_repo(None, {})
+
+
+def test_resolve_omni_repo_errors_when_not_a_checkout(tmp_path):
+    import pytest
+
+    with pytest.raises(SystemExit):
+        resolve_omni_repo(str(tmp_path), {})
+
+
+# --------------------------------------------------------------------------- #
+# run_backfill -- orchestration wiring (git IO stubbed, fake DB cursor)
+# --------------------------------------------------------------------------- #
+
+
+class FakeCursor:
+    """Records execute calls; returns the event universe for the taxonomy SELECT."""
+
+    def __init__(self, events):
+        self._events = events
+        self.executed = []
+        self._fetch: list = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        self._fetch = [(e,) for e in self._events] if "int__amplitude_event_taxonomy" in sql else []
+
+    def fetchall(self):
+        return self._fetch
+
+
+def test_run_backfill_inserts_then_merges_then_watermarks(monkeypatch):
+    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_STREAM))
+    monkeypatch.setattr(
+        bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "'Event A'\n'Event C'"
+    )
+    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "deadbeef")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 42)
+
+    cur = FakeCursor(["Event A", "Event B", "Event C"])
+    rows = bf.run_backfill(cur, "/omni", "2024-06-01", datetime(2026, 6, 17, tzinfo=UTC))
+
+    assert {r["event_type"] for r in rows} == {"Event A", "Event B", "Event C"}
+    # rows inserted via a parameterized bulk INSERT (3 events -> 3 tuples in one chunk)
+    inserts = [(s, p) for s, p in cur.executed if s.startswith("INSERT INTO")]
+    assert len(inserts) == 1
+    insert_sql, params = inserts[0]
+    assert insert_sql.count("?") == 3 * len(PROVENANCE_COLUMNS)
+    assert len(params) == 3 * len(PROVENANCE_COLUMNS)
+    # provenance MERGE on event_type, then watermark MERGE on job_name (with 5 bound params)
+    merges = [(s, p) for s, p in cur.executed if "MERGE INTO" in s]
+    assert any("ON t.event_type = s.event_type" in s for s, _ in merges)
+    wm = [(s, p) for s, p in merges if "ON t.job_name = s.job_name" in s]
+    assert len(wm) == 1 and wm[0][1] == (bf.JOB_NAME, "deadbeef", "origin/develop", 42, "2026-06-17T00:00:00")
+    prov_i = next(i for i, (s, _) in enumerate(cur.executed) if "ON t.event_type = s.event_type" in s)
+    wm_i = next(i for i, (s, _) in enumerate(cur.executed) if "ON t.job_name = s.job_name" in s)
+    assert wm_i > prov_i
+
+
+def test_run_backfill_applies_pr_resolver(monkeypatch):
+    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_STREAM))
+    monkeypatch.setattr(
+        bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "'Event A'\n'Event C'"
+    )
+    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "deadbeef")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 42)
+
+    cur = FakeCursor(["Event A", "Event B", "Event C"])
+    # Event A is instrumented at "aaaa" whose subject "WEB-1: add events" has no PR ref;
+    # the merge-walk resolver backfills instrumented_pr from the introducing merge commit.
+    rows = bf.run_backfill(
+        cur,
+        "/omni",
+        "2024-06-01",
+        datetime(2026, 6, 17, tzinfo=UTC),
+        pr_resolver=lambda sha: "4321" if sha == "aaaa" else None,
+    )
+    row_a = next(r for r in rows if r["event_type"] == "Event A")
+    assert row_a["instrumented_pr"] == "4321"
+
+
+# --------------------------------------------------------------------------- #
+# Git-native PR resolution -- merge-walk fills *_pr gaps parse_pr_number cannot
+# --------------------------------------------------------------------------- #
+
+
+def test_pick_introducing_merge_takes_oldest_merge_on_ancestry_path():
+    # rev-list emits newest-first; the merge that *introduced* a commit is the oldest
+    # on the ancestry path to the deploy ref, i.e. the last line.
+    rev_list = "newmerge111\noldmerge222\n"
+    assert bf._pick_introducing_merge(rev_list) == "oldmerge222"
+
+
+def test_pick_introducing_merge_none_when_no_merge():
+    assert bf._pick_introducing_merge("") is None
+    assert bf._pick_introducing_merge("\n") is None
+
+
+def test_make_merge_walk_resolver_delegates_to_git_merge_pr(monkeypatch):
+    monkeypatch.setattr(bf, "git_merge_pr", lambda root, sha, ref: f"{root}:{sha}:{ref}")
+    resolver = bf.make_merge_walk_resolver("/omni", "origin/develop")
+    assert resolver("abc123") == "/omni:abc123:origin/develop"
+
+
+def test_git_merge_pr_resolves_pr_from_real_merge_commit(tmp_path):
+    # Build a tiny repo: main -> feature -> non-ff merge with omni's merge-commit subject,
+    # then confirm git_merge_pr recovers the PR number for the feature commit.
+    import subprocess
+
+    repo = str(tmp_path)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+
+    def git(*args):
+        subprocess.run(["git", "-C", repo, *args], check=True, capture_output=True, env=env)
+
+    git("init", "-q", "-b", "main")
+    (tmp_path / "f.txt").write_text("base\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "base")
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "f.txt").write_text("base\nevent\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "feat: add an event literal")
+    feature_sha = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    git("checkout", "-q", "main")
+    git("merge", "--no-ff", "-m", "Merge pull request #42 from thegoodparty/feature", "feature")
+
+    assert bf.git_merge_pr(repo, feature_sha, "main") == "42"
+
+
+def test_git_merge_pr_none_for_commit_with_no_merge(tmp_path):
+    import subprocess
+
+    repo = str(tmp_path)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+
+    def git(*args):
+        subprocess.run(["git", "-C", repo, *args], check=True, capture_output=True, env=env)
+
+    git("init", "-q", "-b", "main")
+    (tmp_path / "f.txt").write_text("base\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "base committed straight to main")
+    head = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    assert bf.git_merge_pr(repo, head, "main") is None
+
+
+def test_resolve_pr_gaps_fills_null_instrumented_pr():
+    rows = [
+        {"instrumented_commit": "aaaa", "instrumented_pr": None, "retired_commit": None, "retired_pr": None}
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, lambda sha: "777" if sha == "aaaa" else None)
+    assert out[0]["instrumented_pr"] == "777"
+    assert filled == 1
+
+
+def test_resolve_pr_gaps_does_not_overwrite_existing_pr():
+    rows = [
+        {"instrumented_commit": "aaaa", "instrumented_pr": "111", "retired_commit": None, "retired_pr": None}
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, lambda sha: "999")
+    assert out[0]["instrumented_pr"] == "111"
+    assert filled == 0
+
+
+def test_resolve_pr_gaps_resolves_retired_commit_too():
+    rows = [
+        {
+            "instrumented_commit": "aaaa",
+            "instrumented_pr": "111",
+            "retired_commit": "bbbb",
+            "retired_pr": None,
+        }
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, lambda sha: "888")
+    assert out[0]["retired_pr"] == "888"
+    assert filled == 1
+
+
+def test_resolve_pr_gaps_resolves_each_distinct_sha_once():
+    calls: list[str] = []
+
+    def resolver(sha):
+        calls.append(sha)
+        return "5"
+
+    rows = [
+        {
+            "instrumented_commit": "same",
+            "instrumented_pr": None,
+            "retired_commit": "same",
+            "retired_pr": None,
+        },
+        {"instrumented_commit": "same", "instrumented_pr": None, "retired_commit": None, "retired_pr": None},
+    ]
+    bf.resolve_pr_gaps(rows, resolver)
+    assert calls == ["same"]  # 3 references, one lookup
+
+
+def test_resolve_pr_gaps_noop_when_resolver_none():
+    rows = [
+        {"instrumented_commit": "aaaa", "instrumented_pr": None, "retired_commit": None, "retired_pr": None}
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, None)
+    assert out[0]["instrumented_pr"] is None
+    assert filled == 0
+
+
+def test_resolve_pr_gaps_skips_rows_without_commit():
+    rows = [
+        {"instrumented_commit": None, "instrumented_pr": None, "retired_commit": None, "retired_pr": None}
+    ]
+    _, filled = bf.resolve_pr_gaps(rows, lambda sha: "1")
+    assert filled == 0
+
+
+# --------------------------------------------------------------------------- #
+# Schema resolution -- env-configurable landing schema (airflow_source convention)
+# --------------------------------------------------------------------------- #
+
+
+def test_provenance_tables_builds_table_and_state_from_schema():
+    table, state = bf.provenance_tables("airflow_source")
+    assert table == "goodparty_data_catalog.airflow_source.amplitude_event_provenance"
+    assert state == "goodparty_data_catalog.airflow_source.amplitude_event_provenance_state"
+
+
+def test_provenance_tables_honors_a_dev_schema():
+    table, state = bf.provenance_tables("private_tristan")
+    assert table == "goodparty_data_catalog.private_tristan.amplitude_event_provenance"
+    assert state == "goodparty_data_catalog.private_tristan.amplitude_event_provenance_state"
+
+
+def test_resolve_schema_explicit_override_wins():
+    assert (
+        bf.resolve_schema({"DBT_AIRFLOW_SOURCE_SCHEMA": "airflow_source"}, "private_tristan")
+        == "private_tristan"
+    )
+
+
+def test_resolve_schema_falls_back_through_env_then_default():
+    assert (
+        bf.resolve_schema({"AMPLITUDE_PROVENANCE_SCHEMA": "airflow_source_dev"}, None) == "airflow_source_dev"
+    )
+    assert bf.resolve_schema({"DBT_AIRFLOW_SOURCE_SCHEMA": "airflow_source"}, None) == "airflow_source"
+    assert bf.resolve_schema({}, None) == bf.DEFAULT_SOURCE_SCHEMA
+
+
+def test_default_constants_target_prod_source_schema():
+    assert bf.DEFAULT_SOURCE_SCHEMA == "airflow_source"
+    assert bf.PROVENANCE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance"
+    assert bf.STATE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance_state"

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -1,7 +1,9 @@
 import os
+import subprocess
 from datetime import UTC, datetime
 
 import amplitude_event_provenance_backfill as bf
+import pytest
 from amplitude_event_provenance_backfill import (
     PROVENANCE_COLUMNS,
     PROVENANCE_SCHEMA,
@@ -27,8 +29,15 @@ from amplitude_event_provenance_backfill import (
 SEP = "\x1f"
 
 
-def _header(full, short, date, subject):
-    return "\x00" + SEP.join([full, short, date, subject])
+def _epoch(date):
+    """Synthetic midnight-UTC epoch for a YYYY-MM-DD date, so date order == ts order."""
+    return str(int(datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=UTC).timestamp()))
+
+
+def _header(full, short, date, subject, ts=None):
+    # ts (commit epoch, %at) sits between the short date and the subject; defaults to the
+    # date's midnight so existing single-date streams keep their chronological ordering.
+    return "\x00" + SEP.join([full, short, date, ts or _epoch(date), subject])
 
 
 # --------------------------------------------------------------------------- #
@@ -183,6 +192,27 @@ def test_parse_git_log_omits_events_never_seen():
     assert "Nonexistent Event" not in acc
 
 
+# Two net-changes to the same event on the SAME calendar day, newest-first as git emits.
+# The evening commit (re-add) is seen first; the morning commit (original add) is the true
+# instrumentation point. Date-only comparison can't tell them apart and keeps the first seen.
+_SAME_DAY_STREAM = [
+    _header("evening", "evening", "2025-05-01", "feat: re-add the literal (#2)", ts="1714588200"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -0,0 +1 @@",
+    "+  x: 'Event X',",
+    _header("morning", "morning", "2025-05-01", "feat: add the literal (#1)", ts="1714554600"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -0,0 +1 @@",
+    "+  x: 'Event X',",
+]
+
+
+def test_parse_git_log_same_day_instrumented_breaks_tie_by_commit_time():
+    # Earliest commit of the day must win 'instrumented', not the first one in stream order.
+    acc = parse_git_log(_SAME_DAY_STREAM, compile_event_pattern(["Event X"]))
+    assert acc["Event X"]["instrumented"]["commit"] == "morning"
+
+
 # --------------------------------------------------------------------------- #
 # build_provenance_row
 # --------------------------------------------------------------------------- #
@@ -264,7 +294,7 @@ def test_build_git_log_argv_single_pass_with_since():
     argv = build_git_log_argv("/repo", "2024-06-01", ["packages/gp-webapp"])
     assert argv[:4] == ["git", "-C", "/repo", "log"]
     assert "-p" in argv
-    assert "--format=%x00%H%x1f%h%x1f%ad%x1f%s" in argv
+    assert "--format=%x00%H%x1f%h%x1f%ad%x1f%at%x1f%s" in argv
     assert argv[argv.index("--since") + 1] == "2024-06-01"
     assert argv[argv.index("--") + 1 :] == ["packages/gp-webapp"]
 
@@ -568,6 +598,46 @@ def test_git_merge_pr_none_for_commit_with_no_merge(tmp_path):
     ).stdout.strip()
 
     assert bf.git_merge_pr(repo, head, "main") is None
+
+
+def _init_repo_one_commit(tmp_path):
+    """A minimal repo with a single commit; returns its path."""
+    repo = str(tmp_path)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+    subprocess.run(["git", "-C", repo, "init", "-q", "-b", "main"], check=True, env=env)
+    (tmp_path / "f.txt").write_text("base\n")
+    subprocess.run(["git", "-C", repo, "add", "."], check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "-C", repo, "commit", "-q", "-m", "base"], check=True, capture_output=True, env=env
+    )
+    return repo
+
+
+def test_run_git_log_raises_on_nonzero_exit(tmp_path):
+    # A bad ref makes `git log` exit non-zero; the stream must surface that, not yield nothing.
+    repo = _init_repo_one_commit(tmp_path)
+    with pytest.raises(subprocess.CalledProcessError):
+        list(bf.run_git_log(repo, None, ["f.txt"], ref="no-such-ref-abc123"))
+
+
+def test_run_git_log_streams_lines_on_success(tmp_path):
+    # The happy path still yields the log stream line-by-line.
+    repo = _init_repo_one_commit(tmp_path)
+    lines = list(bf.run_git_log(repo, None, ["f.txt"]))
+    assert any("base" in line for line in lines)
+
+
+def test_git_fetch_raises_on_failure(tmp_path):
+    # No 'origin' remote configured -> `git fetch origin develop` fails; must abort, not continue.
+    repo = _init_repo_one_commit(tmp_path)
+    with pytest.raises(SystemExit):
+        bf.git_fetch(repo, "origin/develop")
 
 
 def test_resolve_pr_gaps_fills_null_instrumented_pr():


### PR DESCRIPTION
## What

One-time backfill building the initial git-provenance table for Amplitude events (DATA-2007). One row per `event_type` recording which commit/PR instrumented it and which retired it, plus `code_status`, `still_in_code`, dates, an `event_type_slug` join key, and a commit-SHA watermark for the future incremental refresh.

Lands via idempotent `MERGE` on `event_type`. The landing schema is **env-configurable** (default `airflow_source` — the repo's source for job-written tables; `--schema private_tristan` for local dev), mirroring the `l2_expired_voters` convention. DATA-2005 registers it as a dbt source and stages `stg_airflow_source__amplitude_event_provenance`.

## How

- **Single-pass walk.** One `git log -p` over `packages/gp-webapp` + `packages/gp-api`, matching the authoritative event universe (`dbt.int__amplitude_event_taxonomy`, 419 events) against +/- diff lines. Earliest net-add = instrumented, latest net-remove = retired; reformat moves net to zero.
- **Anchored on `origin/develop`** (fetched first), so provenance reflects what shipped — not whatever branch the local checkout is on.
- **PR attribution is pure git**, matching omni's merge-commit workflow. A feature commit's subject rarely carries a PR ref, so for each gap we walk `--ancestry-path` to the introducing merge (`Merge pull request #N from ...`) and parse it.

## Result

Validated against `origin/develop` (419 rows, written to `private_tristan` in dev): PR fill **instrumented_pr 32% → 59%**, **retired_pr 33% → 100%**. Remaining instrumented gaps are pre-monorepo-migration commits (gp-webapp/gp-api PRs imported during consolidation) and direct-to-develop pushes; the commit SHA is the always-present fallback.

The GitHub `commits/{sha}/pulls` REST endpoint (an earlier approach) was evaluated and returns nothing for this repo, so attribution is fully git-native and offline.

## Production note

The prod landing schema `airflow_source` is owned by the pipeline's service principal; populating it happens when the job runs under that identity (or via a grant). Local/dev runs use `--schema private_tristan`. The validated 419-row table currently lives in `private_tristan`.

## Scope

Backfill only. The SHA-watermark plumbing for the scheduled incremental refresh is in place but the refresh path itself is a follow-up. DATA-2005 stages this table; DATA-2004 consumes it.

## Tests

61 tests (`analytics/tests/test_amplitude_event_provenance_backfill.py`). IO is dependency-injected; pure logic (walk, attribution, slug, merge-pick, schema resolution) is fully unit-tested, plus two temp-repo tests exercising the real `git merge --no-ff` ancestry walk. ruff + ruff-format pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)