### PR TITLE
[DATA-1523] Layer-1 reverse-ETL sendable marts (candidacy_hubspot + candidacy_techspeed)

### DIFF
--- a/dbt/project/dbt_project.yml
+++ b/dbt/project/dbt_project.yml
@@ -58,6 +58,10 @@ models:
       analytics:
         +schema: mart_analytics
         +tags: ["mart", "analytics"]
+      reverse_etl:
+        +schema: mart_reverse_etl
+        +materialized: view
+        +tags: ["mart", "reverse_etl"]
       mban2026:
         +schema: mart_mban2026
       serve_agents:

--- a/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
+++ b/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
@@ -1,0 +1,47 @@
+version: 2
+
+models:
+  - name: candidacy_techspeed
+    description: >
+      Civics-sourced TechSpeed enrichment feed (reverse-ETL sendable mart). One row per
+      gp_candidacy_id. Replaces m_ballotready_internal__records_sent_to_techspeed. Sends
+      missing-contact, non-major-party, future-election candidacies not already in HubSpot and
+      not already known to TechSpeed. The 42-column legacy shape is preserved (24
+      BallotReady-only columns null-filled, partner-confirmed unused); appended are the 4-part
+      match-back key (candidate_code), the reverse-ETL tracking-key inputs (election_year,
+      election_stage), gp_candidacy_id / gp_candidate_id (internal forensic ids), is_keyable,
+      and last_activity_at. See .tickets/DATA-1523/46_layer1_models_design.md.
+    columns:
+      - name: gp_candidacy_id
+        description: GoodParty candidacy id; the model grain and internal match-back backstop.
+        data_tests:
+          - unique
+          - not_null
+      - name: first_name
+        description: Candidate first name (TechSpeed researches missing contact from name + state + office).
+        data_tests:
+          - not_null
+      - name: last_name
+        data_tests:
+          - not_null
+      - name: state
+        data_tests:
+          - not_null
+      - name: election_day
+        description: Upcoming election date sent to TechSpeed (legacy prefer-general contract date).
+        data_tests:
+          - not_null
+      - name: election_stage
+        description: >
+          Nearest-upcoming stage for the reverse-ETL dedup grain; deliberately distinct from
+          election_day (which keeps the legacy prefer-general date).
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["primary", "general"]
+      - name: candidate_code
+        description: 4-part deterministic match-back slug (first/last/state/office_type); no city.
+      - name: is_keyable
+        description: True when candidate_code is non-null; the reverse-ETL diff filters on this.
+        data_tests:
+          - not_null

--- a/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
+++ b/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
@@ -58,7 +58,7 @@ models:
       .tickets/DATA-1523/46_layer1_models_design.md.
     data_tests:
       # Fail-closed owner: a misconfigured prod (blank env var) fails this rather than
-      # silently shipping unassigned leads. Red until CIVICS_HUBSPOT_* env vars are set.
+      # silently shipping unassigned leads. Red until DBT_CIVICS_HUBSPOT_* env vars are set.
       - dbt_utils.expression_is_true:
           arguments:
             expression: "`Contact Owner` <> '' and `Owner Name` <> ''"
@@ -69,12 +69,15 @@ models:
           - unique
           - not_null
       - name: First Name
+        quote: true
         data_tests:
           - not_null
       - name: Last Name
+        quote: true
         data_tests:
           - not_null
       - name: State/Region
+        quote: true
         data_tests:
           - not_null
       - name: candidate_code

--- a/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
+++ b/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
@@ -45,3 +45,61 @@ models:
         description: True when candidate_code is non-null; the reverse-ETL diff filters on this.
         data_tests:
           - not_null
+
+  - name: candidacy_hubspot
+    description: >
+      Civics-sourced HubSpot lead feed (reverse-ETL sendable mart; ops runs it manually now).
+      One row per gp_candidacy_id, provider-agnostic (BallotReady / TechSpeed / DDHQ / gp_api).
+      Replaces both m_ballotready_internal__records_sent_to_hubspot and
+      m_techspeed__candidate_to_hubspot. Output is the Title-Case HubSpot import contract
+      (fuzzy-match diagnostics dropped; ER replaces them); Type and the owner columns are set
+      for all rows (owner via env_var); the match-back key (candidate_code), gp ids,
+      election_year/stage, and last_activity_at are appended. See
+      .tickets/DATA-1523/46_layer1_models_design.md.
+    data_tests:
+      # Fail-closed owner: a misconfigured prod (blank env var) fails this rather than
+      # silently shipping unassigned leads. Red until CIVICS_HUBSPOT_* env vars are set.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "`Contact Owner` <> '' and `Owner Name` <> ''"
+    columns:
+      - name: gp_candidacy_id
+        description: GoodParty candidacy id; the model grain and internal match-back backstop.
+        data_tests:
+          - unique
+          - not_null
+      - name: First Name
+        data_tests:
+          - not_null
+      - name: Last Name
+        data_tests:
+          - not_null
+      - name: State/Region
+        data_tests:
+          - not_null
+      - name: candidate_code
+        description: 4-part deterministic match-back slug (first/last/state/office_type); no city.
+      - name: icp_win
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: icp_serve
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: icp_win_supersize
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: viability_rating_2_0
+        description: Viability 2.0 score (0-5); null for the not-yet-scored provider expansion.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 5
+              config:
+                where: "viability_rating_2_0 is not null"

