### PR TITLE
[DATA-2013] Widen substrate to cohort-occupied district types

### DIFF
--- a/dbt/project/macros/get_l2_major_district_columns.sql
+++ b/dbt/project/macros/get_l2_major_district_columns.sql
@@ -1,20 +1,30 @@
 {% macro get_l2_major_district_columns(use_backticks=true, cast_to_string=false) %}
     {#-
-    The v1 major office-bearing district-type subset (DATA-1992): the L2
-    district columns the district/census substrate UNPIVOTs. General-purpose
-    government, municipal, county/city subdivisions, schools, and fire -- the
-    TDD §4.5 buckets that hold essentially the whole serve cohort, plus the
-    universal-governance types the comparison/Win consumers need. Excludes
+    The curated district-type subset the District/Census substrate UNPIVOTs
+    (DATA-1992; widened in DATA-2013). Selection rule: every office-bearing L2
+    district type the SERVE COHORT occupies that has a clean L2 binding. That is
+    the general-purpose / municipal / county-subdivision / school / fire core
+    that holds the bulk of the cohort (the original v1 subset), PLUS the
+    previously-deferred special-district and sub-jurisdiction types that bind
+    real cohort officials: community colleges, county boards of education,
+    judicial districts, park / library / water / sewer / fire-protection / port /
+    conservation / soil-and-water / aquatic districts, town & township wards,
+    community-council sub-districts, county legislative districts, and the
+    educational-service / vocational / learning-community types. Excludes
     synthetic State/Country, non-offices (Designated_Market_Area_DMA,
-    Hamlet_Community_Area, Other), at-large/sub-seat columns, and the sparse
-    special-district long tail (a sized fast-follow).
+    Hamlet_Community_Area, Other), and any type with no cohort official or no L2
+    binding (e.g. Precinct has no L2 column). The name is kept as "major" for
+    continuity; it now means "the curated substrate subset," not a size cut.
 
     Deliberately a DEDICATED macro, not a `major_only` flag on
     get_l2_district_columns: that shared macro feeds the election-api mart and
     int__l2_district_aggregations, so editing it marks those (heavy) models as
     state:modified and pulls their full-refresh rebuild into every PR/merge
-    build. Isolating the v1 scope policy here keeps that blast radius out. The
-    subset names carry no aliases, so the formatting is simple.
+    build. Isolating the substrate's type policy here keeps that blast radius
+    out. The subset names carry no aliases, so the formatting is simple. The two
+    accepted_values tests on district_type (int__l2_block_district_map and
+    district_census_stats) mirror this list; their subset semantics make a
+    forgotten update fail CI loudly, so this macro stays the source of truth.
 
     Args:
         use_backticks (bool): true wraps names in backticks (SELECT); false
@@ -50,6 +60,31 @@
         "Elementary_School_District",
         "High_School_District",
         "Fire_District",
+        "Community_College",
+        "Community_College_SubDistrict",
+        "County_Board_of_Education_District",
+        "School_Subdistrict",
+        "School_District_Vocational",
+        "Educational_Service_District",
+        "Learning_Community_Coordinating_Council_District",
+        "Town_Ward",
+        "Township_Ward",
+        "Community_Council_SubDistrict",
+        "County_Legislative_District",
+        "Judicial_Justice_of_the_Peace",
+        "Judicial_Superior_Court_District",
+        "Judicial_District_Court_District",
+        "Park_District",
+        "Library_District",
+        "Water_District",
+        "Water_SubDistrict",
+        "Sewer_District",
+        "Fire_Protection_District",
+        "Port_District",
+        "Conservation_District",
+        "Conservation_SubDistrict",
+        "Soil_and_Water_District",
+        "Aquatic_District",
     ] -%}
     {%- set out = [] -%}
     {%- for c in cols -%}

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3337,7 +3337,7 @@ models:
         data_tests:
           - not_null
       - name: district_type
-        description: L2 district column name (v1 major office-bearing subset)
+        description: L2 district column name (the curated substrate subset)
         data_tests:
           - not_null
       - name: district_name
