### PR TITLE
Amplitude event provenance as a committed CSV (DATA-2014, folds DATA-2007)

### DIFF
--- a/analytics/data/amplitude_event_provenance.csv
+++ b/analytics/data/amplitude_event_provenance.csv
@@ -1,0 +1,435 @@
+event_type,event_type_slug,instrumented_commit,instrumented_pr,instrumented_date,retired_commit,retired_pr,retired_date,last_code_change_date,updated_at
+10 DLC Compliance - PIN Verification Completed,10_dlc_compliance_pin_verification_completed,ecf326d35c1db1bd0af368b87a335b47286e8716,1049,2025-10-06,,,,2025-10-06,2026-06-23T16:53:54
+10 DLC Compliance - Registration Submitted,10_dlc_compliance_registration_submitted,ecf326d35c1db1bd0af368b87a335b47286e8716,1049,2025-10-06,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,2026-06-05,2026-06-23T16:53:54
+AI Assistant - Chat History: Click delete,ai_assistant_chat_history_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant - Chat History: Click menu,ai_assistant_chat_history_click_menu,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant - Chat: Click copy,ai_assistant_chat_click_copy,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant - Chat: Click regenerate,ai_assistant_chat_click_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant - Chat: Click thumbs down,ai_assistant_chat_click_thumbs_down,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant - Chat: Click thumbs up,ai_assistant_chat_click_thumbs_up,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant - Response Completed,ai_assistant_response_completed,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-23T16:53:54
+AI Assistant: Ask a question,ai_assistant_ask_a_question,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant: Click new chat,ai_assistant_click_new_chat,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+AI Assistant: Click view chat history,ai_assistant_click_view_chat_history,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Account - Password Reset Completed,account_password_reset_completed,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-23T16:53:54
+Account - Password Reset Requested,account_password_reset_requested,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-27,2026-06-23T16:53:54
+Account - Password Set Completed,account_password_set_completed,2fc365543df992198d512fbe2d6053a6d38a1aa7,888,2025-08-18,,,,2025-08-18,2026-06-23T16:53:54
+Account - Pro Subscription Canceled,account_pro_subscription_canceled,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
+Account - Pro Subscription Confirmed,account_pro_subscription_confirmed,ac3e04fb428f001d0ab7bcc471c5c85ef726e2b5,319,2025-06-27,,,,2025-06-27,2026-06-23T16:53:54
+Account - User Deleted,account_user_deleted,9582a5844f58fb5a53304f8a8dfef0ef25ffb532,1487,2026-04-20,,,,2026-04-20,2026-06-23T16:53:54
+Briefing Assistant - Agenda Created,briefing_assistant_agenda_created,acb9d347d9513d1aa6f49c97e9fbb14f6d581b28,1676,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - Agenda Not Created,briefing_assistant_agenda_not_created,5b8b5d6d70a84b9178fc66152cda021a6b4a1c03,30,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
+Briefing Assistant - Agenda Submission Failed,briefing_assistant_agenda_submission_failed,c339b19dec1b846127f34a99f0c6cf406e42a982,30,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
+Briefing Assistant - Agenda Submitted,briefing_assistant_agenda_submitted,c339b19dec1b846127f34a99f0c6cf406e42a982,30,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
+Briefing Assistant - Briefing Viewed,briefing_assistant_briefing_viewed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - Download Clicked,briefing_assistant_download_clicked,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - Feedback Completed,briefing_assistant_feedback_completed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - List Viewed,briefing_assistant_list_viewed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - Share Completed,briefing_assistant_share_completed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - Share Drawer Opened,briefing_assistant_share_drawer_opened,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - Sources Expanded,briefing_assistant_sources_expanded,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefing Assistant - TOC Item Clicked,briefing_assistant_toc_item_clicked,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
+Briefings - Briefing Viewed,briefings_briefing_viewed,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
+Briefings - Click Download,briefings_click_download,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
+Briefings - Click Read Full Briefing,briefings_click_read_full_briefing,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
+Briefings - Feedback: Helpful,briefings_feedback_helpful,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
+Briefings - Feedback: Not Helpful,briefings_feedback_not_helpful,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
+Briefings - Issue Detail Viewed,briefings_issue_detail_viewed,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
+Campaign - Follow-On Created,campaign_follow_on_created,d55fa245190deb34c93bd32b863b7c776bbff190,152,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
+Campaign Plan - Weekly Tasks Digest,campaign_plan_weekly_tasks_digest,61d552cc6974dfbb0696f8aad51563686e07e814,1472,2026-04-21,,,,2026-04-21,2026-06-23T16:53:54
+Campaign Plan V2 - Community Events Generation Completed,campaign_plan_v2_community_events_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Community Events Generation Started,campaign_plan_v2_community_events_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Media Generation Completed,campaign_plan_v2_media_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Media Generation Started,campaign_plan_v2_media_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Opportunities & Challenges Generation Completed,campaign_plan_v2_opportunities_challenges_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Opportunities & Challenges Generation Started,campaign_plan_v2_opportunities_challenges_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Opposition Research Generation Completed,campaign_plan_v2_opposition_research_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Opposition Research Generation Started,campaign_plan_v2_opposition_research_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Campaign Plan V2 - Strategy Race Changed,campaign_plan_v2_strategy_race_changed,f920787b11cffc31ae84b70f9b148a89f9431466,104,2026-06-12,,,,2026-06-12,2026-06-23T16:53:54
+Campaign Verify Token Status Update,campaign_verify_token_status_update,362c9b448065c166e4f742836d508cafc825054b,593,2025-10-07,,,,2025-10-07,2026-06-23T16:53:54
+Candidacy - Campaign Completed,candidacy_campaign_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
+Candidacy - Debrief Clicked,candidacy_debrief_clicked,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-23T16:53:54
+Candidacy - Did You Win Modal Completed,candidacy_did_you_win_modal_completed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-23T16:53:54
+Candidacy - Did You Win Modal Viewed,candidacy_did_you_win_modal_viewed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-23T16:53:54
+Candidate Website - Continued,candidate_website_continued,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
+Candidate Website - Edited,candidate_website_edited,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
+Candidate Website - Published,candidate_website_published,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2026-03-03,2026-06-23T16:53:54
+Candidate Website - Purchased domain,candidate_website_purchased_domain,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2026-03-03,2026-06-23T16:53:54
+Candidate Website - Selected domain,candidate_website_selected_domain,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
+Candidate Website - Started,candidate_website_started,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
+Candidate Website - Started domain selection,candidate_website_started_domain_selection,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
+Candidate Website - Unpublished,candidate_website_unpublished,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
+Click to Call CTA Clicked,click_to_call_cta_clicked,,,,,,,,2026-06-23T16:53:54
+Click to Call CTA Viewed,click_to_call_cta_viewed,,,,,,,,2026-06-23T16:53:54
+Click to Call Phone Submitted,click_to_call_phone_submitted,,,,,,,,2026-06-23T16:53:54
+Contacts - Column Edited,contacts_column_edited,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
+Contacts - Contacts Viewed,contacts_contacts_viewed,89f97d0c41382d4c48e72db3ffe591be4694d12a,194,2026-06-17,,,,2026-06-17,2026-06-23T16:53:54
+Contacts - Download,contacts_download,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2026-06-17,2026-06-23T16:53:54
+Contacts - Segment Created,contacts_segment_created,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
+Contacts - Segment Deleted,contacts_segment_deleted,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
+Contacts - Segment Updated,contacts_segment_updated,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
+Contacts - Segment Viewed,contacts_segment_viewed,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
+Content Builder - Editor: Click Copy,content_builder_editor_click_copy,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Click Delete,content_builder_editor_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Click Regenerate,content_builder_editor_click_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Click Rename,content_builder_editor_click_rename,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Click Translate,content_builder_editor_click_translate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Open Kebab Menu,content_builder_editor_open_kebab_menu,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Open Version Picker,content_builder_editor_open_version_picker,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Select Version,content_builder_editor_select_version,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Submit Regenerate,content_builder_editor_submit_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder - Editor: Submit Translate,content_builder_editor_submit_translate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Click Content,content_builder_click_content,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Click Continue Questions,content_builder_click_continue_questions,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Click Generate,content_builder_click_generate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Close Additional Inputs,content_builder_close_additional_inputs,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Generation Completed,content_builder_generation_completed,3968af2dffa446ff83c6625da709ebb45c5ef31e,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Generation Started,content_builder_generation_started,3968af2dffa446ff83c6625da709ebb45c5ef31e,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Select Template,content_builder_select_template,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Content Builder: Submit Additional Inputs,content_builder_submit_additional_inputs,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Custom Voter file created,custom_voter_file_created,93fabd843cdc5e60795b99327819517c76426f3a,,2024-06-07,,,,2024-06-07,2026-06-23T16:53:54
+Daily Ad Metrics,daily_ad_metrics,,,,,,,,2026-06-23T16:53:54
+Dashboard - Campaign Plan Generation Completed,dashboard_campaign_plan_generation_completed,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-07,2026-06-23T16:53:54
+Dashboard - Campaign Plan Task CTA Clicked,dashboard_campaign_plan_task_cta_clicked,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-03,2026-06-23T16:53:54
+Dashboard - Campaign Plan View Mode Toggled,dashboard_campaign_plan_view_mode_toggled,99a9be2e39794c5d3eaeb2b897be4eea422ecc92,1720,2026-04-17,,,,2026-04-17,2026-06-23T16:53:54
+Dashboard - Campaign Plan Viewed,dashboard_campaign_plan_viewed,329017f7e2c2ecd299b09f81f081db9a2168722f,,2026-01-28,,,,2026-04-03,2026-06-23T16:53:54
+Dashboard - Campaign Plan Week Navigated,dashboard_campaign_plan_week_navigated,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-03,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Campaign Manager Clicked,dashboard_campaign_plan_campaign_manager_clicked,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Community Events Displayed,dashboard_campaign_plan_community_events_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Community Events Requested,dashboard_campaign_plan_community_events_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Community Events Results Received,dashboard_campaign_plan_community_events_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Media Displayed,dashboard_campaign_plan_media_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Media Requested,dashboard_campaign_plan_media_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Media Results Received,dashboard_campaign_plan_media_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Plan Downloaded,dashboard_campaign_plan_plan_downloaded,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Strategic Landscape Displayed,dashboard_campaign_plan_strategic_landscape_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Strategic Landscape Requested,dashboard_campaign_plan_strategic_landscape_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Plan: Strategic Landscape Results Received,dashboard_campaign_plan_strategic_landscape_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Dashboard - Campaign Task Status Updated,dashboard_campaign_task_status_updated,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-03,2026-06-23T16:53:54
+Dashboard - Candidate Dashboard Viewed,dashboard_candidate_dashboard_viewed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2025-06-18,2026-06-23T16:53:54
+Dashboard - Path to Victory: Exit Understand Path to Victory,dashboard_path_to_victory_exit_understand_path_to_victory,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Download Voter File Failure,download_voter_file_failure,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-23T16:53:54
+Download Voter File Success,download_voter_file_success,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-23T16:53:54
+Download Voter File attempt,download_voter_file_attempt,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-23T16:53:54
+Experiment Viewed,experiment_viewed,,,,,,,,2026-06-23T16:53:54
+Invalid Party,invalid_party,f4290f167ee16aaaed0299d64c48ae8a3452eeb3,,2024-06-13,85954771b6d545e35af77bf5ca3ae86e9cbdb80d,1790,2026-05-05,2026-05-05,2026-06-23T16:53:54
+Navigation - Dashboard: Click AI Assistant,navigation_dashboard_click_ai_assistant,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation - Dashboard: Click Briefings,navigation_dashboard_click_briefings,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,,,,2026-04-09,2026-06-23T16:53:54
+Navigation - Dashboard: Click Campaign Plan,navigation_dashboard_click_campaign_plan,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
+Navigation - Dashboard: Click Community,navigation_dashboard_click_community,ab19165b23e99ec39c1dbe8feef281ba6d1bc284,576,2025-04-03,,,,2026-06-19,2026-06-23T16:53:54
+Navigation - Dashboard: Click Contacts,navigation_dashboard_click_contacts,b54392a3217e2e427dc5c39f86b98d70a94289c0,938,2025-09-04,,,,2025-09-04,2026-06-23T16:53:54
+Navigation - Dashboard: Click Content Builder,navigation_dashboard_click_content_builder,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation - Dashboard: Click Dashboard,navigation_dashboard_click_dashboard,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation - Dashboard: Click Door Knocking,navigation_dashboard_click_door_knocking,27bef878da7c3238d22d65e27e4b37afee213ed7,522,2025-03-09,,,,2025-03-09,2026-06-23T16:53:54
+Navigation - Dashboard: Click Free Resources,navigation_dashboard_click_free_resources,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,2025-10-14,2026-06-23T16:53:54
+Navigation - Dashboard: Click Issues,navigation_dashboard_click_issues,d4a6c5feef4c178a4619e51f79c3090c9191e7dd,733,2025-07-01,,,,2025-07-01,2026-06-23T16:53:54
+Navigation - Dashboard: Click My Profile,navigation_dashboard_click_my_profile,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation - Dashboard: Click Polls,navigation_dashboard_click_polls,405a687410467f5dc4b89616f282135384a421e8,,2025-10-08,,,,2025-10-08,2026-06-23T16:53:54
+Navigation - Dashboard: Click Resources,navigation_dashboard_click_resources,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,3f6a11a2d717831603f3640b481d6ce9ca6c6698,1459,2026-02-23,2026-02-23,2026-06-23T16:53:54
+Navigation - Dashboard: Click Text Messaging,navigation_dashboard_click_text_messaging,fdf692bfb6171d2436153dff317c995684c94770,,2025-03-22,70a5c952c7fc6b985b062d1b7d9ceb8707bc7dd5,923,2025-08-27,2025-08-27,2026-06-23T16:53:54
+Navigation - Dashboard: Click Voter Data,navigation_dashboard_click_voter_data,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation - Dashboard: Click Voter Outreach,navigation_dashboard_click_voter_outreach,2a9e9929d18f38be852ff8233c76f644cfc6bff6,900,2025-08-20,,,,2025-08-20,2026-06-23T16:53:54
+Navigation - Dashboard: Click Website,navigation_dashboard_click_website,9b740f9d306dba90477c9d2860876585bce07ea4,,2025-06-19,,,,2025-06-19,2026-06-23T16:53:54
+Navigation - Top - Avatar Dropdown: Close Dropdown,navigation_top_avatar_dropdown_close_dropdown,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation - Top: Click Avatar Dropdown,navigation_top_click_avatar_dropdown,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation - Top: Click Logo,navigation_top_click_logo,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation Top - Avatar Dropdown: Click Logout,navigation_top_avatar_dropdown_click_logout,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Navigation Top - Avatar Dropdown: Click Profile,navigation_top_avatar_dropdown_click_profile,a747931b6d3aa7b74f3b331bf53c423d81b641ad,1524,2026-04-16,,,,2026-04-16,2026-06-23T16:53:54
+Navigation Top - Avatar Dropdown: Click Settings,navigation_top_avatar_dropdown_click_settings,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Ballot Status Completed,onboarding_ballot_status_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding - Candidate Affiliation Completed,onboarding_candidate_affiliation_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
+Onboarding - Candidate Office Completed,onboarding_candidate_office_completed,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-23T16:53:54
+Onboarding - Candidate Office Searched,onboarding_candidate_office_searched,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-23T16:53:54
+Onboarding - Candidate Pledge Completed,onboarding_candidate_pledge_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
+Onboarding - Complete Step: Click Go to Dashboard,onboarding_complete_step_click_go_to_dashboard,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Know Your Voters Completed,onboarding_know_your_voters_completed,712fb71051988420909b538f89ea4da4703c1b8b,1804,2026-05-07,,,,2026-05-07,2026-06-23T16:53:54
+Onboarding - Office Selection Completed,onboarding_office_selection_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding - Office Step: Click Can't See Office,onboarding_office_step_click_cant_see_office,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Office Step: Click Next,onboarding_office_step_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Office Step: Office Selected,onboarding_office_step_office_selected,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Party Selection Completed,onboarding_party_selection_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding - Party Step: Click Submit,onboarding_party_step_click_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Path To Victory Completed,onboarding_path_to_victory_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding - Path To Victory Errored,onboarding_path_to_victory_errored,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding - Path To Victory Updated,onboarding_path_to_victory_updated,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding - Pledge Completed,onboarding_pledge_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding - Pledge Step: Click Ask a Question,onboarding_pledge_step_click_ask_a_question,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Pledge Step: Click Submit,onboarding_pledge_step_click_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Onboarding - Registration Completed,onboarding_registration_completed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2025-06-18,2026-06-23T16:53:54
+Onboarding - User Created,onboarding_user_created,ac3e04fb428f001d0ab7bcc471c5c85ef726e2b5,319,2025-06-27,,,,2025-06-27,2026-06-23T16:53:54
+Onboarding - Welcome Completed,onboarding_welcome_completed,85954771b6d545e35af77bf5ca3ae86e9cbdb80d,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
+Onboarding V2 - Ballot Status Completed,onboarding_v2_ballot_status_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Ballot Status Viewed,onboarding_v2_ballot_status_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Campaign Manager Clicked,onboarding_v2_campaign_manager_clicked,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Community Events Displayed,onboarding_v2_community_events_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Community Events Requested,onboarding_v2_community_events_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Community Events Results Received,onboarding_v2_community_events_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Media Displayed,onboarding_v2_media_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Media Requested,onboarding_v2_media_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Media Results Received,onboarding_v2_media_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - New Campaign Context Completed,onboarding_v2_new_campaign_context_completed,9cd8b68a5e50b3eec249595ea4d927de286b9680,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
+Onboarding V2 - New Campaign Context Viewed,onboarding_v2_new_campaign_context_viewed,9cd8b68a5e50b3eec249595ea4d927de286b9680,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
+Onboarding V2 - Office Completed,onboarding_v2_office_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Office Next Clicked,onboarding_v2_office_next_clicked,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
+Onboarding V2 - Office Viewed,onboarding_v2_office_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Party Designation Blocked,onboarding_v2_party_designation_blocked,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Party Designation Completed,onboarding_v2_party_designation_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Party Designation Viewed,onboarding_v2_party_designation_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Plan Downloaded,onboarding_v2_plan_downloaded,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Plan Shared,onboarding_v2_plan_shared,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-23T16:53:54
+Onboarding V2 - Pledge Completed,onboarding_v2_pledge_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Pledge Submit Clicked,onboarding_v2_pledge_submit_clicked,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
+Onboarding V2 - Pledge Viewed,onboarding_v2_pledge_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Resources Completed,onboarding_v2_resources_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Resources Viewed,onboarding_v2_resources_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Strategic Landscape Displayed,onboarding_v2_strategic_landscape_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Strategic Landscape Requested,onboarding_v2_strategic_landscape_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Strategic Landscape Results Received,onboarding_v2_strategic_landscape_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Voter Insights Completed,onboarding_v2_voter_insights_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Voter Insights Viewed,onboarding_v2_voter_insights_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Votes Needed Calculated,onboarding_v2_votes_needed_calculated,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
+Onboarding V2 - Votes Needed Completed,onboarding_v2_votes_needed_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Votes Needed Failed,onboarding_v2_votes_needed_failed,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
+Onboarding V2 - Votes Needed Viewed,onboarding_v2_votes_needed_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Onboarding V2 - Welcome Completed,onboarding_v2_welcome_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-10,2026-06-23T16:53:54
+Onboarding V2 - Welcome Viewed,onboarding_v2_welcome_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-10,2026-06-23T16:53:54
+Onboarding: Click Finish Later,onboarding_click_finish_later,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Org Switcher - Organization Switched,org_switcher_organization_switched,7d6668ba391fe68eb744fd6f98f4fdcf4377a295,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
+Org Switcher - Run For Office Clicked,org_switcher_run_for_office_clicked,7d6668ba391fe68eb744fd6f98f4fdcf4377a295,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
+Outreach - Action Clicked,outreach_action_clicked,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
+Outreach - Click Create,outreach_click_create,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
+Outreach - Door Knocking: Complete,outreach_door_knocking_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
+Outreach - Phone Banking: Complete,outreach_phone_banking_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
+Outreach - Social Media: Complete,outreach_social_media_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
+Outreach - View Accessed,outreach_view_accessed,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
+P2P Upgrade - Modal: Click Button,p2p_upgrade_modal_click_button,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
+P2P Upgrade - Modal: Exit,p2p_upgrade_modal_exit,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
+P2P Upgrade - Modal: Modal Shown,p2p_upgrade_modal_modal_shown,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
+Page,page,a1e5ff46199301c71153b531950bc30ee11bf791,,2024-06-08,,,,2026-06-20,2026-06-23T16:53:54
+Page Viewed,page_viewed,,,,,,,,2026-06-23T16:53:54
+Payment - Completed,payment_completed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2026-02-08,2026-06-23T16:53:54
+Payment - Review and Pay Screen Viewed,payment_review_and_pay_screen_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
+Payment - Schedule and Pay Viewed,payment_schedule_and_pay_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Poll - Results Synthesis Complete,poll_results_synthesis_complete,8293df56527c17f0fa9e42c99caf625438dd7242,636,2025-10-13,,,,2025-10-15,2026-06-23T16:53:54
+Polls - Add Image Completed,polls_add_image_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Add Image Viewed,polls_add_image_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Audience Selection Completed,polls_audience_selection_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Audience Selection Viewed,polls_audience_selection_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Create Poll Clicked,polls_create_poll_clicked,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Expand Poll Recommendations Completed,polls_expand_poll_recommendations_completed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
+Polls - Expand Poll Recommendations Viewed,polls_expand_poll_recommendations_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
+Polls - Expand Poll Review Viewed,polls_expand_poll_review_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
+Polls - Low Confidence Modal Clicked,polls_low_confidence_modal_clicked,907174177b76b62992ff33439ebcd8b1d59d5e0a,1382,2026-03-09,,,,2026-03-09,2026-06-23T16:53:54
+Polls - Poll Bias Detection Shown,polls_poll_bias_detection_shown,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Poll Preview Completed,polls_poll_preview_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Poll Preview Viewed,polls_poll_preview_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Poll Question Completed,polls_poll_question_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Poll Question Optimized,polls_poll_question_optimized,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Poll Question Viewed,polls_poll_question_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Poll Results Issue Details Viewed,polls_poll_results_issue_details_viewed,24d9f8f48bfc6f173af3257d28bb7c35fc2d5c0f,1135,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
+Polls - Poll Results Overview Viewed,polls_poll_results_overview_viewed,24d9f8f48bfc6f173af3257d28bb7c35fc2d5c0f,1135,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
+Polls - Schedule Poll Completed,polls_schedule_poll_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Polls - Schedule Poll Viewed,polls_schedule_poll_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
+Pro Upgrade - Banner Viewed,pro_upgrade_banner_viewed,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Pro Upgrade - Banner: Click Get Pro,pro_upgrade_banner_click_get_pro,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Pro Upgrade - Candidate Profile Submitted,pro_upgrade_candidate_profile_submitted,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,,,,2026-06-05,2026-06-23T16:53:54
+Pro Upgrade - Candidate Profile Viewed,pro_upgrade_candidate_profile_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-23T16:53:54
+Pro Upgrade - Committee Check Page: Click Upload,pro_upgrade_committee_check_page_click_upload,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Pro Upgrade - Committee Check Page: Click back,pro_upgrade_committee_check_page_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Pro Upgrade - Committee Check Page: Click next,pro_upgrade_committee_check_page_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+"Pro Upgrade - Committee Check Page: Hover ""EIN number"" help",pro_upgrade_committee_check_page_hover_ein_number_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
+"Pro Upgrade - Committee Check Page: Hover ""Name of Campaign Committee"" help",pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
+"Pro Upgrade - Committee Check Page: Hover ""Upload"" help",pro_upgrade_committee_check_page_hover_upload_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
+Pro Upgrade - Committee Check Page: Hover “EIN number” help,pro_upgrade_committee_check_page_hover_ein_number_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-23T16:53:54
+Pro Upgrade - Committee Check Page: Hover “Name of Campaign Committee” help,pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-23T16:53:54
+Pro Upgrade - Committee Check Page: Hover “Upload” help,pro_upgrade_committee_check_page_hover_upload_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-23T16:53:54
+Pro Upgrade - Committee Check Page: Toggle EIN requirement,pro_upgrade_committee_check_page_toggle_ein_requirement,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Pro Upgrade - EIN Viewed,pro_upgrade_ein_viewed,c1183769c51e92e8e7177d09c9604c083f3b8454,1987,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - EIN: Click continue,pro_upgrade_ein_click_continue,c1183769c51e92e8e7177d09c9604c083f3b8454,1987,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - EIN: Hover help,pro_upgrade_ein_hover_help,0b66488415b7ecbcf217d96901a9a5c15ad50b0c,1987,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Filing Details Submitted,pro_upgrade_filing_details_submitted,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,,,,2026-06-05,2026-06-23T16:53:54
+Pro Upgrade - Filing Details Viewed,pro_upgrade_filing_details_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-23T16:53:54
+Pro Upgrade - Filing Instructions Viewed,pro_upgrade_filing_instructions_viewed,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Filing Instructions: Click continue to dashboard,pro_upgrade_filing_instructions_click_continue_to_dashboard,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Filing Instructions: Click email this to me,pro_upgrade_filing_instructions_click_email_this_to_me,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Filing Status Viewed,pro_upgrade_filing_status_viewed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Filing Status: Click already filed,pro_upgrade_filing_status_click_already_filed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Filing Status: Click not yet filed,pro_upgrade_filing_status_click_not_yet_filed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Guidance Viewed,pro_upgrade_guidance_viewed,7f6db6f25fc3e3277698af890bce5a7e3bd7de36,1986,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Guidance: Click let's go,pro_upgrade_guidance_click_lets_go,7f6db6f25fc3e3277698af890bce5a7e3bd7de36,1986,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Locked Item: Click,pro_upgrade_locked_item_click,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Pro Upgrade - Modal: Click Button,pro_upgrade_modal_click_button,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade - Modal: Exit,pro_upgrade_modal_exit,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade - Modal: Modal Shown,pro_upgrade_modal_modal_shown,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade - PIN Entry Viewed,pro_upgrade_pin_entry_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-23T16:53:54
+Pro Upgrade - Payment Viewed,pro_upgrade_payment_viewed,c465ade2992cad108b60684aa48d84e57b125f6e,1990,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
+Pro Upgrade - Service Agreement Page: Click back,pro_upgrade_service_agreement_page_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Pro Upgrade - Service Agreement Page: Click finish,pro_upgrade_service_agreement_page_click_finish,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Pro Upgrade - Splash Page: Click upgrade,pro_upgrade_splash_page_click_upgrade,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade - Splash Page: Exit,pro_upgrade_splash_page_exit,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade - Success Viewed,pro_upgrade_success_viewed,9a3d5e1de57e975a9a194e681e4f216a63c642d6,1992,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Pro Upgrade - Success: Click continue,pro_upgrade_success_click_continue,9a3d5e1de57e975a9a194e681e4f216a63c642d6,1992,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
+Pro Upgrade - Value Prop Viewed,pro_upgrade_value_prop_viewed,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-23T16:53:54
+Pro Upgrade - Value Prop: Click Get Pro,pro_upgrade_value_prop_click_get_pro,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-23T16:53:54
+Pro Upgrade - Value Prop: Click Maybe later,pro_upgrade_value_prop_click_maybe_later,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-23T16:53:54
+Pro Upgrade: Click Go to Stripe,pro_upgrade_click_go_to_stripe,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Pro Upgrade: Click exit top nav,pro_upgrade_click_exit_top_nav,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade: Confirm office,pro_upgrade_confirm_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade: Edit office,pro_upgrade_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade: Exit edit office,pro_upgrade_exit_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro Upgrade: Submit edit office,pro_upgrade_submit_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
+Pro user can not download voter file page,pro_user_can_not_download_voter_file_page,7d03f67f7ae53ade7b5894b5841fccbb35e16dcc,,2024-06-30,,,,2024-06-30,2026-06-23T16:53:54
+Profile - Campaign Details: Click Save,profile_campaign_details_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Candidate Profile: Click Submit,profile_candidate_profile_click_submit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Candidate Profile: Submit Success,profile_candidate_profile_submit_success,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,2026-06-05,2026-06-23T16:53:54
+Profile - Fun Fact: Click Save,profile_fun_fact_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Office Details: Click Edit,profile_office_details_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Office Details: Click Save,profile_office_details_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Policy Priorities: Cancel Add,profile_policy_priorities_cancel_add,e2e5ed9386a69f3cfa83791cd0de5adce47f9413,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Policy Priorities: Cancel Edit,profile_policy_priorities_cancel_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Policy Priorities: Click Add,profile_policy_priorities_click_add,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Policy Priorities: Click Delete,profile_policy_priorities_click_delete,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Policy Priorities: Click Edit,profile_policy_priorities_click_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Policy Priorities: Click Save,profile_policy_priorities_click_save,e1371f746f1db7146bb55de165e8725613e3d6aa,1778,2026-04-30,,,,2026-04-30,2026-06-23T16:53:54
+Profile - Policy Priorities: Submit Add,profile_policy_priorities_submit_add,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Policy Priorities: Submit Delete,profile_policy_priorities_submit_delete,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Policy Priorities: Submit Edit,profile_policy_priorities_submit_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
+Profile - Running Against: Cancel Add New,profile_running_against_cancel_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Running Against: Cancel Edit,profile_running_against_cancel_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Running Against: Click Add New,profile_running_against_click_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Running Against: Click Delete,profile_running_against_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Running Against: Click Edit,profile_running_against_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Running Against: Click Save,profile_running_against_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Running Against: Submit Add New,profile_running_against_submit_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Running Against: Submit Edit,profile_running_against_submit_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Top Issues: Cancel Delete,profile_top_issues_cancel_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Top Issues: Cancel Edit,profile_top_issues_cancel_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Top Issues: Click Delete,profile_top_issues_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Top Issues: Click Edit,profile_top_issues_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Top Issues: Click Finish Entering Issues,profile_top_issues_click_finish_entering_issues,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Top Issues: Submit Delete,profile_top_issues_submit_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Top Issues: Submit Edit,profile_top_issues_submit_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Profile - Why Running: Click Save,profile_why_running_click_save,e1371f746f1db7146bb55de165e8725613e3d6aa,1778,2026-04-30,,,,2026-04-30,2026-06-23T16:53:54
+Profile - Why Section: Click Save,profile_why_section_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Resources - Resource Clicked,resources_resource_clicked,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,3f6a11a2d717831603f3640b481d6ce9ca6c6698,1459,2026-02-23,2026-02-23,2026-06-23T16:53:54
+Schedule Text Campaign - Audience: Check Age,schedule_text_campaign_audience_check_age,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Audience: Check Audience,schedule_text_campaign_audience_check_audience,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Audience: Check Gender,schedule_text_campaign_audience_check_gender,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Audience: Check Political Party,schedule_text_campaign_audience_check_political_party,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Audience: Enter Audience Request,schedule_text_campaign_audience_enter_audience_request,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Script: Click Add your own script,schedule_text_campaign_script_click_add_your_own_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Script: Click Generate a new script,schedule_text_campaign_script_click_generate_a_new_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Script: Click Use a saved script,schedule_text_campaign_script_click_use_a_saved_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Script: Select Saved Script,schedule_text_campaign_script_select_saved_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign - Script: Submit added script,schedule_text_campaign_script_submit_added_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign: Back,schedule_text_campaign_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign: Exit,schedule_text_campaign_exit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign: Next,schedule_text_campaign_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Schedule Text Campaign: Submit,schedule_text_campaign_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Scroll Depth,scroll_depth,,,,,,,,2026-06-23T16:53:54
+Segment Consent Preference Updated,segment_consent_preference_updated,,,,,,,,2026-06-23T16:53:54
+Serve Onboarding - Add Image Viewed,serve_onboarding_add_image_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Constituency Profile Viewed,serve_onboarding_constituency_profile_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Getting Started Viewed,serve_onboarding_getting_started_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Magic Link Activated,serve_onboarding_magic_link_activated,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,,,,2026-06-18,2026-06-23T16:53:54
+Serve Onboarding - Meet Your Constituents Viewed,serve_onboarding_meet_your_constituents_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Poll Image Uploaded,serve_onboarding_poll_image_uploaded,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Poll Preview Viewed,serve_onboarding_poll_preview_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Poll Strategy Viewed,serve_onboarding_poll_strategy_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Poll Value Props Viewed,serve_onboarding_poll_value_props_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - SMS Poll Creation Failed,serve_onboarding_sms_poll_creation_failed,4537360b9cd5f5071c5b1f99364e310e0b225620,1374,2026-02-04,,,,2026-02-04,2026-06-23T16:53:54
+Serve Onboarding - SMS Poll Sent,serve_onboarding_sms_poll_sent,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
+Serve Onboarding - Success Page Viewed,serve_onboarding_success_page_viewed,33f319823719eb25aef1fe2812184a61b23a41f6,1098,2025-10-29,,,,2025-10-29,2026-06-23T16:53:54
+Serve Onboarding - Sworn In Completed,serve_onboarding_sworn_in_completed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-23T16:53:54
+Serve Onboarding - Sworn In Viewed,serve_onboarding_sworn_in_viewed,33f319823719eb25aef1fe2812184a61b23a41f6,1098,2025-10-29,,,,2025-10-29,2026-06-23T16:53:54
+Set Password: Click Set Password,set_password_click_set_password,aeb23786b697e849c6684f4fc08acb0964fae1fe,513,2025-03-06,,,,2025-03-06,2026-06-23T16:53:54
+Settings - Account Settings: Click Manage Pro Subscription,settings_account_settings_click_manage_pro_subscription,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Account Settings: Click Send Email,settings_account_settings_click_send_email,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Account Settings: Click Upgrade,settings_account_settings_click_upgrade,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Delete Account: Cancel Delete,settings_delete_account_cancel_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Delete Account: Click Delete,settings_delete_account_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Delete Account: Submit Delete,settings_delete_account_submit_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Notifications: Toggle Email,settings_notifications_toggle_email,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Password: Click Save,settings_password_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Personal Info: Click Save,settings_personal_info_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Settings - Personal Info: Click Upload,settings_personal_info_click_upload,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Sign In: Click Create Account,sign_in_click_create_account,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Sign In: Click Forgot Password,sign_in_click_forgot_password,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Sign Up Clicked,sign_up_clicked,,,,,,,,2026-06-23T16:53:54
+Sign Up: Click Login,sign_up_click_login,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Viewed,viewed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2026-06-19,2026-06-23T16:53:54
+Viewed /elections/ak/tanana-city-school-district,viewed_elections_ak_tanana_city_school_district,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/chippewa-county-clerk/145f1d,viewed_elections_chippewa_county_clerk_145f1d,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/ia/red-oak-community-school-district,viewed_elections_ia_red_oak_community_school_district,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/mi/monroe-county/monroe/position/city-clerk-ward-officer,viewed_elections_mi_monroe_county_monroe_position_city_clerk_ward_officer,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/nv/elko/point-of-rocks,viewed_elections_nv_elko_point_of_rocks,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/pa,viewed_elections_pa,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/tx/borger-independent-school-district,viewed_elections_tx_borger_independent_school_district,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/tx/gray/hoover,viewed_elections_tx_gray_hoover,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/tx/saint-jo-independent-school-district,viewed_elections_tx_saint_jo_independent_school_district,,,,,,,,2026-06-23T16:53:54
+Viewed /elections/va/wise/dixiana,viewed_elections_va_wise_dixiana,,,,,,,,2026-06-23T16:53:54
+Voter Data - Custom Voter File - Audience: Click Back,voter_data_custom_voter_file_audience_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Custom Voter File: Click Create,voter_data_custom_voter_file_click_create,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Custom Voter File: Click Next,voter_data_custom_voter_file_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Custom Voter File: Exit modal,voter_data_custom_voter_file_exit_modal,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Custom Voter File: Select Channel,voter_data_custom_voter_file_select_channel,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Custom Voter File: Select Purpose,voter_data_custom_voter_file_select_purpose,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail - Learn & Take Action: Click Read More,voter_data_file_detail_learn_take_action_click_read_more,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail - Learn & Take Action: Click Schedule,voter_data_file_detail_learn_take_action_click_schedule,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail - Learn & Take Action: Click Write Script,voter_data_file_detail_learn_take_action_click_write_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail - Recommended Partners: Click Read More,voter_data_file_detail_recommended_partners_click_read_more,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail: Click Back,voter_data_file_detail_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail: Click Custom File Info Icon,voter_data_file_detail_click_custom_file_info_icon,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail: Click Download CSV,voter_data_file_detail_click_download_csv,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - File Detail: Click View Audience Filters,voter_data_file_detail_click_view_audience_filters,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Need Help: Exit modal,voter_data_need_help_exit_modal,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Need Help: Select Voter File type,voter_data_need_help_select_voter_file_type,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data - Need Help: Submit,voter_data_need_help_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data: Click Create Custom Voter File,voter_data_click_create_custom_voter_file,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data: Click Detail View,voter_data_click_detail_view,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Data: Click Need Help,voter_data_click_need_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
+Voter Outreach - 10DLC Compliance Completed,voter_outreach_10dlc_compliance_completed,a52bc1af5ee58f5b2492165ff4d973a76cf4db8b,457,2025-08-19,,,,2026-02-02,2026-06-23T16:53:54
+Voter Outreach - 10DLC Compliance Form Submitted,voter_outreach_10dlc_compliance_form_submitted,8434d128fc9812dcdde58effacd26458fccd95cc,894,2025-08-20,,,,2026-03-03,2026-06-23T16:53:54
+Voter Outreach - 10DLC Compliance Modal Viewed,voter_outreach_10dlc_compliance_modal_viewed,3f45b71a832475c190658d02e61151e16b0c6e65,1497,2026-03-03,,,,2026-03-03,2026-06-23T16:53:54
+Voter Outreach - 10DLC Compliance PIN Submitted,voter_outreach_10dlc_compliance_pin_submitted,8434d128fc9812dcdde58effacd26458fccd95cc,894,2025-08-20,,,,2026-03-03,2026-06-23T16:53:54
+Voter Outreach - 10DLC Compliance Started,voter_outreach_10dlc_compliance_started,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
+Voter Outreach - Campaign Completed,voter_outreach_campaign_completed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2026-06-10,2026-06-23T16:53:54
+Voter Outreach - Free Texts Offer Redeemed,voter_outreach_free_texts_offer_redeemed,aa90af3d789823511f82e9d81dee84417a82b0c2,520,2025-09-08,,,,2025-09-08,2026-06-23T16:53:54
+Voter Outreach - Payment Started,voter_outreach_payment_started,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
+[AI Visibility] Brand Snapshot,ai_visibility_brand_snapshot,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Dead Click,amplitude_dead_click,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Element Changed,amplitude_element_changed,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Element Clicked,amplitude_element_clicked,,,,,,,,2026-06-23T16:53:54
+[Amplitude] File Downloaded,amplitude_file_downloaded,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Form Started,amplitude_form_started,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Form Submitted,amplitude_form_submitted,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Network Request,amplitude_network_request,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Page Viewed,amplitude_page_viewed,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Rage Click,amplitude_rage_click,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Replay Captured,amplitude_replay_captured,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Viewport Content Updated,amplitude_viewport_content_updated,,,,,,,,2026-06-23T16:53:54
+[Amplitude] Web Vitals,amplitude_web_vitals,,,,,,,,2026-06-23T16:53:54
+[Experiment] Assignment,experiment_assignment,,,,,,,,2026-06-23T16:53:54
+[Experiment] Exposure,experiment_exposure,,,,,,,,2026-06-23T16:53:54
+[Experiment] Impression,experiment_impression,,,,,,,,2026-06-23T16:53:54
+ai_content_generation_start,ai_content_generation_start,a295f87f437a729b81c86adc2dc789ad9f1e3d18,316,2024-10-18,,,,2024-10-18,2026-06-23T16:53:54
+campaign_assistant_chatbot_input,campaign_assistant_chatbot_input,505dda0aafa691533330bcc405dd3d1bc796335d,315,2024-10-18,,,,2024-10-18,2026-06-23T16:53:54
+candidate CTA cancelled,candidate_cta_cancelled,5a9f8ed2d3b00f846e0d28fbb264d38e930d31f7,,2024-06-10,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-23T16:53:54
+candidate CTA clicked,candidate_cta_clicked,c0a574c0e56c270af68bf4cf82729bc30f967bf0,,2024-06-08,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-23T16:53:54
+candidate CTA selected,candidate_cta_selected,5a9f8ed2d3b00f846e0d28fbb264d38e930d31f7,,2024-06-10,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-23T16:53:54
+gtm.dom,gtm_dom,,,,,,,,2026-06-23T16:53:54
+gtm.init,gtm_init,,,,,,,,2026-06-23T16:53:54
+gtm.init_consent,gtm_init_consent,,,,,,,,2026-06-23T16:53:54
+gtm.js,gtm_js,,,,,,,,2026-06-23T16:53:54
+likelihood-to-cancel,likelihood_to_cancel,,,,,,,,2026-06-23T16:53:54
+onboarding_complete,onboarding_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2026-06-18,2026-06-23T16:53:54
+page,page,bcc9c195b46c214cb83ce829a49c8ab2b1fdffbf,,2024-06-05,,,,2026-06-22,2026-06-23T16:53:54
+page viewed,page_viewed,,,,,,,,2026-06-23T16:53:54
+page_view,page_view,abc192c40633b5bb1a9da10936bfcd433f621366,1268,2025-12-18,3ea4ebae6647d4a36c2e78cfb5da7eb706749b57,1551,2026-03-12,2026-03-12,2026-06-23T16:53:54
+pro_upgrade_complete,pro_upgrade_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2026-05-08,2026-06-23T16:53:54
+question_complete,question_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2025-12-17,2026-06-23T16:53:54
+schedule_campaign_image_too_large,schedule_campaign_image_too_large,4bed7aad64c8a8212e618db564bcb28ad2b9be5e,338,2024-10-30,,,,2024-10-30,2026-06-23T16:53:54
+screen,screen,a53d6050d2cf19c71a89fcbbef716951cdd12c22,,2024-06-13,,,,2026-06-22,2026-06-23T16:53:54
+session_end,session_end,,,,,,,,2026-06-23T16:53:54
+session_start,session_start,,,,,,,,2026-06-23T16:53:54
+usersnap_submission,usersnap_submission,634a1c354de73cca6e6a0393dbdd0ac6dc3c7ae2,293,2024-10-04,e256bd33a54df1a412dcbe055be41d284f5ce195,1495,2026-03-02,2026-03-02,2026-06-23T16:53:54

