### PR TITLE
[DATA-1982] Expose EO annotation/chat app-db tables as staging models

### DIFF
--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -80,8 +80,26 @@ sources:
         description: >
           Race-level data loaded from the DDHQ Elections gsheet for races whose
           results have not yet been reported. One row per ddhq_race_id.
+      - name: gp_api_db_annotation
+        description: raw data load from gp_api_db postgres db from table `annotation`
+      - name: gp_api_db_annotation_bug_report
+        description: raw data load from gp_api_db postgres db from table `annotation_bug_report`
+      - name: gp_api_db_annotation_note
+        description: raw data load from gp_api_db postgres db from table `annotation_note`
+      - name: gp_api_db_annotation_note_attachment
+        description: raw data load from gp_api_db postgres db from table `annotation_note_attachment`
+      - name: gp_api_db_annotation_review
+        description: raw data load from gp_api_db postgres db from table `annotation_review`
+      - name: gp_api_db_artifact_feedback
+        description: raw data load from gp_api_db postgres db from table `artifact_feedback`
       - name: gp_api_db_campaign
         description: raw data load from gp_api_db postgres db from table `campaign`
+      - name: gp_api_db_chat_conversation
+        description: raw data load from gp_api_db postgres db from table `chat_conversation`
+      - name: gp_api_db_chat_message
+        description: raw data load from gp_api_db postgres db from table `chat_message`
+      - name: gp_api_db_meeting_briefing
+        description: raw data load from gp_api_db postgres db from table `meeting_briefing`
       - name: gp_api_db_campaign_position
         description: raw data load from gp_api_db postgres db from table `campaign_position`
       - name: gp_api_db_domain

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db.yaml
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db.yaml
@@ -198,6 +198,8 @@ models:
         description: "Scope of the conversation"
       - name: title
         description: "Title of the conversation"
+      - name: anchor
+        description: "Anchor reference locating the conversation within its resource"
       - name: owner_user_id
         description: "Foreign key to the user who owns the conversation"
         data_tests:

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db.yaml
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db.yaml
@@ -1,4 +1,160 @@
 models:
+  - name: stg_airbyte_source__gp_api_db_annotation
+    description: >
+      Annotation records (notes, chats, bug reports) attached to EO Meeting
+      Briefing artifacts. One row per annotation.
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the annotation"
+        data_tests:
+          - not_null
+          - unique
+      - name: kind
+        description: "Type of annotation: note, chat, bug_report, or review"
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["note", "chat", "bug_report", "review"]
+      - name: author_user_id
+        description: "Foreign key to the user who authored the annotation"
+        data_tests:
+          - not_null
+      - name: resource_id
+        description: "ID of the annotated resource (e.g. a meeting briefing)"
+        data_tests:
+          - not_null
+      - name: resource_type
+        description: "Type of the annotated resource"
+        data_tests:
+          - not_null
+      - name: note_id
+        description: "Foreign key to annotation_note when kind = note"
+      - name: chat_conversation_id
+        description: "Foreign key to chat_conversation when kind = chat"
+      - name: annotation_bug_report_id
+        description: "Foreign key to annotation_bug_report when kind = bug_report"
+      - name: annotation_review_id
+        description: "Foreign key to annotation_review"
+  - name: stg_airbyte_source__gp_api_db_annotation_bug_report
+    description: raw data load from gp_api_db postgres db from table `annotation_bug_report`
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the bug report"
+        data_tests:
+          - not_null
+          - unique
+      - name: description
+        description: "Free-text description of the reported bug"
+      - name: submitted_at
+        description: "Timestamp when the bug report was submitted"
+  - name: stg_airbyte_source__gp_api_db_annotation_note
+    description: raw data load from gp_api_db postgres db from table `annotation_note`
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the note"
+        data_tests:
+          - not_null
+          - unique
+      - name: body
+        description: "Free-text body of the note"
+      - name: created_at
+        description: "Timestamp when the note was created"
+      - name: updated_at
+        description: "Timestamp when the note was last updated"
+  - name: stg_airbyte_source__gp_api_db_annotation_note_attachment
+    description: raw data load from gp_api_db postgres db from table `annotation_note_attachment`
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the attachment"
+        data_tests:
+          - not_null
+          - unique
+      - name: note_id
+        description: "Foreign key to the annotation_note this attachment belongs to"
+        data_tests:
+          - not_null
+      - name: storage_key
+        description: "Storage key/path for the attachment file"
+      - name: file_name
+        description: "Original file name of the attachment"
+      - name: mime_type
+        description: "MIME type of the attachment"
+      - name: size_bytes
+        description: "Size of the attachment in bytes"
+      - name: ocr_status
+        description: "OCR processing status: pending, processing, completed, failed, or skipped"
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["pending", "processing", "completed", "failed", "skipped"]
+      - name: ocr_text
+        description: "Extracted text from OCR processing"
+      - name: ocr_error
+        description: "Error message if OCR processing failed"
+      - name: ocr_completed_at
+        description: "Timestamp when OCR processing completed"
+      - name: created_at
+        description: "Timestamp when the attachment was created"
+  - name: stg_airbyte_source__gp_api_db_annotation_review
+    description: raw data load from gp_api_db postgres db from table `annotation_review`
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the review"
+        data_tests:
+          - not_null
+          - unique
+      - name: body
+        description: "Free-text body of the review"
+      - name: reviewer_email
+        description: "Email of the reviewer"
+      - name: reviewer_clerk_sub
+        description: "Clerk subject identifier of the reviewer"
+      - name: created_at
+        description: "Timestamp when the review was created"
+      - name: updated_at
+        description: "Timestamp when the review was last updated"
+  - name: stg_airbyte_source__gp_api_db_artifact_feedback
+    description: >
+      Positive/negative feedback submitted on EO Meeting Briefing artifacts.
+      One row per (submitter, briefing, artifact) feedback submission.
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the feedback submission"
+        data_tests:
+          - not_null
+          - unique
+      - name: feedback
+        description: "Feedback value: positive or negative"
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["positive", "negative"]
+      - name: comment
+        description: "Optional free-text comment accompanying the feedback"
+      - name: artifact_id
+        description: "ID of the artifact the feedback is about"
+        data_tests:
+          - not_null
+      - name: artifact_type
+        description: "Type of the artifact (e.g. agenda_item)"
+        data_tests:
+          - not_null
+      - name: briefing_id
+        description: "Foreign key to the meeting_briefing"
+        data_tests:
+          - not_null
+      - name: organization_slug
+        description: "Foreign key to the organization"
+        data_tests:
+          - not_null
+      - name: submitter_user_id
+        description: "Foreign key to the user who submitted the feedback"
+        data_tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp when the feedback was created"
+      - name: updated_at
+        description: "Timestamp when the feedback was last updated"
   - name: stg_airbyte_source__gp_api_db_campaign
     description: raw data load from gp_api_db postgres db from table `campaign`
     columns:
@@ -28,6 +184,92 @@ models:
       - name: top_issue_id
         data_tests:
           - not_null
+  - name: stg_airbyte_source__gp_api_db_chat_conversation
+    description: >
+      Chat conversations collected from EO Meeting Briefings. One row per
+      conversation.
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the conversation"
+        data_tests:
+          - not_null
+          - unique
+      - name: scope
+        description: "Scope of the conversation"
+      - name: title
+        description: "Title of the conversation"
+      - name: owner_user_id
+        description: "Foreign key to the user who owns the conversation"
+        data_tests:
+          - not_null
+      - name: organization_slug
+        description: "Foreign key to the organization"
+      - name: deleted_at
+        description: "Timestamp when the conversation was soft-deleted, if any"
+      - name: created_at
+        description: "Timestamp when the conversation was created"
+      - name: updated_at
+        description: "Timestamp when the conversation was last updated"
+  - name: stg_airbyte_source__gp_api_db_chat_message
+    description: raw data load from gp_api_db postgres db from table `chat_message`
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the message"
+        data_tests:
+          - not_null
+          - unique
+      - name: conversation_id
+        description: "Foreign key to the chat_conversation this message belongs to"
+        data_tests:
+          - not_null
+      - name: role
+        description: "Role of the message author: user, assistant, system, or tool"
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["user", "assistant", "system", "tool"]
+      - name: content
+        description: "Text content of the message"
+      - name: client_message_id
+        description: "Optional client-supplied idempotency key for the send attempt"
+      - name: created_at
+        description: "Timestamp when the message was created"
+  - name: stg_airbyte_source__gp_api_db_meeting_briefing
+    description: >
+      EO Meeting Briefing artifacts generated for an elected office and meeting
+      date. One row per briefing.
+    columns:
+      - name: id
+        description: "Primary key - unique identifier for the briefing"
+        data_tests:
+          - not_null
+          - unique
+      - name: elected_office_id
+        description: "Foreign key to the elected_office this briefing was generated for"
+        data_tests:
+          - not_null
+      - name: experiment_run_id
+        description: "Foreign key to the experiment run that produced the briefing"
+        data_tests:
+          - not_null
+      - name: meeting_date
+        description: "Date of the meeting the briefing covers"
+        data_tests:
+          - not_null
+      - name: meeting_time
+        description: "Time of the meeting the briefing covers"
+      - name: meeting_timezone
+        description: "Timezone of the meeting time"
+      - name: artifact
+        description: "JSON artifact payload for the briefing"
+      - name: artifact_bucket
+        description: "Storage bucket holding the briefing artifact"
+      - name: artifact_key
+        description: "Storage key/path of the briefing artifact"
+      - name: created_at
+        description: "Timestamp when the briefing was created"
+      - name: updated_at
+        description: "Timestamp when the briefing was last updated"
   - name: stg_airbyte_source__gp_api_db_domain
     description: raw data load from gp_api_db postgres db from table `domain`
     columns:

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation.sql
@@ -2,25 +2,24 @@ with
     source as (select * from {{ source("airbyte_source", "gp_api_db_annotation") }}),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("end") }},