--- a/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
+++ b/dbt/project/models/marts/reverse_etl/_reverse_etl__models.yml
@@ -62,6 +62,15 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "`Contact Owner` <> '' and `Owner Name` <> ''"
+      # Routing fields are coalesced to '' for the Title-Case import contract, so a not_null
+      # test is vacuous (blank passes). Assert not-blank instead so blank routing fields are
+      # visible. Severity warn (not error like the owner): blanks here are single-row upstream
+      # name-parsing edges, not a systemic misconfig, so they surface without blocking.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "trim(`First Name`) <> '' and trim(`Last Name`) <> '' and trim(`State/Region`) <> ''"
+          config:
+            severity: warn
     columns:
       - name: gp_candidacy_id
         description: GoodParty candidacy id; the model grain and internal match-back backstop.
@@ -69,17 +78,8 @@ models:
           - unique
           - not_null
       - name: First Name
-        quote: true
-        data_tests:
-          - not_null
       - name: Last Name
-        quote: true
-        data_tests:
-          - not_null
       - name: State/Region
-        quote: true
-        data_tests:
-          - not_null
       - name: candidate_code
         description: 4-part deterministic match-back slug (first/last/state/office_type); no city.
       - name: icp_win

--- a/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
@@ -1,0 +1,291 @@
+-- Civics -> HubSpot lead feed (reverse-ETL sendable mart `candidacy_hubspot`).
+--
+-- Replaces BOTH m_ballotready_internal__records_sent_to_hubspot AND
+-- m_techspeed__candidate_to_hubspot with one provider-agnostic civics-sourced feed:
+-- one row
+-- per gp_candidacy_id regardless of whether BallotReady, TechSpeed, DDHQ, or gp_api
+-- identified
+-- the candidacy. Ops runs it manually now; the reverse-ETL HubSpot flow (DATA-1840
+-- §12) later
+-- automates it. Output = the Title-Case HubSpot import contract (fuzzy-match
+-- diagnostics
+-- dropped; ER replaces them), with owner/Type set for ALL rows and the match-back/key
+-- columns
+-- appended. Materialized as a view in mart_reverse_etl (dbt_project.yml).
+--
+-- Design: .tickets/DATA-1523/46_layer1_models_design.md. Validation:
+-- 40_stream3_validation.md.
+-- WINDOW: 30-day rolling on greatest(created_at, updated_at) -- interim/manual-era
+-- recency.
+with
+    icp_ts_offices as (
+        select
+            explode(
+                array(
+                    'city council',
+                    'city commission',
+                    'city commissioner',
+                    'alderman',
+                    'alderperson',
+                    'village board',
+                    'village council',
+                    'village trustee',
+                    'village councill',
+                    'village president',
+                    'municipal assembly',
+                    'metro council',
+                    'legislative council',
+                    'city legislative council',
+                    'mayor',
+                    'town council',
+                    'town board',
+                    'town commission',
+                    'town commissioner',
+                    'town trustee',
+                    'town board member',
+                    'township board',
+                    'town board chairperson',
+                    'state legislature',
+                    'county council',
+                    'county commission',
+                    'county commissioner',
+                    'county legislator',
+                    'board of supervisor',
+                    'board of supervisors',
+                    'board of commissioner',
+                    'county committee',
+                    'township supervisor',
+                    'town supervisor',
+                    'county supervisor',
+                    'county executive',
+                    'city council president',
+                    'city president',
+                    'town select board',
+                    'town selectmen',
+                    'town selectperson',
+                    'town selectboard',
+                    'town meeting representative',
+                    'city ward moderator',
+                    'town moderator'
+                )
+            ) as ts_office
+    ),
+
+    civics_base as (
+        select
+            cy.gp_candidacy_id,
+            cy.gp_candidate_id,
+            cy.candidate_id_source,
+            cy.candidate_office,
+            cy.official_office_name,
+            cy.office_level,
+            cy.office_type,
+            cy.party_affiliation,
+            cy.is_partisan,
+            cy.is_open_seat,
+            cy.is_win_icp,
+            cy.is_serve_icp,
+            cy.is_win_supersize_icp,
+            cy.primary_election_date,
+            cy.general_election_date,
+            cy.viability_score,
+            cy.score_viability_automated,
+            cy.source_systems,
+            cy.created_at,
+            cy.updated_at,
+            c.candidate_id_tier,
+            c.first_name,
+            c.last_name,
+            c.state,
+            c.email,
+            c.phone_number,
+            c.birth_date,
+            c.street_address,
+            c.website_url,
+            c.linkedin_url,
+            c.twitter_handle,
+            c.facebook_url,
+            c.instagram_handle,
+            -- the existing 5-part TechSpeed code; internal-only join key to the
+            -- TS-passthrough
+            -- table (aliased to free `candidate_code` for the emitted 4-part
+            -- match-back key).
+            ts_int.candidate_code as candidate_code_ts,
+            br_int.br_candidacy_id,
+            e.population,
+            e.city,
+            e.district,
+            e.filing_deadline,
+            e.seats_available,
+            e.election_date
+        from {{ ref("candidacy") }} as cy
+        join {{ ref("candidate") }} as c on cy.gp_candidate_id = c.gp_candidate_id
+        left join {{ ref("election") }} as e on cy.gp_election_id = e.gp_election_id
+        left join
+            {{ ref("int__civics_candidacy_ballotready") }} as br_int
+            on cy.gp_candidacy_id = br_int.gp_candidacy_id
+        -- LEFT JOIN, never INNER: an INNER join here silently collapses the unified
+        -- feed back
+        -- to TechSpeed-sourced candidacies only, re-creating the provider
+        -- stratification this
+        -- feed exists to remove.
+        left join
+            {{ ref("int__civics_candidacy_techspeed") }} as ts_int
+            on cy.gp_candidacy_id = ts_int.gp_candidacy_id
+        where
+            greatest(cy.created_at, cy.updated_at) >= current_date() - interval 30 day
+            -- HS-eligible: has email or phone
+            and (
+                (c.email is not null and c.email != '')
+                or (c.phone_number is not null and c.phone_number != '')
+            )
+            -- non-major-party (inherited verbatim from the legacy feeds)
+            and (
+                cy.party_affiliation is null
+                or (
+                    cy.party_affiliation not ilike '%democrat%'
+                    and cy.party_affiliation not ilike '%republican%'
+                )
+            )
+            -- belt-and-suspenders not-already-in-HubSpot
+            and cy.hubspot_contact_id is null
+            and not exists (
+                select 1
+                from {{ ref("int__hubspot_contacts") }} as hs
+                where
+                    (
+                        c.email is not null
+                        and c.email != ''
+                        and lower(trim(hs.email)) = lower(trim(c.email))
+                    )
+                    or (
+                        c.phone_number is not null
+                        and c.phone_number != ''
+                        and hs.phone_number = c.phone_number
+                    )
+                    or (
+                        br_int.br_candidacy_id is not null
+                        and hs.br_candidacy_id = try_cast(br_int.br_candidacy_id as int)
+                    )
+            )
+    )
+
+select
+    coalesce(b.candidate_id_source, '') as `Candidate ID Source`,
+    coalesce(b.first_name, '') as `First Name`,
+    coalesce(b.last_name, '') as `Last Name`,
+    coalesce(f.candidate_type, '') as `Candidate Type`,
+    coalesce(b.party_affiliation, '') as `Party Affiliation`,
+    coalesce(b.email, '') as `Email`,
+    coalesce(b.phone_number, '') as `Phone Number`,
+    coalesce(b.candidate_id_tier, '') as `Candidate ID Tier`,
+    coalesce(b.website_url, '') as `Website URL`,
+    coalesce(b.linkedin_url, '') as `LinkedIn URL`,
+    coalesce(b.instagram_handle, '') as `Instagram Handle`,
+    coalesce(b.twitter_handle, '') as `Twitter Handle`,
+    coalesce(b.facebook_url, '') as `Facebook URL`,
+    coalesce(cast(b.birth_date as string), '') as `Birth Date`,
+    coalesce(b.street_address, '') as `Street Address`,
+    coalesce(b.state, '') as `State/Region`,
+    coalesce(
+        right(concat('00000', cast(f.postal_code as varchar(10))), 5), ''
+    ) as postal_code,
+    coalesce(b.district, '') as `District`,
+    coalesce(b.city, '') as `City`,
+    b.population as `population`,
+    coalesce(b.official_office_name, '') as `Official Office Name`,
+    coalesce(b.candidate_office, '') as `Candidate Office`,
+    coalesce(b.office_type, '') as `Office Type`,
+    coalesce(b.office_level, '') as `Office Level`,
+    coalesce(cast(b.filing_deadline as string), '') as `Filing Deadline`,
+    coalesce(cast(f.br_race_id as string), '') as br_race_id,
+    coalesce(cast(b.primary_election_date as string), '') as `Primary Election Date`,
+    coalesce(cast(b.general_election_date as string), '') as `General Election Date`,
+    coalesce(cast(b.election_date as string), '') as `Election Date`,
+    coalesce(f.election_type, '') as `Election Type`,
+    coalesce(f.uncontested, '') as `Uncontested`,
+    f.number_of_candidates as `Number of Candidates`,
+    b.seats_available as `Number of Seats Available`,
+    case
+        when b.is_open_seat then 'Yes' when not b.is_open_seat then 'No' else ''
+    end as `Open Seat`,
+    case
+        when b.is_partisan
+        then 'Partisan'
+        when not b.is_partisan
+        then 'Nonpartisan'
+        else ''
+    end as `Partisan Type`,
+    -- Type / Contact Owner / Owner Name set for ALL rows (the legacy feed sourced
+    -- these from
+    -- the TechSpeed passthrough join, leaving non-TS rows unassigned). Owner via
+    -- env_var keeps
+    -- the real name out of the repo; the empty default is caught by the not-blank
+    -- test, so a
+    -- misconfigured prod fails closed rather than silently shipping unassigned leads.
+    'Self-Filer Lead' as `Type`,
+    env_var('DBT_CIVICS_HUBSPOT_CONTACT_OWNER', '') as `Contact Owner`,
+    env_var('DBT_CIVICS_HUBSPOT_OWNER_NAME', '') as `Owner Name`,
+    f._ab_source_file_url as _ab_source_file_url,
+    f.uploaded as uploaded,
+    f._airbyte_extracted_at as _airbyte_extracted_at,
+    current_timestamp() as added_to_mart_at,
+    -- viability comes straight from the civics SOT (the TS scoring join recovers zero
+    -- rows on
+    -- this feed's population -- validated in 40_stream3_validation.md).
+    b.viability_score as viability_rating_2_0,
+    b.score_viability_automated as score_viability_automated,
+    coalesce(
+        b.is_win_icp,
+        b.population between 500 and 100000
+        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices)
+    ) as icp_win,
+    coalesce(
+        b.is_serve_icp,
+        b.population between 1000 and 100000
+        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices)
+    ) as icp_serve,
+    coalesce(
+        b.is_win_supersize_icp,
+        b.population > 100000
+        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices)
+    ) as icp_win_supersize,
+    'Civics Net New' as lead_source,
+
+    -- === appended: match-back key + reverse-ETL key inputs + recency (DATA-1523) ===
+    cast(b.br_candidacy_id as string) as candidacy_id,
+    {{
+        generate_candidate_code(
+            "b.first_name", "b.last_name", "b.state", "b.office_type"
+        )
+    }} as candidate_code,
+    b.gp_candidacy_id,
+    b.gp_candidate_id,
+    -- informational on this feed (no future-date filter, so a row may have only past
+    -- stages);
+    -- nearest-upcoming where one exists, else null/most-recent.
+    year(
+        coalesce(
+            case
+                when b.primary_election_date >= current_date()
+                then b.primary_election_date
+            end,
+            case
+                when b.general_election_date >= current_date()
+                then b.general_election_date
+            end,
+            b.general_election_date,
+            b.primary_election_date
+        )
+    ) as election_year,
+    case
+        when b.primary_election_date >= current_date()
+        then 'primary'
+        when b.general_election_date >= current_date()
+        then 'general'
+    end as election_stage,
+    greatest(b.created_at, b.updated_at) as last_activity_at
+from civics_base as b
+left join
+    {{ ref("int__techspeed_candidates_fuzzy_deduped") }} as f
+    on b.candidate_code_ts = f.techspeed_candidate_code