--- a/analytics/data/amplitude_event_provenance_state.json
+++ b/analytics/data/amplitude_event_provenance_state.json
@@ -1,0 +1,7 @@
+{
+  "job_name": "amplitude_event_provenance_backfill",
+  "last_processed_sha": "aba52ee4eb01f84148d98b19f8188bde8254d16d",
+  "head_ref": "origin/develop",
+  "commit_count": 7722,
+  "last_run_at": "2026-06-23T16:53:54"
+}

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -322,6 +322,47 @@ def build_provenance_row(
     return row
 
 
+def _pseudo_commit(commit: str | None, pr: str | None, date: str | None) -> dict:
+    """A minimal commit dict reconstructed from a stored row.
+
+    Carries only the keys ``build_provenance_row`` reads (commit, pr, date). It is never
+    fed to ``_record``, so the epoch ``ts`` ordering key is not needed: the windowed
+    commits are strictly newer than the watermark, so precedence is positional, not timed.
+    """
+    return {"commit": commit, "pr": pr, "date": date}
+
+
+def merge_provenance_entry(existing_row: dict | None, new_entry: dict) -> dict:
+    """Combine an event's existing table row with its new-window accumulator entry.
+
+    The window only contains commits newer than the watermark, so:
+      - instrumented: the existing (older) instrumentation wins; the window's add is used
+        only when the row had no instrumentation yet (genuinely new event).
+      - retired: the window's removal wins (it is the latest); else the existing retired is
+        carried forward. ``build_provenance_row`` still clears retired unless the event is
+        absent at HEAD, so a re-add naturally drops a stale retired.
+      - last_change: always the window's -- the event net-changed in the window.
+    """
+    if existing_row and existing_row.get("instrumented_commit"):
+        instrumented = _pseudo_commit(
+            existing_row["instrumented_commit"],
+            existing_row["instrumented_pr"],
+            existing_row["instrumented_date"],
+        )
+    else:
+        instrumented = new_entry["instrumented"]
+
+    retired = new_entry["retired"]
+    if retired is None and existing_row and existing_row.get("retired_commit"):
+        retired = _pseudo_commit(
+            existing_row["retired_commit"],
+            existing_row["retired_pr"],
+            existing_row["retired_date"],
+        )
+
+    return {"instrumented": instrumented, "retired": retired, "last_change": new_entry["last_change"]}
+
+
 def collect_provenance(
     events: Sequence[str],
     git_log_lines: Iterable[str],

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -395,7 +395,7 @@ def present_at_head(events: Sequence[str], grep_text: str) -> dict[str, bool]:
 
 
 # --------------------------------------------------------------------------- #
-# SQL builders (pure)
+# Git argv builder (pure)
 # --------------------------------------------------------------------------- #
 
 
@@ -682,6 +682,11 @@ def run_refresh(
     Reads the whole CSV, replaces only the events that changed in the window (giving them a
     fresh updated_at), carries every other row forward verbatim, and rewrites the full sorted
     CSV. Always advances the watermark file so the next run resumes from HEAD.
+
+    Limitation: a refresh only adds/updates events that changed in the ``last_sha..ref``
+    window. Events that are new to (or removed from) the universe but did NOT net-change in
+    that window are not added or pruned until a full backfill -- delete the state file and
+    re-run to resync.
     """
     updated_at = now.replace(tzinfo=None).isoformat(timespec="seconds")
     watermark = read_watermark(state_path)
@@ -709,6 +714,14 @@ def run_refresh(
     print(f"Affected events in window: {len(affected)}", file=sys.stderr)
 
     existing = read_provenance_rows(csv_path)
+    missing = set(events) - set(existing)
+    if missing:
+        print(
+            f"WARNING: {len(missing)} universe event(s) absent from the CSV; a refresh only adds "
+            f"events that changed in the window. Delete the state file and re-run for a full backfill "
+            f"to resync.",
+            file=sys.stderr,
+        )
     if affected:
         grep_text = git_grep_present_text(root, affected, INSTRUMENTATION_PATHS, ref)
         present = present_at_head(affected, grep_text)
@@ -735,6 +748,9 @@ def run_refresh(
 
 
 def _summarize(rows: Sequence[dict]) -> str:
+    # not_found_in_code counts rows with no instrumentation date: this includes both events
+    # never seen in code AND events present in code whose instrumentation predates the --since
+    # window (the dropped still_in_code column was the only thing that distinguished them).
     present = removed = not_found = 0
     for r in rows:
         if r.get("instrumented_date") is None:

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -291,12 +291,18 @@ def _pseudo_commit(commit: str | None, pr: str | None, date: str | None) -> dict
     return {"commit": commit, "pr": pr, "date": date}
 
 
-def merge_provenance_entry(existing_row: dict | None, new_entry: dict) -> dict:
+def merge_provenance_entry(
+    existing_row: dict | None, new_entry: dict, present_before_window: bool = False
+) -> dict:
     """Combine an event's existing table row with its new-window accumulator entry.
 
     The window only contains commits newer than the watermark, so:
       - instrumented: the existing (older) instrumentation wins; the window's add is used
-        only when the row had no instrumentation yet (genuinely new event).
+        only when the row had no instrumentation yet AND the event was absent before the
+        window (a genuinely new event). If the event was already present at the watermark
+        (``present_before_window``) its true instrumentation predates the window and is not
+        visible in it -- the window's net-add is a spurious edit, so instrumentation stays
+        null rather than being stamped with a false, too-recent date.
       - retired: the window's removal wins (it is the latest); else the existing retired is
         carried forward. ``build_provenance_row`` still clears retired unless the event is
         absent at HEAD, so a re-add naturally drops a stale retired.
@@ -308,6 +314,8 @@ def merge_provenance_entry(existing_row: dict | None, new_entry: dict) -> dict:
             existing_row["instrumented_pr"],
             existing_row["instrumented_date"],
         )
+    elif present_before_window:
+        instrumented = None
     else:
         instrumented = new_entry["instrumented"]
 
@@ -725,9 +733,15 @@ def run_refresh(
     if affected:
         grep_text = git_grep_present_text(root, affected, INSTRUMENTATION_PATHS, ref)
         present = present_at_head(affected, grep_text)
+        # Presence at the watermark distinguishes a genuinely new event (absent before the
+        # window -> the window's net-add is its true instrumentation) from one whose
+        # instrumentation predates the window (present before it -> the net-add is a
+        # spurious edit, so merge_provenance_entry must not stamp a false instrumented date).
+        before_text = git_grep_present_text(root, affected, INSTRUMENTATION_PATHS, last_sha)
+        present_before = present_at_head(affected, before_text)
         updated_rows: list[dict] = []
         for ev in affected:
-            merged = merge_provenance_entry(existing.get(ev), acc[ev])
+            merged = merge_provenance_entry(existing.get(ev), acc[ev], present_before.get(ev, False))
             updated_rows.append(build_provenance_row(ev, merged, present.get(ev), updated_at))
         _, filled = resolve_pr_gaps(updated_rows, pr_resolver)
         if pr_resolver is not None:

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -4,8 +4,9 @@ Walks the omni git history over the instrumentation paths and writes one provena
 Amplitude ``event_type`` to a CSV committed in this repo
 (``analytics/data/amplitude_event_provenance.csv``), plus a sidecar JSON watermark
 (``..._state.json``) recording the last processed commit SHA. With no watermark it does a full
-backfill; with one it walks ``git log <lastSHA>..origin/develop``, updates only the events that
-changed, carries the rest forward, and advances the watermark.
+backfill; with one it walks ``git log <lastSHA>..origin/develop``, updates the events that
+changed, carries the rest forward, onboards any universe events absent from the CSV via a
+full-history pickaxe walk, and advances the watermark.
 
 It READS the omni working tree's git history (``--repo`` / ``OMNI_REPO``) and the Amplitude
 Govern event universe from Databricks (``airbyte_source.amplitude_taxonomy_event_type``, the one
@@ -408,16 +409,22 @@ def present_at_head(events: Sequence[str], grep_text: str) -> dict[str, bool]:
 
 
 def build_git_log_argv(
-    root: str, since: str | None, paths: Sequence[str], ref: str | None = None
+    root: str, since: str | None, paths: Sequence[str], ref: str | None = None, pickaxe: str | None = None
 ) -> list[str]:
-    """argv for the single ``git log -p`` pass over the instrumentation paths.
+    """argv for a ``git log -p`` pass over the instrumentation paths.
 
     ``ref`` (e.g. ``origin/develop``) bounds the walk to a revision; placed before the ``--``
-    so git reads it as a rev, not a path. None walks HEAD (current checkout).
+    so git reads it as a rev, not a path. None walks HEAD (current checkout). ``pickaxe`` adds
+    ``-S<literal>`` so the walk streams only the commits that changed that literal's occurrence
+    count -- far cheaper than the full diff stream, and the count-change semantics match our
+    net-add / net-remove attribution exactly. ``-S`` is a fixed string by default, so quotes and
+    spaces in an event name are matched literally.
     """
     argv = ["git", "-C", root, "log", "-p", "--date=short", _GIT_LOG_FORMAT]
     if since:
         argv += ["--since", since]
+    if pickaxe is not None:
+        argv.append(f"-S{pickaxe}")
     if ref:
         argv.append(ref)
     return [*argv, "--", *paths]
@@ -428,14 +435,17 @@ def build_git_log_argv(
 # --------------------------------------------------------------------------- #
 
 
-def run_git_log(root: str, since: str | None, paths: Sequence[str], ref: str | None = None) -> Iterator[str]:
-    """Stream the single ``git log -p`` pass line-by-line (the diff stream is large).
+def run_git_log(
+    root: str, since: str | None, paths: Sequence[str], ref: str | None = None, pickaxe: str | None = None
+) -> Iterator[str]:
+    """Stream a ``git log -p`` pass line-by-line (the diff stream is large).
 
     A non-zero exit (bad ref, corrupt repo) raises ``CalledProcessError`` once the stream
     is exhausted: otherwise a failed log parses as an empty history and we would MERGE a
-    table of all-null provenance rows with no error signal.
+    table of all-null provenance rows with no error signal. ``pickaxe`` restricts the walk
+    to commits that changed a single literal's count (see ``build_git_log_argv``).
     """
-    argv = build_git_log_argv(root, since, paths, ref)
+    argv = build_git_log_argv(root, since, paths, ref, pickaxe)
     proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     assert proc.stdout is not None
     try:
@@ -682,6 +692,36 @@ def run_backfill(
     return rows
 
 
+def attribute_events_from_history(
+    root: str,
+    events: Sequence[str],
+    since: str | None,
+    ref: str,
+    updated_at: str,
+    pr_resolver: Callable[[str], str | None] | None = None,
+    paths: Sequence[str] = INSTRUMENTATION_PATHS,
+) -> list[dict]:
+    """Full-history provenance rows for a specific set of events, via per-event pickaxe walks.
+
+    Used to onboard universe events absent from the CSV during a refresh: events new to the
+    Govern taxonomy but instrumented before the watermark, which the bounded ``last_sha..ref``
+    window never sees. Each event gets a ``git log -S<literal>`` walk that streams only the
+    commits changing its count, so onboarding a handful of events does not pay the full
+    ``git log -p`` walk. Attribution then reuses the same ``build_provenance_row`` /
+    ``present_at_head`` / ``resolve_pr_gaps`` path as the backfill, so an onboarded row matches
+    what a full backfill would produce.
+    """
+    acc: dict[str, dict] = {}
+    for event in events:
+        lines = run_git_log(root, since, paths, ref, pickaxe=event)
+        acc.update(parse_git_log(lines, compile_event_pattern([event])))
+    grep_text = git_grep_present_text(root, events, paths, ref)
+    present = present_at_head(events, grep_text)
+    rows = [build_provenance_row(e, acc.get(e), present.get(e), updated_at) for e in events]
+    resolve_pr_gaps(rows, pr_resolver)
+    return rows
+
+
 def run_refresh(
     cursor: Any,
     root: str,
@@ -698,10 +738,11 @@ def run_refresh(
     fresh updated_at), carries every other row forward verbatim, and rewrites the full sorted
     CSV. Always advances the watermark file so the next run resumes from HEAD.
 
-    Limitation: a refresh only adds/updates events that changed in the ``last_sha..ref``
-    window. Events that are new to (or removed from) the universe but did NOT net-change in
-    that window are not added or pruned until a full backfill -- delete the state file and
-    re-run to resync.
+    New universe events absent from the CSV are onboarded in the same run via
+    ``attribute_events_from_history`` (full-history pickaxe attribution), so a routine refresh
+    covers both existing-event updates and brand-new events without a manual full backfill.
+    Events removed from the universe are left in the CSV (their provenance is kept); a full
+    rebuild from scratch is delete-the-state-file-and-re-run.
     """
     updated_at = now.replace(tzinfo=None).isoformat(timespec="seconds")
     watermark = read_watermark(state_path)
@@ -729,31 +770,40 @@ def run_refresh(
     print(f"Affected events in window: {len(affected)}", file=sys.stderr)
 
     existing = read_provenance_rows(csv_path)
-    missing = set(events) - set(existing)
-    if missing:
-        print(
-            f"WARNING: {len(missing)} universe event(s) absent from the CSV; a refresh only adds "
-            f"events that changed in the window. Delete the state file and re-run for a full backfill "
-            f"to resync.",
-            file=sys.stderr,
-        )
-    if affected:
-        grep_text = git_grep_present_text(root, affected, INSTRUMENTATION_PATHS, ref)
-        present = present_at_head(affected, grep_text)
+    missing = sorted(set(events) - set(existing))
+
+    # Existing CSV events that changed in the window: cheap windowed update. (Events that are
+    # both new to the CSV and changed in-window are excluded here and onboarded below from full
+    # history, which is the more accurate attribution.)
+    affected_existing = [ev for ev in affected if ev not in set(missing)]
+    if affected_existing:
+        grep_text = git_grep_present_text(root, affected_existing, INSTRUMENTATION_PATHS, ref)
+        present = present_at_head(affected_existing, grep_text)
         # Presence at the watermark distinguishes a genuinely new event (absent before the
         # window -> the window's net-add is its true instrumentation) from one whose
         # instrumentation predates the window (present before it -> the net-add is a
         # spurious edit, so merge_provenance_entry must not stamp a false instrumented date).
-        before_text = git_grep_present_text(root, affected, INSTRUMENTATION_PATHS, last_sha)
-        present_before = present_at_head(affected, before_text)
+        before_text = git_grep_present_text(root, affected_existing, INSTRUMENTATION_PATHS, last_sha)
+        present_before = present_at_head(affected_existing, before_text)
         updated_rows: list[dict] = []
-        for ev in affected:
+        for ev in affected_existing:
             merged = merge_provenance_entry(existing.get(ev), acc[ev], present_before.get(ev, False))
             updated_rows.append(build_provenance_row(ev, merged, present.get(ev), updated_at))
         _, filled = resolve_pr_gaps(updated_rows, pr_resolver)
         if pr_resolver is not None:
             print(f"Merge-walk PR backfill: filled {filled} *_pr gaps", file=sys.stderr)
         for row in updated_rows:
+            existing[row["event_type"]] = row
+
+    # New universe events absent from the CSV: instrumented before the watermark, so invisible
+    # to the window. Onboard them from full history so a routine refresh needs no full backfill.
+    if missing:
+        print(
+            f"Onboarding {len(missing)} new universe event(s) absent from the CSV "
+            f"via full-history attribution ...",
+            file=sys.stderr,
+        )
+        for row in attribute_events_from_history(root, missing, since, ref, updated_at, pr_resolver):
             existing[row["event_type"]] = row
 
     rows = list(existing.values())

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -637,8 +637,7 @@ def _ensure_columns(cursor: Any, table: str, schema: Sequence[tuple[str, str]]) 
 def fetch_event_universe(cursor: Any, taxonomy_table: str = TAXONOMY_TABLE) -> list[str]:
     """The authoritative ~408 distinct event_type values to attribute provenance for."""
     cursor.execute(
-        f"SELECT DISTINCT event_type FROM {taxonomy_table} "
-        f"WHERE event_type IS NOT NULL ORDER BY event_type"
+        f"SELECT DISTINCT event_type FROM {taxonomy_table} WHERE event_type IS NOT NULL ORDER BY event_type"
     )
     return [str(r[0]) for r in cursor.fetchall()]
 
@@ -674,6 +673,34 @@ def write_watermark(
         build_watermark_merge_sql(state_table),
         (JOB_NAME, last_processed_sha, head_ref, commit_count, last_run_at),
     )
+
+
+def read_watermark(
+    cursor: Any,
+    state_table: str = STATE_TABLE,
+    job_name: str = JOB_NAME,
+) -> dict | None:
+    """Read the SHA high-water mark for ``job_name``; None when there is no row yet.
+
+    Creates the state table if absent (idempotent, mirroring ``write_watermark``), so a
+    first run reads an empty table and gets None -> the caller does a full backfill.
+    """
+    cursor.execute(_CREATE_STATE_TABLE_SQL.format(table=state_table))
+    cursor.execute(
+        f"SELECT last_processed_sha, head_ref, commit_count, last_run_at "
+        f"FROM {state_table} WHERE job_name = ?",
+        (job_name,),
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        return None
+    sha, head_ref, commit_count, last_run_at = rows[0]
+    return {
+        "last_processed_sha": sha,
+        "head_ref": head_ref,
+        "commit_count": commit_count,
+        "last_run_at": last_run_at,
+    }
 
 
 # --------------------------------------------------------------------------- #

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -654,12 +654,12 @@ def run_backfill(
     root: str,
     since: str | None,
     now: datetime,
-    table: str = "",
-    state_table: str = "",
+    csv_path: str = DEFAULT_CSV_PATH,
+    state_path: str = DEFAULT_STATE_PATH,
     ref: str = DEPLOY_REF,
     pr_resolver: Callable[[str], str | None] | None = None,
 ) -> list[dict]:
-    """Fetch the universe, walk git once, write the table + watermark. Returns the rows."""
+    """Fetch the universe, walk git once, write the CSV + watermark file. Returns the rows."""
     updated_at = now.replace(tzinfo=None).isoformat(timespec="seconds")
     events = fetch_event_universe(cursor)
     print(f"Event universe: {len(events)} event_types", file=sys.stderr)
@@ -670,22 +670,19 @@ def run_backfill(
     )
     lines = run_git_log(root, since, INSTRUMENTATION_PATHS, ref)
     grep_text = git_grep_present_text(root, events, INSTRUMENTATION_PATHS, ref)
-    # parse_git_log consumes the stream; collect_provenance needs both, so materialize
-    # the (small) grep dump first and stream the (large) log into collect_provenance.
     rows = collect_provenance(events, lines, grep_text, updated_at)
 
-    _, filled = resolve_pr_gaps(rows, pr_resolver)  # mutates rows in place
+    _, filled = resolve_pr_gaps(rows, pr_resolver)
     if pr_resolver is not None:
         print(f"Merge-walk PR backfill: filled {filled} *_pr gaps", file=sys.stderr)
 
-    write_provenance(cursor, rows, table)
+    write_provenance(rows, csv_path)
     write_watermark(
-        cursor,
+        state_path,
         git_head_sha(root, ref),
         git_head_ref(root, ref),
         git_commit_count(root, since, INSTRUMENTATION_PATHS, ref),
         updated_at,
-        state_table,
     )
     return rows
 

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -5,9 +5,10 @@ provenance row per Amplitude ``event_type`` to a Databricks landing table via an
 idempotent MERGE, plus a commit-SHA watermark so DATA-2006's incremental updater
 can resume with ``git log <lastSHA>..HEAD``.
 
-This is phase 1 extracted from DATA-2006; it builds nothing incremental and writes
-nothing back to Amplitude. DATA-2005 builds ``stg__amplitude_event_provenance`` over
-the table this produces.
+DATA-2007 shipped the one-time backfill; DATA-2014 adds the watermark-bounded ``--refresh``
+path (read the SHA watermark, walk ``git log <lastSHA>..origin/develop``, MERGE only affected
+events, advance the watermark; full backfill when no watermark exists). Neither writes back to
+Amplitude. DATA-2005 builds ``stg__amplitude_event_provenance`` over the table this produces.
 
 Cross-repo by nature: it READS the omni working tree's git history (``--repo`` /
 ``OMNI_REPO``) and WRITES this repo's Databricks data layer (via the analytics
@@ -41,6 +42,9 @@ Usage::
     # local dev (writable schema):
     cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
         --repo ~/Documents/0_goodparty/0_repos/omni --schema private_tristan
+    # scheduled refresh (incremental; full backfill on first run):
+    cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
+        --repo ~/Documents/0_goodparty/0_repos/omni --refresh
 """
 
 from __future__ import annotations
@@ -910,6 +914,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         action="store_true",
         help="Skip the merge-walk PR backfill; *_pr stays whatever the commit subject yielded.",
     )
+    p.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Incremental watermark-bounded refresh (full backfill if no watermark exists).",
+    )
     return p.parse_args(argv)
 
 
@@ -934,7 +943,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     connection = get_connection()
     try:
         with connection.cursor() as cursor:
-            rows = run_backfill(
+            runner = run_refresh if args.refresh else run_backfill
+            rows = runner(
                 cursor,
                 root,
                 since,

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -451,13 +451,20 @@ def git_grep_present_text(root: str, events: Sequence[str], paths: Sequence[str]
     """Dump of ``ref`` lines containing any known literal, via one fixed-string git grep.
 
     ``-F`` treats each event as a literal; ``-h`` drops filenames. git grep exits 1
-    when nothing matches (an empty dump), which is not an error here.
+    when nothing matches (an empty dump), which is not an error here; it exits 2+ on a
+    real failure (bad ref, repo corruption, permission denied). We must raise on 2+:
+    swallowing it returns an empty dump indistinguishable from "no matches", so every
+    event would map to absent at HEAD, be written as ``removed``, and the watermark would
+    advance on a fully corrupted CSV with no error signal -- the same silent-corruption
+    risk ``run_git_log`` guards against.
     """
     patterns: list[str] = []
     for e in events:
         patterns += ["-e", e]
     argv = ["git", "-C", root, "grep", "-F", "-h", "--no-color", *patterns, ref, "--", *paths]
     proc = subprocess.run(argv, capture_output=True, text=True)
+    if proc.returncode not in (0, 1):
+        raise subprocess.CalledProcessError(proc.returncode, argv, stderr=proc.stderr)
     return proc.stdout
 
 

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -1,0 +1,791 @@
+"""One-time backfill: build the initial git-provenance table for Amplitude events (DATA-2007).
+
+Walks the omni git history ONCE over the instrumentation paths and writes one
+provenance row per Amplitude ``event_type`` to a Databricks landing table via an
+idempotent MERGE, plus a commit-SHA watermark so DATA-2006's incremental updater
+can resume with ``git log <lastSHA>..HEAD``.
+
+This is phase 1 extracted from DATA-2006; it builds nothing incremental and writes
+nothing back to Amplitude. DATA-2005 builds ``stg__amplitude_event_provenance`` over
+the table this produces.
+
+Cross-repo by nature: it READS the omni working tree's git history (``--repo`` /
+``OMNI_REPO``) and WRITES this repo's Databricks data layer (via the analytics
+``databricks_conn`` profile auth -- no PAT).
+
+Extraction note: ``trackEvent(...)`` in omni is called with *constant references*
+(``trackEvent(EVENTS.ServeOnboarding.SwornInCompleted)``), not string literals. The
+event-type strings live as VALUES in the ``EVENTS`` map
+(packages/gp-webapp/helpers/analyticsHelper.ts) and a few gp-api type/string files.
+So we do not parse ``trackEvent('...')``; instead we anchor on the authoritative event
+universe (``dbt.int__amplitude_event_taxonomy``, ~408 events) and match those literals
+against added/removed diff lines in a single ``git log -p`` pass.
+
+Deploy-ref anchored: the walk, the HEAD-presence grep, and PR attribution all target the
+deployed default branch (``origin/develop``, fetched first), so provenance reflects what
+shipped rather than whatever branch the local checkout is on.
+
+PR attribution is pure git, matching omni's merge-commit workflow: a commit's own subject
+rarely carries a PR ref, so for any gap we walk the ancestry path to the merge commit that
+introduced it (``Merge pull request #N from ...``) and parse that. (The GitHub
+``commits/{sha}/pulls`` REST endpoint was evaluated and returns nothing for this repo.)
+
+The landing schema is env-configurable (airflow_source in prod, --schema private_tristan for
+local dev; see ``resolve_schema``).
+
+Usage::
+
+    # prod (orchestrated, lands in airflow_source):
+    cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
+        --repo ~/Documents/0_goodparty/0_repos/omni
+    # local dev (writable schema):
+    cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
+        --repo ~/Documents/0_goodparty/0_repos/omni --schema private_tristan
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+# Instrumentation packages whose history defines when an event was added/removed.
+INSTRUMENTATION_PATHS = ["packages/gp-webapp", "packages/gp-api"]
+
+# Events came online in Amplitude ~2025-05; the EVENTS map + segment wiring landed
+# ~2025-02. Bounding the walk here skips the large pre-2024 scaffold-era diffs while
+# keeping an 8-month margin before real instrumentation. None walks full history.
+DEFAULT_SINCE = "2024-06-01"
+
+# Rows per multi-row INSERT. One round-trip per chunk; small enough to stay well under
+# any bound-parameter ceiling (chunk * ~12 cols params), large enough that the whole
+# ~400-row table writes in a couple of round-trips (minimizes warehouse-drop exposure).
+INSERT_CHUNK_ROWS = 200
+
+# Deployed default branch we attribute against. Provenance must reflect what shipped, so
+# the walk, the HEAD-presence grep, and the merge-walk all target this ref (fetched first),
+# not whatever branch the local omni checkout happens to be on.
+DEPLOY_REF = "origin/develop"
+
+DATABRICKS_CATALOG = "goodparty_data_catalog"
+TAXONOMY_TABLE = f"{DATABRICKS_CATALOG}.dbt.int__amplitude_event_taxonomy"
+
+# Landing schema is env-configurable, mirroring the airflow_source convention
+# (l2_expired_voters reads Variable `databricks_source_schema`: airflow_source in prod,
+# airflow_source_dev in dev). airflow_source is the repo's source for job-written tables and
+# is where DATA-2005 registers this as a dbt source; the state table sits beside it, like
+# l2_expired_voters + l2_expired_voters_loads. Local dev runs (whose creds can't write the
+# airflow_source* schemas) pass --schema private_tristan. The prod default is zero-config.
+DEFAULT_SOURCE_SCHEMA = "airflow_source"
+_PROVENANCE_BASENAME = "amplitude_event_provenance"
+JOB_NAME = "amplitude_event_provenance_backfill"
+
+
+def provenance_tables(schema: str, catalog: str = DATABRICKS_CATALOG) -> tuple[str, str]:
+    """``(landing_table, state_table)`` fully-qualified names for a landing schema."""
+    base = f"{catalog}.{schema}.{_PROVENANCE_BASENAME}"
+    return base, f"{base}_state"
+
+
+def resolve_schema(env: dict[str, str], override: str | None = None) -> str:
+    """Landing schema: explicit --schema, else env, else the prod default (airflow_source)."""
+    return (
+        override
+        or env.get("AMPLITUDE_PROVENANCE_SCHEMA")
+        or env.get("DBT_AIRFLOW_SOURCE_SCHEMA")
+        or DEFAULT_SOURCE_SCHEMA
+    )
+
+
+PROVENANCE_TABLE, STATE_TABLE = provenance_tables(DEFAULT_SOURCE_SCHEMA)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (self-contained; mirror the DATA-1952 monitor's git correlation)
+# --------------------------------------------------------------------------- #
+
+
+def parse_pr_number(subject: str | None) -> str | None:
+    """Pull a PR number from a commit subject, else None.
+
+    Handles both conventions: omni's dominant merge-commit form
+    ("Merge pull request #1892 from ...") and the squash suffix ("... (#1234)").
+    """
+    text = subject or ""
+    match = re.search(r"Merge pull request #(\d+)", text) or re.search(r"\(#(\d+)\)", text)
+    return match.group(1) if match else None
+
+
+def classify_code_status(present_in_head: bool | None, has_history: bool) -> str:
+    """Map (grep-at-HEAD result, whether the literal has any git history) to a status."""
+    if present_in_head is None:
+        return "unknown"  # git unavailable / errored
+    if present_in_head:
+        return "present"  # instrumentation still in the codebase
+    if has_history:
+        return "removed"  # was there, now gone -> deprecated/renamed in code
+    return "not_found_in_code"  # literal never appeared in the instrumentation paths
+
+
+# Quote-family chars dropped (not separated) when slugging, so "Can't" -> "cant".
+_QUOTE_CHARS = "'`’‘“”′″\""
+
+
+def slugify_event(name: str) -> str:
+    """Punctuation-robust key: lowercase, drop quotes/apostrophes, other non-alnum -> '_'.
+
+    Amplitude's stored ``event_type`` and the code literal sometimes differ only by an
+    apostrophe (e.g. "Click Can't See Office" vs "Click Cant See Office"); both slug to
+    the same value so downstream can join on the slug without punctuation drift. This is
+    a convenience join key alongside the verbatim ``event_type`` -- not the walk's match
+    key, which stays exact.
+    """
+    stripped = "".join(c for c in name.lower() if c not in _QUOTE_CHARS)
+    return re.sub(r"[^a-z0-9]+", "_", stripped).strip("_")
+
+
+# --------------------------------------------------------------------------- #
+# Event-literal extraction -- anchored on the known event universe
+# --------------------------------------------------------------------------- #
+
+
+def compile_event_pattern(events: Iterable[str]) -> re.Pattern[str]:
+    """Compile one alternation regex over the known event_type literals.
+
+    Sorted longest-first so a longer event name wins over a shorter one it
+    contains (regex alternation is ordered + non-overlapping left-to-right),
+    which stops a short literal from being double-counted inside a longer one.
+    """
+    ordered = sorted(set(events), key=len, reverse=True)
+    return re.compile("|".join(re.escape(e) for e in ordered))
+
+
+def find_events(text: str, pattern: re.Pattern[str]) -> set[str]:
+    """Set of known event literals appearing in ``text`` (a diff line or grep dump)."""
+    return set(pattern.findall(text))
+
+
+# --------------------------------------------------------------------------- #
+# Single-pass history walk
+# --------------------------------------------------------------------------- #
+
+# Header line emitted by: git log -p --date=short
+#   --format='%x00%H%x1f%h%x1f%ad%x1f%s'
+# A NUL marks the start of each commit; the remaining fields are 0x1f-separated.
+_HEADER_PREFIX = "\x00"
+_FIELD_SEP = "\x1f"
+_GIT_LOG_FORMAT = "--format=%x00%H%x1f%h%x1f%ad%x1f%s"
+
+Commit = dict[str, str | None]
+
+
+def _commit_from_header(line: str) -> Commit:
+    """Parse a NUL-prefixed header line into a commit dict (pr derived from subject)."""
+    full, short, cdate, subject = line[len(_HEADER_PREFIX) :].split(_FIELD_SEP, 3)
+    return {"commit": full, "short": short, "date": cdate, "subject": subject, "pr": parse_pr_number(subject)}
+
+
+def parse_git_log(lines: Iterable[str], pattern: re.Pattern[str]) -> dict[str, dict]:
+    """Single pass over a ``git log -p`` stream -> per-event provenance accumulator.
+
+    Returns ``{event_type: {'instrumented', 'retired', 'last_change'}}`` where each
+    value is a commit dict or None. Attribution is by COMMIT DATE, not stream order,
+    so it is robust to git's newest-first output and to non-monotonic dates:
+      - instrumented = earliest-dated commit that net-ADDED the literal
+      - retired      = latest-dated commit that net-REMOVED it
+      - last_change  = latest-dated commit that net-added OR net-removed it
+    Within a commit, a literal on both + and - lines (a move/reindent) nets to zero
+    and is ignored, so reformatting never looks like an add or a remove.
+    """
+    acc: dict[str, dict] = {}
+    cur: Commit | None = None
+    added: set[str] = set()
+    removed: set[str] = set()
+
+    def flush() -> None:
+        if cur is None:
+            return
+        net_added = added - removed
+        net_removed = removed - added
+        for ev in net_added:
+            _record(acc, ev, cur, "instrumented")
+        for ev in net_removed:
+            _record(acc, ev, cur, "retired")
+        for ev in net_added | net_removed:
+            _record(acc, ev, cur, "last_change")
+
+    for line in lines:
+        if line.startswith(_HEADER_PREFIX):
+            flush()
+            cur = _commit_from_header(line)
+            added, removed = set(), set()
+        elif cur is None:
+            continue
+        elif line.startswith("+") and not line.startswith("+++"):
+            added |= find_events(line[1:], pattern)
+        elif line.startswith("-") and not line.startswith("---"):
+            removed |= find_events(line[1:], pattern)
+    flush()
+    return acc
+
+
+def _record(acc: dict[str, dict], event: str, commit: Commit, slot: str) -> None:
+    """Keep the earliest commit for 'instrumented', the latest for 'retired'/'last_change'.
+
+    Dates are 'YYYY-MM-DD' strings, so lexical comparison is chronological.
+    """
+    entry = acc.setdefault(event, {"instrumented": None, "retired": None, "last_change": None})
+    current = entry[slot]
+    if current is None:
+        entry[slot] = commit
+    elif slot == "instrumented":
+        if commit["date"] < current["date"]:
+            entry[slot] = commit
+    elif commit["date"] > current["date"]:  # 'retired' / 'last_change'
+        entry[slot] = commit
+
+
+# --------------------------------------------------------------------------- #
+# Row assembly (schema shared with DATA-2005 staging and DATA-2006 incremental)
+# --------------------------------------------------------------------------- #
+
+# (column, Databricks type) in write order.
+PROVENANCE_SCHEMA = [
+    ("event_type", "STRING"),
+    ("event_type_slug", "STRING"),
+    ("instrumented_commit", "STRING"),
+    ("instrumented_pr", "STRING"),
+    ("instrumented_date", "DATE"),
+    ("retired_commit", "STRING"),
+    ("retired_pr", "STRING"),
+    ("retired_date", "DATE"),
+    ("code_status", "STRING"),
+    ("still_in_code", "BOOLEAN"),
+    ("last_code_change_date", "DATE"),
+    ("updated_at", "TIMESTAMP"),
+]
+PROVENANCE_COLUMNS = [c for c, _ in PROVENANCE_SCHEMA]
+
+
+def build_provenance_row(
+    event_type: str,
+    accum_entry: dict | None,
+    present_in_head: bool | None,
+    updated_at: str,
+) -> dict:
+    """Turn one accumulator entry + HEAD-presence into a provenance row dict.
+
+    ``accum_entry`` is None when the literal never net-changed inside the walked
+    window (either it does not exist in code, or it predates the ``--since`` bound).
+    We never guess provenance: instrumented/retired come only from observed commits.
+    ``retired_*`` is emitted only when the event is genuinely gone at HEAD.
+    """
+    instrumented = accum_entry["instrumented"] if accum_entry else None
+    retired = accum_entry["retired"] if accum_entry else None
+    last_change = accum_entry["last_change"] if accum_entry else None
+    has_history = bool(instrumented or retired or last_change)
+    code_status = classify_code_status(present_in_head, has_history)
+
+    row = {
+        "event_type": event_type,
+        "event_type_slug": slugify_event(event_type),
+        "instrumented_commit": instrumented["commit"] if instrumented else None,
+        "instrumented_pr": instrumented["pr"] if instrumented else None,
+        "instrumented_date": instrumented["date"] if instrumented else None,
+        "retired_commit": None,
+        "retired_pr": None,
+        "retired_date": None,
+        "code_status": code_status,
+        "still_in_code": present_in_head,
+        "last_code_change_date": last_change["date"] if last_change else None,
+        "updated_at": updated_at,
+    }
+    if code_status == "removed" and retired:
+        row["retired_commit"] = retired["commit"]
+        row["retired_pr"] = retired["pr"]
+        row["retired_date"] = retired["date"]
+    return row
+
+
+def collect_provenance(
+    events: Sequence[str],
+    git_log_lines: Iterable[str],
+    grep_text: str,
+    updated_at: str,
+) -> list[dict]:
+    """Full pure pipeline: walk -> HEAD presence -> one provenance row per event."""
+    pattern = compile_event_pattern(events)
+    acc = parse_git_log(git_log_lines, pattern)
+    present = present_at_head(events, grep_text)
+    return [build_provenance_row(e, acc.get(e), present.get(e), updated_at) for e in events]
+
+
+# --------------------------------------------------------------------------- #
+# PR resolution (pure): backfill *_pr gaps the squash-suffix heuristic misses
+# --------------------------------------------------------------------------- #
+
+# parse_pr_number reads a PR ref straight off a commit subject -- but the *feature* commits
+# that add/remove an event literal carry no ref; the PR number lives only on the merge commit
+# that brought them into the deployed branch. So for any commit still missing a PR we walk the
+# ancestry path to that introducing merge and parse its subject. Pure git, offline, and aligned
+# with omni's merge-commit workflow (commits/{sha}/pulls returns nothing for this repo).
+
+_PR_FIELDS = (("instrumented_commit", "instrumented_pr"), ("retired_commit", "retired_pr"))
+
+
+def _pick_introducing_merge(rev_list_output: str) -> str | None:
+    """From ``git rev-list --ancestry-path --merges <sha>..<ref>`` output, the introducing merge.
+
+    rev-list emits newest-first, so the merge that actually brought the commit into the ref
+    is the *oldest* on the ancestry path (later lines are subsequent merges on the mainline).
+    """
+    shas = rev_list_output.split()
+    return shas[-1] if shas else None
+
+
+def resolve_pr_gaps(
+    rows: Sequence[dict], resolver: Callable[[str], str | None] | None
+) -> tuple[Sequence[dict], int]:
+    """Fill null ``*_pr`` from ``resolver(sha)``; each distinct SHA resolved once.
+
+    Only touches a ``*_pr`` that is null and whose ``*_commit`` is set, so a PR already
+    found by parse_pr_number is never overwritten. ``resolver`` is None when offline (no
+    token, no gh CLI) -- a no-op, leaving whatever the subject heuristic found. Mutates the
+    rows in place and returns ``(rows, n_filled)``.
+    """
+    if resolver is None:
+        return rows, 0
+    cache: dict[str, str | None] = {}
+
+    def lookup(sha: str) -> str | None:
+        if sha not in cache:
+            cache[sha] = resolver(sha)
+        return cache[sha]
+
+    filled = 0
+    for row in rows:
+        for commit_key, pr_key in _PR_FIELDS:
+            if row.get(pr_key) is None and row.get(commit_key):
+                pr = lookup(row[commit_key])
+                if pr is not None:
+                    row[pr_key] = pr
+                    filled += 1
+    return rows, filled
+
+
+def present_at_head(events: Sequence[str], grep_text: str) -> dict[str, bool]:
+    """{event: bool} -- whether each known literal appears in a HEAD ``git grep`` dump."""
+    found = find_events(grep_text, compile_event_pattern(events))
+    return {e: e in found for e in events}
+
+
+# --------------------------------------------------------------------------- #
+# SQL builders (pure)
+# --------------------------------------------------------------------------- #
+
+
+def build_git_log_argv(
+    root: str, since: str | None, paths: Sequence[str], ref: str | None = None
+) -> list[str]:
+    """argv for the single ``git log -p`` pass over the instrumentation paths.
+
+    ``ref`` (e.g. ``origin/develop``) bounds the walk to a revision; placed before the ``--``
+    so git reads it as a rev, not a path. None walks HEAD (current checkout).
+    """
+    argv = ["git", "-C", root, "log", "-p", "--date=short", _GIT_LOG_FORMAT]
+    if since:
+        argv += ["--since", since]
+    if ref:
+        argv.append(ref)
+    return [*argv, "--", *paths]
+
+
+def build_create_table_sql(table: str, or_replace: bool = False) -> str:
+    """Typed Delta DDL for the shared provenance schema (CREATE [OR REPLACE] / IF NOT EXISTS)."""
+    cols = ",\n  ".join(f"{c} {t}" for c, t in PROVENANCE_SCHEMA)
+    verb = "CREATE OR REPLACE TABLE" if or_replace else "CREATE TABLE IF NOT EXISTS"
+    return f"{verb} {table} (\n  {cols}\n) USING DELTA"
+
+
+def build_merge_sql(target: str, staging: str, columns: Sequence[str], key: str = "event_type") -> str:
+    """Idempotent MERGE of ``staging`` into ``target`` keyed on ``key`` (UPDATE/INSERT)."""
+    non_key = [c for c in columns if c != key]
+    set_clause = ", ".join(f"t.{c} = s.{c}" for c in non_key)
+    insert_cols = ", ".join(columns)
+    insert_vals = ", ".join(f"s.{c}" for c in columns)
+    return (
+        f"MERGE INTO {target} AS t\n"
+        f"USING {staging} AS s\n"
+        f"ON t.{key} = s.{key}\n"
+        f"WHEN MATCHED THEN UPDATE SET {set_clause}\n"
+        f"WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})"
+    )
+
+
+def row_params(row: dict, columns: Sequence[str]) -> tuple:
+    """Row dict -> positional bind tuple in ``columns`` order (raw values, no escaping)."""
+    return tuple(row.get(c) for c in columns)
+
+
+def build_bulk_insert(table: str, columns: Sequence[str], rows: Sequence[dict]) -> tuple[str, list]:
+    """One multi-row parameterized INSERT + flattened (row-major) bind params.
+
+    Values are BOUND, never interpolated -- this is what makes event names with
+    apostrophes (e.g. "Click Can't See Office") store correctly. A single multi-row
+    INSERT is one network round-trip, far more robust than ``executemany`` (which
+    round-trips per row and holds the warehouse connection long enough to be dropped).
+    """
+    tuple_sql = "(" + ", ".join("?" for _ in columns) + ")"
+    sql = f"INSERT INTO {table} ({', '.join(columns)}) VALUES " + ", ".join(tuple_sql for _ in rows)
+    params = [v for row in rows for v in row_params(row, columns)]
+    return sql, params
+
+
+STATE_COLUMNS = ["job_name", "last_processed_sha", "head_ref", "commit_count", "last_run_at"]
+
+_CREATE_STATE_TABLE_SQL = (
+    "CREATE TABLE IF NOT EXISTS {table} (\n"
+    "  job_name STRING,\n"
+    "  last_processed_sha STRING,\n"
+    "  head_ref STRING,\n"
+    "  commit_count BIGINT,\n"
+    "  last_run_at TIMESTAMP\n"
+    ") USING DELTA"
+)
+
+
+def build_watermark_merge_sql(state_table: str) -> str:
+    """Parameterized single-row MERGE of the high-water mark, keyed on ``job_name``.
+
+    Five bound params, in ``STATE_COLUMNS`` order. ``commit_count`` / ``last_run_at``
+    are CAST to their column types so string/int binds land correctly.
+    """
+    return (
+        f"MERGE INTO {state_table} AS t\n"
+        f"USING (SELECT ? AS job_name, ? AS last_processed_sha, ? AS head_ref, "
+        f"CAST(? AS BIGINT) AS commit_count, CAST(? AS TIMESTAMP) AS last_run_at) AS s\n"
+        f"ON t.job_name = s.job_name\n"
+        f"WHEN MATCHED THEN UPDATE SET "
+        f"t.last_processed_sha = s.last_processed_sha, t.head_ref = s.head_ref, "
+        f"t.commit_count = s.commit_count, t.last_run_at = s.last_run_at\n"
+        f"WHEN NOT MATCHED THEN INSERT "
+        f"(job_name, last_processed_sha, head_ref, commit_count, last_run_at) "
+        f"VALUES (s.job_name, s.last_processed_sha, s.head_ref, s.commit_count, s.last_run_at)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Git IO (thin subprocess wrappers; injectable for tests)
+# --------------------------------------------------------------------------- #
+
+
+def run_git_log(root: str, since: str | None, paths: Sequence[str], ref: str | None = None) -> Iterator[str]:
+    """Stream the single ``git log -p`` pass line-by-line (the diff stream is large)."""
+    argv = build_git_log_argv(root, since, paths, ref)
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, text=True)
+    assert proc.stdout is not None
+    try:
+        yield from (line.rstrip("\n") for line in proc.stdout)
+    finally:
+        proc.stdout.close()
+        proc.wait()
+
+
+def git_grep_present_text(root: str, events: Sequence[str], paths: Sequence[str], ref: str = "HEAD") -> str:
+    """Dump of ``ref`` lines containing any known literal, via one fixed-string git grep.
+
+    ``-F`` treats each event as a literal; ``-h`` drops filenames. git grep exits 1
+    when nothing matches (an empty dump), which is not an error here.
+    """
+    patterns: list[str] = []
+    for e in events:
+        patterns += ["-e", e]
+    argv = ["git", "-C", root, "grep", "-F", "-h", "--no-color", *patterns, ref, "--", *paths]
+    proc = subprocess.run(argv, capture_output=True, text=True)
+    return proc.stdout
+
+
+def git_head_sha(root: str, ref: str = "HEAD") -> str:
+    return subprocess.run(
+        ["git", "-C", root, "rev-parse", ref], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def git_head_ref(root: str, ref: str | None = None) -> str:
+    """The ref name to record as the watermark's branch: the deploy ref, else current HEAD."""
+    if ref:
+        return ref
+    return subprocess.run(
+        ["git", "-C", root, "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def git_commit_count(root: str, since: str | None, paths: Sequence[str], ref: str = "HEAD") -> int:
+    argv = ["git", "-C", root, "rev-list", "--count", ref]
+    if since:
+        argv += ["--since", since]
+    out = subprocess.run([*argv, "--", *paths], capture_output=True, text=True, check=True).stdout
+    return int(out.strip() or "0")
+
+
+def git_fetch(root: str, ref: str) -> None:
+    """Update the deploy ref from its remote (``origin/develop`` -> ``git fetch origin develop``)."""
+    remote, _, branch = ref.partition("/")
+    argv = ["git", "-C", root, "fetch", "--quiet", remote]
+    if branch:
+        argv.append(branch)
+    subprocess.run(argv, capture_output=True, text=True)
+
+
+# --------------------------------------------------------------------------- #
+# Git PR resolution IO (merge-walk; no network, matches omni's merge-commit flow)
+# --------------------------------------------------------------------------- #
+
+
+def git_merge_pr(root: str, sha: str, deploy_ref: str) -> str | None:
+    """PR number for the merge commit that introduced ``sha`` into ``deploy_ref``, else None.
+
+    Walks the ancestry path from the commit to the deploy ref, takes the introducing merge,
+    and parses its subject. None when the commit reached the ref without a merge (e.g. a
+    direct push) or is not an ancestor of the ref.
+    """
+    rev_list = subprocess.run(
+        ["git", "-C", root, "rev-list", "--ancestry-path", "--merges", f"{sha}..{deploy_ref}"],
+        capture_output=True,
+        text=True,
+    )
+    if rev_list.returncode != 0:
+        return None
+    merge_sha = _pick_introducing_merge(rev_list.stdout)
+    if not merge_sha:
+        return None
+    subject = subprocess.run(
+        ["git", "-C", root, "log", "-1", "--format=%s", merge_sha], capture_output=True, text=True
+    ).stdout
+    return parse_pr_number(subject)
+
+
+def make_merge_walk_resolver(root: str, deploy_ref: str) -> Callable[[str], str | None]:
+    """A ``sha -> PR`` resolver bound to a checkout + deploy ref, for ``resolve_pr_gaps``."""
+    return lambda sha: git_merge_pr(root, sha, deploy_ref)
+
+
+# --------------------------------------------------------------------------- #
+# Databricks IO (cursor is injected -- a DB-API cursor from databricks_conn)
+# --------------------------------------------------------------------------- #
+
+
+def _missing_columns(existing: set[str], schema: Sequence[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Schema entries whose column is absent from ``existing`` (order preserved)."""
+    return [(c, t) for c, t in schema if c not in existing]
+
+
+def _ensure_columns(cursor: Any, table: str, schema: Sequence[tuple[str, str]]) -> None:
+    """Add any schema columns missing from an existing table (Delta schema evolution).
+
+    Needed because ``CREATE TABLE IF NOT EXISTS`` will not evolve a table that already
+    exists with an older schema -- e.g. when this shared table predates ``event_type_slug``.
+    """
+    cursor.execute(f"DESCRIBE TABLE {table}")
+    existing: set[str] = set()
+    for row in cursor.fetchall():
+        name = row[0]
+        if not name or name.startswith("#"):  # partition / detail section -> stop
+            break
+        existing.add(name)
+    missing = _missing_columns(existing, schema)
+    if missing:
+        adds = ", ".join(f"{c} {t}" for c, t in missing)
+        cursor.execute(f"ALTER TABLE {table} ADD COLUMNS ({adds})")
+
+
+def fetch_event_universe(cursor: Any, taxonomy_table: str = TAXONOMY_TABLE) -> list[str]:
+    """The authoritative ~408 distinct event_type values to attribute provenance for."""
+    cursor.execute(
+        f"SELECT DISTINCT event_type FROM {taxonomy_table} "
+        f"WHERE event_type IS NOT NULL ORDER BY event_type"
+    )
+    return [str(r[0]) for r in cursor.fetchall()]
+
+
+def write_provenance(cursor: Any, rows: Sequence[dict], table: str = PROVENANCE_TABLE) -> None:
+    """Create the table if needed and MERGE rows in via a staging table (idempotent).
+
+    Rows are bound via ``executemany`` -- no inline SQL -- so apostrophes/quotes in
+    event names survive intact.
+    """
+    staging = f"{table}__stage"
+    cursor.execute(build_create_table_sql(table))
+    _ensure_columns(cursor, table, PROVENANCE_SCHEMA)  # evolve a pre-existing older table
+    cursor.execute(build_create_table_sql(staging, or_replace=True))
+    for i in range(0, len(rows), INSERT_CHUNK_ROWS):
+        chunk = rows[i : i + INSERT_CHUNK_ROWS]
+        cursor.execute(*build_bulk_insert(staging, PROVENANCE_COLUMNS, chunk))
+    cursor.execute(build_merge_sql(table, staging, PROVENANCE_COLUMNS))
+    cursor.execute(f"DROP TABLE IF EXISTS {staging}")
+
+
+def write_watermark(
+    cursor: Any,
+    last_processed_sha: str,
+    head_ref: str,
+    commit_count: int,
+    last_run_at: str,
+    state_table: str = STATE_TABLE,
+) -> None:
+    """Upsert the SHA high-water mark so DATA-2006 can resume with git log <sha>..HEAD."""
+    cursor.execute(_CREATE_STATE_TABLE_SQL.format(table=state_table))
+    cursor.execute(
+        build_watermark_merge_sql(state_table),
+        (JOB_NAME, last_processed_sha, head_ref, commit_count, last_run_at),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def resolve_omni_repo(arg: str | None, env: dict[str, str]) -> str:
+    """The omni checkout to walk: --repo, else $OMNI_REPO. Must be an existing dir."""
+    root = arg or env.get("OMNI_REPO")
+    if not root:
+        raise SystemExit("ERROR: pass --repo or set OMNI_REPO to an omni checkout path.")
+    root = os.path.expanduser(root)
+    if not os.path.isdir(os.path.join(root, ".git")) and not os.path.exists(os.path.join(root, ".git")):
+        raise SystemExit(f"ERROR: {root} is not a git checkout (no .git).")
+    return root
+
+
+def run_backfill(
+    cursor: Any,
+    root: str,
+    since: str | None,
+    now: datetime,
+    table: str = PROVENANCE_TABLE,
+    state_table: str = STATE_TABLE,
+    ref: str = DEPLOY_REF,
+    pr_resolver: Callable[[str], str | None] | None = None,
+) -> list[dict]:
+    """Fetch the universe, walk git once, write the table + watermark. Returns the rows."""
+    updated_at = now.replace(tzinfo=None).isoformat(timespec="seconds")
+    events = fetch_event_universe(cursor)
+    print(f"Event universe: {len(events)} event_types", file=sys.stderr)
+
+    print(
+        f"Walking git log -p {ref} {' '.join(INSTRUMENTATION_PATHS)} (since {since or 'all history'}) ...",
+        file=sys.stderr,
+    )
+    lines = run_git_log(root, since, INSTRUMENTATION_PATHS, ref)
+    grep_text = git_grep_present_text(root, events, INSTRUMENTATION_PATHS, ref)
+    # parse_git_log consumes the stream; collect_provenance needs both, so materialize
+    # the (small) grep dump first and stream the (large) log into collect_provenance.
+    rows = collect_provenance(events, lines, grep_text, updated_at)
+
+    _, filled = resolve_pr_gaps(rows, pr_resolver)  # mutates rows in place
+    if pr_resolver is not None:
+        print(f"Merge-walk PR backfill: filled {filled} *_pr gaps", file=sys.stderr)
+
+    write_provenance(cursor, rows, table)
+    write_watermark(
+        cursor,
+        git_head_sha(root, ref),
+        git_head_ref(root, ref),
+        git_commit_count(root, since, INSTRUMENTATION_PATHS, ref),
+        updated_at,
+        state_table,
+    )
+    return rows
+
+
+def _summarize(rows: Sequence[dict]) -> str:
+    by_status: dict[str, int] = {}
+    for r in rows:
+        by_status[r["code_status"]] = by_status.get(r["code_status"], 0) + 1
+    parts = ", ".join(f"{k}={v}" for k, v in sorted(by_status.items()))
+    return f"{len(rows)} rows ({parts})"
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--repo", default=None, help="Path to an omni checkout (else $OMNI_REPO).")
+    p.add_argument(
+        "--since",
+        default=DEFAULT_SINCE,
+        help=f"Lower-bound git history (default {DEFAULT_SINCE}). 'all' walks full history.",
+    )
+    p.add_argument(
+        "--schema",
+        default=None,
+        help=(
+            f"Landing schema (default: $AMPLITUDE_PROVENANCE_SCHEMA / $DBT_AIRFLOW_SOURCE_SCHEMA "
+            f"/ {DEFAULT_SOURCE_SCHEMA}). Use --schema private_tristan for local dev."
+        ),
+    )
+    p.add_argument("--table", default=None, help="Full landing table name; overrides --schema.")
+    p.add_argument("--state-table", default=None, help="Full state table name; overrides --schema.")
+    p.add_argument(
+        "--ref",
+        default=DEPLOY_REF,
+        help=f"Deploy ref to attribute against (default {DEPLOY_REF}).",
+    )
+    p.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Skip the git fetch of the deploy ref (use the local checkout's current ref state).",
+    )
+    p.add_argument(
+        "--no-pr-resolve",
+        action="store_true",
+        help="Skip the merge-walk PR backfill; *_pr stays whatever the commit subject yielded.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    root = resolve_omni_repo(args.repo, dict(os.environ))
+    since = None if args.since == "all" else args.since
+
+    schema = resolve_schema(dict(os.environ), args.schema)
+    default_table, default_state = provenance_tables(schema)
+    table = args.table or default_table
+    state_table = args.state_table or default_state
+    print(f"Landing schema: {schema} -> {table}", file=sys.stderr)
+
+    if not args.no_fetch:
+        print(f"Fetching {args.ref} ...", file=sys.stderr)
+        git_fetch(root, args.ref)
+    pr_resolver = None if args.no_pr_resolve else make_merge_walk_resolver(root, args.ref)
+
+    from databricks_conn import get_connection  # lazy: pure logic imports without pandas/SDK
+
+    connection = get_connection()
+    try:
+        with connection.cursor() as cursor:
+            rows = run_backfill(
+                cursor,
+                root,
+                since,
+                datetime.now(UTC),
+                table=table,
+                state_table=state_table,
+                ref=args.ref,
+                pr_resolver=pr_resolver,
+            )
+    finally:
+        connection.close()
+    print(_summarize(rows), file=sys.stderr)
+    print(f"Wrote {table} and watermark {state_table}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -866,7 +866,7 @@ def run_refresh(
         cursor,
         git_head_sha(root, ref),
         git_head_ref(root, ref),
-        git_commit_count(root, None, INSTRUMENTATION_PATHS, ref),
+        git_commit_count(root, None, INSTRUMENTATION_PATHS, ref),  # total count at ref tip, not incremental
         updated_at,
         state_table,
     )

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -692,23 +692,30 @@ def run_refresh(
     root: str,
     since: str | None,
     now: datetime,
-    table: str = "",
-    state_table: str = "",
+    csv_path: str = DEFAULT_CSV_PATH,
+    state_path: str = DEFAULT_STATE_PATH,
     ref: str = DEPLOY_REF,
     pr_resolver: Callable[[str], str | None] | None = None,
 ) -> list[dict]:
     """Incremental refresh bounded by the SHA watermark; full backfill when there is none.
 
-    ``since`` is used only on the no-watermark fallback path. On the incremental path the
-    ``<last_sha>..ref`` range supersedes any date bound. Always advances the watermark so
-    the next run resumes from HEAD; only MERGEs provenance rows for events that changed.
+    Reads the whole CSV, replaces only the events that changed in the window (giving them a
+    fresh updated_at), carries every other row forward verbatim, and rewrites the full sorted
+    CSV. Always advances the watermark file so the next run resumes from HEAD.
     """
     updated_at = now.replace(tzinfo=None).isoformat(timespec="seconds")
-    watermark = read_watermark(cursor, state_table)
+    watermark = read_watermark(state_path)
     if watermark is None:
         print("No watermark found -> full backfill", file=sys.stderr)
         return run_backfill(
-            cursor, root, since, now, table=table, state_table=state_table, ref=ref, pr_resolver=pr_resolver
+            cursor,
+            root,
+            since,
+            now,
+            csv_path=csv_path,
+            state_path=state_path,
+            ref=ref,
+            pr_resolver=pr_resolver,
         )
 
     last_sha = watermark["last_processed_sha"]
@@ -721,26 +728,28 @@ def run_refresh(
     affected = sorted(acc.keys())
     print(f"Affected events in window: {len(affected)}", file=sys.stderr)
 
-    rows: list[dict] = []
+    existing = read_provenance_rows(csv_path)
     if affected:
-        existing = read_provenance_rows(cursor, table)
         grep_text = git_grep_present_text(root, affected, INSTRUMENTATION_PATHS, ref)
         present = present_at_head(affected, grep_text)
+        updated_rows: list[dict] = []
         for ev in affected:
             merged = merge_provenance_entry(existing.get(ev), acc[ev])
-            rows.append(build_provenance_row(ev, merged, present.get(ev), updated_at))
-        _, filled = resolve_pr_gaps(rows, pr_resolver)
+            updated_rows.append(build_provenance_row(ev, merged, present.get(ev), updated_at))
+        _, filled = resolve_pr_gaps(updated_rows, pr_resolver)
         if pr_resolver is not None:
             print(f"Merge-walk PR backfill: filled {filled} *_pr gaps", file=sys.stderr)
-        write_provenance(cursor, rows, table)
+        for row in updated_rows:
+            existing[row["event_type"]] = row
 
+    rows = list(existing.values())
+    write_provenance(rows, csv_path)
     write_watermark(
-        cursor,
+        state_path,
         git_head_sha(root, ref),
         git_head_ref(root, ref),
-        git_commit_count(root, None, INSTRUMENTATION_PATHS, ref),  # total count at ref tip, not incremental
+        git_commit_count(root, None, INSTRUMENTATION_PATHS, ref),
         updated_at,
-        state_table,
     )
     return rows
 

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -811,6 +811,64 @@ def run_backfill(
     return rows
 
 
+def run_refresh(
+    cursor: Any,
+    root: str,
+    since: str | None,
+    now: datetime,
+    table: str = PROVENANCE_TABLE,
+    state_table: str = STATE_TABLE,
+    ref: str = DEPLOY_REF,
+    pr_resolver: Callable[[str], str | None] | None = None,
+) -> list[dict]:
+    """Incremental refresh bounded by the SHA watermark; full backfill when there is none.
+
+    ``since`` is used only on the no-watermark fallback path. On the incremental path the
+    ``<last_sha>..ref`` range supersedes any date bound. Always advances the watermark so
+    the next run resumes from HEAD; only MERGEs provenance rows for events that changed.
+    """
+    updated_at = now.replace(tzinfo=None).isoformat(timespec="seconds")
+    watermark = read_watermark(cursor, state_table)
+    if watermark is None:
+        print("No watermark found -> full backfill", file=sys.stderr)
+        return run_backfill(
+            cursor, root, since, now, table=table, state_table=state_table, ref=ref, pr_resolver=pr_resolver
+        )
+
+    last_sha = watermark["last_processed_sha"]
+    events = fetch_event_universe(cursor)
+    range_ref = f"{last_sha}..{ref}"
+    print(f"Refresh: walking git log -p {range_ref} {' '.join(INSTRUMENTATION_PATHS)} ...", file=sys.stderr)
+
+    lines = run_git_log(root, None, INSTRUMENTATION_PATHS, range_ref)
+    acc = parse_git_log(lines, compile_event_pattern(events))
+    affected = sorted(acc.keys())
+    print(f"Affected events in window: {len(affected)}", file=sys.stderr)
+
+    rows: list[dict] = []
+    if affected:
+        existing = read_provenance_rows(cursor, table)
+        grep_text = git_grep_present_text(root, affected, INSTRUMENTATION_PATHS, ref)
+        present = present_at_head(affected, grep_text)
+        for ev in affected:
+            merged = merge_provenance_entry(existing.get(ev), acc[ev])
+            rows.append(build_provenance_row(ev, merged, present.get(ev), updated_at))
+        _, filled = resolve_pr_gaps(rows, pr_resolver)
+        if pr_resolver is not None:
+            print(f"Merge-walk PR backfill: filled {filled} *_pr gaps", file=sys.stderr)
+        write_provenance(cursor, rows, table)
+
+    write_watermark(
+        cursor,
+        git_head_sha(root, ref),
+        git_head_ref(root, ref),
+        git_commit_count(root, None, INSTRUMENTATION_PATHS, ref),
+        updated_at,
+        state_table,
+    )
+    return rows
+
+
 def _summarize(rows: Sequence[dict]) -> str:
     by_status: dict[str, int] = {}
     for r in rows:

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -683,6 +683,16 @@ def fetch_event_universe(cursor: Any, taxonomy_table: str = TAXONOMY_TABLE) -> l
     return [str(r[0]) for r in cursor.fetchall()]
 
 
+def read_provenance_rows(cursor: Any, table: str = PROVENANCE_TABLE) -> dict[str, dict]:
+    """Existing provenance rows keyed by ``event_type`` (the table is ~400 rows).
+
+    Read whole rather than filtered: the table is tiny, so a single SELECT is simpler
+    and cheaper than binding an IN-list of affected events.
+    """
+    cursor.execute(f"SELECT {', '.join(PROVENANCE_COLUMNS)} FROM {table}")
+    return {row[0]: dict(zip(PROVENANCE_COLUMNS, row, strict=False)) for row in cursor.fetchall()}
+
+
 def write_provenance(cursor: Any, rows: Sequence[dict], table: str = PROVENANCE_TABLE) -> None:
     """Create the table if needed and MERGE rows in via a staging table (idempotent).
 

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -1,51 +1,29 @@
-"""One-time backfill: build the initial git-provenance table for Amplitude events (DATA-2007).
+"""Build and maintain the git-provenance dataset for Amplitude events (DATA-2014).
 
-Walks the omni git history ONCE over the instrumentation paths and writes one
-provenance row per Amplitude ``event_type`` to a Databricks landing table via an
-idempotent MERGE, plus a commit-SHA watermark so DATA-2006's incremental updater
-can resume with ``git log <lastSHA>..HEAD``.
+Walks the omni git history over the instrumentation paths and writes one provenance row per
+Amplitude ``event_type`` to a CSV committed in this repo
+(``analytics/data/amplitude_event_provenance.csv``), plus a sidecar JSON watermark
+(``..._state.json``) recording the last processed commit SHA. With no watermark it does a full
+backfill; with one it walks ``git log <lastSHA>..origin/develop``, updates only the events that
+changed, carries the rest forward, and advances the watermark.
 
-DATA-2007 shipped the one-time backfill; DATA-2014 adds the watermark-bounded ``--refresh``
-path (read the SHA watermark, walk ``git log <lastSHA>..origin/develop``, MERGE only affected
-events, advance the watermark; full backfill when no watermark exists). Neither writes back to
-Amplitude. DATA-2005 builds ``stg__amplitude_event_provenance`` over the table this produces.
+It READS the omni working tree's git history (``--repo`` / ``OMNI_REPO``) and the Amplitude
+Govern event universe from Databricks (``airbyte_source.amplitude_taxonomy_event_type``, the one
+Databricks read), and WRITES the CSV + JSON into this repo. It never writes back to Amplitude.
 
-Cross-repo by nature: it READS the omni working tree's git history (``--repo`` /
-``OMNI_REPO``) and WRITES this repo's Databricks data layer (via the analytics
-``databricks_conn`` profile auth -- no PAT).
-
-Extraction note: ``trackEvent(...)`` in omni is called with *constant references*
-(``trackEvent(EVENTS.ServeOnboarding.SwornInCompleted)``), not string literals. The
-event-type strings live as VALUES in the ``EVENTS`` map
-(packages/gp-webapp/helpers/analyticsHelper.ts) and a few gp-api type/string files.
-So we do not parse ``trackEvent('...')``; instead we anchor on the authoritative event
-universe (``airbyte_source.amplitude_taxonomy_event_type``, ~434 events synced directly
-from Amplitude Govern) and match those literals against added/removed diff lines in a
-single ``git log -p`` pass.
-
-Deploy-ref anchored: the walk, the HEAD-presence grep, and PR attribution all target the
-deployed default branch (``origin/develop``, fetched first), so provenance reflects what
-shipped rather than whatever branch the local checkout is on.
-
-PR attribution is pure git, matching omni's merge-commit workflow: a commit's own subject
-rarely carries a PR ref, so for any gap we walk the ancestry path to the merge commit that
-introduced it (``Merge pull request #N from ...``) and parse that. (The GitHub
-``commits/{sha}/pulls`` REST endpoint was evaluated and returns nothing for this repo.)
-
-The landing schema is env-configurable (airflow_source in prod, --schema private_tristan for
-local dev; see ``resolve_schema``).
+Extraction note: ``trackEvent(...)`` in omni is called with *constant references*, so we anchor
+on the authoritative event universe and match those literals against added/removed diff lines in
+a single ``git log -p`` pass. Deploy-ref anchored (``origin/develop``, fetched first). PR
+attribution is pure git via the merge-commit ancestry walk.
 
 Usage::
 
-    # prod (orchestrated, lands in airflow_source):
+    # incremental refresh (full backfill on first run, when no state file exists):
     cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
         --repo ~/Documents/0_goodparty/0_repos/omni
-    # local dev (writable schema):
+    # custom output locations (e.g. for a dry run):
     cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
-        --repo ~/Documents/0_goodparty/0_repos/omni --schema private_tristan
-    # scheduled refresh (incremental; full backfill on first run):
-    cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \\
-        --repo ~/Documents/0_goodparty/0_repos/omni --refresh
+        --repo ~/Documents/0_goodparty/0_repos/omni --csv /tmp/prov.csv --state /tmp/state.json
 """
 
 from __future__ import annotations
@@ -755,9 +733,15 @@ def run_refresh(
 
 
 def _summarize(rows: Sequence[dict]) -> str:
-    instrumented = sum(1 for r in rows if r.get("instrumented_commit"))
-    retired = sum(1 for r in rows if r.get("retired_commit"))
-    return f"{len(rows)} rows (instrumented={instrumented}, retired={retired})"
+    present = removed = not_found = 0
+    for r in rows:
+        if r.get("instrumented_date") is None:
+            not_found += 1
+        elif r.get("retired_date") is None:
+            present += 1
+        else:
+            removed += 1
+    return f"{len(rows)} rows (present={present}, removed={removed}, not_found_in_code={not_found})"
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -768,14 +752,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         default=DEFAULT_SINCE,
         help=f"Lower-bound git history (default {DEFAULT_SINCE}). 'all' walks full history.",
     )
-    p.add_argument("--table", default=None, help="Full landing table name (deprecated; write goes to CSV).")
     p.add_argument(
-        "--state-table", default=None, help="Full state table name (deprecated; state goes to JSON)."
+        "--csv", default=DEFAULT_CSV_PATH, help="Output provenance CSV (default analytics/data/...)."
     )
     p.add_argument(
-        "--ref",
-        default=DEPLOY_REF,
-        help=f"Deploy ref to attribute against (default {DEPLOY_REF}).",
+        "--state", default=DEFAULT_STATE_PATH, help="Watermark JSON sidecar (default analytics/data/...)."
+    )
+    p.add_argument(
+        "--ref", default=DEPLOY_REF, help=f"Deploy ref to attribute against (default {DEPLOY_REF})."
     )
     p.add_argument(
         "--no-fetch",
@@ -787,11 +771,6 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         action="store_true",
         help="Skip the merge-walk PR backfill; *_pr stays whatever the commit subject yielded.",
     )
-    p.add_argument(
-        "--refresh",
-        action="store_true",
-        help="Incremental watermark-bounded refresh (full backfill if no watermark exists).",
-    )
     return p.parse_args(argv)
 
 
@@ -799,6 +778,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parse_args(argv if argv is not None else sys.argv[1:])
     root = resolve_omni_repo(args.repo, dict(os.environ))
     since = None if args.since == "all" else args.since
+    print(f"Provenance CSV: {args.csv}", file=sys.stderr)
 
     if not args.no_fetch:
         print(f"Fetching {args.ref} ...", file=sys.stderr)
@@ -810,19 +790,20 @@ def main(argv: Sequence[str] | None = None) -> None:
     connection = get_connection()
     try:
         with connection.cursor() as cursor:
-            runner = run_refresh if args.refresh else run_backfill
-            rows = runner(
+            rows = run_refresh(
                 cursor,
                 root,
                 since,
                 datetime.now(UTC),
+                csv_path=args.csv,
+                state_path=args.state,
                 ref=args.ref,
                 pr_resolver=pr_resolver,
             )
     finally:
         connection.close()
     print(_summarize(rows), file=sys.stderr)
-    print(f"Wrote provenance to {DEFAULT_CSV_PATH}", file=sys.stderr)
+    print(f"Wrote {args.csv} and watermark {args.state}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
 import re
 import subprocess
@@ -436,39 +437,6 @@ def build_git_log_argv(
     return [*argv, "--", *paths]
 
 
-STATE_COLUMNS = ["job_name", "last_processed_sha", "head_ref", "commit_count", "last_run_at"]
-
-_CREATE_STATE_TABLE_SQL = (
-    "CREATE TABLE IF NOT EXISTS {table} (\n"
-    "  job_name STRING,\n"
-    "  last_processed_sha STRING,\n"
-    "  head_ref STRING,\n"
-    "  commit_count BIGINT,\n"
-    "  last_run_at TIMESTAMP\n"
-    ") USING DELTA"
-)
-
-
-def build_watermark_merge_sql(state_table: str) -> str:
-    """Parameterized single-row MERGE of the high-water mark, keyed on ``job_name``.
-
-    Five bound params, in ``STATE_COLUMNS`` order. ``commit_count`` / ``last_run_at``
-    are CAST to their column types so string/int binds land correctly.
-    """
-    return (
-        f"MERGE INTO {state_table} AS t\n"
-        f"USING (SELECT ? AS job_name, ? AS last_processed_sha, ? AS head_ref, "
-        f"CAST(? AS BIGINT) AS commit_count, CAST(? AS TIMESTAMP) AS last_run_at) AS s\n"
-        f"ON t.job_name = s.job_name\n"
-        f"WHEN MATCHED THEN UPDATE SET "
-        f"t.last_processed_sha = s.last_processed_sha, t.head_ref = s.head_ref, "
-        f"t.commit_count = s.commit_count, t.last_run_at = s.last_run_at\n"
-        f"WHEN NOT MATCHED THEN INSERT "
-        f"(job_name, last_processed_sha, head_ref, commit_count, last_run_at) "
-        f"VALUES (s.job_name, s.last_processed_sha, s.head_ref, s.commit_count, s.last_run_at)"
-    )
-
-
 # --------------------------------------------------------------------------- #
 # Git IO (thin subprocess wrappers; injectable for tests)
 # --------------------------------------------------------------------------- #
@@ -632,46 +600,36 @@ def read_provenance_rows(csv_path: str = DEFAULT_CSV_PATH) -> dict[str, dict]:
 
 
 def write_watermark(
-    cursor: Any,
+    state_path: str,
     last_processed_sha: str,
     head_ref: str,
     commit_count: int,
     last_run_at: str,
-    state_table: str = "",
 ) -> None:
-    """Upsert the SHA high-water mark so DATA-2006 can resume with git log <sha>..HEAD."""
-    cursor.execute(_CREATE_STATE_TABLE_SQL.format(table=state_table))
-    cursor.execute(
-        build_watermark_merge_sql(state_table),
-        (JOB_NAME, last_processed_sha, head_ref, commit_count, last_run_at),
-    )
-
-
-def read_watermark(
-    cursor: Any,
-    state_table: str = "",
-    job_name: str = JOB_NAME,
-) -> dict | None:
-    """Read the SHA high-water mark for ``job_name``; None when there is no row yet.
-
-    Creates the state table if absent (idempotent, mirroring ``write_watermark``), so a
-    first run reads an empty table and gets None -> the caller does a full backfill.
-    """
-    cursor.execute(_CREATE_STATE_TABLE_SQL.format(table=state_table))
-    cursor.execute(
-        f"SELECT last_processed_sha, head_ref, commit_count, last_run_at "
-        f"FROM {state_table} WHERE job_name = ?",
-        (job_name,),
-    )
-    rows = cursor.fetchall()
-    if not rows:
-        return None
-    sha, head_ref, commit_count, last_run_at = rows[0]
-    return {
-        "last_processed_sha": sha,
+    """Write the SHA high-water mark to a sidecar JSON so the next run resumes from it."""
+    path = Path(state_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "job_name": JOB_NAME,
+        "last_processed_sha": last_processed_sha,
         "head_ref": head_ref,
         "commit_count": commit_count,
         "last_run_at": last_run_at,
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def read_watermark(state_path: str = DEFAULT_STATE_PATH) -> dict | None:
+    """Read the SHA high-water mark; None when the file is absent (first run -> backfill)."""
+    path = Path(state_path)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "last_processed_sha": data["last_processed_sha"],
+        "head_ref": data["head_ref"],
+        "commit_count": data["commit_count"],
+        "last_run_at": data["last_run_at"],
     }
 
 

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -51,12 +51,14 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import csv
 import os
 import re
 import subprocess
 import sys
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 # Instrumentation packages whose history defines when an event was added/removed.
@@ -67,11 +69,6 @@ INSTRUMENTATION_PATHS = ["packages/gp-webapp", "packages/gp-api"]
 # keeping an 8-month margin before real instrumentation. None walks full history.
 DEFAULT_SINCE = "2024-06-01"
 
-# Rows per multi-row INSERT. One round-trip per chunk; small enough to stay well under
-# any bound-parameter ceiling (chunk * ~12 cols params), large enough that the whole
-# ~400-row table writes in a couple of round-trips (minimizes warehouse-drop exposure).
-INSERT_CHUNK_ROWS = 200
-
 # Deployed default branch we attribute against. Provenance must reflect what shipped, so
 # the walk, the HEAD-presence grep, and the merge-walk all target this ref (fetched first),
 # not whatever branch the local omni checkout happens to be on.
@@ -79,38 +76,16 @@ DEPLOY_REF = "origin/develop"
 
 DATABRICKS_CATALOG = "goodparty_data_catalog"
 # Event universe: Amplitude Govern taxonomy synced directly via Airbyte (~434 events, all
-# is_active). Replaced dbt.int__amplitude_event_taxonomy as the anchor on 2026-06-22 -- the
-# Airbyte feed is the first-party source of truth (int__ is being rebuilt to source from it).
+# is_active). The one Databricks read this pipeline still makes.
 TAXONOMY_TABLE = f"{DATABRICKS_CATALOG}.airbyte_source.amplitude_taxonomy_event_type"
 
-# Landing schema is env-configurable, mirroring the airflow_source convention
-# (l2_expired_voters reads Variable `databricks_source_schema`: airflow_source in prod,
-# airflow_source_dev in dev). airflow_source is the repo's source for job-written tables and
-# is where DATA-2005 registers this as a dbt source; the state table sits beside it, like
-# l2_expired_voters + l2_expired_voters_loads. Local dev runs (whose creds can't write the
-# airflow_source* schemas) pass --schema private_tristan. The prod default is zero-config.
-DEFAULT_SOURCE_SCHEMA = "airflow_source"
-_PROVENANCE_BASENAME = "amplitude_event_provenance"
 JOB_NAME = "amplitude_event_provenance_backfill"
 
-
-def provenance_tables(schema: str, catalog: str = DATABRICKS_CATALOG) -> tuple[str, str]:
-    """``(landing_table, state_table)`` fully-qualified names for a landing schema."""
-    base = f"{catalog}.{schema}.{_PROVENANCE_BASENAME}"
-    return base, f"{base}_state"
-
-
-def resolve_schema(env: dict[str, str], override: str | None = None) -> str:
-    """Landing schema: explicit --schema, else env, else the prod default (airflow_source)."""
-    return (
-        override
-        or env.get("AMPLITUDE_PROVENANCE_SCHEMA")
-        or env.get("DBT_AIRFLOW_SOURCE_SCHEMA")
-        or DEFAULT_SOURCE_SCHEMA
-    )
-
-
-PROVENANCE_TABLE, STATE_TABLE = provenance_tables(DEFAULT_SOURCE_SCHEMA)
+# Committed outputs. Resolved from this file so paths are cwd-independent:
+# analytics/lib/<this file> -> analytics/data/.
+_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+DEFAULT_CSV_PATH = str(_DATA_DIR / "amplitude_event_provenance.csv")
+DEFAULT_STATE_PATH = str(_DATA_DIR / "amplitude_event_provenance_state.json")
 
 
 # --------------------------------------------------------------------------- #
@@ -272,22 +247,21 @@ def _record(acc: dict[str, dict], event: str, commit: Commit, slot: str) -> None
 # Row assembly (schema shared with DATA-2005 staging and DATA-2006 incremental)
 # --------------------------------------------------------------------------- #
 
-# (column, Databricks type) in write order.
-PROVENANCE_SCHEMA = [
-    ("event_type", "STRING"),
-    ("event_type_slug", "STRING"),
-    ("instrumented_commit", "STRING"),
-    ("instrumented_pr", "STRING"),
-    ("instrumented_date", "DATE"),
-    ("retired_commit", "STRING"),
-    ("retired_pr", "STRING"),
-    ("retired_date", "DATE"),
-    ("code_status", "STRING"),
-    ("still_in_code", "BOOLEAN"),
-    ("last_code_change_date", "DATE"),
-    ("updated_at", "TIMESTAMP"),
+# Output columns in write order. code_status / still_in_code dropped: both are derivable
+# from the date null-pattern (present = instrumented set + retired null; removed = both set;
+# not_found_in_code = instrumented null), so consumers derive them at read time.
+PROVENANCE_COLUMNS = [
+    "event_type",
+    "event_type_slug",
+    "instrumented_commit",
+    "instrumented_pr",
+    "instrumented_date",
+    "retired_commit",
+    "retired_pr",
+    "retired_date",
+    "last_code_change_date",
+    "updated_at",
 ]
-PROVENANCE_COLUMNS = [c for c, _ in PROVENANCE_SCHEMA]
 
 
 def build_provenance_row(
@@ -318,8 +292,6 @@ def build_provenance_row(
         "retired_commit": None,
         "retired_pr": None,
         "retired_date": None,
-        "code_status": code_status,
-        "still_in_code": present_in_head,
         "last_code_change_date": last_change["date"] if last_change else None,
         "updated_at": updated_at,
     }
@@ -462,47 +434,6 @@ def build_git_log_argv(
     if ref:
         argv.append(ref)
     return [*argv, "--", *paths]
-
-
-def build_create_table_sql(table: str, or_replace: bool = False) -> str:
-    """Typed Delta DDL for the shared provenance schema (CREATE [OR REPLACE] / IF NOT EXISTS)."""
-    cols = ",\n  ".join(f"{c} {t}" for c, t in PROVENANCE_SCHEMA)
-    verb = "CREATE OR REPLACE TABLE" if or_replace else "CREATE TABLE IF NOT EXISTS"
-    return f"{verb} {table} (\n  {cols}\n) USING DELTA"
-
-
-def build_merge_sql(target: str, staging: str, columns: Sequence[str], key: str = "event_type") -> str:
-    """Idempotent MERGE of ``staging`` into ``target`` keyed on ``key`` (UPDATE/INSERT)."""
-    non_key = [c for c in columns if c != key]
-    set_clause = ", ".join(f"t.{c} = s.{c}" for c in non_key)
-    insert_cols = ", ".join(columns)
-    insert_vals = ", ".join(f"s.{c}" for c in columns)
-    return (
-        f"MERGE INTO {target} AS t\n"
-        f"USING {staging} AS s\n"
-        f"ON t.{key} = s.{key}\n"
-        f"WHEN MATCHED THEN UPDATE SET {set_clause}\n"
-        f"WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})"
-    )
-
-
-def row_params(row: dict, columns: Sequence[str]) -> tuple:
-    """Row dict -> positional bind tuple in ``columns`` order (raw values, no escaping)."""
-    return tuple(row.get(c) for c in columns)
-
-
-def build_bulk_insert(table: str, columns: Sequence[str], rows: Sequence[dict]) -> tuple[str, list]:
-    """One multi-row parameterized INSERT + flattened (row-major) bind params.
-
-    Values are BOUND, never interpolated -- this is what makes event names with
-    apostrophes (e.g. "Click Can't See Office") store correctly. A single multi-row
-    INSERT is one network round-trip, far more robust than ``executemany`` (which
-    round-trips per row and holds the warehouse connection long enough to be dropped).
-    """
-    tuple_sql = "(" + ", ".join("?" for _ in columns) + ")"
-    sql = f"INSERT INTO {table} ({', '.join(columns)}) VALUES " + ", ".join(tuple_sql for _ in rows)
-    params = [v for row in rows for v in row_params(row, columns)]
-    return sql, params
 
 
 STATE_COLUMNS = ["job_name", "last_processed_sha", "head_ref", "commit_count", "last_run_at"]
@@ -659,30 +590,6 @@ def make_merge_walk_resolver(root: str, deploy_ref: str) -> Callable[[str], str 
 # --------------------------------------------------------------------------- #
 
 
-def _missing_columns(existing: set[str], schema: Sequence[tuple[str, str]]) -> list[tuple[str, str]]:
-    """Schema entries whose column is absent from ``existing`` (order preserved)."""
-    return [(c, t) for c, t in schema if c not in existing]
-
-
-def _ensure_columns(cursor: Any, table: str, schema: Sequence[tuple[str, str]]) -> None:
-    """Add any schema columns missing from an existing table (Delta schema evolution).
-
-    Needed because ``CREATE TABLE IF NOT EXISTS`` will not evolve a table that already
-    exists with an older schema -- e.g. when this shared table predates ``event_type_slug``.
-    """
-    cursor.execute(f"DESCRIBE TABLE {table}")
-    existing: set[str] = set()
-    for row in cursor.fetchall():
-        name = row[0]
-        if not name or name.startswith("#"):  # partition / detail section -> stop
-            break
-        existing.add(name)
-    missing = _missing_columns(existing, schema)
-    if missing:
-        adds = ", ".join(f"{c} {t}" for c, t in missing)
-        cursor.execute(f"ALTER TABLE {table} ADD COLUMNS ({adds})")
-
-
 def fetch_event_universe(cursor: Any, taxonomy_table: str = TAXONOMY_TABLE) -> list[str]:
     """The authoritative ~434 distinct event_type values to attribute provenance for."""
     cursor.execute(
@@ -691,31 +598,37 @@ def fetch_event_universe(cursor: Any, taxonomy_table: str = TAXONOMY_TABLE) -> l
     return [str(r[0]) for r in cursor.fetchall()]
 
 
-def read_provenance_rows(cursor: Any, table: str = PROVENANCE_TABLE) -> dict[str, dict]:
-    """Existing provenance rows keyed by ``event_type`` (the table is ~400 rows).
+def write_provenance(rows: Sequence[dict], csv_path: str = DEFAULT_CSV_PATH) -> None:
+    """Write the full provenance dataset to a CSV, sorted by event_type.
 
-    Read whole rather than filtered: the table is tiny, so a single SELECT is simpler
-    and cheaper than binding an IN-list of affected events.
+    Full rewrite (the dataset is ~434 rows): a deterministic column and row order keeps the
+    committed file's git diffs minimal. Nulls render as empty fields. The csv module quotes
+    event names containing commas or apostrophes correctly.
     """
-    cursor.execute(f"SELECT {', '.join(PROVENANCE_COLUMNS)} FROM {table}")
-    return {row[0]: dict(zip(PROVENANCE_COLUMNS, row, strict=False)) for row in cursor.fetchall()}
+    ordered = sorted(rows, key=lambda r: r["event_type"])
+    path = Path(csv_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=PROVENANCE_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        for row in ordered:
+            writer.writerow({c: ("" if row.get(c) is None else row[c]) for c in PROVENANCE_COLUMNS})
 
 
-def write_provenance(cursor: Any, rows: Sequence[dict], table: str = PROVENANCE_TABLE) -> None:
-    """Create the table if needed and MERGE rows in via a staging table (idempotent).
+def read_provenance_rows(csv_path: str = DEFAULT_CSV_PATH) -> dict[str, dict]:
+    """Existing provenance rows keyed by event_type; {} when the file does not exist.
 
-    Rows are bound via ``executemany`` -- no inline SQL -- so apostrophes/quotes in
-    event names survive intact.
+    Empty CSV fields parse back to None (the inverse of write_provenance's null rendering).
     """
-    staging = f"{table}__stage"
-    cursor.execute(build_create_table_sql(table))
-    _ensure_columns(cursor, table, PROVENANCE_SCHEMA)  # evolve a pre-existing older table
-    cursor.execute(build_create_table_sql(staging, or_replace=True))
-    for i in range(0, len(rows), INSERT_CHUNK_ROWS):
-        chunk = rows[i : i + INSERT_CHUNK_ROWS]
-        cursor.execute(*build_bulk_insert(staging, PROVENANCE_COLUMNS, chunk))
-    cursor.execute(build_merge_sql(table, staging, PROVENANCE_COLUMNS))
-    cursor.execute(f"DROP TABLE IF EXISTS {staging}")
+    path = Path(csv_path)
+    if not path.exists():
+        return {}
+    out: dict[str, dict] = {}
+    with path.open(newline="", encoding="utf-8") as fh:
+        for raw in csv.DictReader(fh):
+            row = {c: (raw.get(c) or None) for c in PROVENANCE_COLUMNS}
+            out[row["event_type"]] = row
+    return out
 
 
 def write_watermark(
@@ -724,7 +637,7 @@ def write_watermark(
     head_ref: str,
     commit_count: int,
     last_run_at: str,
-    state_table: str = STATE_TABLE,
+    state_table: str = "",
 ) -> None:
     """Upsert the SHA high-water mark so DATA-2006 can resume with git log <sha>..HEAD."""
     cursor.execute(_CREATE_STATE_TABLE_SQL.format(table=state_table))
@@ -736,7 +649,7 @@ def write_watermark(
 
 def read_watermark(
     cursor: Any,
-    state_table: str = STATE_TABLE,
+    state_table: str = "",
     job_name: str = JOB_NAME,
 ) -> dict | None:
     """Read the SHA high-water mark for ``job_name``; None when there is no row yet.
@@ -783,8 +696,8 @@ def run_backfill(
     root: str,
     since: str | None,
     now: datetime,
-    table: str = PROVENANCE_TABLE,
-    state_table: str = STATE_TABLE,
+    table: str = "",
+    state_table: str = "",
     ref: str = DEPLOY_REF,
     pr_resolver: Callable[[str], str | None] | None = None,
 ) -> list[dict]:
@@ -824,8 +737,8 @@ def run_refresh(
     root: str,
     since: str | None,
     now: datetime,
-    table: str = PROVENANCE_TABLE,
-    state_table: str = STATE_TABLE,
+    table: str = "",
+    state_table: str = "",
     ref: str = DEPLOY_REF,
     pr_resolver: Callable[[str], str | None] | None = None,
 ) -> list[dict]:
@@ -878,11 +791,9 @@ def run_refresh(
 
 
 def _summarize(rows: Sequence[dict]) -> str:
-    by_status: dict[str, int] = {}
-    for r in rows:
-        by_status[r["code_status"]] = by_status.get(r["code_status"], 0) + 1
-    parts = ", ".join(f"{k}={v}" for k, v in sorted(by_status.items()))
-    return f"{len(rows)} rows ({parts})"
+    instrumented = sum(1 for r in rows if r.get("instrumented_commit"))
+    retired = sum(1 for r in rows if r.get("retired_commit"))
+    return f"{len(rows)} rows (instrumented={instrumented}, retired={retired})"
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -893,16 +804,10 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         default=DEFAULT_SINCE,
         help=f"Lower-bound git history (default {DEFAULT_SINCE}). 'all' walks full history.",
     )
+    p.add_argument("--table", default=None, help="Full landing table name (deprecated; write goes to CSV).")
     p.add_argument(
-        "--schema",
-        default=None,
-        help=(
-            f"Landing schema (default: $AMPLITUDE_PROVENANCE_SCHEMA / $DBT_AIRFLOW_SOURCE_SCHEMA "
-            f"/ {DEFAULT_SOURCE_SCHEMA}). Use --schema private_tristan for local dev."
-        ),
+        "--state-table", default=None, help="Full state table name (deprecated; state goes to JSON)."
     )
-    p.add_argument("--table", default=None, help="Full landing table name; overrides --schema.")
-    p.add_argument("--state-table", default=None, help="Full state table name; overrides --schema.")
     p.add_argument(
         "--ref",
         default=DEPLOY_REF,
@@ -931,12 +836,6 @@ def main(argv: Sequence[str] | None = None) -> None:
     root = resolve_omni_repo(args.repo, dict(os.environ))
     since = None if args.since == "all" else args.since
 
-    schema = resolve_schema(dict(os.environ), args.schema)
-    default_table, default_state = provenance_tables(schema)
-    table = args.table or default_table
-    state_table = args.state_table or default_state
-    print(f"Landing schema: {schema} -> {table}", file=sys.stderr)
-
     if not args.no_fetch:
         print(f"Fetching {args.ref} ...", file=sys.stderr)
         git_fetch(root, args.ref)
@@ -953,15 +852,13 @@ def main(argv: Sequence[str] | None = None) -> None:
                 root,
                 since,
                 datetime.now(UTC),
-                table=table,
-                state_table=state_table,
                 ref=args.ref,
                 pr_resolver=pr_resolver,
             )
     finally:
         connection.close()
     print(_summarize(rows), file=sys.stderr)
-    print(f"Wrote {table} and watermark {state_table}", file=sys.stderr)
+    print(f"Wrote provenance to {DEFAULT_CSV_PATH}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -19,8 +19,9 @@ Extraction note: ``trackEvent(...)`` in omni is called with *constant references
 event-type strings live as VALUES in the ``EVENTS`` map
 (packages/gp-webapp/helpers/analyticsHelper.ts) and a few gp-api type/string files.
 So we do not parse ``trackEvent('...')``; instead we anchor on the authoritative event
-universe (``dbt.int__amplitude_event_taxonomy``, ~408 events) and match those literals
-against added/removed diff lines in a single ``git log -p`` pass.
+universe (``airbyte_source.amplitude_taxonomy_event_type``, ~434 events synced directly
+from Amplitude Govern) and match those literals against added/removed diff lines in a
+single ``git log -p`` pass.
 
 Deploy-ref anchored: the walk, the HEAD-presence grep, and PR attribution all target the
 deployed default branch (``origin/develop``, fetched first), so provenance reflects what
@@ -77,7 +78,10 @@ INSERT_CHUNK_ROWS = 200
 DEPLOY_REF = "origin/develop"
 
 DATABRICKS_CATALOG = "goodparty_data_catalog"
-TAXONOMY_TABLE = f"{DATABRICKS_CATALOG}.dbt.int__amplitude_event_taxonomy"
+# Event universe: Amplitude Govern taxonomy synced directly via Airbyte (~434 events, all
+# is_active). Replaced dbt.int__amplitude_event_taxonomy as the anchor on 2026-06-22 -- the
+# Airbyte feed is the first-party source of truth (int__ is being rebuilt to source from it).
+TAXONOMY_TABLE = f"{DATABRICKS_CATALOG}.airbyte_source.amplitude_taxonomy_event_type"
 
 # Landing schema is env-configurable, mirroring the airflow_source convention
 # (l2_expired_voters reads Variable `databricks_source_schema`: airflow_source in prod,
@@ -680,7 +684,7 @@ def _ensure_columns(cursor: Any, table: str, schema: Sequence[tuple[str, str]]) 
 
 
 def fetch_event_universe(cursor: Any, taxonomy_table: str = TAXONOMY_TABLE) -> list[str]:
-    """The authoritative ~408 distinct event_type values to attribute provenance for."""
+    """The authoritative ~434 distinct event_type values to attribute provenance for."""
     cursor.execute(
         f"SELECT DISTINCT event_type FROM {taxonomy_table} WHERE event_type IS NOT NULL ORDER BY event_type"
     )

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -549,13 +549,15 @@ def write_provenance(rows: Sequence[dict], csv_path: str = DEFAULT_CSV_PATH) -> 
 
     Full rewrite (the dataset is ~434 rows): a deterministic column and row order keeps the
     committed file's git diffs minimal. Nulls render as empty fields. The csv module quotes
-    event names containing commas or apostrophes correctly.
+    event names containing commas or apostrophes correctly. ``lineterminator="\\n"`` forces
+    LF (the csv default is CRLF), so the committed file matches the repo's line-ending hook
+    and regenerating it produces no spurious diff.
     """
     ordered = sorted(rows, key=lambda r: r["event_type"])
     path = Path(csv_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="", encoding="utf-8") as fh:
-        writer = csv.DictWriter(fh, fieldnames=PROVENANCE_COLUMNS, extrasaction="ignore")
+        writer = csv.DictWriter(fh, fieldnames=PROVENANCE_COLUMNS, extrasaction="ignore", lineterminator="\n")
         writer.writeheader()
         for row in ordered:
             writer.writerow({c: ("" if row.get(c) is None else row[c]) for c in PROVENANCE_COLUMNS})

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -175,19 +175,28 @@ def find_events(text: str, pattern: re.Pattern[str]) -> set[str]:
 # --------------------------------------------------------------------------- #
 
 # Header line emitted by: git log -p --date=short
-#   --format='%x00%H%x1f%h%x1f%ad%x1f%s'
+#   --format='%x00%H%x1f%h%x1f%ad%x1f%at%x1f%s'
 # A NUL marks the start of each commit; the remaining fields are 0x1f-separated.
+# %ad (--date=short) is the human-readable date we store; %at (commit epoch) is the
+# precise ordering key, so same-day commits break ties by true time, not stream order.
 _HEADER_PREFIX = "\x00"
 _FIELD_SEP = "\x1f"
-_GIT_LOG_FORMAT = "--format=%x00%H%x1f%h%x1f%ad%x1f%s"
+_GIT_LOG_FORMAT = "--format=%x00%H%x1f%h%x1f%ad%x1f%at%x1f%s"
 
 Commit = dict[str, str | None]
 
 
 def _commit_from_header(line: str) -> Commit:
     """Parse a NUL-prefixed header line into a commit dict (pr derived from subject)."""
-    full, short, cdate, subject = line[len(_HEADER_PREFIX) :].split(_FIELD_SEP, 3)
-    return {"commit": full, "short": short, "date": cdate, "subject": subject, "pr": parse_pr_number(subject)}
+    full, short, cdate, ts, subject = line[len(_HEADER_PREFIX) :].split(_FIELD_SEP, 4)
+    return {
+        "commit": full,
+        "short": short,
+        "date": cdate,
+        "ts": ts,
+        "subject": subject,
+        "pr": parse_pr_number(subject),
+    }
 
 
 def parse_git_log(lines: Iterable[str], pattern: re.Pattern[str]) -> dict[str, dict]:
@@ -237,16 +246,17 @@ def parse_git_log(lines: Iterable[str], pattern: re.Pattern[str]) -> dict[str, d
 def _record(acc: dict[str, dict], event: str, commit: Commit, slot: str) -> None:
     """Keep the earliest commit for 'instrumented', the latest for 'retired'/'last_change'.
 
-    Dates are 'YYYY-MM-DD' strings, so lexical comparison is chronological.
+    Ordering is by commit epoch ('ts'), so two net-changes on the same calendar day
+    are disambiguated by their true time rather than by git's newest-first stream order.
     """
     entry = acc.setdefault(event, {"instrumented": None, "retired": None, "last_change": None})
     current = entry[slot]
     if current is None:
         entry[slot] = commit
     elif slot == "instrumented":
-        if commit["date"] < current["date"]:
+        if int(commit["ts"]) < int(current["ts"]):
             entry[slot] = commit
-    elif commit["date"] > current["date"]:  # 'retired' / 'last_change'
+    elif int(commit["ts"]) > int(current["ts"]):  # 'retired' / 'last_change'
         entry[slot] = commit
 
 
@@ -485,15 +495,22 @@ def build_watermark_merge_sql(state_table: str) -> str:
 
 
 def run_git_log(root: str, since: str | None, paths: Sequence[str], ref: str | None = None) -> Iterator[str]:
-    """Stream the single ``git log -p`` pass line-by-line (the diff stream is large)."""
+    """Stream the single ``git log -p`` pass line-by-line (the diff stream is large).
+
+    A non-zero exit (bad ref, corrupt repo) raises ``CalledProcessError`` once the stream
+    is exhausted: otherwise a failed log parses as an empty history and we would MERGE a
+    table of all-null provenance rows with no error signal.
+    """
     argv = build_git_log_argv(root, since, paths, ref)
-    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, text=True)
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     assert proc.stdout is not None
     try:
         yield from (line.rstrip("\n") for line in proc.stdout)
     finally:
         proc.stdout.close()
-        proc.wait()
+        _, stderr = proc.communicate()
+        if proc.returncode != 0:
+            raise subprocess.CalledProcessError(proc.returncode, argv, stderr=stderr)
 
 
 def git_grep_present_text(root: str, events: Sequence[str], paths: Sequence[str], ref: str = "HEAD") -> str:
@@ -537,12 +554,22 @@ def git_commit_count(root: str, since: str | None, paths: Sequence[str], ref: st
 
 
 def git_fetch(root: str, ref: str) -> None:
-    """Update the deploy ref from its remote (``origin/develop`` -> ``git fetch origin develop``)."""
+    """Update the deploy ref from its remote (``origin/develop`` -> ``git fetch origin develop``).
+
+    Aborts on a non-zero exit (network outage, missing remote, bad credentials) rather than
+    silently walking — and watermarking — stale local ``origin/develop`` state.
+    """
     remote, _, branch = ref.partition("/")
     argv = ["git", "-C", root, "fetch", "--quiet", remote]
     if branch:
         argv.append(branch)
-    subprocess.run(argv, capture_output=True, text=True)
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"ERROR: git fetch {remote} {branch} failed (exit {result.returncode}).\n"
+            f"{result.stderr.strip()}\n"
+            "Use --no-fetch to skip the fetch and walk the local ref state."
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/analytics/lib/databricks_conn.py
+++ b/analytics/lib/databricks_conn.py
@@ -104,12 +104,15 @@ def _to_dataframe(description: Sequence[Any], rows: Sequence[Any]) -> pd.DataFra
     return pd.DataFrame(list(rows), columns=columns)
 
 
-def run_query(sql: str, *, max_retries: int = 5, retry_delay: int = 10) -> pd.DataFrame:
-    """Execute ``sql`` against the profile's SQL warehouse, return a DataFrame.
+def get_connection(*, max_retries: int = 5, retry_delay: int = 10) -> Any:
+    """Open an authenticated connection to the profile's SQL warehouse.
 
     Auth is resolved by the SDK ``Config`` (M2M service principal if configured,
     else the ``~/.databrickscfg`` profile). The SQL warehouse comes from
-    ``DATABRICKS_HTTP_PATH`` (``/sql/1.0/warehouses/<id>``).
+    ``DATABRICKS_HTTP_PATH`` (``/sql/1.0/warehouses/<id>``). The caller owns the
+    connection (use it as a context manager or ``close()`` it). Use this when you
+    need a cursor for writes / parameterized binding / executemany; for a one-shot
+    read use ``run_query``.
     """
     from databricks import sql as dbsql
     from databricks.sdk.core import Config, oauth_service_principal
@@ -120,7 +123,17 @@ def run_query(sql: str, *, max_retries: int = 5, retry_delay: int = 10) -> pd.Da
         os.environ.get("DATABRICKS_HTTP_PATH", ""),
         oauth_m2m=oauth_service_principal,
     )
-    connection = _connect_with_retry(dbsql.connect, kwargs, max_retries=max_retries, retry_delay=retry_delay)
+    return _connect_with_retry(dbsql.connect, kwargs, max_retries=max_retries, retry_delay=retry_delay)
+
+
+def run_query(sql: str, *, max_retries: int = 5, retry_delay: int = 10) -> pd.DataFrame:
+    """Execute ``sql`` against the profile's SQL warehouse, return a DataFrame.
+
+    Auth is resolved by the SDK ``Config`` (M2M service principal if configured,
+    else the ``~/.databrickscfg`` profile). The SQL warehouse comes from
+    ``DATABRICKS_HTTP_PATH`` (``/sql/1.0/warehouses/<id>``).
+    """
+    connection = get_connection(max_retries=max_retries, retry_delay=retry_delay)
     try:
         with connection.cursor() as cursor:
             cursor.execute(sql)

--- a/analytics/runbook/refresh-event-provenance.md
+++ b/analytics/runbook/refresh-event-provenance.md
@@ -3,14 +3,14 @@ Regenerate the committed Amplitude event git-provenance dataset and open a PR wi
 ## Prerequisites
 
 - **Omni checkout.** `OMNI_REPO` must be set to a local omni checkout (machine-specific; keep it in `~/.zshrc`, not committed). The script resolves `--repo` else `$OMNI_REPO`, expands `~`, and aborts if the path is unset or not a git checkout. It fetches `origin/develop` itself, so the checkout only needs a reachable remote, not a clean working tree.
-- **Databricks access.** One read per run (the event universe from `airbyte_source.amplitude_taxonomy_event_type`). Auth is the Databricks SDK profile in `~/.databrickscfg` (default profile `tristana_goodparty`; refresh with `databricks auth login --profile tristana_goodparty`). `DATABRICKS_HTTP_PATH` must be set. No PAT.
+- **Databricks access.** One read per run (the event universe from `airbyte_source.amplitude_taxonomy_event_type`). Auth resolves the executor's default Databricks SDK profile in `~/.databrickscfg` (whoever runs it; refresh with `databricks auth login`, or `databricks auth login --profile <name>` for a named profile). `DATABRICKS_HTTP_PATH` must be set. No PAT.
 - **Git/PR access.** `gh` authenticated and push access to the repo, since the run opens a PR. Never push to `main`.
 - **Python env.** Run from `analytics/` via `uv` (the subproject's own env), per the repo's multi-venv setup.
 
 ## Steps
 
 1. **Preflight. Stop loudly on any failure; never commit a half-run.**
-   - `databricks auth profiles` shows `Valid: YES` for the default profile. If not, stop and report that re-auth is needed (`databricks auth login --profile tristana_goodparty`). An expired token is the most common unattended failure.
+   - `databricks auth profiles` shows `Valid: YES` for the executor's default profile. If not, stop and report that re-auth is needed (`databricks auth login`, or `--profile <name>` for a named profile). An expired token is the most common unattended failure.
    - `OMNI_REPO` is set and `"$OMNI_REPO/.git"` exists. (The script also checks this, but failing here gives a cleaner message.)
 2. **Branch.** From an up-to-date `main`, create `chore/refresh-event-provenance-<YYYY-MM-DD>`. Do the work on the branch, not on `main`.
 3. **Run the refresh.**
@@ -37,7 +37,7 @@ Regenerate the committed Amplitude event git-provenance dataset and open a PR wi
 
 ## Troubleshooting
 
-- Databricks auth / token-refresh error → the profile's OAuth token is stale; run `databricks auth login --profile tristana_goodparty`. This needs a browser, so it cannot be done by the unattended run; the run fails loudly and waits for the next scheduled run after you re-auth.
+- Databricks auth / token-refresh error → the executor's OAuth token is stale; run `databricks auth login` (or `--profile <name>`). This needs a browser, so it cannot be done by the unattended run; the run fails loudly and waits for the next scheduled run after you re-auth.
 - `ERROR: pass --repo or set OMNI_REPO …` → `OMNI_REPO` is not set in the run's environment.
 - `git fetch … failed` → the omni checkout's remote is unreachable or its credentials lapsed; the script aborts rather than walking stale `origin/develop` state.
 - `WARNING: N universe event(s) absent from the CSV` → see the refresh-limitation note above; resync with a full backfill if the gap matters.

--- a/analytics/runbook/refresh-event-provenance.md
+++ b/analytics/runbook/refresh-event-provenance.md
@@ -34,7 +34,7 @@ Regenerate the committed Amplitude event git-provenance dataset and open a PR wi
 ## Notes
 
 - **Idempotent and self-catching-up.** The watermark is the last processed commit SHA, so a missed or failed run is harmless: the next successful run walks a larger window and catches up. There is no need to backfill a skipped day.
-- **Refresh limitation.** A refresh only adds or updates events that changed in the window. A brand-new universe event whose instrumentation predates the watermark is not added automatically; the run logs a `WARNING: … absent from the CSV`. To fully resync, delete `analytics/data/amplitude_event_provenance_state.json` and run again for a full backfill.
+- **New and removed events.** A refresh covers both existing-event updates (the windowed walk) and brand-new events. A universe event absent from the CSV is onboarded in the same run via full-history attribution (logged as `Onboarding N new universe event(s) ...`), so new Govern events need no manual full backfill. Events removed from the universe are left in the CSV, since their provenance is worth keeping. Deleting `analytics/data/amplitude_event_provenance_state.json` and re-running is only needed for a clean rebuild from scratch.
 
 ## Troubleshooting
 
@@ -42,7 +42,7 @@ Regenerate the committed Amplitude event git-provenance dataset and open a PR wi
 - `DATABRICKS_HTTP_PATH is not set` → the scheduled (non-interactive) shell did not load `~/.zshrc`; set `DATABRICKS_HTTP_PATH` (and `OMNI_REPO`) via a `~/.claude/settings.json` env block or `~/.zshenv`. See the Scheduled-shell environment note in Prerequisites.
 - `ERROR: pass --repo or set OMNI_REPO …` → `OMNI_REPO` is not set in the run's environment (same non-interactive-shell cause as above).
 - `git fetch … failed` → the omni checkout's remote is unreachable or its credentials lapsed; the script aborts rather than walking stale `origin/develop` state.
-- `WARNING: N universe event(s) absent from the CSV` → see the refresh-limitation note above; resync with a full backfill if the gap matters.
+- `Onboarding N new universe event(s) ...` → informational, not an error: the refresh found N universe events not yet in the CSV and is attributing them from full history. This is expected whenever Govern gains events.
 
 ## Test run (no commit, no PR)
 

--- a/analytics/runbook/refresh-event-provenance.md
+++ b/analytics/runbook/refresh-event-provenance.md
@@ -1,0 +1,47 @@
+Regenerate the committed Amplitude event git-provenance dataset and open a PR with the refreshed file. Built to run unattended on a schedule (a Claude Code Desktop routine), and to work by hand. The data work lives in `analytics/lib/amplitude_event_provenance_backfill.py`; this runbook is the orchestration around it (preflight, verify, branch, commit, PR).
+
+## Prerequisites
+
+- **Omni checkout.** `OMNI_REPO` must be set to a local omni checkout (machine-specific; keep it in `~/.zshrc`, not committed). The script resolves `--repo` else `$OMNI_REPO`, expands `~`, and aborts if the path is unset or not a git checkout. It fetches `origin/develop` itself, so the checkout only needs a reachable remote, not a clean working tree.
+- **Databricks access.** One read per run (the event universe from `airbyte_source.amplitude_taxonomy_event_type`). Auth is the Databricks SDK profile in `~/.databrickscfg` (default profile `tristana_goodparty`; refresh with `databricks auth login --profile tristana_goodparty`). `DATABRICKS_HTTP_PATH` must be set. No PAT.
+- **Git/PR access.** `gh` authenticated and push access to the repo, since the run opens a PR. Never push to `main`.
+- **Python env.** Run from `analytics/` via `uv` (the subproject's own env), per the repo's multi-venv setup.
+
+## Steps
+
+1. **Preflight. Stop loudly on any failure; never commit a half-run.**
+   - `databricks auth profiles` shows `Valid: YES` for the default profile. If not, stop and report that re-auth is needed (`databricks auth login --profile tristana_goodparty`). An expired token is the most common unattended failure.
+   - `OMNI_REPO` is set and `"$OMNI_REPO/.git"` exists. (The script also checks this, but failing here gives a cleaner message.)
+2. **Branch.** From an up-to-date `main`, create `chore/refresh-event-provenance-<YYYY-MM-DD>`. Do the work on the branch, not on `main`.
+3. **Run the refresh.**
+   ```sh
+   cd analytics && uv run python lib/amplitude_event_provenance_backfill.py
+   ```
+   The script auto-detects: no state file means a full backfill, a state file means an incremental walk of `last_sha..origin/develop`. It rewrites `analytics/data/amplitude_event_provenance.csv` and `..._state.json`.
+4. **Verify before committing.**
+   - Read the summary line on stderr: `N rows (present=…, removed=…, not_found_in_code=…)`. `N` should be ~430+. If it has collapsed toward zero, something went wrong upstream (bad universe read, empty walk); stop and report rather than commit.
+   - `git status --porcelain` shows only `analytics/data/amplitude_event_provenance.csv` and `analytics/data/amplitude_event_provenance_state.json`. Any other changed path means stop and investigate.
+   - If `git status` is clean (no new commits on `origin/develop` since the last watermark), there is nothing to refresh. Delete the throwaway branch and finish without a PR.
+5. **Commit and open a PR.** Commit the two data files; push the branch; open a PR summarizing the row delta (e.g. the before/after summary counts). Commit message ends with the co-author trailer:
+   ```
+   chore(analytics): refresh Amplitude event provenance dataset
+
+   Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+   ```
+6. **Report** the PR URL in the run summary.
+
+## Notes
+
+- **Idempotent and self-catching-up.** The watermark is the last processed commit SHA, so a missed or failed run is harmless: the next successful run walks a larger window and catches up. There is no need to backfill a skipped day.
+- **Refresh limitation.** A refresh only adds or updates events that changed in the window. A brand-new universe event whose instrumentation predates the watermark is not added automatically; the run logs a `WARNING: … absent from the CSV`. To fully resync, delete `analytics/data/amplitude_event_provenance_state.json` and run again for a full backfill.
+
+## Troubleshooting
+
+- Databricks auth / token-refresh error → the profile's OAuth token is stale; run `databricks auth login --profile tristana_goodparty`. This needs a browser, so it cannot be done by the unattended run; the run fails loudly and waits for the next scheduled run after you re-auth.
+- `ERROR: pass --repo or set OMNI_REPO …` → `OMNI_REPO` is not set in the run's environment.
+- `git fetch … failed` → the omni checkout's remote is unreachable or its credentials lapsed; the script aborts rather than walking stale `origin/develop` state.
+- `WARNING: N universe event(s) absent from the CSV` → see the refresh-limitation note above; resync with a full backfill if the gap matters.
+
+## Running it on a schedule (Claude Code Desktop)
+
+Create a Local routine whose working directory is the repo root and whose prompt is "follow `analytics/runbook/refresh-event-provenance.md`." Set the permission mode to auto-approve so it can run `uv`, `git`, and `gh` without stalling, and pick a cadence and a time the machine is awake and 1Password / the Databricks profile are usable. A missed run is harmless (see Notes), so err toward a time you are typically logged in.

--- a/analytics/runbook/refresh-event-provenance.md
+++ b/analytics/runbook/refresh-event-provenance.md
@@ -42,6 +42,27 @@ Regenerate the committed Amplitude event git-provenance dataset and open a PR wi
 - `git fetch … failed` → the omni checkout's remote is unreachable or its credentials lapsed; the script aborts rather than walking stale `origin/develop` state.
 - `WARNING: N universe event(s) absent from the CSV` → see the refresh-limitation note above; resync with a full backfill if the gap matters.
 
+## Test run (no commit, no PR)
+
+To validate the pipeline end to end without touching the repo or opening a PR, point the output at files outside the repo (`--csv` / `--state`). This exercises everything (auth, the `origin/develop` fetch, the walk, the write) and leaves an inspectable dataset in `~/Downloads`. The only in-repo side effect is the `git fetch` inside the omni checkout, which is expected.
+
+1. Preflight as in Step 1 above (profile valid, `OMNI_REPO` set).
+2. Seed the test output from the committed dataset so the run takes the incremental path (what the scheduled job does each run):
+   ```sh
+   cp analytics/data/amplitude_event_provenance.csv ~/Downloads/amplitude_event_provenance_TEST.csv
+   cp analytics/data/amplitude_event_provenance_state.json ~/Downloads/amplitude_event_provenance_state_TEST.json
+   ```
+3. Run, writing only to the Downloads copies:
+   ```sh
+   cd analytics && uv run python lib/amplitude_event_provenance_backfill.py \
+     --repo "$OMNI_REPO" \
+     --csv ~/Downloads/amplitude_event_provenance_TEST.csv \
+     --state ~/Downloads/amplitude_event_provenance_state_TEST.json
+   ```
+4. Inspect: read the summary line on stderr, `diff` the Downloads CSV against `analytics/data/amplitude_event_provenance.csv` to see the delta, and confirm `git status --porcelain` is clean.
+
+For a clean full backfill instead of the incremental path, skip step 2 and point `--state` at a Downloads path that does not exist yet; with no watermark the script rebuilds the whole dataset into Downloads (slower, a few minutes).
+
 ## Running it on a schedule (Claude Code Desktop)
 
 Create a Local routine whose working directory is the repo root and whose prompt is "follow `analytics/runbook/refresh-event-provenance.md`." Set the permission mode to auto-approve so it can run `uv`, `git`, and `gh` without stalling, and pick a cadence and a time the machine is awake and 1Password / the Databricks profile are usable. A missed run is harmless (see Notes), so err toward a time you are typically logged in.

--- a/analytics/runbook/refresh-event-provenance.md
+++ b/analytics/runbook/refresh-event-provenance.md
@@ -2,8 +2,9 @@ Regenerate the committed Amplitude event git-provenance dataset and open a PR wi
 
 ## Prerequisites
 
-- **Omni checkout.** `OMNI_REPO` must be set to a local omni checkout (machine-specific; keep it in `~/.zshrc`, not committed). The script resolves `--repo` else `$OMNI_REPO`, expands `~`, and aborts if the path is unset or not a git checkout. It fetches `origin/develop` itself, so the checkout only needs a reachable remote, not a clean working tree.
-- **Databricks access.** One read per run (the event universe from `airbyte_source.amplitude_taxonomy_event_type`). Auth resolves the executor's default Databricks SDK profile in `~/.databrickscfg` (whoever runs it; refresh with `databricks auth login`, or `databricks auth login --profile <name>` for a named profile). `DATABRICKS_HTTP_PATH` must be set. No PAT.
+- **Omni checkout.** `OMNI_REPO` must be set to a local omni checkout (machine-specific, not committed; see Scheduled-shell environment below for where to set it). The script resolves `--repo` else `$OMNI_REPO`, expands `~`, and aborts if the path is unset or not a git checkout. It fetches `origin/develop` itself, so the checkout only needs a reachable remote, not a clean working tree.
+- **Databricks access.** One read per run (the event universe from `airbyte_source.amplitude_taxonomy_event_type`). Auth resolves the executor's default Databricks SDK profile in `~/.databrickscfg` (whoever runs it; refresh with `databricks auth login`, or `databricks auth login --profile <name>` for a named profile). `DATABRICKS_HTTP_PATH` (the SQL warehouse path, non-secret) must be set; see below. No PAT.
+- **Scheduled-shell environment.** A Claude Code scheduled run is a non-interactive shell and does NOT source `~/.zshrc`, so any var defined only there is absent (symptom: `DATABRICKS_HTTP_PATH is not set`). Set the two non-secret vars this job needs, `DATABRICKS_HTTP_PATH` and `OMNI_REPO`, where a non-interactive shell reads them: a `~/.claude/settings.json` `env` block (Claude Code injects it into every Bash subprocess it spawns) or `~/.zshenv`. Auth itself needs no env here, since it reads the file-based OAuth profile.
 - **Git/PR access.** `gh` authenticated and push access to the repo, since the run opens a PR. Never push to `main`.
 - **Python env.** Run from `analytics/` via `uv` (the subproject's own env), per the repo's multi-venv setup.
 
@@ -38,7 +39,8 @@ Regenerate the committed Amplitude event git-provenance dataset and open a PR wi
 ## Troubleshooting
 
 - Databricks auth / token-refresh error → the executor's OAuth token is stale; run `databricks auth login` (or `--profile <name>`). This needs a browser, so it cannot be done by the unattended run; the run fails loudly and waits for the next scheduled run after you re-auth.
-- `ERROR: pass --repo or set OMNI_REPO …` → `OMNI_REPO` is not set in the run's environment.
+- `DATABRICKS_HTTP_PATH is not set` → the scheduled (non-interactive) shell did not load `~/.zshrc`; set `DATABRICKS_HTTP_PATH` (and `OMNI_REPO`) via a `~/.claude/settings.json` env block or `~/.zshenv`. See the Scheduled-shell environment note in Prerequisites.
+- `ERROR: pass --repo or set OMNI_REPO …` → `OMNI_REPO` is not set in the run's environment (same non-interactive-shell cause as above).
 - `git fetch … failed` → the omni checkout's remote is unreachable or its credentials lapsed; the script aborts rather than walking stale `origin/develop` state.
 - `WARNING: N universe event(s) absent from the CSV` → see the refresh-limitation note above; resync with a full backfill if the gap matters.
 

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -793,3 +793,64 @@ def test_read_watermark_returns_row_as_dict():
 def test_read_watermark_none_when_no_row():
     cur = RefreshCursor(["Event A"], watermark_row=None)
     assert bf.read_watermark(cur) is None
+
+
+# --------------------------------------------------------------------------- #
+# merge_provenance_entry -- existing row + new-window observation
+# --------------------------------------------------------------------------- #
+
+# A window commit that net-removes an event (newer than any watermarked commit).
+COMMIT_E = {
+    "commit": "eeee",
+    "short": "eeee",
+    "date": "2026-06-18",
+    "ts": "1781827200",
+    "subject": "feat: remove (#999)",
+    "pr": "999",
+}
+
+_EXISTING_B = {
+    "event_type": "Event B",
+    "event_type_slug": "event_b",
+    "instrumented_commit": "aaaa",
+    "instrumented_pr": None,
+    "instrumented_date": "2025-02-01",
+    "retired_commit": None,
+    "retired_pr": None,
+    "retired_date": None,
+    "code_status": "present",
+    "still_in_code": True,
+    "last_code_change_date": "2025-02-01",
+    "updated_at": "2026-01-01T00:00:00",
+}
+
+
+def test_merge_keeps_existing_instrumented_when_window_only_removes():
+    new_entry = {"instrumented": None, "retired": COMMIT_E, "last_change": COMMIT_E}
+    merged = bf.merge_provenance_entry(_EXISTING_B, new_entry)
+    assert merged["instrumented"]["commit"] == "aaaa"
+    assert merged["instrumented"]["date"] == "2025-02-01"
+    assert merged["retired"]["commit"] == "eeee"
+    assert merged["last_change"]["commit"] == "eeee"
+
+
+def test_merge_new_event_takes_window_instrumented():
+    new_entry = {"instrumented": COMMIT_E, "retired": None, "last_change": COMMIT_E}
+    merged = bf.merge_provenance_entry(None, new_entry)
+    assert merged["instrumented"]["commit"] == "eeee"
+    assert merged["retired"] is None
+
+
+def test_merge_readd_preserves_original_instrumented_and_advances_last_change():
+    existing = {
+        **_EXISTING_B,
+        "retired_commit": "bbbb",
+        "retired_pr": "222",
+        "retired_date": "2025-03-01",
+        "code_status": "removed",
+        "still_in_code": False,
+    }
+    new_entry = {"instrumented": COMMIT_E, "retired": None, "last_change": COMMIT_E}
+    merged = bf.merge_provenance_entry(existing, new_entry)
+    assert merged["instrumented"]["commit"] == "aaaa"  # original instrumentation kept
+    assert merged["last_change"]["commit"] == "eeee"  # window is the latest change

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -821,6 +821,16 @@ def test_write_provenance_writes_sorted_header_and_rows(tmp_path):
     assert lines[2].startswith("Event B,")
 
 
+def test_write_provenance_uses_lf_line_endings(tmp_path):
+    # The csv default is CRLF; we force LF so the committed file matches the repo's
+    # mixed-line-ending hook and regenerating it produces no spurious diff.
+    csv_path = tmp_path / "prov.csv"
+    bf.write_provenance([_row("Event A")], str(csv_path))
+    raw = csv_path.read_bytes()
+    assert b"\r\n" not in raw
+    assert raw.count(b"\n") == 2  # header + one row
+
+
 def test_write_provenance_renders_none_as_empty_field(tmp_path):
     csv_path = tmp_path / "prov.csv"
     bf.write_provenance([_row("Event A")], str(csv_path))

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -687,9 +687,21 @@ def test_merge_keeps_existing_instrumented_when_window_only_removes():
 
 def test_merge_new_event_takes_window_instrumented():
     new_entry = {"instrumented": COMMIT_E, "retired": None, "last_change": COMMIT_E}
-    merged = bf.merge_provenance_entry(None, new_entry)
+    merged = bf.merge_provenance_entry(None, new_entry, present_before_window=False)
     assert merged["instrumented"]["commit"] == "eeee"
     assert merged["retired"] is None
+
+
+def test_merge_predates_window_event_does_not_take_window_instrumented():
+    # An event with no recorded instrumentation that was ALREADY present before the window
+    # (its true instrumentation predates --since). A window net-add here is a spurious edit,
+    # not an introduction, so instrumentation must stay null rather than be stamped with the
+    # window's too-recent date.
+    existing_blank = {**_EXISTING_B, "instrumented_commit": None, "instrumented_date": None}
+    new_entry = {"instrumented": COMMIT_E, "retired": None, "last_change": COMMIT_E}
+    merged = bf.merge_provenance_entry(existing_blank, new_entry, present_before_window=True)
+    assert merged["instrumented"] is None
+    assert merged["last_change"]["commit"] == "eeee"  # the edit still advances last_change
 
 
 def test_merge_readd_preserves_original_instrumented_and_advances_last_change():
@@ -844,6 +856,46 @@ def test_run_refresh_warns_when_universe_event_missing_from_csv(monkeypatch, tmp
     assert {r["event_type"] for r in rows} == {"Event A"}
     # (ii) A warning is emitted to stderr mentioning the divergence.
     assert "absent from the CSV" in capsys.readouterr().err
+
+
+def test_run_refresh_does_not_fabricate_instrumented_for_predates_window_event(monkeypatch, tmp_path):
+    # Event P is in the CSV with blank instrumentation (its true instrumentation predates the
+    # original --since window) but is present in code. Event Q is genuinely new (not in CSV).
+    # A window commit net-adds both literals -- a spurious edit for P, a real introduction for Q.
+    csv_path = tmp_path / "prov.csv"
+    bf.write_provenance(
+        [_row("Event P", last_code_change_date=None, updated_at="2025-02-01T00:00:00")],
+        str(csv_path),
+    )
+    state_path = tmp_path / "state.json"
+    bf.write_watermark(str(state_path), "oldsha", "origin/develop", 10, "2025-04-01T00:00:00")
+    stream = [
+        _header("p1", "p1", "2026-06-10", "feat: edit P, add Q (#7)"),
+        '+  trackEvent(EVENTS.P)  // "Event P"',
+        '+  trackEvent(EVENTS.Q)  // "Event Q"',
+    ]
+    monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter(stream))
+
+    # The 4th positional arg is the grep ref: at the watermark (oldsha) P already exists and Q
+    # does not; at HEAD both exist.
+    def fake_grep(*a, **k):
+        return '"Event P"' if a[3] == "oldsha" else '"Event P" "Event Q"'
+
+    monkeypatch.setattr(bf, "git_grep_present_text", fake_grep)
+    monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")
+    monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 11)
+    cur = FakeCursor(["Event P", "Event Q"])
+
+    rows = bf.run_refresh(cur, "/root", None, DT, csv_path=str(csv_path), state_path=str(state_path))
+
+    by = {r["event_type"]: r for r in rows}
+    # P: no false instrumentation stamped; the edit still advances last_code_change_date.
+    assert by["Event P"]["instrumented_commit"] is None
+    assert by["Event P"]["instrumented_date"] is None
+    assert by["Event P"]["last_code_change_date"] == "2026-06-10"
+    # Q: genuinely new in the window -> takes the window's instrumentation.
+    assert by["Event Q"]["instrumented_commit"] == "p1"
 
 
 def test_write_provenance_writes_sorted_header_and_rows(tmp_path):

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -624,32 +624,6 @@ def test_resolve_pr_gaps_skips_rows_without_commit():
 # --------------------------------------------------------------------------- #
 
 
-class RefreshCursor:
-    """Fake cursor for refresh wiring: serves the event universe, the watermark
-    row, and existing provenance rows depending on the SQL it is handed."""
-
-    def __init__(self, events, watermark_row=None, existing_rows=None):
-        self._events = events
-        self._watermark_row = watermark_row  # 4-tuple or None
-        self._existing = list(existing_rows or [])  # tuples in PROVENANCE_COLUMNS order
-        self.executed = []
-        self._fetch: list = []
-
-    def execute(self, sql, params=None):
-        self.executed.append((sql, params))
-        if "amplitude_taxonomy_event_type" in sql:
-            self._fetch = [(e,) for e in self._events]
-        elif sql.startswith("SELECT last_processed_sha"):
-            self._fetch = [self._watermark_row] if self._watermark_row else []
-        elif sql.startswith("SELECT event_type,"):
-            self._fetch = list(self._existing)
-        else:
-            self._fetch = []
-
-    def fetchall(self):
-        return self._fetch
-
-
 def test_watermark_round_trips_via_json(tmp_path):
     state_path = tmp_path / "state.json"
     bf.write_watermark(str(state_path), "oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
@@ -732,121 +706,6 @@ def test_merge_readd_preserves_original_instrumented_and_advances_last_change():
 
 
 # --------------------------------------------------------------------------- #
-# run_refresh -- orchestration wiring
-# --------------------------------------------------------------------------- #
-
-# A window stream that net-removes only Event B (newer than the watermark).
-_REFRESH_STREAM = [
-    _header("eeee", "eeee", "2026-06-18", "feat: remove Event B (#999)"),
-    "diff --git a/x.ts b/x.ts",
-    "--- a/x.ts",
-    "+++ b/x.ts",
-    "@@ -1,2 +1,1 @@",
-    "-  b: 'Event B',",
-]
-
-_EXISTING_ROWS = [
-    (
-        "Event A",
-        "event_a",
-        "aaaa",
-        None,
-        "2025-02-01",
-        None,
-        None,
-        None,
-        "2025-02-01",
-        "2026-01-01T00:00:00",
-    ),
-    (
-        "Event B",
-        "event_b",
-        "aaaa",
-        None,
-        "2025-02-01",
-        None,
-        None,
-        None,
-        "2025-02-01",
-        "2026-01-01T00:00:00",
-    ),
-]
-
-
-def test_run_refresh_falls_back_to_full_backfill_when_no_watermark(monkeypatch):
-    called = {}
-
-    def fake_backfill(cursor, root, since, now, **kwargs):
-        called["since"] = since
-        return [{"event_type": "Event A"}]
-
-    monkeypatch.setattr(bf, "run_backfill", fake_backfill)
-    cur = RefreshCursor(["Event A", "Event B"], watermark_row=None)
-    rows = bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
-    assert called["since"] == "2024-06-01"
-    assert rows == [{"event_type": "Event A"}]
-
-
-def test_run_refresh_walks_bounded_range_from_watermark(monkeypatch):
-    captured = {}
-
-    def fake_git_log(root, since, paths, ref=None):
-        captured["ref"] = ref
-        captured["since"] = since
-        return iter(_REFRESH_STREAM)
-
-    monkeypatch.setattr(bf, "run_git_log", fake_git_log)
-    monkeypatch.setattr(bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "")
-    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "newhead")
-    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/main")
-    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 50)
-
-    wm = ("oldsha", "origin/main", 42, "2026-06-01T00:00:00")
-    cur = RefreshCursor(["Event A", "Event B"], watermark_row=wm, existing_rows=_EXISTING_ROWS)
-    bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC), ref="origin/main")
-    assert captured["ref"] == "oldsha..origin/main"
-    assert captured["since"] is None  # the range supersedes --since
-
-
-def test_run_refresh_merges_only_affected_events_and_advances_watermark(monkeypatch):
-    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_REFRESH_STREAM))
-    # Event B absent at HEAD -> grep empty -> code_status removed
-    monkeypatch.setattr(bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "")
-    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "newhead")
-    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
-    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 50)
-
-    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
-    cur = RefreshCursor(["Event A", "Event B"], watermark_row=wm, existing_rows=_EXISTING_ROWS)
-    rows = bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
-
-    # only Event B is rewritten, and its existing instrumentation is preserved
-    assert [r["event_type"] for r in rows] == ["Event B"]
-    assert rows[0]["instrumented_commit"] == "aaaa"
-    assert rows[0]["retired_commit"] == "eeee"
-
-    wm_merges = [(s, p) for s, p in cur.executed if "ON t.job_name = s.job_name" in s]
-    assert len(wm_merges) == 1
-    assert wm_merges[0][1] == (bf.JOB_NAME, "newhead", "origin/develop", 50, "2026-06-18T00:00:00")
-
-
-def test_run_refresh_advances_watermark_when_nothing_changed(monkeypatch):
-    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter([]))
-    monkeypatch.setattr(bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "")
-    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "newhead")
-    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
-    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 50)
-
-    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
-    cur = RefreshCursor(["Event A", "Event B"], watermark_row=wm, existing_rows=_EXISTING_ROWS)
-    rows = bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
-
-    assert rows == []
-    assert not [s for s, _ in cur.executed if s.startswith("INSERT INTO")]  # no provenance write
-    assert any("ON t.job_name = s.job_name" in s for s, _ in cur.executed)  # watermark still advanced
-
-
-# --------------------------------------------------------------------------- #
 # CSV persistence
 # --------------------------------------------------------------------------- #
 
@@ -858,6 +717,98 @@ def _row(event_type, **over):
     base["updated_at"] = "2026-06-22T00:00:00"
     base.update(over)
     return base
+
+
+def _seed_csv(tmp_path):
+    csv_path = tmp_path / "prov.csv"
+    bf.write_provenance(
+        [
+            _row(
+                "Event A",
+                instrumented_commit="aaaa",
+                instrumented_date="2025-02-01",
+                last_code_change_date="2025-02-01",
+                updated_at="2025-02-01T00:00:00",
+            ),
+            _row(
+                "Event B",
+                instrumented_commit="bbbb",
+                instrumented_date="2025-03-01",
+                last_code_change_date="2025-03-01",
+                updated_at="2025-03-01T00:00:00",
+            ),
+        ],
+        str(csv_path),
+    )
+    return csv_path
+
+
+# --------------------------------------------------------------------------- #
+# run_refresh -- orchestration wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_run_refresh_falls_back_to_backfill_when_no_state(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_backfill(cursor, root, since, now, **kw):
+        calls["hit"] = kw
+        return [_row("Event A")]
+
+    monkeypatch.setattr(bf, "run_backfill", fake_backfill)
+    cur = FakeCursor(["Event A"])
+    rows = bf.run_refresh(
+        cur,
+        "/root",
+        None,
+        DT,
+        csv_path=str(tmp_path / "absent.csv"),
+        state_path=str(tmp_path / "absent.json"),
+    )
+    assert calls["hit"]["csv_path"] == str(tmp_path / "absent.csv")
+    assert [r["event_type"] for r in rows] == ["Event A"]
+
+
+def test_run_refresh_updates_affected_and_carries_forward_unaffected(monkeypatch, tmp_path):
+    csv_path = _seed_csv(tmp_path)
+    state_path = tmp_path / "state.json"
+    bf.write_watermark(str(state_path), "oldsha", "origin/develop", 10, "2025-04-01T00:00:00")
+    # Window net-removes Event A only.
+    stream = [
+        _header("z9", "z9", "2026-06-18", "feat: remove A (#9)"),
+        '-  trackEvent(EVENTS.X)  // "Event A"',
+    ]
+    monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter(stream))
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '"Event B"')  # A gone, B present
+    monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")
+    monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 11)
+    cur = FakeCursor(["Event A", "Event B"])
+
+    rows = bf.run_refresh(cur, "/root", None, DT, csv_path=str(csv_path), state_path=str(state_path))
+
+    by = {r["event_type"]: r for r in rows}
+    assert set(by) == {"Event A", "Event B"}  # full dataset rewritten
+    assert by["Event A"]["retired_commit"] == "z9"  # affected event updated
+    assert by["Event A"]["updated_at"] == "2026-06-22T00:00:00"  # affected gets fresh stamp
+    assert by["Event B"]["updated_at"] == "2025-03-01T00:00:00"  # unaffected carried forward
+    assert bf.read_watermark(str(state_path))["last_processed_sha"] == "newsha"
+
+
+def test_run_refresh_advances_watermark_when_nothing_changed(monkeypatch, tmp_path):
+    csv_path = _seed_csv(tmp_path)
+    state_path = tmp_path / "state.json"
+    bf.write_watermark(str(state_path), "oldsha", "origin/develop", 10, "2025-04-01T00:00:00")
+    monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter([]))  # empty window
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: "")
+    monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")
+    monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 10)
+    cur = FakeCursor(["Event A", "Event B"])
+    rows = bf.run_refresh(cur, "/root", None, DT, csv_path=str(csv_path), state_path=str(state_path))
+    assert {r["event_type"] for r in rows} == {"Event A", "Event B"}
+    assert all(r["updated_at"].startswith("2025-") for r in rows)  # nothing restamped
+    assert bf.read_watermark(str(state_path))["last_processed_sha"] == "newsha"
 
 
 def test_write_provenance_writes_sorted_header_and_rows(tmp_path):

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -459,10 +459,21 @@ class FakeCursor:
 
     def execute(self, sql, params=None):
         self.executed.append((sql, params))