-            {{ adapter.quote("kind") }},
-            {{ adapter.quote("start") }},
-            {{ adapter.quote("note_id") }},
-            {{ adapter.quote("json_path") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("updated_at") }},
-            {{ adapter.quote("resource_id") }},
-            {{ adapter.quote("resource_type") }},
-            {{ adapter.quote("author_user_id") }},
-            {{ adapter.quote("annotation_review_id") }},
-            {{ adapter.quote("chat_conversation_id") }},
-            {{ adapter.quote("annotation_bug_report_id") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            cast(`start` as int) as `start`,
+            cast(`end` as int) as `end`,
+            kind,
+            note_id,
+            json_path,
+            cast(created_at as timestamp) as created_at,
+            cast(updated_at as timestamp) as updated_at,
+            resource_id,
+            resource_type,
+            cast(author_user_id as int) as author_user_id,
+            annotation_review_id,
+            chat_conversation_id,
+            annotation_bug_report_id
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation.sql
@@ -1,0 +1,27 @@
+with
+    source as (select * from {{ source("airbyte_source", "gp_api_db_annotation") }}),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("end") }},
+            {{ adapter.quote("kind") }},
+            {{ adapter.quote("start") }},
+            {{ adapter.quote("note_id") }},
+            {{ adapter.quote("json_path") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("updated_at") }},
+            {{ adapter.quote("resource_id") }},
+            {{ adapter.quote("resource_type") }},
+            {{ adapter.quote("author_user_id") }},
+            {{ adapter.quote("annotation_review_id") }},
+            {{ adapter.quote("chat_conversation_id") }},
+            {{ adapter.quote("annotation_bug_report_id") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_bug_report.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_bug_report.sql
@@ -1,0 +1,18 @@
+with
+    source as (
+        select * from {{ source("airbyte_source", "gp_api_db_annotation_bug_report") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("description") }},
+            {{ adapter.quote("submitted_at") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_bug_report.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_bug_report.sql
@@ -4,14 +4,13 @@ with
     ),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("description") }},
-            {{ adapter.quote("submitted_at") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            description,
+            cast(submitted_at as timestamp) as submitted_at
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note.sql
@@ -4,15 +4,14 @@ with
     ),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("body") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("updated_at") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            body,
+            cast(created_at as timestamp) as created_at,
+            cast(updated_at as timestamp) as updated_at
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note.sql
@@ -1,0 +1,19 @@
+with
+    source as (
+        select * from {{ source("airbyte_source", "gp_api_db_annotation_note") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("body") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("updated_at") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note_attachment.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note_attachment.sql
@@ -1,0 +1,27 @@
+with
+    source as (
+        select *
+        from {{ source("airbyte_source", "gp_api_db_annotation_note_attachment") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("note_id") }},
+            {{ adapter.quote("ocr_text") }},
+            {{ adapter.quote("file_name") }},
+            {{ adapter.quote("mime_type") }},
+            {{ adapter.quote("ocr_error") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("ocr_status") }},
+            {{ adapter.quote("size_bytes") }},
+            {{ adapter.quote("storage_key") }},
+            {{ adapter.quote("ocr_completed_at") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note_attachment.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_note_attachment.sql
@@ -5,22 +5,21 @@ with
     ),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("note_id") }},
-            {{ adapter.quote("ocr_text") }},
-            {{ adapter.quote("file_name") }},
-            {{ adapter.quote("mime_type") }},
-            {{ adapter.quote("ocr_error") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("ocr_status") }},
-            {{ adapter.quote("size_bytes") }},
-            {{ adapter.quote("storage_key") }},
-            {{ adapter.quote("ocr_completed_at") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            note_id,
+            ocr_text,
+            file_name,
+            mime_type,
+            ocr_error,
+            ocr_status,
+            storage_key,
+            cast(size_bytes as int) as size_bytes,
+            cast(created_at as timestamp) as created_at,
+            cast(ocr_completed_at as timestamp) as ocr_completed_at
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_review.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_review.sql
@@ -1,0 +1,21 @@
+with
+    source as (
+        select * from {{ source("airbyte_source", "gp_api_db_annotation_review") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("body") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("updated_at") }},
+            {{ adapter.quote("reviewer_email") }},
+            {{ adapter.quote("reviewer_clerk_sub") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_review.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_annotation_review.sql
@@ -4,17 +4,16 @@ with
     ),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("body") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("updated_at") }},
-            {{ adapter.quote("reviewer_email") }},
-            {{ adapter.quote("reviewer_clerk_sub") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            body,
+            reviewer_email,
+            reviewer_clerk_sub,
+            cast(created_at as timestamp) as created_at,
+            cast(updated_at as timestamp) as updated_at
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_artifact_feedback.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_artifact_feedback.sql
@@ -1,0 +1,25 @@
+with
+    source as (
+        select * from {{ source("airbyte_source", "gp_api_db_artifact_feedback") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("comment") }},
+            {{ adapter.quote("feedback") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("updated_at") }},
+            {{ adapter.quote("artifact_id") }},
+            {{ adapter.quote("briefing_id") }},
+            {{ adapter.quote("artifact_type") }},
+            {{ adapter.quote("organization_slug") }},
+            {{ adapter.quote("submitter_user_id") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_artifact_feedback.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_artifact_feedback.sql
@@ -4,21 +4,20 @@ with
     ),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("comment") }},
-            {{ adapter.quote("feedback") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("updated_at") }},
-            {{ adapter.quote("artifact_id") }},
-            {{ adapter.quote("briefing_id") }},
-            {{ adapter.quote("artifact_type") }},
-            {{ adapter.quote("organization_slug") }},
-            {{ adapter.quote("submitter_user_id") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            comment,
+            feedback,
+            artifact_id,
+            briefing_id,
+            artifact_type,
+            organization_slug,
+            cast(submitter_user_id as int) as submitter_user_id,
+            cast(created_at as timestamp) as created_at,
+            cast(updated_at as timestamp) as updated_at
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_conversation.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_conversation.sql
@@ -4,19 +4,19 @@ with
     ),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("scope") }},
-            {{ adapter.quote("title") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("deleted_at") }},
-            {{ adapter.quote("updated_at") }},
-            {{ adapter.quote("owner_user_id") }},
-            {{ adapter.quote("organization_slug") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            scope,
+            title,
+            anchor,
+            organization_slug,
+            cast(owner_user_id as int) as owner_user_id,
+            cast(created_at as timestamp) as created_at,
+            cast(updated_at as timestamp) as updated_at,
+            cast(deleted_at as timestamp) as deleted_at
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_conversation.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_conversation.sql
@@ -1,0 +1,23 @@
+with
+    source as (
+        select * from {{ source("airbyte_source", "gp_api_db_chat_conversation") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("scope") }},
+            {{ adapter.quote("title") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("deleted_at") }},
+            {{ adapter.quote("updated_at") }},
+            {{ adapter.quote("owner_user_id") }},
+            {{ adapter.quote("organization_slug") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_message.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_message.sql
@@ -2,17 +2,16 @@ with
     source as (select * from {{ source("airbyte_source", "gp_api_db_chat_message") }}),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("role") }},
-            {{ adapter.quote("content") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("conversation_id") }},
-            {{ adapter.quote("client_message_id") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            role,
+            content,
+            conversation_id,
+            client_message_id,
+            cast(created_at as timestamp) as created_at
         from source
     )
 select *

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_message.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_chat_message.sql
@@ -1,0 +1,19 @@
+with
+    source as (select * from {{ source("airbyte_source", "gp_api_db_chat_message") }}),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("role") }},
+            {{ adapter.quote("content") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("conversation_id") }},
+            {{ adapter.quote("client_message_id") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_meeting_briefing.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_meeting_briefing.sql
@@ -1,0 +1,26 @@
+with
+    source as (
+        select * from {{ source("airbyte_source", "gp_api_db_meeting_briefing") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("_airbyte_raw_id") }},
+            {{ adapter.quote("_airbyte_extracted_at") }},
+            {{ adapter.quote("_airbyte_meta") }},
+            {{ adapter.quote("_airbyte_generation_id") }},
+            {{ adapter.quote("id") }},
+            {{ adapter.quote("artifact") }},
+            {{ adapter.quote("created_at") }},
+            {{ adapter.quote("updated_at") }},
+            {{ adapter.quote("artifact_key") }},
+            {{ adapter.quote("meeting_date") }},
+            {{ adapter.quote("meeting_time") }},
+            {{ adapter.quote("artifact_bucket") }},
+            {{ adapter.quote("meeting_timezone") }},
+            {{ adapter.quote("elected_office_id") }},
+            {{ adapter.quote("experiment_run_id") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_meeting_briefing.sql
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db_meeting_briefing.sql
@@ -4,22 +4,21 @@ with
     ),
     renamed as (
         select
-            {{ adapter.quote("_airbyte_raw_id") }},
-            {{ adapter.quote("_airbyte_extracted_at") }},
-            {{ adapter.quote("_airbyte_meta") }},
-            {{ adapter.quote("_airbyte_generation_id") }},
-            {{ adapter.quote("id") }},
-            {{ adapter.quote("artifact") }},
-            {{ adapter.quote("created_at") }},
-            {{ adapter.quote("updated_at") }},
-            {{ adapter.quote("artifact_key") }},
-            {{ adapter.quote("meeting_date") }},
-            {{ adapter.quote("meeting_time") }},
-            {{ adapter.quote("artifact_bucket") }},
-            {{ adapter.quote("meeting_timezone") }},
-            {{ adapter.quote("elected_office_id") }},
-            {{ adapter.quote("experiment_run_id") }}
-
+            _airbyte_raw_id,
+            _airbyte_extracted_at,
+            _airbyte_meta,
+            _airbyte_generation_id,
+            id,
+            artifact,
+            artifact_key,
+            artifact_bucket,
+            meeting_time,
+            meeting_timezone,
+            elected_office_id,
+            experiment_run_id,
+            cast(meeting_date as date) as meeting_date,
+            cast(created_at as timestamp) as created_at,
+            cast(updated_at as timestamp) as updated_at
         from source
     )
 select *


### PR DESCRIPTION
## Summary

Adds the nine EO Meeting Briefing app-db tables as `airbyte_source` sources and exposes each as a staging model. The tables are already loading into `airbyte_source` via Airbyte, so this is the dbt side: sources + staging models + tests.

Tables: `annotation`, `annotation_bug_report`, `annotation_note`, `annotation_note_attachment`, `annotation_review`, `artifact_feedback`, `chat_conversation`, `chat_message`, `meeting_briefing`.

## Changes

- `__sources.yaml`: 9 new `gp_api_db_*` source entries.
- 9 staging models under `models/staging/airbyte_source/gp_api_db/`, each selecting from its source with explicit renamed columns (taken from the live Databricks table schemas).
- `stg_airbyte_source__gp_api_db.yaml`: column docs plus `not_null` / `unique` / `accepted_values` tests.

## Notes

- `annotation_review` is not in the local Prisma snapshot but is a real, populated table in prod, so it is included. The prod `AnnotationKind` enum is ahead of the local schema (prod has a `review` value and `annotation` carries an `annotation_review_id` FK), so the `kind` accepted-values test allows `note, chat, bug_report, review`.
- A few loaded columns exceed the local Prisma schema (e.g. `chat_conversation.scope`/`title`/`organization_slug`, `artifact_feedback.comment`); models follow the live table columns, which is what Airbyte loads.

## Testing

`dbt build` against Databricks: all 9 views build, 36 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive staging-only dbt changes with no downstream mart refactors; risk is mainly new CI test surface on prod-synced columns.
> 
> **Overview**
> Adds **nine** EO Meeting Briefing `gp_api_db` tables to dbt as `airbyte_source` sources and matching `stg_airbyte_source__gp_api_db_*` staging views (annotations, notes, attachments, reviews, bug reports, artifact feedback, chat conversations/messages, and meeting briefings).
> 
> Each staging model follows the existing Airbyte pattern: explicit column selection from the live Databricks schemas. **`stg_airbyte_source__gp_api_db.yaml`** gains column descriptions plus **`not_null`**, **`unique`**, and **`accepted_values`** tests (e.g. annotation `kind` including **`review`**, chat message `role`, OCR status, feedback polarity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3581677e71fefd908c27b827137bac392fd9e5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->