@@ -3423,10 +3423,10 @@ models:
       distinct-PERSON union across overlapping district types, which the counts-only
       substrate cannot produce (cross-type voter dedup needs voter IDs), so this model
       scans int__l2_nationwide_uniform once -- the "scanned, never surfaced" node from
-      TDD 7.1 -- and emits only block-grain counts (PII-free). Scoped to the same 22
+      TDD 7.1 -- and emits only block-grain counts (PII-free). Scoped to the same
       district types as the substrate (get_l2_major_district_columns), so count-once <=
       count-multiple holds. served_set is 'all' (served by any cohort district) or one
-      of the 22 L2 district types; statewide officials are read from the exact T5
+      of the substrate's L2 district types; statewide officials are read from the exact T5
       'State' rows in people_served, not here.
     columns:
       - name: block_geoid
@@ -3449,7 +3449,7 @@ models:
                 inclusive: true
       - name: total_voters
         description: >
-          Distinct voters in this block carrying >=1 of the 22 major district values
+          Distinct voters in this block carrying >=1 of the substrate's district values
           (the count-once denominator; ~= the block's total voters since County covers
           essentially all)
         data_tests:

--- a/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
@@ -17,15 +17,16 @@
 -- (Dan's "break out only if it grows complex" clause); it restores the original TDD
 -- DAG.
 --
--- Scoped to the SAME 22 district types as the substrate
+-- Scoped to the SAME district types as the substrate
 -- (get_l2_major_district_columns),
--- so count-once <= count-multiple holds while the substrate is at 22 types. state is
+-- so count-once <= count-multiple holds for the substrate's curated type set. state is
 -- derived from the block's geoid FIPS prefix (the substrate's rule), matching the
 -- substrate block-for-block; the '06'=6 numeric coercion is proven (the merged
 -- substrate
 -- has all 51 states, 0 null state). served_set: 'all' (any cohort district) or one of
 -- the
--- 22 l2 types. Statewide officials are NOT here -- they are read from the exact T5
+-- substrate l2 types. Statewide officials are NOT here -- they are read from the
+-- exact T5
 -- 'State'
 -- rows in people_served and reported separately (TDD 4.5), avoiding a basis mix.
 with

--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -289,7 +289,7 @@ models:
       district_name) with the L2 voter count in that intersection
       (voters_in_block_district) and the per-(block, district_type) voter total
       (voters_in_block). The block-grain map underlying the district/census
-      substrate (DATA-1992); UNPIVOTs only the v1 major office-bearing district
+      substrate (DATA-1992; widened DATA-2013); UNPIVOTs the curated substrate district
       columns. Block grain is the source of truth for overlap (do NOT count by
       joining the district-level int__l2_district_aggregations on the
       normalized name - its key is non-unique and would fan out).
@@ -311,7 +311,7 @@ models:
               arguments:
                 value_set: "{{ get_us_states_list(include_DC=true, include_US=false) }}"
       - name: district_type
-        description: "L2 district column name; restricted to the v1 major office-bearing subset (DATA-1992)."
+        description: "L2 district column name; the curated substrate subset (DATA-1992; widened DATA-2013)."
         tests:
           - not_null
           - accepted_values:
@@ -339,6 +339,31 @@ models:
                   - Elementary_School_District
                   - High_School_District
                   - Fire_District
+                  - Community_College
+                  - Community_College_SubDistrict
+                  - County_Board_of_Education_District
+                  - School_Subdistrict
+                  - School_District_Vocational
+                  - Educational_Service_District
+                  - Learning_Community_Coordinating_Council_District
+                  - Town_Ward
+                  - Township_Ward
+                  - Community_Council_SubDistrict
+                  - County_Legislative_District
+                  - Judicial_Justice_of_the_Peace
+                  - Judicial_Superior_Court_District
+                  - Judicial_District_Court_District
+                  - Park_District
+                  - Library_District
+                  - Water_District
+                  - Water_SubDistrict
+                  - Sewer_District
+                  - Fire_Protection_District
+                  - Port_District
+                  - Conservation_District
+                  - Conservation_SubDistrict
+                  - Soil_and_Water_District
+                  - Aquatic_District
       - name: district_name
         description: "Normalized L2 district name (normalize_l2_district_name): upper, trimmed, no ' (EST.)'."
         tests:

--- a/dbt/project/models/intermediate/l2/int__l2_block_district_map.sql
+++ b/dbt/project/models/intermediate/l2/int__l2_block_district_map.sql
@@ -10,9 +10,9 @@
 -- (voters_in_block). The block-grain twin of int__zip_code_to_l2_district and
 -- the input to int__district_census_allocation (the substrate, DATA-1992).
 --
--- UNPIVOTs ONLY the v1 major office-bearing district columns
--- (get_l2_major_district_columns); the sparse special-district long tail is a
--- documented fast-follow. District names are normalized here so the grain and
+-- UNPIVOTs the curated substrate district columns
+-- (get_l2_major_district_columns) -- the cohort-occupied office-bearing types
+-- (widened in DATA-2013). District names are normalized here so the grain and
 -- every downstream name-join key match the serve resolver's
 -- normalized_district_name (L2 "(EST.)"/whitespace drift between snapshots).
 --

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1464,7 +1464,7 @@ models:
       int__serve_block_coverage); the count_multiple variants are sums off the substrate
       via district_census_stats. Ordering holds within every office_type: count_once <=
       count_multiple_per_district <= per_seat <= per_org. office_type is 'all' (the local
-      cohort-wide North Star headline) or one of the 22 L2 district types, PLUS 'State'
+      cohort-wide North Star headline) or one of the substrate's L2 district types, PLUS 'State'
       for statewide officials, which are read from the EXACT T5 'State' census totals and
       reported SEPARATELY (TDD 4.5) -- never folded into 'all'. Filter office_type !=
       'State' for the local reading, = 'State' for the statewide breakout. The live 'all'

--- a/dbt/project/models/marts/analytics/people_served.sql
+++ b/dbt/project/models/marts/analytics/people_served.sql
@@ -3,14 +3,16 @@
 -- people_served (DATA-1993): the People Served metrics, one row per
 -- (metric_variant, office_type). count-once is the distinct-person union from
 -- int__serve_block_coverage; count-multiple variants are pure sums off the substrate
--- via district_census_stats. Scoped to the 22 office-bearing district types, so
+-- via district_census_stats. Scoped to the substrate's office-bearing district types,
+-- so
 -- count-once <= count_multiple_per_district <= per_seat <= per_org by construction
 -- (a distinct union is <= a sum; a per-district sum <= per-seat <= per-org because
 -- 1 <= n_seats <= n_orgs per district).
 --
 -- office_type: 'all' (the cohort-wide local rollup -- the North Star headline) or one
 -- of
--- the 22 local types, PLUS 'State' for STATEWIDE officials. Statewide is read from T5's
+-- the substrate's local types, PLUS 'State' for STATEWIDE officials. Statewide is
+-- read from T5's
 -- EXACT 'State' census rows and reported SEPARATELY (TDD 4.5): it is never folded
 -- into the
 -- local 'all' rollup (which would mix population bases and swamp the local story). The
@@ -95,7 +97,8 @@ with
         group by s.state_postal_code, s.district_population
     ),
 
-    -- count-multiple per office_type (the 22 types + 'State'), and a local-only 'all'
+    -- count-multiple per office_type (the substrate types + 'State'), and a
+    -- local-only 'all'
     -- rollup
     cm_by_type as (
         select

--- a/dbt/project/models/marts/civics/district_census_stats.sql
+++ b/dbt/project/models/marts/civics/district_census_stats.sql
@@ -1,6 +1,6 @@
 -- Civics mart district_census_stats: the universal district population reference
 -- (DATA-1994). One row per district -- (state_postal_code, district_type,
--- district_name) -- for every district of the 22 v1 major office-bearing types
+-- district_name) -- for every district of the substrate's curated office-bearing types
 -- nationwide, PLUS one clearly-flagged statewide row per state (50 + DC).
 --
 -- Rolls up int__district_census_allocation (THE SUBSTRATE). The substrate already