-        self._fetch = [(e,) for e in self._events] if "int__amplitude_event_taxonomy" in sql else []
+        self._fetch = [(e,) for e in self._events] if "amplitude_taxonomy_event_type" in sql else []
 
     def fetchall(self):
         return self._fetch
+
+
+def test_fetch_event_universe_anchors_on_airbyte_taxonomy_source():
+    # The event universe is anchored on the Airbyte-synced Amplitude Govern taxonomy,
+    # not the dbt int__ model (repointed 2026-06-22).
+    cur = FakeCursor(["Event A", "Event B"])
+    events = bf.fetch_event_universe(cur)
+    assert events == ["Event A", "Event B"]
+    sql = cur.executed[-1][0]
+    assert "airbyte_source.amplitude_taxonomy_event_type" in sql
+    assert "int__amplitude_event_taxonomy" not in sql
 
 
 def test_run_backfill_inserts_then_merges_then_watermarks(monkeypatch):
@@ -765,7 +776,7 @@ class RefreshCursor:
 
     def execute(self, sql, params=None):
         self.executed.append((sql, params))
-        if "int__amplitude_event_taxonomy" in sql:
+        if "amplitude_taxonomy_event_type" in sql:
             self._fetch = [(e,) for e in self._events]
         elif sql.startswith("SELECT last_processed_sha"):
             self._fetch = [self._watermark_row] if self._watermark_row else []

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -854,6 +854,7 @@ def test_merge_readd_preserves_original_instrumented_and_advances_last_change():
     merged = bf.merge_provenance_entry(existing, new_entry)
     assert merged["instrumented"]["commit"] == "aaaa"  # original instrumentation kept
     assert merged["last_change"]["commit"] == "eeee"  # window is the latest change
