### PR TITLE
[DATA-1734] Add race-key guard to candidacy ER

### DIFF
--- a/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
+++ b/dbt/project/models/intermediate/civics/int__er_prematch_candidacy_stages.sql
@@ -405,7 +405,25 @@ select
     party,
     candidate_office,
     office_level,
-    office_type,
+    -- Normalize office_type into a clean candidacy-ER race-key discriminator.
+    case
+        when
+            lower(trim(office_type)) in (
+                'alderman',
+                'alderperson',
+                'town council',
+                'town chair',
+                'township council',
+                'city commission',
+                'city commissioner',
+                'city council'
+            )
+        then 'City Council'
+        -- Non-discriminating buckets -> NULL so the race-key clause wildcards.
+        when lower(trim(office_type)) in ('other', 'local', 'county', 'state')
+        then null
+        else nullif(initcap(trim(office_type)), '')
+    end as office_type,
     nullif(district_raw, '') as district_raw,
     district_identifier,
     election_date,

--- a/matcha/scripts/configs/candidacy.py
+++ b/matcha/scripts/configs/candidacy.py
@@ -134,17 +134,16 @@ CANDIDACY_CONFIG = EntityConfig(
     clustered_output_name="clustered_candidacies.csv",
     post_prediction_filters=[
         BASE_POST_PREDICTION_FILTER,
-        # Race ID guard: drop pairs whose br_race_ids differ unless the office
-        # names are reasonably similar (JW >= 0.88, gamma 3 with the levels
-        # below). Threshold tracks the JW>=0.88 level — keep this in sync if
-        # the official_office_name comparison's level order changes.
-        # Levels: 0=Else, 1=ArrayIntersect, 2=JW>=0.75, 3=JW>=0.88, 4=JW>=0.95.
+        # Race key: keep only if offices match strongly (gamma 3 == JW >= 0.88), br_race_id is shared, or br_race_id/district/office_type do not conflict (null-wildcards).
         """
-          NOT (
-            br_race_id_l IS NOT NULL
-            AND br_race_id_r IS NOT NULL
-            AND br_race_id_l != br_race_id_r
-            AND gamma_official_office_name < 3
+          (
+            gamma_official_office_name >= 3
+            OR (br_race_id_l IS NOT NULL AND br_race_id_l = br_race_id_r)
+            OR (
+              (br_race_id_l IS NULL OR br_race_id_r IS NULL OR br_race_id_l = br_race_id_r)
+              AND (district_identifier_l IS NULL OR district_identifier_r IS NULL OR district_identifier_l = district_identifier_r)
+              AND (office_type_l IS NULL OR office_type_r IS NULL OR office_type_l = office_type_r)
+            )
           )
         """,
         # Same-stage guard: candidacy_stage entities are stage-grained, so


### PR DESCRIPTION
In candidacy-stage entity resolution, same-person records were bridging a candidate's distinct races into one cluster. Example: one person's Racine school board, city council, and county board candidacies all merged into a single cluster.

The existing `br_race_id` guard only worked when both sides carried a `br_race_id`, so ddhq (which carries none) slipped through and bridged races.

This change replaces the office-name-only `br_race_id` guard with a single race-key post-prediction filter. Keep a pair only if:

- a strong office-name match (gamma 3 == JW >= 0.88), or
- a shared `br_race_id`, or
- it conflicts on none of `br_race_id` / `district_identifier` / `office_type` (each null-wildcards).

Also normalizes `office_type` in the prematch model so the equality is not defeated by noise.

## Validation

Built the prematch model and ran the matcher against it. Versus baseline:

- 504 pairs dropped (439 involve ddhq), 0 gained, 0 same-`br_race_id` regressions
- clusters larger than 4: 57 -> 38; max cluster size 8 -> 7
- coverage flat: ddhq 72.7 -> 71.9%, techspeed 35.8 -> 35.6%, ballotready 21.4 -> 21.2%, gp_api 8.0%
- the Racine example splits into 3 correct clusters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Splink post-prediction logic and prematch `office_type` values, which can drop previously linked pairs and alter cluster membership across civics ER outputs.
> 
> **Overview**
> Stops candidacy-stage entity resolution from merging **one person’s different races** into a single cluster when identity signals are strong but race signals are weak (notably **DDHQ**, which has no `br_race_id`).
> 
> **Matcher (`candidacy.py`):** Replaces the old **`br_race_id` + office-name** drop rule with a **race-key** post-prediction filter. A pair is kept only if there is a **strong office-name match** (`gamma_official_office_name >= 3`, JW ≥ 0.88), **matching `br_race_id`**, or **no conflict** on `br_race_id`, `district_identifier`, and `office_type` (nulls wildcard on each field).
> 
> **Prematch (`int__er_prematch_candidacy_stages.sql`):** **`office_type`** is normalized for that race-key equality—local legislature labels collapse to **`City Council`**, broad buckets (`other`, `local`, `county`, `state`) become **NULL** so they do not falsely split or block pairs, and remaining values are trimmed/`initcap`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723e59d422a50a8aca466c80c61e2d64a7b53612. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->