@@ -11,7 +11,7 @@
 -- UNION with the integer-valued statewide branch.
 --
 -- TWO POPULATION BASES live in district_population, distinguished by district_type:
--- * local rows (the 22 types): voter-block-ALLOCATED population -- inferred from
+-- * local rows (the curated types): voter-block-ALLOCATED population -- inferred from
 -- blocks that carry >=1 L2 voter, so they carry the documented ~2.4%
 -- zero-voter-block undercount (TDD App B.1).
 -- * statewide rows (district_type='State'): EXACT whole-state 2020 census
@@ -32,7 +32,8 @@
 with
     substrate as (select * from {{ ref("int__district_census_allocation") }}),
 
-    -- the 22-type local districts: a pure rollup of the substrate. Exact-binds to
+    -- the local (substrate-type) districts: a pure rollup of the substrate.
+    -- Exact-binds to
     -- the substrate (assert_district_census_stats_binds_substrate).
     local_districts as (
         select
@@ -68,7 +69,7 @@ with
     ),
 
     -- state registered-voter total: per block take the max voter count across the
-    -- 22 types, then sum per state. Verified to equal the universal-County voter
+    -- substrate types, then sum per state. Verified to equal the universal-County voter
     -- total to the voter (County covers every voter block), so this is the state's
     -- L2 voter count, robust for DC / independent cities that lack a County row.
     statewide_voters as (

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -2657,14 +2657,14 @@ models:
   - name: district_census_stats
     description: >
       The universal district population reference: one row per district for every
-      district of the 22 v1 major office-bearing types nationwide, plus one
+      district of the substrate's curated office-bearing types nationwide, plus one
       clearly-flagged statewide row per state (district_type='State'). A rollup of
       int__district_census_allocation (the substrate). The first consumer of the
       Constituents Served substrate (DATA-1359); read by official_constituents.
 
       Grain: One row per (state_postal_code, district_type, district_name).
 
-      Population basis differs by district_type. Local rows (the 22 types) carry
+      Population basis differs by district_type. Local rows (the curated types) carry
       voter-block-ALLOCATED population (inferred from blocks with >=1 L2 voter; carry
       the ~2.4% zero-voter-block undercount). Statewide rows carry EXACT whole-state
       2020 census population. Read one district_type at a time: summing
@@ -2683,7 +2683,7 @@ models:
           - not_null
       - name: district_type
         description: >
-          L2 district-column type (one of the 22 v1 major office-bearing types), or
+          L2 district-column type (one of the substrate's curated office-bearing types), or
           'State' for the synthetic statewide rows.
         data_tests:
           - not_null
@@ -2712,6 +2712,31 @@ models:
                   - Elementary_School_District
                   - High_School_District
                   - Fire_District
+                  - Community_College
+                  - Community_College_SubDistrict
+                  - County_Board_of_Education_District
+                  - School_Subdistrict
+                  - School_District_Vocational
+                  - Educational_Service_District
+                  - Learning_Community_Coordinating_Council_District
+                  - Town_Ward
+                  - Township_Ward
+                  - Community_Council_SubDistrict
+                  - County_Legislative_District
+                  - Judicial_Justice_of_the_Peace
+                  - Judicial_Superior_Court_District
+                  - Judicial_District_Court_District
+                  - Park_District
+                  - Library_District
+                  - Water_District
+                  - Water_SubDistrict
+                  - Sewer_District
+                  - Fire_Protection_District
+                  - Port_District
+                  - Conservation_District
+                  - Conservation_SubDistrict
+                  - Soil_and_Water_District
+                  - Aquatic_District
                   - State
       - name: district_name
         description: >


### PR DESCRIPTION
## What

Widens the District/Census substrate from 22 to **47** L2 district-type columns by adding 25 cohort-occupied types to the dedicated `get_l2_major_district_columns` macro. **Macro-only logic change** — `int__l2_block_district_map`, the count-once engine `int__serve_block_coverage`, and all consumers (`int__district_census_allocation`, `district_census_stats`, `people_served`, `official_constituents`) are type-agnostic and pick up the new types automatically.

Epic DATA-1359; T3 / DATA-1992 follow-up. Plan + recon + codex plan-gate: `.tickets/constituents_served/35-substrate-type-widen-plan.md`.

## Why

After v1, **82 local serve officials show no constituents** in `official_constituents` (`has_census_match = false`) because their district *type* was not in the substrate's 22 — a per-official product gap. Widening binds **66 of the 82**.

## Scope (data-driven)

The rule is **every office-bearing district type the serve cohort occupies that has a clean L2 binding** — verified on live data, not chosen by "biggest types." (The original handoff suggested only `County_Board_of_Education_District` + `Community_College`; the recon showed those bind just 6 officials — the gap lives in a long tail of special-district / sub-jurisdiction types.)

25 types added (education / municipal-subdivision / county / judicial / special-district). 16 officials remain unbound and are **routed, not silently dropped**:
- **13 name-drift** (type present, resolver's name string differs) → DATA-1990 re-match
- **2 `Precinct`** (no `Precinct` column exists in L2) → structural
- **1 `Other`** (catch-all column, not a real district type) → documented

## Verification (pre-PR, Category C in Claude)
- All 25 columns exist in `int__l2_nationwide_uniform` (compile-safe).
- **0 normalization collisions** across the 25 types — no two distinct districts merge under the substrate's `(state, type, normalized_name)` key.
- Ordering invariant `count_once <= per_district` holds **by construction** (count-once uses the all-types block denominator, which is `>=` the per-type denominator); re-checked by `assert_people_served_ordering_invariant`.

## Expected on the CI preview (reconciliation to be posted)
- `official_constituents`: binding **1708 -> 1774**; the specific 16 still `has_census_match = false`.
- `district_census_stats`: `distinct district_type` = 47 (+ `State`); ~+14,400 district rows.
- `people_served` 'all': **count-multiple rises** (overlapping cohort districts = genuine multi-representation, by design) while **count-once (the North Star) rises only slightly** (the block-union absorbs the mostly-overlapping new districts).
- All `accepted_values` + unique-combo + ordering-invariant tests pass.

## Notes for review
- count-multiple 'all' inflation is intentional and bounded to *cohort-occupied* districts (only districts a serve official actually holds are counted; count-once dedups).
- The build is the heavy ~230M-row L2 scan x2 (map + coverage) — reinforces the open per-model warehouse-sizing infra item.
- Rollback: all affected models are full-refresh `table`s, so reverting the macro + rebuilding restores prior state (no incremental state to unwind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core Constituents Served substrate and forces large L2 UNPIVOT rebuilds; metric and `official_constituents` binding shifts are intentional but need preview reconciliation.
> 
> **Overview**
> **Widens** the District/Census substrate from **22 to 47** L2 `district_type` columns by extending `get_l2_major_district_columns` with **25** cohort-occupied types (community colleges, county boards of education, judicial districts, wards/sub-districts, and special districts such as park, library, water, sewer, port, conservation, soil-and-water, aquatic).
> 
> Downstream UNPIVOT models (`int__l2_block_district_map`, `int__serve_block_coverage`) and type-agnostic consumers (substrate allocation, `district_census_stats`, `people_served`) **pick up the new types automatically**—no separate model logic changes. **`accepted_values`** on `district_type` in `int__l2_block_district_map` and `district_census_stats` are updated to mirror the macro so CI fails if the lists drift.
> 
> Docs and comments are reframed from a fixed “22-type v1 major” set to the **curated substrate subset** (every serve-cohort office-bearing type with a clean L2 binding). Expect **more district rows**, **higher count-multiple** where overlap is real, a **modest count-once** bump, and **full-refresh** cost on the heavy L2 block scans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2415bb4a253ceed993dbe1ec9cfbcfadbd8471. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->