--- a/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
@@ -224,8 +224,8 @@ select
     -- test, so a
     -- misconfigured prod fails closed rather than silently shipping unassigned leads.
     'Self-Filer Lead' as `Type`,
-    env_var('DBT_CIVICS_HUBSPOT_CONTACT_OWNER', '') as `Contact Owner`,
-    env_var('DBT_CIVICS_HUBSPOT_OWNER_NAME', '') as `Owner Name`,
+    '{{ env_var("DBT_CIVICS_HUBSPOT_CONTACT_OWNER", "") }}' as `Contact Owner`,
+    '{{ env_var("DBT_CIVICS_HUBSPOT_OWNER_NAME", "") }}' as `Owner Name`,
     f._ab_source_file_url as _ab_source_file_url,
     f.uploaded as uploaded,
     f._airbyte_extracted_at as _airbyte_extracted_at,

--- a/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
@@ -161,7 +161,9 @@ with
                     or (
                         c.phone_number is not null
                         and c.phone_number != ''
-                        and hs.phone_number = c.phone_number
+                        and length(regexp_replace(c.phone_number, '[^0-9]', '')) >= 10
+                        and regexp_replace(hs.phone_number, '[^0-9]', '')
+                        = regexp_replace(c.phone_number, '[^0-9]', '')
                     )
                     or (
                         br_int.br_candidacy_id is not null

--- a/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/reverse_etl/candidacy_hubspot.sql
@@ -112,6 +112,7 @@ with
             -- match-back key).
             ts_int.candidate_code as candidate_code_ts,
             br_int.br_candidacy_id,