+    assert merged["retired"]["commit"] == "bbbb"  # carried forward from existing row
 
 
 # --------------------------------------------------------------------------- #
@@ -970,13 +971,13 @@ def test_run_refresh_walks_bounded_range_from_watermark(monkeypatch):
     monkeypatch.setattr(bf, "run_git_log", fake_git_log)
     monkeypatch.setattr(bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "")
     monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "newhead")
-    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/main")
     monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 50)
 
-    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
+    wm = ("oldsha", "origin/main", 42, "2026-06-01T00:00:00")
     cur = RefreshCursor(["Event A", "Event B"], watermark_row=wm, existing_rows=_EXISTING_ROWS)
-    bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
-    assert captured["ref"] == "oldsha..origin/develop"
+    bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC), ref="origin/main")
+    assert captured["ref"] == "oldsha..origin/main"
     assert captured["since"] is None  # the range supersedes --since
 
 

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -745,3 +745,51 @@ def test_default_constants_target_prod_source_schema():
     assert bf.DEFAULT_SOURCE_SCHEMA == "airflow_source"
     assert bf.PROVENANCE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance"
     assert bf.STATE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance_state"
+
+
+# --------------------------------------------------------------------------- #
+# read_watermark / refresh
+# --------------------------------------------------------------------------- #
+
+
+class RefreshCursor:
+    """Fake cursor for refresh wiring: serves the event universe, the watermark
+    row, and existing provenance rows depending on the SQL it is handed."""
+
+    def __init__(self, events, watermark_row=None, existing_rows=None):
+        self._events = events
+        self._watermark_row = watermark_row  # 4-tuple or None
+        self._existing = list(existing_rows or [])  # tuples in PROVENANCE_COLUMNS order
+        self.executed = []
+        self._fetch: list = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        if "int__amplitude_event_taxonomy" in sql:
+            self._fetch = [(e,) for e in self._events]
+        elif sql.startswith("SELECT last_processed_sha"):
+            self._fetch = [self._watermark_row] if self._watermark_row else []
+        elif sql.startswith("SELECT event_type,"):
+            self._fetch = list(self._existing)
+        else:
+            self._fetch = []
+
+    def fetchall(self):
+        return self._fetch
+
+
+def test_read_watermark_returns_row_as_dict():
+    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
+    cur = RefreshCursor(["Event A"], watermark_row=wm)
+    result = bf.read_watermark(cur)
+    assert result == {
+        "last_processed_sha": "oldsha",
+        "head_ref": "origin/develop",
+        "commit_count": 42,
+        "last_run_at": "2026-06-01T00:00:00",
+    }
+
+
+def test_read_watermark_none_when_no_row():
+    cur = RefreshCursor(["Event A"], watermark_row=None)
+    assert bf.read_watermark(cur) is None

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -846,10 +846,30 @@ def test_read_provenance_rows_empty_when_file_absent(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# parse_args --refresh flag
+# parse_args / default paths / _summarize
 # --------------------------------------------------------------------------- #
 
 
-def test_parse_args_refresh_flag_defaults_false_and_sets_true():
-    assert bf.parse_args([]).refresh is False
-    assert bf.parse_args(["--refresh"]).refresh is True
+def test_parse_args_defaults_to_data_dir_paths():
+    args = bf.parse_args([])
+    assert args.csv == bf.DEFAULT_CSV_PATH
+    assert args.state == bf.DEFAULT_STATE_PATH
+    assert not hasattr(args, "refresh")
+    assert not hasattr(args, "schema")
+
+
+def test_default_paths_live_under_analytics_data():
+    assert bf.DEFAULT_CSV_PATH.endswith("analytics/data/amplitude_event_provenance.csv")
+    assert bf.DEFAULT_STATE_PATH.endswith("analytics/data/amplitude_event_provenance_state.json")
+
+
+def test_summarize_counts_from_null_pattern():
+    rows = [
+        _row("Present", instrumented_date="2025-02-01"),
+        _row("Removed", instrumented_date="2025-02-01", retired_date="2026-01-01"),
+        _row("NotFound"),
+    ]
+    out = bf._summarize(rows)
+    assert "present=1" in out
+    assert "removed=1" in out
+    assert "not_found_in_code=1" in out

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -6,12 +6,7 @@ import amplitude_event_provenance_backfill as bf
 import pytest
 from amplitude_event_provenance_backfill import (
     PROVENANCE_COLUMNS,
-    PROVENANCE_SCHEMA,
-    _missing_columns,
-    build_bulk_insert,
-    build_create_table_sql,
     build_git_log_argv,
-    build_merge_sql,
     build_provenance_row,
     build_watermark_merge_sql,
     classify_code_status,
@@ -22,7 +17,6 @@ from amplitude_event_provenance_backfill import (
     parse_pr_number,
     present_at_head,
     resolve_omni_repo,
-    row_params,
     slugify_event,
 )
 
@@ -237,8 +231,6 @@ COMMIT_B = {
 def test_build_row_present_event_has_instrumented_and_no_retire():
     acc = {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A}
     row = build_provenance_row("Event A", acc, present_in_head=True, updated_at=UPDATED)
-    assert row["code_status"] == "present"
-    assert row["still_in_code"] is True
     assert row["instrumented_commit"] == "aaaa"
     assert row["instrumented_pr"] is None
     assert row["instrumented_date"] == "2025-02-01"
@@ -256,8 +248,6 @@ def test_build_row_includes_slug():
 def test_build_row_removed_event_populates_retire():
     acc = {"instrumented": COMMIT_A, "retired": COMMIT_B, "last_change": COMMIT_B}
     row = build_provenance_row("Event B", acc, present_in_head=False, updated_at=UPDATED)
-    assert row["code_status"] == "removed"
-    assert row["still_in_code"] is False
     assert row["retired_commit"] == "bbbb"
     assert row["retired_pr"] == "222"
     assert row["retired_date"] == "2025-03-01"
@@ -265,7 +255,6 @@ def test_build_row_removed_event_populates_retire():
 
 def test_build_row_not_found_event_is_all_null():
     row = build_provenance_row("Sign Up Clicked", None, present_in_head=False, updated_at=UPDATED)
-    assert row["code_status"] == "not_found_in_code"
     assert row["instrumented_commit"] is None
     assert row["retired_commit"] is None
     assert row["last_code_change_date"] is None
@@ -273,8 +262,6 @@ def test_build_row_not_found_event_is_all_null():
 
 def test_build_row_present_but_predates_window_does_not_guess():
     row = build_provenance_row("Old Event", None, present_in_head=True, updated_at=UPDATED)
-    assert row["code_status"] == "present"
-    assert row["still_in_code"] is True
     assert row["instrumented_commit"] is None
     assert row["last_code_change_date"] is None
 
@@ -282,7 +269,29 @@ def test_build_row_present_but_predates_window_does_not_guess():
 def test_build_row_event_type_preserved():
     row = build_provenance_row("Event A", None, present_in_head=None, updated_at=UPDATED)
     assert row["event_type"] == "Event A"
-    assert row["code_status"] == "unknown"
+
+
+def test_build_row_drops_code_status_and_still_in_code():
+    entry = {
+        "instrumented": {"commit": "aaaa", "pr": "1", "date": "2025-02-01"},
+        "retired": None,
+        "last_change": {"commit": "aaaa", "pr": "1", "date": "2025-02-01"},
+    }
+    row = bf.build_provenance_row("Event A", entry, True, "2026-06-22T00:00:00")
+    assert set(row) == set(bf.PROVENANCE_COLUMNS)
+    assert "code_status" not in row
+    assert "still_in_code" not in row
+
+
+def test_build_row_removed_event_still_populates_retire_via_internal_status():
+    entry = {
+        "instrumented": {"commit": "aaaa", "pr": "1", "date": "2025-02-01"},
+        "retired": {"commit": "zzzz", "pr": "9", "date": "2026-01-01"},
+        "last_change": {"commit": "zzzz", "pr": "9", "date": "2026-01-01"},
+    }
+    row = bf.build_provenance_row("Event A", entry, False, "2026-06-22T00:00:00")
+    assert row["retired_commit"] == "zzzz"
+    assert row["retired_date"] == "2026-01-01"
 
 
 # --------------------------------------------------------------------------- #
@@ -317,93 +326,20 @@ def test_present_at_head_marks_found_literals():
     assert present == {"Event A": True, "Event B": False, "Event C": True}
 
 
-def test_collect_provenance_one_row_per_event_with_correct_status():
+def test_collect_provenance_one_row_per_event():
     grep_text = "'Event A'\n'Event C'"  # B is gone at HEAD
     rows = collect_provenance(["Event A", "Event B", "Event C"], _STREAM, grep_text, updated_at=UPDATED)
     by_event = {r["event_type"]: r for r in rows}
     assert len(rows) == 3
-    assert by_event["Event A"]["code_status"] == "present"
+    # Event A: instrumented set, retired null -> present
     assert by_event["Event A"]["instrumented_commit"] == "aaaa"
-    assert by_event["Event B"]["code_status"] == "removed"
+    assert by_event["Event A"]["retired_commit"] is None
+    # Event B: instrumented set, retired set -> removed
+    assert by_event["Event B"]["instrumented_commit"] == "aaaa"
     assert by_event["Event B"]["retired_commit"] == "bbbb"
-    assert by_event["Event C"]["code_status"] == "present"
+    # Event C: instrumented set, retired null -> present
     assert by_event["Event C"]["instrumented_commit"] == "bbbb"
-
-
-# --------------------------------------------------------------------------- #
-# SQL builders (parameterized -- no hand-escaping)
-# --------------------------------------------------------------------------- #
-
-
-def test_build_create_table_sql_declares_typed_columns():
-    sql = build_create_table_sql("cat.sch.t")
-    assert "CREATE TABLE IF NOT EXISTS cat.sch.t" in sql
-    assert "event_type STRING" in sql
-    assert "event_type_slug STRING" in sql
-    assert "instrumented_date DATE" in sql
-    assert "still_in_code BOOLEAN" in sql
-    assert "updated_at TIMESTAMP" in sql
-
-
-def test_build_create_table_sql_or_replace():
-    assert build_create_table_sql("cat.sch.stage", or_replace=True).startswith(
-        "CREATE OR REPLACE TABLE cat.sch.stage"
-    )
-
-
-def test_missing_columns_returns_schema_entries_absent_from_table_in_order():
-    existing = {"event_type", "instrumented_commit", "updated_at"}
-    missing = _missing_columns(existing, PROVENANCE_SCHEMA)
-    names = [c for c, _ in missing]
-    assert "event_type_slug" in names  # the newly-added column is flagged
-    assert "event_type" not in names  # already present, not re-added
-    assert names == [c for c, _ in PROVENANCE_SCHEMA if c not in existing]  # order preserved
-
-
-def test_missing_columns_empty_when_all_present():
-    existing = {c for c, _ in PROVENANCE_SCHEMA}
-    assert _missing_columns(existing, PROVENANCE_SCHEMA) == []
-
-
-def test_build_bulk_insert_one_tuple_per_row_with_flattened_params():
-    rows = [
-        build_provenance_row(
-            "A", {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A}, True, UPDATED
-        ),
-        build_provenance_row("Can't B", None, False, UPDATED),
-    ]
-    sql, params = build_bulk_insert("cat.sch.stage", PROVENANCE_COLUMNS, rows)
-    assert sql.startswith("INSERT INTO cat.sch.stage (")
-    n = len(PROVENANCE_COLUMNS)
-    assert sql.count("?") == 2 * n  # 2 rows worth of placeholders
-    assert sql.count("), (") == 1  # two value tuples
-    assert len(params) == 2 * n  # flattened, row-major
-    assert params[0] == "A" and params[n] == "Can't B"  # row boundaries; apostrophe intact
-
-
-def test_row_params_orders_values_and_preserves_apostrophe():
-    row = build_provenance_row(
-        "Onboarding - Office Step: Click Can't See Office",
-        {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A},
-        present_in_head=True,
-        updated_at=UPDATED,
-    )
-    params = row_params(row, PROVENANCE_COLUMNS)
-    assert params[0] == "Onboarding - Office Step: Click Can't See Office"  # apostrophe intact
-    assert params[1] == "onboarding_office_step_click_cant_see_office"  # slug
-    assert params[PROVENANCE_COLUMNS.index("still_in_code")] is True
-    assert len(params) == len(PROVENANCE_COLUMNS)
-
-
-def test_build_merge_sql_keys_on_event_type_and_updates_non_key_columns():
-    sql = build_merge_sql("cat.sch.target", "cat.sch.stage", ["event_type", "code_status", "updated_at"])
-    assert "MERGE INTO cat.sch.target AS t" in sql
-    assert "USING cat.sch.stage AS s" in sql
-    assert "ON t.event_type = s.event_type" in sql
-    assert "t.code_status = s.code_status" in sql
-    set_block = sql.split("UPDATE SET", 1)[1].split("WHEN NOT MATCHED", 1)[0]
-    assert "t.event_type = s.event_type" not in set_block
-    assert "WHEN NOT MATCHED THEN INSERT" in sql
+    assert by_event["Event C"]["retired_commit"] is None
 
 
 def test_build_watermark_merge_sql_is_parameterized_and_keys_on_job_name():
@@ -721,44 +657,6 @@ def test_resolve_pr_gaps_skips_rows_without_commit():
 
 
 # --------------------------------------------------------------------------- #
-# Schema resolution -- env-configurable landing schema (airflow_source convention)
-# --------------------------------------------------------------------------- #
-
-
-def test_provenance_tables_builds_table_and_state_from_schema():
-    table, state = bf.provenance_tables("airflow_source")
-    assert table == "goodparty_data_catalog.airflow_source.amplitude_event_provenance"
-    assert state == "goodparty_data_catalog.airflow_source.amplitude_event_provenance_state"
-
-
-def test_provenance_tables_honors_a_dev_schema():
-    table, state = bf.provenance_tables("private_tristan")
-    assert table == "goodparty_data_catalog.private_tristan.amplitude_event_provenance"
-    assert state == "goodparty_data_catalog.private_tristan.amplitude_event_provenance_state"
-
-
-def test_resolve_schema_explicit_override_wins():
-    assert (
-        bf.resolve_schema({"DBT_AIRFLOW_SOURCE_SCHEMA": "airflow_source"}, "private_tristan")
-        == "private_tristan"
-    )
-
-
-def test_resolve_schema_falls_back_through_env_then_default():
-    assert (
-        bf.resolve_schema({"AMPLITUDE_PROVENANCE_SCHEMA": "airflow_source_dev"}, None) == "airflow_source_dev"
-    )
-    assert bf.resolve_schema({"DBT_AIRFLOW_SOURCE_SCHEMA": "airflow_source"}, None) == "airflow_source"
-    assert bf.resolve_schema({}, None) == bf.DEFAULT_SOURCE_SCHEMA
-
-
-def test_default_constants_target_prod_source_schema():
-    assert bf.DEFAULT_SOURCE_SCHEMA == "airflow_source"
-    assert bf.PROVENANCE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance"
-    assert bf.STATE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance_state"
-
-
-# --------------------------------------------------------------------------- #
 # read_watermark / refresh
 # --------------------------------------------------------------------------- #
 
@@ -829,8 +727,6 @@ _EXISTING_B = {
     "retired_commit": None,
     "retired_pr": None,
     "retired_date": None,
-    "code_status": "present",
-    "still_in_code": True,
     "last_code_change_date": "2025-02-01",
     "updated_at": "2026-01-01T00:00:00",
 }
@@ -858,57 +754,12 @@ def test_merge_readd_preserves_original_instrumented_and_advances_last_change():
         "retired_commit": "bbbb",
         "retired_pr": "222",
         "retired_date": "2025-03-01",
-        "code_status": "removed",
-        "still_in_code": False,
     }
     new_entry = {"instrumented": COMMIT_E, "retired": None, "last_change": COMMIT_E}
     merged = bf.merge_provenance_entry(existing, new_entry)
     assert merged["instrumented"]["commit"] == "aaaa"  # original instrumentation kept
     assert merged["last_change"]["commit"] == "eeee"  # window is the latest change
     assert merged["retired"]["commit"] == "bbbb"  # carried forward from existing row
-
-
-# --------------------------------------------------------------------------- #
-# read_provenance_rows
-# --------------------------------------------------------------------------- #
-
-
-def test_read_provenance_rows_keys_by_event_type():
-    existing = [
-        (
-            "Event A",
-            "event_a",
-            "aaaa",
-            None,
-            "2025-02-01",
-            None,
-            None,
-            None,
-            "present",
-            True,
-            "2025-02-01",
-            "2026-01-01T00:00:00",
-        ),
-        (
-            "Event B",
-            "event_b",
-            "aaaa",
-            None,
-            "2025-02-01",
-            None,
-            None,
-            None,
-            "present",
-            True,
-            "2025-02-01",
-            "2026-01-01T00:00:00",
-        ),
-    ]
-    cur = RefreshCursor(["Event A", "Event B"], existing_rows=existing)
-    rows = bf.read_provenance_rows(cur)
-    assert set(rows) == {"Event A", "Event B"}
-    assert rows["Event A"]["instrumented_commit"] == "aaaa"
-    assert rows["Event B"]["code_status"] == "present"
 
 
 # --------------------------------------------------------------------------- #
@@ -935,8 +786,6 @@ _EXISTING_ROWS = [
         None,
         None,
         None,
-        "present",
-        True,
         "2025-02-01",
         "2026-01-01T00:00:00",
     ),
@@ -949,8 +798,6 @@ _EXISTING_ROWS = [
         None,
         None,
         None,
-        "present",
-        True,
         "2025-02-01",
         "2026-01-01T00:00:00",
     ),
@@ -1007,12 +854,7 @@ def test_run_refresh_merges_only_affected_events_and_advances_watermark(monkeypa
     # only Event B is rewritten, and its existing instrumentation is preserved
     assert [r["event_type"] for r in rows] == ["Event B"]
     assert rows[0]["instrumented_commit"] == "aaaa"
-    assert rows[0]["code_status"] == "removed"
     assert rows[0]["retired_commit"] == "eeee"
-
-    inserts = [(s, p) for s, p in cur.executed if s.startswith("INSERT INTO")]
-    assert len(inserts) == 1
-    assert inserts[0][0].count("?") == 1 * len(PROVENANCE_COLUMNS)  # exactly one row
 
     wm_merges = [(s, p) for s, p in cur.executed if "ON t.job_name = s.job_name" in s]
     assert len(wm_merges) == 1
@@ -1033,6 +875,54 @@ def test_run_refresh_advances_watermark_when_nothing_changed(monkeypatch):
     assert rows == []
     assert not [s for s, _ in cur.executed if s.startswith("INSERT INTO")]  # no provenance write
     assert any("ON t.job_name = s.job_name" in s for s, _ in cur.executed)  # watermark still advanced
+
+
+# --------------------------------------------------------------------------- #
+# CSV persistence
+# --------------------------------------------------------------------------- #
+
+
+def _row(event_type, **over):
+    base = {c: None for c in bf.PROVENANCE_COLUMNS}
+    base["event_type"] = event_type
+    base["event_type_slug"] = bf.slugify_event(event_type)
+    base["updated_at"] = "2026-06-22T00:00:00"
+    base.update(over)
+    return base
+
+
+def test_write_provenance_writes_sorted_header_and_rows(tmp_path):
+    csv_path = tmp_path / "prov.csv"
+    rows = [_row("Event B"), _row("Event A")]
+    bf.write_provenance(rows, str(csv_path))
+    lines = csv_path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == ",".join(bf.PROVENANCE_COLUMNS)
+    assert lines[1].startswith("Event A,")
+    assert lines[2].startswith("Event B,")
+
+
+def test_write_provenance_renders_none_as_empty_field(tmp_path):
+    csv_path = tmp_path / "prov.csv"
+    bf.write_provenance([_row("Event A")], str(csv_path))
+    back = bf.read_provenance_rows(str(csv_path))
+    assert back["Event A"]["retired_commit"] is None
+
+
+def test_provenance_csv_round_trips(tmp_path):
+    csv_path = tmp_path / "prov.csv"
+    rows = [
+        _row("Event A", instrumented_commit="aaaa", instrumented_date="2025-02-01"),
+        _row("Click Can't See Office", instrumented_commit="bbbb", instrumented_pr="7"),
+    ]
+    bf.write_provenance(rows, str(csv_path))
+    back = bf.read_provenance_rows(str(csv_path))
+    assert back["Event A"]["instrumented_commit"] == "aaaa"
+    assert back["Click Can't See Office"]["instrumented_pr"] == "7"
+    assert set(back) == {"Event A", "Click Can't See Office"}
+
+
+def test_read_provenance_rows_empty_when_file_absent(tmp_path):
+    assert bf.read_provenance_rows(str(tmp_path / "missing.csv")) == {}
 
 
 # --------------------------------------------------------------------------- #

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -1,0 +1,677 @@
+import os
+from datetime import UTC, datetime
+
+import amplitude_event_provenance_backfill as bf
+from amplitude_event_provenance_backfill import (
+    PROVENANCE_COLUMNS,
+    PROVENANCE_SCHEMA,
+    _missing_columns,
+    build_bulk_insert,
+    build_create_table_sql,
+    build_git_log_argv,
+    build_merge_sql,
+    build_provenance_row,
+    build_watermark_merge_sql,
+    classify_code_status,
+    collect_provenance,
+    compile_event_pattern,
+    find_events,
+    parse_git_log,
+    parse_pr_number,
+    present_at_head,
+    resolve_omni_repo,
+    row_params,
+    slugify_event,
+)
+
+SEP = "\x1f"
+
+
+def _header(full, short, date, subject):
+    return "\x00" + SEP.join([full, short, date, subject])
+
+
+# --------------------------------------------------------------------------- #
+# parse_pr_number / classify_code_status
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_pr_number_pulls_squash_merge_suffix():
+    assert parse_pr_number("feat: add events (#1234)") == "1234"
+
+
+def test_parse_pr_number_pulls_merge_commit_form():
+    # omni's dominant convention is merge commits, not squash suffixes.
+    assert parse_pr_number("Merge pull request #1892 from thegoodparty/feat/briefings") == "1892"
+
+
+def test_parse_pr_number_none_when_no_suffix():
+    assert parse_pr_number("WEB-3658: fullstory events") is None
+    assert parse_pr_number("") is None
+    assert parse_pr_number(None) is None
+
+
+def test_classify_code_status_present_when_in_head():
+    assert classify_code_status(True, True) == "present"
+    assert classify_code_status(True, False) == "present"
+
+
+def test_classify_code_status_removed_when_absent_with_history():
+    assert classify_code_status(False, True) == "removed"
+
+
+def test_classify_code_status_not_found_when_absent_without_history():
+    assert classify_code_status(False, False) == "not_found_in_code"
+
+
+def test_classify_code_status_unknown_when_git_unavailable():
+    assert classify_code_status(None, True) == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# slugify_event -- punctuation-robust matching key
+# --------------------------------------------------------------------------- #
+
+
+def test_slugify_event_lowercases_and_separates_on_punctuation():
+    assert slugify_event("Polls - Poll Results Overview Viewed") == "polls_poll_results_overview_viewed"
+
+
+def test_slugify_event_apostrophe_variants_collapse_to_same_slug():
+    # The whole point: the Amplitude name and the code literal may differ only by
+    # an apostrophe; both must yield the same slug so they reconcile downstream.
+    with_apos = slugify_event("Onboarding - Office Step: Click Can't See Office")
+    without = slugify_event("Onboarding - Office Step: Click Cant See Office")
+    assert with_apos == without == "onboarding_office_step_click_cant_see_office"
+
+
+def test_slugify_event_handles_curly_quotes_and_trailing_punct():
+    assert slugify_event("Pro Upgrade - Guidance: Click let’s go!") == "pro_upgrade_guidance_click_lets_go"
+
+
+def test_slugify_event_already_snake_case_passthrough():
+    assert slugify_event("pro_upgrade_complete") == "pro_upgrade_complete"
+
+
+# --------------------------------------------------------------------------- #
+# find_events
+# --------------------------------------------------------------------------- #
+
+
+def test_find_events_matches_map_value_literal():
+    pattern = compile_event_pattern(["Polls - Create Poll Clicked", "Polls - Poll Question Completed"])
+    line = "  createPollClicked: 'Polls - Create Poll Clicked',"
+    assert find_events(line, pattern) == {"Polls - Create Poll Clicked"}
+
+
+def test_find_events_empty_when_no_known_literal():
+    pattern = compile_event_pattern(["Polls - Create Poll Clicked"])
+    assert find_events("  const x = doThing()", pattern) == set()
+
+
+def test_find_events_prefers_longest_to_avoid_substring_shadowing():
+    pattern = compile_event_pattern(["Completed", "Pledge Completed"])
+    line = "  pledge: 'Pledge Completed',"
+    assert find_events(line, pattern) == {"Pledge Completed"}
+
+
+def test_find_events_matches_double_quoted_and_multiple():
+    pattern = compile_event_pattern(["pro_upgrade_complete", "onboarding_complete"])
+    line = '  PRO: "pro_upgrade_complete", ONB: "onboarding_complete",'
+    assert find_events(line, pattern) == {"pro_upgrade_complete", "onboarding_complete"}
+
+
+# --------------------------------------------------------------------------- #
+# parse_git_log -- the single-pass history walk
+# --------------------------------------------------------------------------- #
+
+# Newest-first, as real `git log` emits. Commit 3 reindents Event A (a move:
+# it appears on both - and + lines, so it must net to no change).
+_STREAM = [
+    _header("cccc", "cccc", "2025-04-01", "refactor: reindent (#333)"),
+    "diff --git a/x.ts b/x.ts",
+    "--- a/x.ts",
+    "+++ b/x.ts",
+    "@@ -1,3 +1,3 @@",
+    "-  a: 'Event A',",
+    "+    a: 'Event A',",
+    _header("bbbb", "bbbb", "2025-03-01", "feat: tweak (#222)"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -1,2 +1,2 @@",
+    "-  b: 'Event B',",
+    "+  c: 'Event C',",
+    _header("aaaa", "aaaa", "2025-02-01", "WEB-1: add events"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -0,0 +1,2 @@",
+    "+  a: 'Event A',",
+    "+  b: 'Event B',",
+]
+
+
+def _parsed():
+    return parse_git_log(_STREAM, compile_event_pattern(["Event A", "Event B", "Event C"]))
+
+
+def test_parse_git_log_instrumented_is_earliest_add():
+    acc = _parsed()
+    assert acc["Event A"]["instrumented"]["commit"] == "aaaa"
+    assert acc["Event A"]["instrumented"]["date"] == "2025-02-01"
+    assert acc["Event A"]["instrumented"]["pr"] is None
+
+
+def test_parse_git_log_retire_is_latest_net_removal():
+    acc = _parsed()
+    assert acc["Event B"]["instrumented"]["commit"] == "aaaa"
+    assert acc["Event B"]["retired"]["commit"] == "bbbb"
+    assert acc["Event B"]["retired"]["pr"] == "222"
+
+
+def test_parse_git_log_reindent_move_is_not_a_change():
+    acc = _parsed()
+    assert acc["Event A"]["retired"] is None
+    assert acc["Event A"]["last_change"]["commit"] == "aaaa"
+
+
+def test_parse_git_log_event_added_later_has_no_retire():
+    acc = _parsed()
+    assert acc["Event C"]["instrumented"]["commit"] == "bbbb"
+    assert acc["Event C"]["retired"] is None
+
+
+def test_parse_git_log_omits_events_never_seen():
+    acc = parse_git_log(_STREAM, compile_event_pattern(["Event A", "Nonexistent Event"]))
+    assert "Nonexistent Event" not in acc
+
+
+# --------------------------------------------------------------------------- #
+# build_provenance_row
+# --------------------------------------------------------------------------- #
+
+UPDATED = "2026-06-17T00:00:00"
+COMMIT_A = {
+    "commit": "aaaa",
+    "short": "aaaa",
+    "date": "2025-02-01",
+    "subject": "WEB-1: add events",
+    "pr": None,
+}
+COMMIT_B = {
+    "commit": "bbbb",
+    "short": "bbbb",
+    "date": "2025-03-01",
+    "subject": "feat: remove (#222)",
+    "pr": "222",
+}
+
+
+def test_build_row_present_event_has_instrumented_and_no_retire():
+    acc = {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A}
+    row = build_provenance_row("Event A", acc, present_in_head=True, updated_at=UPDATED)
+    assert row["code_status"] == "present"
+    assert row["still_in_code"] is True
+    assert row["instrumented_commit"] == "aaaa"
+    assert row["instrumented_pr"] is None
+    assert row["instrumented_date"] == "2025-02-01"
+    assert row["retired_commit"] is None
+    assert row["last_code_change_date"] == "2025-02-01"
+    assert row["updated_at"] == UPDATED
+
+
+def test_build_row_includes_slug():
+    row = build_provenance_row("Polls - Create Poll Clicked", None, present_in_head=True, updated_at=UPDATED)
+    assert row["event_type"] == "Polls - Create Poll Clicked"
+    assert row["event_type_slug"] == "polls_create_poll_clicked"
+
+
+def test_build_row_removed_event_populates_retire():
+    acc = {"instrumented": COMMIT_A, "retired": COMMIT_B, "last_change": COMMIT_B}
+    row = build_provenance_row("Event B", acc, present_in_head=False, updated_at=UPDATED)
+    assert row["code_status"] == "removed"
+    assert row["still_in_code"] is False
+    assert row["retired_commit"] == "bbbb"
+    assert row["retired_pr"] == "222"
+    assert row["retired_date"] == "2025-03-01"
+
+
+def test_build_row_not_found_event_is_all_null():
+    row = build_provenance_row("Sign Up Clicked", None, present_in_head=False, updated_at=UPDATED)
+    assert row["code_status"] == "not_found_in_code"
+    assert row["instrumented_commit"] is None
+    assert row["retired_commit"] is None
+    assert row["last_code_change_date"] is None
+
+
+def test_build_row_present_but_predates_window_does_not_guess():
+    row = build_provenance_row("Old Event", None, present_in_head=True, updated_at=UPDATED)
+    assert row["code_status"] == "present"
+    assert row["still_in_code"] is True
+    assert row["instrumented_commit"] is None
+    assert row["last_code_change_date"] is None
+
+
+def test_build_row_event_type_preserved():
+    row = build_provenance_row("Event A", None, present_in_head=None, updated_at=UPDATED)
+    assert row["event_type"] == "Event A"
+    assert row["code_status"] == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# build_git_log_argv / present_at_head / collect_provenance
+# --------------------------------------------------------------------------- #
+
+
+def test_build_git_log_argv_single_pass_with_since():
+    argv = build_git_log_argv("/repo", "2024-06-01", ["packages/gp-webapp"])
+    assert argv[:4] == ["git", "-C", "/repo", "log"]
+    assert "-p" in argv
+    assert "--format=%x00%H%x1f%h%x1f%ad%x1f%s" in argv
+    assert argv[argv.index("--since") + 1] == "2024-06-01"
+    assert argv[argv.index("--") + 1 :] == ["packages/gp-webapp"]
+
+
+def test_build_git_log_argv_omits_since_when_none():
+    argv = build_git_log_argv("/repo", None, ["packages/gp-api"])
+    assert "--since" not in argv
+
+
+def test_build_git_log_argv_walks_the_deploy_ref():
+    argv = build_git_log_argv("/repo", "2024-06-01", ["packages/gp-webapp"], ref="origin/develop")
+    # the ref must precede the pathspec separator so git treats it as a revision, not a path
+    assert "origin/develop" in argv
+    assert argv.index("origin/develop") < argv.index("--")
+
+
+def test_present_at_head_marks_found_literals():
+    grep_text = "  a: 'Event A',\n  c: 'Event C',"
+    present = present_at_head(["Event A", "Event B", "Event C"], grep_text)
+    assert present == {"Event A": True, "Event B": False, "Event C": True}
+
+
+def test_collect_provenance_one_row_per_event_with_correct_status():
+    grep_text = "'Event A'\n'Event C'"  # B is gone at HEAD
+    rows = collect_provenance(["Event A", "Event B", "Event C"], _STREAM, grep_text, updated_at=UPDATED)
+    by_event = {r["event_type"]: r for r in rows}
+    assert len(rows) == 3
+    assert by_event["Event A"]["code_status"] == "present"
+    assert by_event["Event A"]["instrumented_commit"] == "aaaa"
+    assert by_event["Event B"]["code_status"] == "removed"
+    assert by_event["Event B"]["retired_commit"] == "bbbb"
+    assert by_event["Event C"]["code_status"] == "present"
+    assert by_event["Event C"]["instrumented_commit"] == "bbbb"
+
+
+# --------------------------------------------------------------------------- #
+# SQL builders (parameterized -- no hand-escaping)
+# --------------------------------------------------------------------------- #
+
+
+def test_build_create_table_sql_declares_typed_columns():
+    sql = build_create_table_sql("cat.sch.t")
+    assert "CREATE TABLE IF NOT EXISTS cat.sch.t" in sql
+    assert "event_type STRING" in sql
+    assert "event_type_slug STRING" in sql
+    assert "instrumented_date DATE" in sql
+    assert "still_in_code BOOLEAN" in sql
+    assert "updated_at TIMESTAMP" in sql
+
+
+def test_build_create_table_sql_or_replace():
+    assert build_create_table_sql("cat.sch.stage", or_replace=True).startswith(
+        "CREATE OR REPLACE TABLE cat.sch.stage"
+    )
+
+
+def test_missing_columns_returns_schema_entries_absent_from_table_in_order():
+    existing = {"event_type", "instrumented_commit", "updated_at"}
+    missing = _missing_columns(existing, PROVENANCE_SCHEMA)
+    names = [c for c, _ in missing]
+    assert "event_type_slug" in names  # the newly-added column is flagged
+    assert "event_type" not in names  # already present, not re-added
+    assert names == [c for c, _ in PROVENANCE_SCHEMA if c not in existing]  # order preserved
+
+
+def test_missing_columns_empty_when_all_present():
+    existing = {c for c, _ in PROVENANCE_SCHEMA}
+    assert _missing_columns(existing, PROVENANCE_SCHEMA) == []
+
+
+def test_build_bulk_insert_one_tuple_per_row_with_flattened_params():
+    rows = [
+        build_provenance_row(
+            "A", {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A}, True, UPDATED
+        ),
+        build_provenance_row("Can't B", None, False, UPDATED),
+    ]
+    sql, params = build_bulk_insert("cat.sch.stage", PROVENANCE_COLUMNS, rows)
+    assert sql.startswith("INSERT INTO cat.sch.stage (")
+    n = len(PROVENANCE_COLUMNS)
+    assert sql.count("?") == 2 * n  # 2 rows worth of placeholders
+    assert sql.count("), (") == 1  # two value tuples
+    assert len(params) == 2 * n  # flattened, row-major
+    assert params[0] == "A" and params[n] == "Can't B"  # row boundaries; apostrophe intact
+
+
+def test_row_params_orders_values_and_preserves_apostrophe():
+    row = build_provenance_row(
+        "Onboarding - Office Step: Click Can't See Office",
+        {"instrumented": COMMIT_A, "retired": None, "last_change": COMMIT_A},
+        present_in_head=True,
+        updated_at=UPDATED,
+    )
+    params = row_params(row, PROVENANCE_COLUMNS)
+    assert params[0] == "Onboarding - Office Step: Click Can't See Office"  # apostrophe intact
+    assert params[1] == "onboarding_office_step_click_cant_see_office"  # slug
+    assert params[PROVENANCE_COLUMNS.index("still_in_code")] is True
+    assert len(params) == len(PROVENANCE_COLUMNS)
+
+
+def test_build_merge_sql_keys_on_event_type_and_updates_non_key_columns():
+    sql = build_merge_sql("cat.sch.target", "cat.sch.stage", ["event_type", "code_status", "updated_at"])
+    assert "MERGE INTO cat.sch.target AS t" in sql
+    assert "USING cat.sch.stage AS s" in sql
+    assert "ON t.event_type = s.event_type" in sql
+    assert "t.code_status = s.code_status" in sql
+    set_block = sql.split("UPDATE SET", 1)[1].split("WHEN NOT MATCHED", 1)[0]
+    assert "t.event_type = s.event_type" not in set_block
+    assert "WHEN NOT MATCHED THEN INSERT" in sql
+
+
+def test_build_watermark_merge_sql_is_parameterized_and_keys_on_job_name():
+    sql = build_watermark_merge_sql("cat.sch.state")
+    assert "MERGE INTO cat.sch.state AS t" in sql
+    assert "ON t.job_name = s.job_name" in sql
+    assert "CAST(? AS BIGINT) AS commit_count" in sql
+    assert "CAST(? AS TIMESTAMP) AS last_run_at" in sql
+    assert sql.count("?") == 5  # job_name, sha, head_ref, commit_count, last_run_at
+
+
+# --------------------------------------------------------------------------- #
+# resolve_omni_repo
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_omni_repo_prefers_arg(tmp_path):
+    (tmp_path / ".git").mkdir()
+    assert resolve_omni_repo(str(tmp_path), {}) == str(tmp_path)
+
+
+def test_resolve_omni_repo_falls_back_to_env(tmp_path):
+    (tmp_path / ".git").mkdir()
+    assert resolve_omni_repo(None, {"OMNI_REPO": str(tmp_path)}) == str(tmp_path)
+
+
+def test_resolve_omni_repo_errors_when_unset():
+    import pytest
+
+    with pytest.raises(SystemExit):
+        resolve_omni_repo(None, {})
+
+
+def test_resolve_omni_repo_errors_when_not_a_checkout(tmp_path):
+    import pytest
+
+    with pytest.raises(SystemExit):
+        resolve_omni_repo(str(tmp_path), {})
+
+
+# --------------------------------------------------------------------------- #
+# run_backfill -- orchestration wiring (git IO stubbed, fake DB cursor)
+# --------------------------------------------------------------------------- #
+
+
+class FakeCursor:
+    """Records execute calls; returns the event universe for the taxonomy SELECT."""
+
+    def __init__(self, events):
+        self._events = events
+        self.executed = []
+        self._fetch: list = []
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        self._fetch = [(e,) for e in self._events] if "int__amplitude_event_taxonomy" in sql else []
+
+    def fetchall(self):
+        return self._fetch
+
+
+def test_run_backfill_inserts_then_merges_then_watermarks(monkeypatch):
+    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_STREAM))
+    monkeypatch.setattr(
+        bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "'Event A'\n'Event C'"
+    )
+    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "deadbeef")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 42)
+
+    cur = FakeCursor(["Event A", "Event B", "Event C"])
+    rows = bf.run_backfill(cur, "/omni", "2024-06-01", datetime(2026, 6, 17, tzinfo=UTC))
+
+    assert {r["event_type"] for r in rows} == {"Event A", "Event B", "Event C"}
+    # rows inserted via a parameterized bulk INSERT (3 events -> 3 tuples in one chunk)
+    inserts = [(s, p) for s, p in cur.executed if s.startswith("INSERT INTO")]
+    assert len(inserts) == 1
+    insert_sql, params = inserts[0]
+    assert insert_sql.count("?") == 3 * len(PROVENANCE_COLUMNS)
+    assert len(params) == 3 * len(PROVENANCE_COLUMNS)
+    # provenance MERGE on event_type, then watermark MERGE on job_name (with 5 bound params)
+    merges = [(s, p) for s, p in cur.executed if "MERGE INTO" in s]
+    assert any("ON t.event_type = s.event_type" in s for s, _ in merges)
+    wm = [(s, p) for s, p in merges if "ON t.job_name = s.job_name" in s]
+    assert len(wm) == 1 and wm[0][1] == (bf.JOB_NAME, "deadbeef", "origin/develop", 42, "2026-06-17T00:00:00")
+    prov_i = next(i for i, (s, _) in enumerate(cur.executed) if "ON t.event_type = s.event_type" in s)
+    wm_i = next(i for i, (s, _) in enumerate(cur.executed) if "ON t.job_name = s.job_name" in s)
+    assert wm_i > prov_i
+
+
+def test_run_backfill_applies_pr_resolver(monkeypatch):
+    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_STREAM))
+    monkeypatch.setattr(
+        bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "'Event A'\n'Event C'"
+    )
+    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "deadbeef")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 42)
+
+    cur = FakeCursor(["Event A", "Event B", "Event C"])
+    # Event A is instrumented at "aaaa" whose subject "WEB-1: add events" has no PR ref;
+    # the merge-walk resolver backfills instrumented_pr from the introducing merge commit.
+    rows = bf.run_backfill(
+        cur,
+        "/omni",
+        "2024-06-01",
+        datetime(2026, 6, 17, tzinfo=UTC),
+        pr_resolver=lambda sha: "4321" if sha == "aaaa" else None,
+    )
+    row_a = next(r for r in rows if r["event_type"] == "Event A")
+    assert row_a["instrumented_pr"] == "4321"
+
+
+# --------------------------------------------------------------------------- #
+# Git-native PR resolution -- merge-walk fills *_pr gaps parse_pr_number cannot
+# --------------------------------------------------------------------------- #
+
+
+def test_pick_introducing_merge_takes_oldest_merge_on_ancestry_path():
+    # rev-list emits newest-first; the merge that *introduced* a commit is the oldest
+    # on the ancestry path to the deploy ref, i.e. the last line.
+    rev_list = "newmerge111\noldmerge222\n"
+    assert bf._pick_introducing_merge(rev_list) == "oldmerge222"
+
+
+def test_pick_introducing_merge_none_when_no_merge():
+    assert bf._pick_introducing_merge("") is None
+    assert bf._pick_introducing_merge("\n") is None
+
+
+def test_make_merge_walk_resolver_delegates_to_git_merge_pr(monkeypatch):
+    monkeypatch.setattr(bf, "git_merge_pr", lambda root, sha, ref: f"{root}:{sha}:{ref}")
+    resolver = bf.make_merge_walk_resolver("/omni", "origin/develop")
+    assert resolver("abc123") == "/omni:abc123:origin/develop"
+
+
+def test_git_merge_pr_resolves_pr_from_real_merge_commit(tmp_path):
+    # Build a tiny repo: main -> feature -> non-ff merge with omni's merge-commit subject,
+    # then confirm git_merge_pr recovers the PR number for the feature commit.
+    import subprocess
+
+    repo = str(tmp_path)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+
+    def git(*args):
+        subprocess.run(["git", "-C", repo, *args], check=True, capture_output=True, env=env)
+
+    git("init", "-q", "-b", "main")
+    (tmp_path / "f.txt").write_text("base\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "base")
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "f.txt").write_text("base\nevent\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "feat: add an event literal")
+    feature_sha = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    git("checkout", "-q", "main")
+    git("merge", "--no-ff", "-m", "Merge pull request #42 from thegoodparty/feature", "feature")
+
+    assert bf.git_merge_pr(repo, feature_sha, "main") == "42"
+
+
+def test_git_merge_pr_none_for_commit_with_no_merge(tmp_path):
+    import subprocess
+
+    repo = str(tmp_path)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+
+    def git(*args):
+        subprocess.run(["git", "-C", repo, *args], check=True, capture_output=True, env=env)
+
+    git("init", "-q", "-b", "main")
+    (tmp_path / "f.txt").write_text("base\n")
+    git("add", ".")
+    git("commit", "-q", "-m", "base committed straight to main")
+    head = subprocess.run(
+        ["git", "-C", repo, "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    assert bf.git_merge_pr(repo, head, "main") is None
+
+
+def test_resolve_pr_gaps_fills_null_instrumented_pr():
+    rows = [
+        {"instrumented_commit": "aaaa", "instrumented_pr": None, "retired_commit": None, "retired_pr": None}
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, lambda sha: "777" if sha == "aaaa" else None)
+    assert out[0]["instrumented_pr"] == "777"
+    assert filled == 1
+
+
+def test_resolve_pr_gaps_does_not_overwrite_existing_pr():
+    rows = [
+        {"instrumented_commit": "aaaa", "instrumented_pr": "111", "retired_commit": None, "retired_pr": None}
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, lambda sha: "999")
+    assert out[0]["instrumented_pr"] == "111"
+    assert filled == 0
+
+
+def test_resolve_pr_gaps_resolves_retired_commit_too():
+    rows = [
+        {
+            "instrumented_commit": "aaaa",
+            "instrumented_pr": "111",
+            "retired_commit": "bbbb",
+            "retired_pr": None,
+        }
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, lambda sha: "888")
+    assert out[0]["retired_pr"] == "888"
+    assert filled == 1
+
+
+def test_resolve_pr_gaps_resolves_each_distinct_sha_once():
+    calls: list[str] = []
+
+    def resolver(sha):
+        calls.append(sha)
+        return "5"
+
+    rows = [
+        {
+            "instrumented_commit": "same",
+            "instrumented_pr": None,
+            "retired_commit": "same",
+            "retired_pr": None,
+        },
+        {"instrumented_commit": "same", "instrumented_pr": None, "retired_commit": None, "retired_pr": None},
+    ]
+    bf.resolve_pr_gaps(rows, resolver)
+    assert calls == ["same"]  # 3 references, one lookup
+
+
+def test_resolve_pr_gaps_noop_when_resolver_none():
+    rows = [
+        {"instrumented_commit": "aaaa", "instrumented_pr": None, "retired_commit": None, "retired_pr": None}
+    ]
+    out, filled = bf.resolve_pr_gaps(rows, None)
+    assert out[0]["instrumented_pr"] is None
+    assert filled == 0
+
+
+def test_resolve_pr_gaps_skips_rows_without_commit():
+    rows = [
+        {"instrumented_commit": None, "instrumented_pr": None, "retired_commit": None, "retired_pr": None}
+    ]
+    _, filled = bf.resolve_pr_gaps(rows, lambda sha: "1")
+    assert filled == 0
+
+
+# --------------------------------------------------------------------------- #
+# Schema resolution -- env-configurable landing schema (airflow_source convention)
+# --------------------------------------------------------------------------- #
+
+
+def test_provenance_tables_builds_table_and_state_from_schema():
+    table, state = bf.provenance_tables("airflow_source")
+    assert table == "goodparty_data_catalog.airflow_source.amplitude_event_provenance"
+    assert state == "goodparty_data_catalog.airflow_source.amplitude_event_provenance_state"
+
+
+def test_provenance_tables_honors_a_dev_schema():
+    table, state = bf.provenance_tables("private_tristan")
+    assert table == "goodparty_data_catalog.private_tristan.amplitude_event_provenance"
+    assert state == "goodparty_data_catalog.private_tristan.amplitude_event_provenance_state"
+
+
+def test_resolve_schema_explicit_override_wins():
+    assert (
+        bf.resolve_schema({"DBT_AIRFLOW_SOURCE_SCHEMA": "airflow_source"}, "private_tristan")
+        == "private_tristan"
+    )
+
+
+def test_resolve_schema_falls_back_through_env_then_default():
+    assert (
+        bf.resolve_schema({"AMPLITUDE_PROVENANCE_SCHEMA": "airflow_source_dev"}, None) == "airflow_source_dev"
+    )
+    assert bf.resolve_schema({"DBT_AIRFLOW_SOURCE_SCHEMA": "airflow_source"}, None) == "airflow_source"
+    assert bf.resolve_schema({}, None) == bf.DEFAULT_SOURCE_SCHEMA
+
+
+def test_default_constants_target_prod_source_schema():
+    assert bf.DEFAULT_SOURCE_SCHEMA == "airflow_source"
+    assert bf.PROVENANCE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance"
+    assert bf.STATE_TABLE == "goodparty_data_catalog.airflow_source.amplitude_event_provenance_state"

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -425,6 +425,7 @@ def test_run_backfill_writes_csv_and_state(monkeypatch, tmp_path):
     assert csv_path.exists()
     assert bf.read_watermark(str(state_path))["last_processed_sha"] == "headsha"
     assert set(bf.read_provenance_rows(str(csv_path))) == {"Event A", "Event B"}
+    assert bf.read_provenance_rows(str(csv_path))["Event A"]["instrumented_date"] == "2025-02-01"
 
 
 # --------------------------------------------------------------------------- #
@@ -809,6 +810,40 @@ def test_run_refresh_advances_watermark_when_nothing_changed(monkeypatch, tmp_pa
     assert {r["event_type"] for r in rows} == {"Event A", "Event B"}
     assert all(r["updated_at"].startswith("2025-") for r in rows)  # nothing restamped
     assert bf.read_watermark(str(state_path))["last_processed_sha"] == "newsha"
+
+
+def test_run_refresh_warns_when_universe_event_missing_from_csv(monkeypatch, tmp_path, capsys):
+    # CSV has only Event A; universe has Event A + Event C (brand-new, not in CSV).
+    # Refresh with an empty window should: warn about the missing event, and NOT add Event C.
+    csv_path = tmp_path / "prov.csv"
+    bf.write_provenance(
+        [
+            _row(
+                "Event A",
+                instrumented_commit="aaaa",
+                instrumented_date="2025-02-01",
+                last_code_change_date="2025-02-01",
+                updated_at="2025-02-01T00:00:00",
+            )
+        ],
+        str(csv_path),
+    )
+    state_path = tmp_path / "state.json"
+    bf.write_watermark(str(state_path), "oldsha", "origin/develop", 10, "2025-04-01T00:00:00")
+    # Universe has two events; CSV has only one.
+    cur = FakeCursor(["Event A", "Event C"])
+    monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter([]))  # empty window
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: "")
+    monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")
+    monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 10)
+
+    rows = bf.run_refresh(cur, "/root", None, DT, csv_path=str(csv_path), state_path=str(state_path))
+
+    # (i) The missing event is NOT added (limitation holds).
+    assert {r["event_type"] for r in rows} == {"Event A"}
+    # (ii) A warning is emitted to stderr mentioning the divergence.
+    assert "absent from the CSV" in capsys.readouterr().err
 
 
 def test_write_provenance_writes_sorted_header_and_rows(tmp_path):

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -5,7 +5,6 @@ from datetime import UTC, datetime
 import amplitude_event_provenance_backfill as bf
 import pytest
 from amplitude_event_provenance_backfill import (
-    PROVENANCE_COLUMNS,
     build_git_log_argv,
     build_provenance_row,
     classify_code_status,
@@ -20,6 +19,8 @@ from amplitude_event_provenance_backfill import (
 )
 
 SEP = "\x1f"
+
+DT = datetime(2026, 6, 22, tzinfo=UTC)
 
 
 def _epoch(date):
@@ -402,56 +403,28 @@ def test_fetch_event_universe_anchors_on_airbyte_taxonomy_source():
     assert "int__amplitude_event_taxonomy" not in sql
 
 
-def test_run_backfill_inserts_then_merges_then_watermarks(monkeypatch):
-    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_STREAM))
-    monkeypatch.setattr(
-        bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "'Event A'\n'Event C'"
-    )
-    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "deadbeef")
-    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
-    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 42)
+def test_run_backfill_writes_csv_and_state(monkeypatch, tmp_path):
+    csv_path = tmp_path / "prov.csv"
+    state_path = tmp_path / "state.json"
+    cur = FakeCursor(["Event A", "Event B"])
+    stream = [
+        _header("a1", "a1", "2025-02-01", "feat: add A (#1)"),
+        '+  trackEvent(EVENTS.X)  // "Event A"',
+        _header("b1", "b1", "2025-03-01", "feat: add B (#2)"),
+        '+  trackEvent(EVENTS.Y)  // "Event B"',
+    ]
+    monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter(stream))
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '"Event A" "Event B"')
+    monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "headsha")
+    monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 7)
 