+            br_int.br_race_id as br_race_id_br,
             e.population,
             e.city,
             e.district,
@@ -200,7 +201,9 @@ select
     coalesce(b.office_type, '') as `Office Type`,
     coalesce(b.office_level, '') as `Office Level`,
     coalesce(cast(b.filing_deadline as string), '') as `Filing Deadline`,
-    coalesce(cast(f.br_race_id as string), '') as br_race_id,
+    coalesce(
+        cast(b.br_race_id_br as string), cast(f.br_race_id as string), ''
+    ) as br_race_id,
     coalesce(cast(b.primary_election_date as string), '') as `Primary Election Date`,
     coalesce(cast(b.general_election_date as string), '') as `General Election Date`,
     coalesce(cast(b.election_date as string), '') as `Election Date`,
@@ -240,17 +243,20 @@ select
     coalesce(
         b.is_win_icp,
         b.population between 500 and 100000
-        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices)
+        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices),
+        false
     ) as icp_win,
     coalesce(
         b.is_serve_icp,
         b.population between 1000 and 100000
-        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices)
+        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices),
+        false
     ) as icp_serve,
     coalesce(
         b.is_win_supersize_icp,
         b.population > 100000
-        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices)
+        and lower(trim(b.candidate_office)) in (select ts_office from icp_ts_offices),
+        false
     ) as icp_win_supersize,
     'Civics Net New' as lead_source,
 