-    cur = FakeCursor(["Event A", "Event B", "Event C"])
-    rows = bf.run_backfill(cur, "/omni", "2024-06-01", datetime(2026, 6, 17, tzinfo=UTC))
+    rows = bf.run_backfill(cur, "/root", None, DT, csv_path=str(csv_path), state_path=str(state_path))
 
-    assert {r["event_type"] for r in rows} == {"Event A", "Event B", "Event C"}
-    # rows inserted via a parameterized bulk INSERT (3 events -> 3 tuples in one chunk)
-    inserts = [(s, p) for s, p in cur.executed if s.startswith("INSERT INTO")]
-    assert len(inserts) == 1
-    insert_sql, params = inserts[0]
-    assert insert_sql.count("?") == 3 * len(PROVENANCE_COLUMNS)
-    assert len(params) == 3 * len(PROVENANCE_COLUMNS)
-    # provenance MERGE on event_type, then watermark MERGE on job_name (with 5 bound params)
-    merges = [(s, p) for s, p in cur.executed if "MERGE INTO" in s]
-    assert any("ON t.event_type = s.event_type" in s for s, _ in merges)
-    wm = [(s, p) for s, p in merges if "ON t.job_name = s.job_name" in s]
-    assert len(wm) == 1 and wm[0][1] == (bf.JOB_NAME, "deadbeef", "origin/develop", 42, "2026-06-17T00:00:00")
-    prov_i = next(i for i, (s, _) in enumerate(cur.executed) if "ON t.event_type = s.event_type" in s)
-    wm_i = next(i for i, (s, _) in enumerate(cur.executed) if "ON t.job_name = s.job_name" in s)
-    assert wm_i > prov_i
-
-
-def test_run_backfill_applies_pr_resolver(monkeypatch):
-    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_STREAM))
-    monkeypatch.setattr(
-        bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "'Event A'\n'Event C'"
-    )
-    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "deadbeef")
-    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
-    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 42)
-
-    cur = FakeCursor(["Event A", "Event B", "Event C"])
-    # Event A is instrumented at "aaaa" whose subject "WEB-1: add events" has no PR ref;
-    # the merge-walk resolver backfills instrumented_pr from the introducing merge commit.
-    rows = bf.run_backfill(
-        cur,
-        "/omni",
-        "2024-06-01",
-        datetime(2026, 6, 17, tzinfo=UTC),
-        pr_resolver=lambda sha: "4321" if sha == "aaaa" else None,
-    )
-    row_a = next(r for r in rows if r["event_type"] == "Event A")
-    assert row_a["instrumented_pr"] == "4321"
+    assert {r["event_type"] for r in rows} == {"Event A", "Event B"}
+    assert csv_path.exists()
+    assert bf.read_watermark(str(state_path))["last_processed_sha"] == "headsha"
+    assert set(bf.read_provenance_rows(str(csv_path))) == {"Event A", "Event B"}
 
 
 # --------------------------------------------------------------------------- #

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -1021,3 +1021,13 @@ def test_run_refresh_advances_watermark_when_nothing_changed(monkeypatch):
     assert rows == []
     assert not [s for s, _ in cur.executed if s.startswith("INSERT INTO")]  # no provenance write
     assert any("ON t.job_name = s.job_name" in s for s, _ in cur.executed)  # watermark still advanced
+
+
+# --------------------------------------------------------------------------- #
+# parse_args --refresh flag
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_args_refresh_flag_defaults_false_and_sets_true():
+    assert bf.parse_args([]).refresh is False
+    assert bf.parse_args(["--refresh"]).refresh is True

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -544,6 +544,27 @@ def test_run_git_log_streams_lines_on_success(tmp_path):
     assert any("base" in line for line in lines)
 
 
+def test_git_grep_present_text_raises_on_fatal_error(tmp_path):
+    # A bad ref makes `git grep` exit 2+ (fatal). That must raise, not return an empty
+    # dump indistinguishable from "no matches" -- which would map every event to absent
+    # at HEAD, write them all as "removed", and advance the watermark on a corrupted CSV.
+    repo = _init_repo_one_commit(tmp_path)
+    with pytest.raises(subprocess.CalledProcessError):
+        bf.git_grep_present_text(repo, ["base"], ["f.txt"], ref="no-such-ref-abc123")
+
+
+def test_git_grep_present_text_returns_empty_on_no_match(tmp_path):
+    # Exit 1 (no matches) is not an error: return an empty dump, do not raise.
+    repo = _init_repo_one_commit(tmp_path)
+    assert bf.git_grep_present_text(repo, ["nope-not-present"], ["f.txt"], ref="HEAD") == ""
+
+
+def test_git_grep_present_text_returns_matching_lines(tmp_path):
+    # Exit 0: the matching lines come back.
+    repo = _init_repo_one_commit(tmp_path)
+    assert "base" in bf.git_grep_present_text(repo, ["base"], ["f.txt"], ref="HEAD")
+
+
 def test_git_fetch_raises_on_failure(tmp_path):
     # No 'origin' remote configured -> `git fetch origin develop` fails; must abort, not continue.
     repo = _init_repo_one_commit(tmp_path)

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -320,6 +320,15 @@ def test_build_git_log_argv_walks_the_deploy_ref():
     assert argv.index("origin/develop") < argv.index("--")
 
 