--- a/dbt/project/models/marts/reverse_etl/candidacy_techspeed.sql
+++ b/dbt/project/models/marts/reverse_etl/candidacy_techspeed.sql
@@ -85,7 +85,9 @@ with
                     or (
                         c.phone_number is not null
                         and c.phone_number != ''
-                        and hs.phone_number = c.phone_number
+                        and length(regexp_replace(c.phone_number, '[^0-9]', '')) >= 10
+                        and regexp_replace(hs.phone_number, '[^0-9]', '')
+                        = regexp_replace(c.phone_number, '[^0-9]', '')
                     )
                     or (
                         br_int.br_candidacy_id is not null

--- a/dbt/project/models/marts/reverse_etl/candidacy_techspeed.sql
+++ b/dbt/project/models/marts/reverse_etl/candidacy_techspeed.sql
@@ -1,0 +1,192 @@
+-- Civics -> TechSpeed sendable mart (reverse-ETL flow `candidacy_techspeed`).
+--
+-- Replaces m_ballotready_internal__records_sent_to_techspeed. Sends missing-contact,
+-- non-major-party, future-election candidacies that are not already in HubSpot and that
+-- TechSpeed does not already have data on, for phone/email enrichment.
+--
+-- Output preserves the legacy 42-column shape and order so the TechSpeed import is
+-- unchanged; 24 BallotReady-specific columns are null-filled (partner-confirmed
+-- unused).
+-- Appended: the deterministic match-back key (candidate_code), the reverse-ETL
+-- tracking-key
+-- inputs (election_year, election_stage), gp_candidacy_id (internal backstop),
+-- is_keyable,
+-- and last_activity_at. Materialized as a view in mart_reverse_etl (dbt_project.yml).
+--
+-- Design: .tickets/DATA-1523/46_layer1_models_design.md. Validation:
+-- 40_stream3_validation.md.
+-- WINDOW: 16-day rolling on greatest(created_at, updated_at) -- interim/manual-era
+-- dedup;
+-- the reverse-ETL sent_log anti-join replaces it later (the ALREADY-SENT swap point
+-- below).
+with
+    civics_base as (
+        select
+            cy.gp_candidacy_id,
+            cy.gp_candidate_id,
+            cy.official_office_name,
+            cy.candidate_office,
+            cy.office_level,
+            cy.office_type,
+            cy.party_affiliation,
+            cy.primary_election_date,
+            cy.general_election_date,
+            cy.created_at,
+            cy.updated_at,
+            c.first_name,
+            c.last_name,
+            c.state,
+            c.email,
+            c.phone_number,
+            e.is_judicial,
+            e.seats_available,
+            br_int.br_candidacy_id,
+            br_int.br_race_id,
+            br_int.br_position_database_id
+        from {{ ref("candidacy") }} as cy
+        join {{ ref("candidate") }} as c on cy.gp_candidate_id = c.gp_candidate_id
+        left join {{ ref("election") }} as e on cy.gp_election_id = e.gp_election_id
+        left join
+            {{ ref("int__civics_candidacy_ballotready") }} as br_int
+            on cy.gp_candidacy_id = br_int.gp_candidacy_id
+        where
+            -- missing at least one of email/phone (legacy: phone='' OR email='')
+            not (
+                (c.email is not null and c.email != '')
+                and (c.phone_number is not null and c.phone_number != '')
+            )
+            -- non-major-party (inherited verbatim from the legacy feed)
+            and (
+                cy.party_affiliation is null
+                or (
+                    cy.party_affiliation not ilike '%democrat%'
+                    and cy.party_affiliation not ilike '%republican%'
+                )
+            )
+            -- future election: explicit OR (keeps any upcoming stage; not COALESCE)
+            and (
+                cy.general_election_date > current_date() + interval 3 day
+                or cy.primary_election_date > current_date() + interval 3 day
+            )
+            -- 16-day rolling window
+            and greatest(cy.created_at, cy.updated_at)
+            >= current_date() - interval 16 day
+            -- belt-and-suspenders not-already-in-HubSpot
+            and cy.hubspot_contact_id is null
+            and not exists (
+                select 1
+                from {{ ref("int__hubspot_contacts") }} as hs
+                where
+                    (
+                        c.email is not null
+                        and c.email != ''
+                        and lower(trim(hs.email)) = lower(trim(c.email))
+                    )
+                    or (
+                        c.phone_number is not null
+                        and c.phone_number != ''
+                        and hs.phone_number = c.phone_number
+                    )
+                    or (
+                        br_int.br_candidacy_id is not null
+                        and hs.br_candidacy_id = try_cast(br_int.br_candidacy_id as int)
+                    )
+            )
+            -- ALREADY-SENT FILTER (pluggable swap point): reverse-ETL (DATA-1840)
+            -- replaces this
+            -- single predicate with a sent_log anti-join. Today: exclude any
+            -- candidacy TechSpeed
+            -- has already touched -- the most current source signal that they hold
+            -- the data.
+            and not array_contains(cy.source_systems, 'techspeed')
+    )
+
+select
+    -- === legacy 42-column TechSpeed contract (shape + order preserved) ===
+    cast(null as string) as id,
+    b.br_candidacy_id as candidacy_id,
+    cast(null as string) as election_id,
+    cast(null as string) as election_name,
+    -- emit the future date that satisfied the predicate (prefer general, matching
+    -- legacy
+    -- intent), not a blind coalesce that could emit a past general when a future
+    -- primary
+    -- qualified the row. NB: this is the TechSpeed contract date; election_stage
+    -- below is
+    -- the separate reverse-ETL dedup grain and may differ by design.
+    case
+        when b.general_election_date > current_date() + interval 3 day
+        then b.general_election_date
+        when b.primary_election_date > current_date() + interval 3 day
+        then b.primary_election_date
+        else coalesce(b.general_election_date, b.primary_election_date)
+    end as election_day,
+    b.br_position_database_id as position_id,
+    cast(null as string) as mtfcc,
+    cast(null as string) as geo_id,
+    b.official_office_name as position_name,
+    cast(null as string) as sub_area_name,
+    cast(null as string) as sub_area_value,
+    cast(null as string) as sub_area_name_secondary,
+    cast(null as string) as sub_area_value_secondary,
+    b.state as state,
+    b.office_level as level,
+    cast(null as string) as tier,
+    b.is_judicial as is_judicial,
+    cast(null as boolean) as is_retention,
+    b.seats_available as number_of_seats,
+    cast(null as string) as normalized_position_id,
+    b.candidate_office as normalized_position_name,
+    b.br_race_id as race_id,
+    cast(null as string) as geofence_id,
+    cast(null as boolean) as geofence_is_not_exact,
+    cast(null as boolean) as is_primary,
+    cast(null as boolean) as is_runoff,
+    cast(null as boolean) as is_unexpired,
+    cast(null as int) as candidate_id,
+    b.first_name as first_name,
+    cast(null as string) as middle_name,
+    cast(null as string) as nickname,
+    b.last_name as last_name,
+    cast(null as string) as suffix,
+    b.phone_number as phone,
+    b.email as email,
+    cast(null as string) as image_url,
+    b.party_affiliation as parties,
+    cast(null as string) as urls,
+    cast(null as string) as election_result,
+    cast(b.created_at as string) as candidacy_created_at,
+    cast(b.updated_at as string) as candidacy_updated_at,
+    current_timestamp() as upload_datetime,
+
+    -- === appended: match-back key + reverse-ETL key inputs + recency (DATA-1523) ===
+    -- 4-part deterministic slug (no city) -- matches the reverse-ETL sent_log
+    -- tracking key.
+    {{
+        generate_candidate_code(
+            "b.first_name", "b.last_name", "b.state", "b.office_type"
+        )
+    }} as candidate_code,
+    candidate_code is not null as is_keyable,
+    -- election_year / election_stage = the nearest-upcoming stage (reverse-ETL dedup
+    -- grain),
+    -- deliberately distinct from election_day's legacy prefer-general date. Reconcile
+    -- the
+    -- exact CASE with spec_techspeed_tracking.md before the sent_log goes live.
+    year(
+        coalesce(
+            case
+                when b.primary_election_date >= current_date()
+                then b.primary_election_date
+            end,
+            b.general_election_date,
+            b.primary_election_date
+        )
+    ) as election_year,
+    case
+        when b.primary_election_date >= current_date() then 'primary' else 'general'
+    end as election_stage,
+    b.gp_candidacy_id,
+    b.gp_candidate_id,
+    greatest(b.created_at, b.updated_at) as last_activity_at
+from civics_base as b

--- a/dbt/project/tests/assert_candidacy_hubspot_candidate_code_collision.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_candidate_code_collision.sql
@@ -1,0 +1,17 @@
+-- WARN: a candidate_code mapping to more than one distinct person (gp_candidate_id)
+-- is a
+-- cross-person collision -- ambiguous lead identity on match-back. ~0.2% of codes
+-- collide
+-- today, and most apparent collisions are upstream entity-resolution duplicates of
+-- one person
+-- (see .tickets/DATA-1523/46_layer1_models_design.md §11.1). Severity is warn until
+-- the ER
+-- duplicates are cleaned upstream; promote to error after that. (HubSpot leads are
+-- identity-grained, so this checks the code alone -- not code + year + stage like
+-- TechSpeed.)
+{{ config(severity="warn") }}
+select candidate_code, count(distinct gp_candidate_id) as n_distinct_people
+from {{ ref("candidacy_hubspot") }}
+where candidate_code is not null
+group by candidate_code
+having count(distinct gp_candidate_id) > 1

--- a/dbt/project/tests/assert_candidacy_techspeed_candidate_code_collision.sql
+++ b/dbt/project/tests/assert_candidacy_techspeed_candidate_code_collision.sql
@@ -1,0 +1,21 @@
+-- WARN: a tracking key (candidate_code + election_year + election_stage) that maps to
+-- more
+-- than one distinct person (gp_candidate_id) is a cross-person collision -- it would
+-- misroute
+-- a TechSpeed match-back or suppress a distinct person's send under the reverse-ETL
+-- sent_log.
+-- ~0.2% of codes collide today, and most apparent collisions are upstream
+-- entity-resolution
+-- duplicates of one person (see .tickets/DATA-1523/46_layer1_models_design.md §11.1).
+-- Severity
+-- is warn until the ER duplicates are cleaned upstream; promote to error after that.
+{{ config(severity="warn") }}
+select
+    candidate_code,
+    election_year,
+    election_stage,
+    count(distinct gp_candidate_id) as n_distinct_people
+from {{ ref("candidacy_techspeed") }}
+where candidate_code is not null
+group by candidate_code, election_year, election_stage
+having count(distinct gp_candidate_id) > 1


### PR DESCRIPTION
## What

Replaces the three legacy candidate-id marts with two civics-sourced **view** models in a new `mart_reverse_etl` schema:

- `candidacy_hubspot`: provider-agnostic HubSpot lead feed. Replaces both `m_ballotready_internal__records_sent_to_hubspot` and `m_techspeed__candidate_to_hubspot`.
- `candidacy_techspeed`: TechSpeed enrichment feed. Replaces `m_ballotready_internal__records_sent_to_techspeed`.

These are the durable "layer 1" that the reverse-ETL epic (DATA-1840) consumes. `candidacy_techspeed` is that epic's ticket-3 sendable mart, built here so the cutover and the reverse-ETL work share one source of truth.

## Key points

- One row per `gp_candidacy_id` (grain tested). Provider-agnostic: BallotReady, TechSpeed, DDHQ, and gp_api candidacies all flow through (the TechSpeed join is LEFT, never INNER, so non-TechSpeed rows survive).
- Adds a deterministic match-back key `candidate_code` (4-part `generate_candidate_code(first, last, state, office_type)`), with the BallotReady `candidacy_id` and `gp_candidacy_id` as secondary keys. This is also the reverse-ETL `sent_log` key.
- HubSpot owner columns are set for all rows via env vars, so no owner name is hardcoded in the repo.
- The TechSpeed feed preserves the legacy 42-column shape (24 BallotReady-only columns null-filled, partner-confirmed unused); the match-back ids append after column 42.
- The TechSpeed cost filter (`source_systems` excludes candidacies TechSpeed already worked) is isolated as a pluggable swap point for the reverse-ETL `sent_log` anti-join.

## Adopt-then-deprecate

The three legacy marts stay in place. They are retired only after parity is proven, ops repoints the sheets, and the `exports_zapier` consumer is migrated.

## Verification (CI preview schema)

- Grain 1:1 on both feeds, no fan-out (`int__techspeed_candidates_fuzzy_deduped` confirmed 1:1).
- Match-back coverage: ~97.7% via the 4-part `candidate_code` + BR `candidacy_id`; `gp_candidacy_id` (never null, and stable for unmatched rows) backstops the ~2.3% remainder that lack a BR id and have a null `office_type`.
- Provider-agnostic confirmed: non-TechSpeed rows survive the LEFT joins.
- Owner columns populate from the env vars (fail-closed not-blank test passes).
- TechSpeed first-42 columns match the legacy mart's names + order exactly.
- Collision guards (severity `warn`): TechSpeed 0; HubSpot ~30 codes / 2 people (~0.5%, predominantly upstream entity-resolution duplicates). Routing-field not-blank guard is `warn` (one upstream blank-last-name edge).

Full parity + Codex adversarial-review triage: `.tickets/DATA-1523/49`. Query-level parity on byte-equivalent logic: `.tickets/DATA-1523/40`.

## Follow-ups (not blocking this PR)

- `exports_zapier` consumer migration (gates legacy-mart deletion).
- Upstream entity-resolution duplicate cleanup (the collision tail).
- Normative `election_stage`/`election_year` CASE reconciliation with the reverse-ETL spec before the `sent_log` goes live.
- `mart_reverse_etl` read grants (ops + service principal) via terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound lead/enrichment selection logic and HubSpot owner assignment; misconfigured env vars or identity collisions could misroute ops-facing exports until legacy cutover is complete.
> 
> **Overview**
> Introduces a **`mart_reverse_etl`** dbt folder (views in schema `mart_reverse_etl`) with two civics-sourced sendable feeds meant to replace three legacy provider-specific marts while staying compatible with manual ops and future DATA-1840 reverse-ETL.
> 
> **`candidacy_hubspot`** unifies the BallotReady- and TechSpeed-specific HubSpot marts into one row per `gp_candidacy_id` feed: recent non-major-party candidacies with contact info, not already in HubSpot, with Title-Case import columns, **env-var HubSpot owners** (fail-closed tests), ICP flags, and appended **`candidate_code`**, election year/stage, and `gp_*` ids. TechSpeed enrichment is a **LEFT** join so non-TechSpeed sources still appear.
> 
> **`candidacy_techspeed`** replaces the BallotReady TechSpeed send mart: missing-contact, future-election, non-major-party rows with HubSpot dedupe, rolling recency window, and **`source_systems` excluding techspeed** as the interim “already sent” gate (documented swap point for `sent_log`). It keeps the **legacy 42-column** TechSpeed shape with null-filled BR-only fields, plus match-back and tracking columns.
> 
> Adds model documentation/tests (grain, owner not-blank, ICP/viability) and **warn-severity** collision tests on `candidate_code` (and year/stage for TechSpeed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da92d02b8ec85394d49e031dfc2329de97ef114. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->