+def test_build_git_log_argv_adds_pickaxe_before_ref():
+    argv = build_git_log_argv(
+        "/repo", "2024-06-01", ["packages/gp-webapp"], ref="origin/develop", pickaxe='Click "Upload"'
+    )
+    # -S<literal> is one argv element (fixed string), placed before the ref and the pathspec.
+    assert '-SClick "Upload"' in argv
+    assert argv.index('-SClick "Upload"') < argv.index("origin/develop") < argv.index("--")
+
+
 def test_present_at_head_marks_found_literals():
     grep_text = "  a: 'Event A',\n  c: 'Event C',"
     present = present_at_head(["Event A", "Event B", "Event C"], grep_text)
@@ -845,9 +854,10 @@ def test_run_refresh_advances_watermark_when_nothing_changed(monkeypatch, tmp_pa
     assert bf.read_watermark(str(state_path))["last_processed_sha"] == "newsha"
 
 
-def test_run_refresh_warns_when_universe_event_missing_from_csv(monkeypatch, tmp_path, capsys):
-    # CSV has only Event A; universe has Event A + Event C (brand-new, not in CSV).
-    # Refresh with an empty window should: warn about the missing event, and NOT add Event C.
+def test_run_refresh_onboards_new_universe_event_via_full_history(monkeypatch, tmp_path):
+    # CSV has only Event A; universe has Event A + Event C (new to the taxonomy, instrumented
+    # before the watermark so it never appears in the window). The refresh must onboard Event C
+    # from full history, not skip it -- no manual full backfill required.
     csv_path = tmp_path / "prov.csv"
     bf.write_provenance(
         [
@@ -863,20 +873,67 @@ def test_run_refresh_warns_when_universe_event_missing_from_csv(monkeypatch, tmp
     )
     state_path = tmp_path / "state.json"
     bf.write_watermark(str(state_path), "oldsha", "origin/develop", 10, "2025-04-01T00:00:00")
-    # Universe has two events; CSV has only one.
     cur = FakeCursor(["Event A", "Event C"])
-    monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter([]))  # empty window
-    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: "")
+
+    # The window walk (no pickaxe) is empty; the onboarding pickaxe walk for Event C returns its
+    # historical add commit. present_at_head sees Event C in the code at HEAD.
+    def fake_log(*a, **k):
+        if k.get("pickaxe") == "Event C":
+            return iter([_header("c1", "c1", "2025-01-15", "feat: add C (#5)"), '+  EVENTS.C  // "Event C"'])
+        return iter([])
+
+    monkeypatch.setattr(bf, "run_git_log", fake_log)
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '"Event C"')
     monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")
     monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
     monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 10)
 
     rows = bf.run_refresh(cur, "/root", None, DT, csv_path=str(csv_path), state_path=str(state_path))
 
-    # (i) The missing event is NOT added (limitation holds).
-    assert {r["event_type"] for r in rows} == {"Event A"}
-    # (ii) A warning is emitted to stderr mentioning the divergence.
-    assert "absent from the CSV" in capsys.readouterr().err
+    by = {r["event_type"]: r for r in rows}
+    assert set(by) == {"Event A", "Event C"}  # Event C onboarded, not skipped
+    assert by["Event C"]["instrumented_commit"] == "c1"
+    assert by["Event C"]["instrumented_date"] == "2025-01-15"
+    assert by["Event C"]["instrumented_pr"] == "5"  # parsed from the commit subject
+    assert by["Event C"]["retired_commit"] is None  # present at HEAD
+    assert by["Event A"]["updated_at"] == "2025-02-01T00:00:00"  # existing row carried forward
+    assert bf.read_watermark(str(state_path))["last_processed_sha"] == "newsha"
+
+
+def test_attribute_events_from_history_finds_instrumentation_via_pickaxe(tmp_path):
+    # Real repo: a literal introduced in a later commit must be found by the -S pickaxe walk and
+    # attributed (instrumented date + PR from the subject), with no full-diff walk.
+    repo = str(tmp_path)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+    subprocess.run(["git", "-C", repo, "init", "-q", "-b", "main"], check=True, env=env)
+    (tmp_path / "app.ts").write_text("// nothing yet\n")
+    subprocess.run(["git", "-C", repo, "add", "."], check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "-C", repo, "commit", "-q", "-m", "base"], check=True, capture_output=True, env=env
+    )
+    (tmp_path / "app.ts").write_text('trackEvent(EVENTS.X)  // "Event X"\n')
+    subprocess.run(["git", "-C", repo, "add", "."], check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "-C", repo, "commit", "-q", "-m", "feat: add X (#7)"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    rows = bf.attribute_events_from_history(
+        repo, ["Event X"], None, "HEAD", "2026-06-23T00:00:00", paths=["app.ts"]
+    )
+
+    row = {r["event_type"]: r for r in rows}["Event X"]
+    assert row["instrumented_date"]  # found via pickaxe, not None
+    assert row["instrumented_pr"] == "7"
+    assert row["retired_commit"] is None  # still present at HEAD
 
 
 def test_run_refresh_does_not_fabricate_instrumented_for_predates_window_event(monkeypatch, tmp_path):

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -854,3 +854,46 @@ def test_merge_readd_preserves_original_instrumented_and_advances_last_change():
     merged = bf.merge_provenance_entry(existing, new_entry)
     assert merged["instrumented"]["commit"] == "aaaa"  # original instrumentation kept
     assert merged["last_change"]["commit"] == "eeee"  # window is the latest change
+
+
+# --------------------------------------------------------------------------- #
+# read_provenance_rows
+# --------------------------------------------------------------------------- #
+
+
+def test_read_provenance_rows_keys_by_event_type():
+    existing = [
+        (
+            "Event A",
+            "event_a",
+            "aaaa",
+            None,
+            "2025-02-01",
+            None,
+            None,
+            None,
+            "present",
+            True,
+            "2025-02-01",
+            "2026-01-01T00:00:00",
+        ),
+        (
+            "Event B",
+            "event_b",
+            "aaaa",
+            None,
+            "2025-02-01",
+            None,
+            None,
+            None,
+            "present",
+            True,
+            "2025-02-01",
+            "2026-01-01T00:00:00",
+        ),
+    ]
+    cur = RefreshCursor(["Event A", "Event B"], existing_rows=existing)
+    rows = bf.read_provenance_rows(cur)
+    assert set(rows) == {"Event A", "Event B"}
+    assert rows["Event A"]["instrumented_commit"] == "aaaa"
+    assert rows["Event B"]["code_status"] == "present"

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -1,7 +1,9 @@
 import os
+import subprocess
 from datetime import UTC, datetime
 
 import amplitude_event_provenance_backfill as bf
+import pytest
 from amplitude_event_provenance_backfill import (
     PROVENANCE_COLUMNS,
     PROVENANCE_SCHEMA,
@@ -27,8 +29,15 @@ from amplitude_event_provenance_backfill import (
 SEP = "\x1f"
 
 
-def _header(full, short, date, subject):
-    return "\x00" + SEP.join([full, short, date, subject])
+def _epoch(date):
+    """Synthetic midnight-UTC epoch for a YYYY-MM-DD date, so date order == ts order."""
+    return str(int(datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=UTC).timestamp()))
+
+
+def _header(full, short, date, subject, ts=None):
+    # ts (commit epoch, %at) sits between the short date and the subject; defaults to the
+    # date's midnight so existing single-date streams keep their chronological ordering.
+    return "\x00" + SEP.join([full, short, date, ts or _epoch(date), subject])
 
 
 # --------------------------------------------------------------------------- #
@@ -183,6 +192,27 @@ def test_parse_git_log_omits_events_never_seen():
     assert "Nonexistent Event" not in acc
 
 
+# Two net-changes to the same event on the SAME calendar day, newest-first as git emits.
+# The evening commit (re-add) is seen first; the morning commit (original add) is the true
+# instrumentation point. Date-only comparison can't tell them apart and keeps the first seen.
+_SAME_DAY_STREAM = [
+    _header("evening", "evening", "2025-05-01", "feat: re-add the literal (#2)", ts="1714588200"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -0,0 +1 @@",
+    "+  x: 'Event X',",
+    _header("morning", "morning", "2025-05-01", "feat: add the literal (#1)", ts="1714554600"),
+    "diff --git a/x.ts b/x.ts",
+    "@@ -0,0 +1 @@",
+    "+  x: 'Event X',",
+]
+
+
+def test_parse_git_log_same_day_instrumented_breaks_tie_by_commit_time():
+    # Earliest commit of the day must win 'instrumented', not the first one in stream order.
+    acc = parse_git_log(_SAME_DAY_STREAM, compile_event_pattern(["Event X"]))
+    assert acc["Event X"]["instrumented"]["commit"] == "morning"
+
+
 # --------------------------------------------------------------------------- #
 # build_provenance_row
 # --------------------------------------------------------------------------- #
@@ -264,7 +294,7 @@ def test_build_git_log_argv_single_pass_with_since():
     argv = build_git_log_argv("/repo", "2024-06-01", ["packages/gp-webapp"])
     assert argv[:4] == ["git", "-C", "/repo", "log"]
     assert "-p" in argv
-    assert "--format=%x00%H%x1f%h%x1f%ad%x1f%s" in argv
+    assert "--format=%x00%H%x1f%h%x1f%ad%x1f%at%x1f%s" in argv
     assert argv[argv.index("--since") + 1] == "2024-06-01"
     assert argv[argv.index("--") + 1 :] == ["packages/gp-webapp"]
 
@@ -568,6 +598,46 @@ def test_git_merge_pr_none_for_commit_with_no_merge(tmp_path):
     ).stdout.strip()
 
     assert bf.git_merge_pr(repo, head, "main") is None
+
+
+def _init_repo_one_commit(tmp_path):
+    """A minimal repo with a single commit; returns its path."""
+    repo = str(tmp_path)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+    subprocess.run(["git", "-C", repo, "init", "-q", "-b", "main"], check=True, env=env)
+    (tmp_path / "f.txt").write_text("base\n")
+    subprocess.run(["git", "-C", repo, "add", "."], check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "-C", repo, "commit", "-q", "-m", "base"], check=True, capture_output=True, env=env
+    )
+    return repo
+
+
+def test_run_git_log_raises_on_nonzero_exit(tmp_path):
+    # A bad ref makes `git log` exit non-zero; the stream must surface that, not yield nothing.
+    repo = _init_repo_one_commit(tmp_path)
+    with pytest.raises(subprocess.CalledProcessError):
+        list(bf.run_git_log(repo, None, ["f.txt"], ref="no-such-ref-abc123"))
+
+
+def test_run_git_log_streams_lines_on_success(tmp_path):
+    # The happy path still yields the log stream line-by-line.
+    repo = _init_repo_one_commit(tmp_path)
+    lines = list(bf.run_git_log(repo, None, ["f.txt"]))
+    assert any("base" in line for line in lines)
+
+
+def test_git_fetch_raises_on_failure(tmp_path):
+    # No 'origin' remote configured -> `git fetch origin develop` fails; must abort, not continue.
+    repo = _init_repo_one_commit(tmp_path)
+    with pytest.raises(SystemExit):
+        bf.git_fetch(repo, "origin/develop")
 
 
 def test_resolve_pr_gaps_fills_null_instrumented_pr():

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -897,3 +897,127 @@ def test_read_provenance_rows_keys_by_event_type():
     assert set(rows) == {"Event A", "Event B"}
     assert rows["Event A"]["instrumented_commit"] == "aaaa"
     assert rows["Event B"]["code_status"] == "present"
+
+
+# --------------------------------------------------------------------------- #
+# run_refresh -- orchestration wiring
+# --------------------------------------------------------------------------- #
+
+# A window stream that net-removes only Event B (newer than the watermark).
+_REFRESH_STREAM = [
+    _header("eeee", "eeee", "2026-06-18", "feat: remove Event B (#999)"),
+    "diff --git a/x.ts b/x.ts",
+    "--- a/x.ts",
+    "+++ b/x.ts",
+    "@@ -1,2 +1,1 @@",
+    "-  b: 'Event B',",
+]
+
+_EXISTING_ROWS = [
+    (
+        "Event A",
+        "event_a",
+        "aaaa",
+        None,
+        "2025-02-01",
+        None,
+        None,
+        None,
+        "present",
+        True,
+        "2025-02-01",
+        "2026-01-01T00:00:00",
+    ),
+    (
+        "Event B",
+        "event_b",
+        "aaaa",
+        None,
+        "2025-02-01",
+        None,
+        None,
+        None,
+        "present",
+        True,
+        "2025-02-01",
+        "2026-01-01T00:00:00",
+    ),
+]
+
+
+def test_run_refresh_falls_back_to_full_backfill_when_no_watermark(monkeypatch):
+    called = {}
+
+    def fake_backfill(cursor, root, since, now, **kwargs):
+        called["since"] = since
+        return [{"event_type": "Event A"}]
+
+    monkeypatch.setattr(bf, "run_backfill", fake_backfill)
+    cur = RefreshCursor(["Event A", "Event B"], watermark_row=None)
+    rows = bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
+    assert called["since"] == "2024-06-01"
+    assert rows == [{"event_type": "Event A"}]
+
+
+def test_run_refresh_walks_bounded_range_from_watermark(monkeypatch):
+    captured = {}
+
+    def fake_git_log(root, since, paths, ref=None):
+        captured["ref"] = ref
+        captured["since"] = since
+        return iter(_REFRESH_STREAM)
+
+    monkeypatch.setattr(bf, "run_git_log", fake_git_log)
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "")
+    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "newhead")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 50)
+
+    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
+    cur = RefreshCursor(["Event A", "Event B"], watermark_row=wm, existing_rows=_EXISTING_ROWS)
+    bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
+    assert captured["ref"] == "oldsha..origin/develop"
+    assert captured["since"] is None  # the range supersedes --since
+
+
+def test_run_refresh_merges_only_affected_events_and_advances_watermark(monkeypatch):
+    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter(_REFRESH_STREAM))
+    # Event B absent at HEAD -> grep empty -> code_status removed
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "")
+    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "newhead")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 50)
+
+    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
+    cur = RefreshCursor(["Event A", "Event B"], watermark_row=wm, existing_rows=_EXISTING_ROWS)
+    rows = bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
+
+    # only Event B is rewritten, and its existing instrumentation is preserved
+    assert [r["event_type"] for r in rows] == ["Event B"]
+    assert rows[0]["instrumented_commit"] == "aaaa"
+    assert rows[0]["code_status"] == "removed"
+    assert rows[0]["retired_commit"] == "eeee"
+
+    inserts = [(s, p) for s, p in cur.executed if s.startswith("INSERT INTO")]
+    assert len(inserts) == 1
+    assert inserts[0][0].count("?") == 1 * len(PROVENANCE_COLUMNS)  # exactly one row
+
+    wm_merges = [(s, p) for s, p in cur.executed if "ON t.job_name = s.job_name" in s]
+    assert len(wm_merges) == 1
+    assert wm_merges[0][1] == (bf.JOB_NAME, "newhead", "origin/develop", 50, "2026-06-18T00:00:00")
+
+
+def test_run_refresh_advances_watermark_when_nothing_changed(monkeypatch):
+    monkeypatch.setattr(bf, "run_git_log", lambda root, since, paths, ref=None: iter([]))
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda root, events, paths, ref="HEAD": "")
+    monkeypatch.setattr(bf, "git_head_sha", lambda root, ref="HEAD": "newhead")
+    monkeypatch.setattr(bf, "git_head_ref", lambda root, ref=None: "origin/develop")
+    monkeypatch.setattr(bf, "git_commit_count", lambda root, since, paths, ref="HEAD": 50)
+
+    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
+    cur = RefreshCursor(["Event A", "Event B"], watermark_row=wm, existing_rows=_EXISTING_ROWS)
+    rows = bf.run_refresh(cur, "/omni", "2024-06-01", datetime(2026, 6, 18, tzinfo=UTC))
+
+    assert rows == []
+    assert not [s for s, _ in cur.executed if s.startswith("INSERT INTO")]  # no provenance write
+    assert any("ON t.job_name = s.job_name" in s for s, _ in cur.executed)  # watermark still advanced

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -8,7 +8,6 @@ from amplitude_event_provenance_backfill import (
     PROVENANCE_COLUMNS,
     build_git_log_argv,
     build_provenance_row,
-    build_watermark_merge_sql,
     classify_code_status,
     collect_provenance,
     compile_event_pattern,
@@ -340,15 +339,6 @@ def test_collect_provenance_one_row_per_event():
     # Event C: instrumented set, retired null -> present
     assert by_event["Event C"]["instrumented_commit"] == "bbbb"
     assert by_event["Event C"]["retired_commit"] is None
-
-
-def test_build_watermark_merge_sql_is_parameterized_and_keys_on_job_name():
-    sql = build_watermark_merge_sql("cat.sch.state")
-    assert "MERGE INTO cat.sch.state AS t" in sql
-    assert "ON t.job_name = s.job_name" in sql
-    assert "CAST(? AS BIGINT) AS commit_count" in sql
-    assert "CAST(? AS TIMESTAMP) AS last_run_at" in sql
-    assert sql.count("?") == 5  # job_name, sha, head_ref, commit_count, last_run_at
 
 
 # --------------------------------------------------------------------------- #
@@ -687,11 +677,10 @@ class RefreshCursor:
         return self._fetch
 
 
-def test_read_watermark_returns_row_as_dict():
-    wm = ("oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
-    cur = RefreshCursor(["Event A"], watermark_row=wm)
-    result = bf.read_watermark(cur)
-    assert result == {
+def test_watermark_round_trips_via_json(tmp_path):
+    state_path = tmp_path / "state.json"
+    bf.write_watermark(str(state_path), "oldsha", "origin/develop", 42, "2026-06-01T00:00:00")
+    assert bf.read_watermark(str(state_path)) == {
         "last_processed_sha": "oldsha",
         "head_ref": "origin/develop",
         "commit_count": 42,
@@ -699,9 +688,16 @@ def test_read_watermark_returns_row_as_dict():
     }
 
 
-def test_read_watermark_none_when_no_row():
-    cur = RefreshCursor(["Event A"], watermark_row=None)
-    assert bf.read_watermark(cur) is None
+def test_read_watermark_none_when_file_absent(tmp_path):
+    assert bf.read_watermark(str(tmp_path / "missing.json")) is None
+
+
+def test_write_watermark_includes_job_name(tmp_path):
+    import json as _json
+
+    state_path = tmp_path / "state.json"
+    bf.write_watermark(str(state_path), "sha", "origin/develop", 1, "2026-06-01T00:00:00")
+    assert _json.loads(state_path.read_text())["job_name"] == bf.JOB_NAME
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
# PR: Amplitude event provenance as a committed CSV (DATA-2014, folds DATA-2007)

Branch: `data-2014-provenance-refresh` → `main`. Closes DATA-2014. Supersedes and **closes PR #514 without merging** (its DATA-2007 commits are included here).

## What this delivers

A self-contained tool that builds and maintains the Amplitude event git-provenance dataset, and the dataset itself committed to the repo:

- `analytics/data/amplitude_event_provenance.csv` — one row per Amplitude `event_type` (434 rows), recording when it was instrumented / retired in omni, the attributing PR, and the last code change. Derived purely from omni git history.
- `analytics/data/amplitude_event_provenance_state.json` — the SHA watermark for incremental refresh.
- `analytics/lib/amplitude_event_provenance_backfill.py` — the pipeline (+ full test suite).

## Why a CSV (revised approach)

DATA-2014 originally planned a Databricks table refreshed by an Astro DAG under a service principal. That is superseded: the dataset is now a CSV committed in this repo, so its git history is the audit log of when each event's provenance changed, and there is no service-principal write grant to provision. A committed CSV does not fit a plain Astro DAG (which cannot easily commit to git); the scheduling mechanism is being designed separately (likely the Claude Code Desktop scheduler or a scheduled CI job that opens a PR with the refreshed CSV).

## How it works

- Walks `git log -p origin/develop` over `packages/gp-webapp` + `packages/gp-api`, anchoring on the authoritative event universe (`airbyte_source.amplitude_taxonomy_event_type`, ~434 events synced from Amplitude Govern — the one Databricks read the job makes). Earliest net-add = instrumented, latest net-remove = retired.
- PR attribution is pure git via the merge-commit ancestry walk (no GitHub API — it returns nothing for this repo).
- Single auto-detecting entry point: no state file → full backfill; state file present → walk `last_sha..origin/develop`, update only the events that changed (fresh `updated_at`), carry the rest forward verbatim, rewrite the full sorted CSV, advance the watermark.
- Output schema: `event_type, event_type_slug, instrumented_{commit,pr,date}, retired_{commit,pr,date}, last_code_change_date, updated_at`. `code_status` / `still_in_code` are dropped — derivable from the date null-pattern at read time.

## Folds DATA-2007

This branch already contains the DATA-2007 backfill commits and is based on current `main`, so the single PR delivers backfill + incremental refresh + the CSV pivot together. PR #514 should be closed without merging.

## Known limitation

A refresh only adds/updates events that changed in the window; a brand-new universe event whose instrumentation predates the watermark, or an event removed from the universe, is not reflected until a full backfill (delete the state file). The job logs a warning when universe events are missing from the CSV. This is the accepted design (the full backfill is the resync path).

## Testing

72 unit tests pass (`cd analytics && uv run pytest tests/test_amplitude_event_provenance_backfill.py`); ruff + ruff-format clean. The committed CSV was generated by a real backfill against the omni checkout (434 rows: present=370, removed=21, not_found_in_code=43).

## Out of scope / follow-ups

- Scheduling mechanism (separate design).
- Rebuilding `int__amplitude_event_taxonomy` to source from `airbyte_source.amplitude_taxonomy_event_type` (separate dbt PR, DATA-2005-adjacent).
- DATA-2005 reconciles against this CSV at check time; DATA-2006 Govern write-back unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only artifact and offline git/Databricks reads; no runtime app or auth changes. Incremental refresh can drift from the taxonomy until a full backfill (documented with warnings).
> 
> **Overview**
> Adds a **git-provenance dataset** for Amplitude events: a committed `analytics/data/amplitude_event_provenance.csv` (~434 rows) plus a JSON SHA watermark, replacing the earlier Databricks-table approach.
> 
> **New pipeline** `amplitude_event_provenance_backfill.py` loads the event universe from Databricks (`airbyte_source.amplitude_taxonomy_event_type`), walks `git log -p` on omni `origin/develop` over `packages/gp-webapp` and `packages/gp-api`, and attributes earliest net-add / latest net-remove per literal. PR numbers are filled via merge-commit ancestry (no GitHub API). **Incremental refresh** uses the watermark (`last_sha..ref`), updates only changed events, and rewrites the sorted CSV; missing state triggers a full backfill.
> 
> **`databricks_conn`** gains `get_connection()` so the job can hold a cursor; `run_query` delegates to it.
> 
> **Tests** cover parsing, merge logic, CSV round-trip, refresh/backfill orchestration, and git edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65dd3504bf0e7f5fdf049c5b46a44a0e62613ff1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->