### PR TITLE
Add ddhq-miss-audit skill

### DIFF
--- a/.claude/skills/ddhq-miss-audit/SKILL.md
+++ b/.claude/skills/ddhq-miss-audit/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: ddhq-miss-audit
+description: Audit and quantify gp_api product campaigns that have no matching DDHQ election result, for a given election-date window. Classifies every unmatched candidacy into a definitive reason (never ran / race not present in DDHQ data / never made the ballot / product wrong-office or wrong-date / DDHQ omission / genuine matcher false-negative) using a deterministic SQL pre-pass against DDHQ staging plus a web-verification subagent fan-out, then writes an external aggregate summary CSV, an internal per-record detail CSV, and a confirmed-winners list. Use when asked to understand or quantify why product users tied to a 2026 (or later) campaign are not matched to election results, or to refresh the prior DDHQ miss audit.
+---
+
+# DDHQ miss audit
+
+Quantify why gp_api product campaigns in an election-date window have no DDHQ
+election result, and split the unmatched population into definitive, web-verified
+reasons. Worked window: 2026-01-01..2026-05-31 (2026 H1).
+
+## The entity being matched (read this first, it drives every interpretation)
+
+The matching entity is a **candidacy_stage = person + office + election_date**. A
+person who shows up in DDHQ under a **different office** or a **different date** is a
+**different entity**, so not matching it is **correct by design** — not a matcher bug.
+This single fact reframes most "we should have matched" intuitions:
+
+- Person in DDHQ at a different office -> usually our product stored the **wrong
+  office** (data-quality), or they genuinely ran for two different things. Correct non-match.
+- Person in DDHQ at a different date -> our product stored the **wrong / single
+  date** (gp_api hard-codes one general-election date per campaign). Correct non-match.
+- The ONLY genuine matcher false-negative is **same person + same office + same
+  date present in DDHQ that still did not cluster** (deterministic `C3b`).
+
+**Do not re-implement office matching to grade the matcher.** Office strings are not
+comparable across gp_api and DDHQ (different word order, locality embedding, and
+office_type vocab — e.g. "wood county school board" vs "Wood County Board of
+Education"); resolving office identity is exactly what the probabilistic matcher is
+for. So the deterministic pre-pass matches PEOPLE on **name + state + date only** and
+treats office identity as a question for **web verification**, not SQL. A deterministic
+office gate biases the audit toward *hiding* true FNs (a same-person, same-date pair
+whose office is merely reworded gets dismissed as a "correct non-match"), which is the
+one thing the audit must not do.
+
+When you report, attribute different-office/different-date misses to **product data
+quality**, not to the matcher. The bulk of unmatched records are correctly unmatched.
+Because C3b is matched by name+state+date (not office), it surfaces a handful of
+candidate FNs (~15 in the worked H1 run); web verification filters the namesakes, and
+the confirmed genuine matcher-FN count is what you report.
+
+## Setup
+
+Databricks via CLI OAuth (`~/.databrickscfg`). Run SQL through the warehouse
+statement API on Serverless Starter (`18583d8b081c6486`),
+`format=JSON_ARRAY`, `disposition=INLINE`. The miss set is a few hundred rows.
+
+Pick a scratch work dir (the session scratchpad). All intermediate JSON and the
+output CSVs land there.
+
+## Step 0: freshness gate
+
+Confirm `er_source.clustered_candidacy_stages` reflects the latest matcha run and
+`dbt.stg_airbyte_source__ddhq_gdrive_election_results` has the latest DDHQ load
+(`max(election_date)` should cover your window). State both in the report.
+
+## Step 1: deterministic pre-pass (classify.sql)
+
+Edit the window in `classify.sql` (`miss0` WHERE, and `dd0` lookback ~6 months
+earlier), run it, and save the rows as `records.json` (array of objects keyed by
+column name). It excludes test users (`@goodparty.org` email) and emits one row per
+miss with a `category`:
+
+| category | meaning |
+|---|---|
+| `C1_absent_for_state` | DDHQ has no data for the state at all |
+| `C1_race_not_tracked` | state covered, but no DDHQ race in this locality (coverage gap) |
+| `C2_race_tracked_person_absent` | DDHQ holds a race in this locality; this person is absent (split by web) |
+| `C3_singleton_lost_or_unk` | same name+state at a DIFFERENT date in DDHQ (upper bound: may be a namesake) |
+| `C3_singleton_WON` | same, and it was a win we appear to already hold |
+| `C3b_person_sameday_nearFN` | same name+state+date in DDHQ that did not cluster (candidate matcher FN) |
+
+Non-negotiable design rules (undo any and a known bug returns):
+1. Resolve race existence against DDHQ **staging** (not the clustered table, not
+   `official_office_name_tokens` — both are lossy / post-filter).
+2. Match people on **name + state + date only**. Never gate person/FN matching on an
+   office-token comparison: office strings are not comparable across the two sources, so
+   an office gate hides true FNs (see "the entity being matched" above).
+3. Coverage (C1 vs C2) is a **coarse locality-name presence** signal only — does DDHQ
+   hold any race whose place tokens overlap ours. It pre-sorts; web verification is the
+   arbiter. Never infer coverage from office level.
+
+## Step 2: fixture gate (run before trusting counts)
+
+These have known, web-confirmed answers. The classifier MUST reproduce them; if any
+fails, the logic regressed.
+
+| name | state | gp office | expected |
+|---|---|---|---|
+| Mary Adams | DE | colonial school board - district f | `C2_race_tracked_person_absent` |
+| Deirdre Goins | AK | anchorage municipal assembly - seat g, district 4 | `C2_race_tracked_person_absent` |
+| Marisol Ortega | FL | lake hamilton town council - seat 1 | `C3_singleton_WON` |
+| Debra Barnes | AR | crossett school board - zone 2 | `C3_singleton_WON` |
+
+## Step 3: web-verification fan-out (USE A SMALL MODEL)
+
+Verify every C1 + C2 + C3b record. Skip the C3 set: it is matched by name+state at a
+different date, so it is an upper bound on "we already hold this" (some are namesakes),
+but a different-date C3 can never hide a same-date FN, so skipping it is safe for the
+headline. This is the cost driver, so the subagents MUST run on a small model.
+
+1. Filter `records.json` to `category` matching `^(C1_|C2_|C3b_)`. Write to
+   `to_verify.json`.
+2. Shard into batches of ~20. Write each to `batches/batch_NN.json`.
+3. Launch one `general-purpose` subagent per batch, **with `model: "haiku"`**
+   (cheapest; the task is structured web lookups). Each agent: reads
+   `verify_contract.md` (same dir) and its batch file, does the research INCLUDING the
+   required broad state-wide name search, writes its JSON array to
+   `results/result_NN.json`, and returns the same array. Launch ~10 per message.
+
+   Cost rule: do not use the orchestrator's model (usually Opus) for the fan-out.
+   Default `model: "haiku"`. If a spot-check of a batch shows several wrong or
+   low-confidence calls, re-run only those batches with `model: "sonnet"`. Never use
+   `opus` for verification.
+
+4. The contract forbids guessing wins and requires confirming locality/office before
+   trusting a name hit (common-name collisions are the main error mode).
+
+Confirm scope with the user before launching — it is a large, outward-facing run on
+hundreds of real people's names (~30 subagents for a full H1 window).
+
+## Step 3b: AI office-judgment pass (the wrong-office bucket)
+
+Subagents are told to leave `actual_office` null when the office they find matches
+ours, but they routinely rephrase it instead ("Town Commission" -> "Town
+Commissioner", "District 1" -> "Seat 1", "School Board" -> "School District board").
+If you bucket on `actual_office` being non-empty, the product-wrong-office count is
+inflated 2-3x by these rephrasings (Jane Reiser / Hillsboro Beach was the canonical
+example: same office, mislabeled wrong-office).
+
+So decide same-vs-different with a model, not a string rule. The candidate set is
+small (~60 for an H1 window):
+
+1. Collect every record where `category` is `C2_*`/`C3b`, the subagent said the
+   person ran (`final_category` not NON_CANDIDATE / NOT_ON_BALLOT), and
+   `actual_office` is non-empty. Write `{unique_id, state, product_office,
+   reported_office}` rows to `office_judge_input.json`.
+2. Launch ONE small-model subagent (`model: "haiku"`, no web research — pure semantic
+   text judgment) that reads that file and writes `office_judgments.json`:
+   `{unique_id, judgment: same|different|unsure, reason}`. Rule: same locality + same
+   governing body + same/unspecified seat = `same`; different jurisdiction, different
+   body, or a different seat/district NUMBER = `different` (office granularity includes
+   the seat, so a wrong district is a real product error).
+3. `aggregate.py` reads `office_judgments.json` automatically: `same` -> the office is
+   correct, so the record falls to "race in DDHQ, candidate absent" (or matcher FN);
+   `different`/`unsure` -> product wrong-office. The token heuristic in `same_office`
+   is only a fallback for records with no judgment.
+
+## Step 4: aggregate (aggregate.py)
+
+Merge `results/result_*.json` into `all_verified.json`
+(`jq -s 'add' results/result_*.json > all_verified.json`), then run
+`python aggregate.py <work_dir>`. It re-buckets all records under the
+candidacy_stage definition. **Coverage is taken from the deterministic SQL category,
+never predicted from office size** — `C1_*` means no DDHQ race matched our locality;
+`C2_*`/`C3b` means DDHQ holds a race in the locality. Final buckets: the subagent's
+candidacy status (NON_CANDIDATE / NOT_ON_BALLOT / ran) combines with the SQL category —
+a ran record with `category=C1_*` is "race not in DDHQ data"; a ran record with `C2_*`
+and a different `actual_office` is product wrong-office; `C3_*` is product wrong-date; a
+`C3b` (same name+state+date) is the only candidate matcher FN, confirmed by verification.
+
+## Outputs
+
+- `ddhq_unmatched_summary.csv` — **external/shareable**. Aggregate counts by outcome
+  with plain-language descriptions and an "expected to be unmatched" column. No
+  per-person rows. This is the stakeholder artifact.
+- `ddhq_unmatched_by_office_level.csv` — office-level breakdown of real candidates
+  whose race is not in DDHQ data. Descriptive audit aid, not a coverage prediction.
+- `ddhq_unmatched_confirmed_wins.csv` — confirmed election winners (public record),
+  the positive headline, tagged with office level and whether the race is in DDHQ.
+  Shareable, but it identifies people as product users; confirm the sharing use case.
+- `ddhq_unmatched_detail.csv` — **internal only**. One row per record with the
+  candidacy-status label, office level, source URL, confidence. Do NOT publish
+  externally: it labels named individuals as non-candidates / junk signups.
+
+## Reporting
+
+Lead with: share of the unmatched population that is **correctly unmatched** (no
+matchable candidacy_stage exists), then the two real levers —
+**product data quality** (wrong office/date for real candidacies whose race is in
+DDHQ) and the **races not present in DDHQ data** (real candidates, including winners,
+whose race never appears in DDHQ). Report the latter with the office-level breakdown;
+do NOT assert a race "should have been covered" from its size — we contract DDHQ for
+small races, so coverage is whatever the staging data shows, full stop. State the
+genuine matcher-FN count explicitly — report the **verification-confirmed** C3b count,
+not the raw candidate count (the pre-pass surfaces ~15 candidates by name+state+date;
+most are namesakes the web pass clears). Note that "no evidence found" records are an
+upper bound on true non-candidates, not confirmed non-candidates.
+
+## Gotchas
+
+- DDHQ `is_winner` is in staging, typed BOOLEAN in some partitions and STRING in
+  others; cast to string and compare to `'true'`.
+- Do person/name matching in SQL (a join), not an in-memory dict.
+- gp_api `election_date` is unreliable (hard-coded single general date); never gate
+  C1/C2 on date equality — judge race presence date-agnostically.
+- `is_verified` is a bad fake-signup filter (drops ~2/3 of real wins). Don't use it.
+- Coverage is empirical, not predicted. We contract DDHQ to cover small races, so never
+  infer coverage from office level; read it from whether the race is in DDHQ staging.

--- a/.claude/skills/ddhq-miss-audit/aggregate.py
+++ b/.claude/skills/ddhq-miss-audit/aggregate.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Aggregate ddhq-miss-audit results into the candidacy_stage-correct decomposition
+and write the internal detail CSV + the external aggregate summary + winners list.
+
+Usage:
+  python aggregate.py <work_dir>
+
+<work_dir> must contain:
+  records.json     -- all unmatched records w/ deterministic `category` and `office_level`
+                      (the classify.sql output)
+  all_verified.json-- merged web-verification results (one object per C1/C2/C3b record)
+
+The C3 records (same name+state present in DDHQ at a different date) are NOT
+web-verified; they are folded in from records.json by their deterministic category.
+classify.sql matches people on name+state only, so C3 is an UPPER BOUND on "we already
+hold this candidacy elsewhere" -- some are namesakes. This is safe for the headline:
+the matcher-FN signal lives entirely in C3b (same name+state+DATE), which IS verified,
+and a different-date C3 can never hide a same-date FN.
+
+COVERAGE IS A SIGNAL, NOT GROUND TRUTH. Whether DDHQ has the race is pre-sorted by the
+deterministic SQL via a coarse locality-name overlap (C1 = no locality match in DDHQ;
+C2/C3b = DDHQ holds a race in the locality), then refined by web verification. We
+contract DDHQ to cover small races, so do NOT infer coverage from office size. The
+subagents only report what happened (ran / outcome / actual office / office level);
+they do not guess whether DDHQ "should" cover the race.
+"""
+
+import csv
+import json
+import re
+import sys
+from collections import Counter
+
+work = sys.argv[1]
+allrec = {r["unique_id"]: r for r in json.load(open(f"{work}/records.json"))}
+ver = {v["unique_id"]: v for v in json.load(open(f"{work}/all_verified.json"))}
+
+# Optional AI office-judgment pass (office_judgments.json). For every C2/C3b record
+# whose subagent reported a non-empty actual_office, a small model judged whether that
+# office is the SAME seat as ours (just rephrased) or GENUINELY DIFFERENT. This is the
+# primary signal for the product-wrong-office bucket; the token heuristic below is only
+# a fallback for records the judge pass did not cover. See SKILL.md step 3b.
+try:
+    office_judgment = {
+        j["unique_id"]: j["judgment"] for j in json.load(open(f"{work}/office_judgments.json"))
+    }
+except FileNotFoundError:
+    office_judgment = {}
+
+# Tokens that carry no office-identity meaning when comparing two office strings.
+# Subagents routinely rephrase our office ("Town Commission" -> "Town Commissioner",
+# "District 1" -> "Seat 1", "School Board" -> "School District board"); those are the
+# SAME office and must NOT be counted as a product wrong-office error.
+_OFFICE_NOISE = {
+    "the",
+    "of",
+    "for",
+    "and",
+    "a",
+    "an",
+    "at",
+    "no",
+    "number",
+    "district",
+    "seat",
+    "place",
+    "ward",
+    "zone",
+    "position",
+    "subdistrict",
+    "writein",
+    "write",
+    "in",
+    "general",
+    "special",
+    "election",
+    "area",
+    "large",
+}
+# Equivalence classes folded to one token before comparison.
+_OFFICE_SYNONYM = {
+    "commissioner": "commission",
+    "councilman": "council",
+    "councilwoman": "council",
+    "councilmember": "council",
+    "councilor": "council",
+    "aldermanic": "alderman",
+    "directors": "director",
+    "board": "board",
+    "boardofeducation": "school",
+    "schools": "school",
+}
+
+
+def _office_tokens(s):
+    s = re.sub(r"[^a-z0-9]+", " ", (s or "").lower())
+    # keep numeric tokens of any length: a 1-2 digit seat/district number is
+    # office-identity-bearing ("district 1" vs "district 2" are different seats).
+    toks = [_OFFICE_SYNONYM.get(t, t) for t in s.split() if len(t) >= 3 or t.isdigit()]
+    return {t for t in toks if t not in _OFFICE_NOISE}
+
+
+def same_office(uid, ours, actual):
+    """True when `actual` (what the subagent reported) is just a rephrasing of `ours`,
+    not a genuinely different office, so it is NOT a product wrong-office error. Prefers
+    the AI office-judgment pass; falls back to a token heuristic when no judgment exists."""
+    j = office_judgment.get(uid)
+    if j == "same":
+        return True
+    if j in ("different", "unsure"):  # genuinely different (or judge unsure -> keep flagged)
+        return False
+    a, b = _office_tokens(ours), _office_tokens(actual)
+    if not a or not b:
+        return False
+    if a <= b or b <= a:  # one is a subset of the other
+        return True
+    return len(a & b) / len(a | b) >= 0.6
+
+
+def bucket(uid):
+    """Re-bucket under candidacy_stage (person + office + election_date). Coverage is
+    taken from the deterministic SQL category, never from an office-size guess."""
+    dc = allrec[uid]["category"]
+    if dc.startswith("C3_singleton"):  # same name+state in DDHQ, different date
+        return "prod_date"
+    v = ver.get(uid)
+    if v is None:
+        return "other"
+    fc = v.get("final_category", "")
+    ao = (v.get("actual_office") or "").strip()
+    # candidacy status from the subagent (scheme-tolerant: accepts old or new labels)
+    if fc in ("non_candidate", "NON_CANDIDATE"):
+        return "no_candidacy"
+    if fc in ("C2_not_on_ballot", "NOT_ON_BALLOT"):
+        return "not_on_ballot"
+    # the person did run. coverage comes from the SQL category:
+    if dc in ("C1_race_not_tracked", "C1_absent_for_state"):
+        return "race_not_in_ddhq"  # race absent from DDHQ data (any office detail moot)
+    # dc is C2 / C3b -> the race IS present in DDHQ
+    if dc == "C3b_person_sameday_nearFN":  # same name+state+date that didn't cluster
+        # The only genuine matcher FN. Takes precedence over an office rephrasing so a
+        # reworded actual_office can never steal it into prod_office and understate the
+        # headline FN count.
+        return "matcher_fn"
+    if ao and not same_office(uid, allrec[uid]["office"], ao):
+        return "prod_office"  # we stored a genuinely different office for a DDHQ race
+    return "ddhq_present_person_absent"  # race in DDHQ, candidate absent from its results
+
+
+b = Counter(bucket(u) for u in allrec)
+total = sum(b.values())
+
+
+def pct(n):
+    # guard the empty-input case (wrong window / no misses) so the CSVs still write
+    return f"{100 * n / total:.1f}%" if total else "n/a"
+
+
+LABELS = [
+    (
+        "no_candidacy",
+        "Never ran / no evidence of a campaign",
+        "Yes",
+        "Signed up but no evidence of a real candidacy anywhere in the state.",
+    ),
+    (
+        "race_not_in_ddhq",
+        "Real candidate; race not present in DDHQ data",
+        "Yes",
+        "Genuine candidate, but the race does not appear in DDHQ at any date (not loaded or not contracted). See office-level breakdown below. Includes confirmed winners.",
+    ),
+    (
+        "not_on_ballot",
+        "Filed or explored, never appeared on the ballot",
+        "Yes",
+        "Declared, filed, or campaigned but withdrew or missed filing.",
+    ),
+    (
+        "prod_office",
+        "Product record had the wrong office",
+        "Yes (as recorded)",
+        "The race is in DDHQ, but our product stored a different office than the one the person actually ran for.",
+    ),
+    (
+        "prod_date",
+        "Product record had the wrong or single election date",
+        "Yes (as recorded)",
+        "We appear to already hold this candidate in DDHQ at a different date; our product stored a different (often placeholder) date.",
+    ),
+    (
+        "ddhq_present_person_absent",
+        "Race is in DDHQ but the candidate is absent from its results",
+        "Mostly",
+        "On the ballot in a race DDHQ has, but absent from the reported results (DDHQ often lists only winners in minor races).",
+    ),
+    (
+        "matcher_fn",
+        "Possible true results-match miss (under review)",
+        "No",
+        "Same person, office, and date appear in DDHQ but did not link. Flagged for manual review.",
+    ),
+]
+
+# Records with no verification entry bucket to "other". That is a data gap (a batch
+# result was dropped or never written), NOT a result. Surface it as its own row and
+# warn loudly; never fold it into matcher_fn, the highest-severity bucket.
+if b["other"]:
+    print(
+        f"WARNING: {b['other']} record(s) have no verification entry in all_verified.json. "
+        "Listed as 'pending verification' in the summary, not folded into any outcome. "
+        "Re-run the fan-out and merge all batch results before publishing.",
+        file=sys.stderr,
+    )
+
+# external aggregate summary (no per-person labels)
+with open(f"{work}/ddhq_unmatched_summary.csv", "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["outcome_category", "count", "share_of_unmatched", "expected_to_be_unmatched", "description"])
+    for key, label, corr, desc in LABELS:
+        n = b[key]
+        w.writerow([label, n, pct(n), corr, desc])
+    if b["other"]:
+        w.writerow(
+            [
+                "Pending verification (data gap, not a result)",
+                b["other"],
+                pct(b["other"]),
+                "unknown",
+                "No verification entry — batch result(s) missing or failed. Do not publish until resolved.",
+            ]
+        )
+    w.writerow(["Total unmatched", total, "100.0%" if total else "n/a", "", ""])
+
+# office-level breakdown of real candidates whose race is not in DDHQ (audit aid)
+lvl = Counter(allrec[u].get("office_level") or "Unknown" for u in allrec if bucket(u) == "race_not_in_ddhq")
+with open(f"{work}/ddhq_unmatched_by_office_level.csv", "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["office_level", "real_candidates_race_not_in_ddhq"])
+    for level, n in sorted(lvl.items(), key=lambda x: -x[1]):
+        w.writerow([level, n])
+
+# internal per-record detail
+cols = [
+    "unique_id",
+    "fn",
+    "ln",
+    "state",
+    "dt",
+    "office",
+    "office_level",
+    "category",
+    "final_category",
+    "ran",
+    "made_ballot",
+    "result",
+    "actual_office",
+    "name_found_elsewhere_in_state",
+    "confidence",
+    "source_url",
+    "notes",
+]
+with open(f"{work}/ddhq_unmatched_detail.csv", "w", newline="") as f:
+    dw = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
+    dw.writeheader()
+    for uid, d in allrec.items():
+        row = dict(d)
+        row.update(ver.get(uid, {}))
+        dw.writerow(row)
+
+
+# confirmed winners (public record): web-verified wins (C1/C2/C3b) PLUS C3 singleton
+# wins, which are skipped in web verification because we already hold the DDHQ result
+# at a different date — they would otherwise never reach this list.
+def _is_win(uid, d):
+    v = ver.get(uid, {})
+    # result and final_category are independent fields in the contract; trust either so a
+    # WON / result=unknown mismatch is not silently dropped from the winners list.
+    return v.get("result") == "won" or v.get("final_category") == "WON" or d["category"] == "C3_singleton_WON"
+
+
+won_uids = sorted(
+    (uid for uid, d in allrec.items() if _is_win(uid, d)),
+    key=lambda uid: (allrec[uid]["state"], allrec[uid]["ln"]),
+)
+with open(f"{work}/ddhq_unmatched_confirmed_wins.csv", "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["candidate", "state", "office_won", "office_level", "race_in_ddhq", "confidence", "source"])
+    for uid in won_uids:
+        d = allrec[uid]
+        v = ver.get(uid, {})
+        held_in_ddhq = d["category"] == "C3_singleton_WON"  # win we already hold
+        office = (v.get("actual_office") or d["office"]).strip()
+        in_ddhq = "no" if d["category"].startswith("C1_") else "yes"
+        w.writerow(
+            [
+                f"{d['fn']} {d['ln']}".title(),
+                d["state"],
+                office,
+                d.get("office_level") or "",
+                in_ddhq,
+                v.get("confidence", "high" if held_in_ddhq else ""),
+                v.get("source_url", "DDHQ (held at a different date)" if held_in_ddhq else ""),
+            ]
+        )
+
+print(f"total unmatched: {total}")
+for key, label, *_ in LABELS:
+    print(f"  {b[key]:>4}  {label}")
+if b["other"]:
+    print(f"  {b['other']:>4}  Pending verification (data gap, not a result)")
+print(f"confirmed winners: {len(won_uids)}")
+print("office levels (race not in DDHQ):", dict(lvl))
+print(
+    "wrote: ddhq_unmatched_summary.csv, ddhq_unmatched_by_office_level.csv, "
+    "ddhq_unmatched_detail.csv, ddhq_unmatched_confirmed_wins.csv"
+)

--- a/.claude/skills/ddhq-miss-audit/classify.sql
+++ b/.claude/skills/ddhq-miss-audit/classify.sql
@@ -1,0 +1,235 @@
+-- ddhq-miss-audit: deterministic pre-classification of gp_api candidacy-stages
+-- with no DDHQ match. Run via the Databricks SQL statement API. See SKILL.md for the
+-- design rules this encodes and the fixtures that guard them.
+--
+-- PER-AUDIT PARAMETERS:
+-- gp_api window  -> miss0 WHERE election_date BETWEEN '<start>' AND '<end>'
+-- DDHQ lookback  -> dd0 WHERE election_date >= '<start - ~6mo>' (covers prior stages)
+--
+-- The matching entity is a candidacy_stage = person + office + election_date. Office
+-- strings are NOT comparable across gp_api and DDHQ (different word order, different
+-- locality embedding, divergent office_type vocab) -- resolving office identity is what
+-- the probabilistic matcher is for. This audit therefore matches PEOPLE on name + state
+-- + date only and never re-implements an office match to grade the matcher. Coverage
+-- ("is this race in DDHQ at all") is a coarse locality-name presence signal, refined
+-- downstream by web verification; it is never used for person matching.
+with
+    c as (select * from goodparty_data_catalog.er_source.clustered_candidacy_stages),
+    cl as (
+        select
+            cluster_id,
+            max(case when source_name = 'ddhq' then 1 else 0 end) hd,
+            max(case when source_name = 'ballotready' then 1 else 0 end) hb,
+            max(case when source_name = 'techspeed' then 1 else 0 end) ht
+        from c
+        group by 1
+    ),
+    -- generic words stripped from an office name to leave LOCALITY (place) tokens. Used
+    -- ONLY for the coarse coverage signal, never for person matching. Locality naming
+    -- still differs across sources, so coverage is a signal, not ground truth.
+    w as (
+        select
+            array(
+                'the',
+                'for',
+                'and',
+                'of',
+                'a',
+                'an',
+                'at',
+                'seat',
+                'place',
+                'ward',
+                'zone',
+                'district',
+                'subdistrict',
+                'position',
+                'precinct',
+                'no',
+                'number',
+                'large',
+                'general',
+                'special',
+                'election',
+                'member',
+                'school',
+                'board',
+                'council',
+                'councilor',
+                'councilman',
+                'councilwoman',
+                'councilmember',
+                'assembly',
+                'mayor',
+                'mayoral',
+                'supervisor',
+                'trustee',
+                'clerk',
+                'treasurer',
+                'judge',
+                'court',
+                'justice',
+                'commissioner',
+                'commission',
+                'representative',
+                'representatives',
+                'congressional',
+                'senate',
+                'house',
+                'legislature',
+                'director',
+                'directors',
+                'education',
+                'county',
+                'city',
+                'town',
+                'village',
+                'municipal',
+                'township',
+                'borough',
+                'area',
+                'public',
+                'attorney',
+                'auditor',
+                'aldermanic',
+                'alderman',
+                'selectman',
+                'selectmen',
+                'freeholder',
+                'constable',
+                'marshal',
+                'register',
+                'coroner',
+                'assessor',
+                'controller',
+                'comptroller',
+                'sheriff'
+            ) stop
+    ),
+    miss0 as (
+        select
+            g.unique_id,
+            g.cluster_id,
+            g.state,
+            g.election_date dt,
+            lower(trim(g.first_name)) fn,
+            lower(trim(g.last_name)) ln,
+            g.official_office_name office,
+            g.office_level,
+            cl.hb,
+            cl.ht,
+            -- office name -> distinct-by-overlap tokens >=3 chars
+            filter(
+                split(
+                    regexp_replace(lower(g.official_office_name), '[^a-z0-9]+', ' '),
+                    ' '
+                ),
+                x -> length(x) >= 3
+            ) t
+        from c g
+        join cl on g.cluster_id = cl.cluster_id
+        where
+            g.source_name = 'gp_api'
+            and g.election_date between '2026-01-01' and '2026-05-31'
+            and cl.hd = 0
+            -- exclude test users: implicit (@goodparty.org email). is_demo in
+            -- int__civics_candidacy_gp_api is all-false, so it adds nothing here.
+            and lower(coalesce(g.email, '')) not like '%@goodparty.org'
+    ),
+    miss as (select m.*, array_except(t, (select stop from w)) loc from miss0 m),
+    dd0 as (
+        select
+            state_postal_code state,
+            lower(trim(candidate_first_name)) fn,
+            lower(trim(candidate_last_name)) ln,
+            official_office_name ddhq_office,
+            election_date dt,
+            lower(cast(is_winner as string)) = 'true' win,
+            filter(
+                split(
+                    regexp_replace(lower(official_office_name), '[^a-z0-9]+', ' '), ' '
+                ),
+                x -> length(x) >= 3
+            ) t
+        from goodparty_data_catalog.dbt.stg_airbyte_source__ddhq_gdrive_election_results
+        where election_date >= '2025-06-01'
+    ),
+    dd as (select d.*, array_except(t, (select stop from w)) loc from dd0 d),
+    -- same person (name + state) at ANY date. Office is NOT compared: a hit may be the
+    -- same person under a differently-worded office OR a namesake. Web verification
+    -- confirms identity; do not assume a name+state hit is the same candidacy_stage.
+    person as (
+        select
+            m.unique_id,
+            count(*) np,
+            max(case when d.win then 1 else 0 end) won,
+            max(case when d.dt = m.dt then 1 else 0 end) person_sd,
+            max(d.ddhq_office) any_office
+        from miss m
+        join dd d on d.state = m.state and d.fn = m.fn and d.ln = m.ln
+        group by m.unique_id
+    ),
+    -- coarse coverage: does DDHQ hold a race in this LOCALITY (place-token overlap),
+    -- regardless of person. Cross-source locality naming is noisy, so this only
+    -- pre-sorts C1 vs C2; web verification is the arbiter of whether someone ran.
+    race as (
+        select
+            m.unique_id,
+            max(case when arrays_overlap(d.loc, m.loc) then 1 else 0 end) race_any,
+            1 has_state
+        from miss m
+        join dd d on d.state = m.state
+        group by m.unique_id
+    )
+select
+    m.unique_id,
+    m.state,
+    m.dt,
+    m.fn,
+    m.ln,
+    m.office,
+    m.office_level,
+    m.hb,
+    m.ht,
+    coalesce(p.np, 0) np,
+    coalesce(p.won, 0) won,
+    coalesce(p.person_sd, 0) person_sd,
+    coalesce(r.race_any, 0) race_any,
+    coalesce(r.has_state, 0) has_state,
+    -- ns_* mirror the person (name+state) hit for verify_contract.md compatibility
+    coalesce(p.np, 0) ns_n,
+    coalesce(p.won, 0) ns_won,
+    p.any_office,
+    case
+        -- same person (name+state) + same date present in DDHQ but did not cluster: the
+        -- only candidate matcher FN. Name-based, so verification must confirm identity.
+        when coalesce(p.person_sd, 0) = 1
+        then 'C3b_person_sameday_nearFN'
+        -- same person (name+state) at a DIFFERENT date: we may already hold this
+        -- candidacy at another date, or it is a namesake. won vs not split for the
+        -- report.
+        when coalesce(p.np, 0) > 0 and coalesce(p.won, 0) = 1
+        then 'C3_singleton_WON'
+        when coalesce(p.np, 0) > 0
+        then 'C3_singleton_lost_or_unk'
+        -- person absent from DDHQ, but DDHQ holds a race in this locality: on-ballot
+        -- but
+        -- absent from results, DDHQ omission, or product wrong-office. Web splits
+        -- these.
+        when coalesce(r.race_any, 0) = 1
+        then 'C2_race_tracked_person_absent'
+        -- no DDHQ rows for the state at all
+        when coalesce(r.has_state, 0) = 0
+        then 'C1_absent_for_state'
+        -- office name was all generic words (e.g. "town clerk") so loc is empty and the
+        -- coverage signal is indeterminate, not negative. Route to C2 so web
+        -- verification
+        -- decides, rather than falsely asserting the race is absent from DDHQ.
+        when size(m.loc) = 0
+        then 'C2_race_tracked_person_absent'
+        -- state covered but no locality match: likely race not in DDHQ (coverage gap)
+        else 'C1_race_not_tracked'
+    end category
+from miss m
+left join person p on p.unique_id = m.unique_id
+left join race r on r.unique_id = m.unique_id

--- a/.claude/skills/ddhq-miss-audit/verify_contract.md
+++ b/.claude/skills/ddhq-miss-audit/verify_contract.md
@@ -1,0 +1,80 @@
+# Verify a batch of DDHQ misses
+
+You verify whether gp_api product users actually ran for office in the 2026 cycle, and what
+happened, for candidacy records that did NOT match DDHQ election results. For EACH record in
+your batch, do targeted web research and produce one result object.
+
+## Input fields per record
+`unique_id, fn (first name), ln (last name), state, dt (product election date), office,
+office_level, category (our deterministic pre-class), won, ns_n, ns_won, any_office`
+
+- `category` is our SQL pre-classification, NOT ground truth. Confirm or correct it.
+- `any_office` (when present) = an office in DDHQ for this state held by SOMEONE with this
+  exact name. It may be a namesake, or it may be the same person under a different office.
+- The product `dt` is often a hard-coded general-election date and can be WRONG (wrong stage
+  or mis-entered). The real election may be on a nearby date. Do not trust it for filtering.
+
+## What to search (stop when confident)
+1. Ballotpedia: `<first> <last> <office> <state> ballotpedia`
+2. County/city/town clerk or election-office results page for that locality
+3. Local news / candidate website / social: `"<first> <last>" <office or city> <state> 2026 election results`
+
+## BROADEST possible "absent" check (REQUIRED before calling anyone a non-candidate or absent)
+Before concluding a person did not run / is absent from results, search broadly for the NAME
+ANYWHERE in the state, not just the office we have on file:
+- `"<first> <last>" <state> 2026 election` and `"<first> <last>" <state> candidate`
+- Our office string may be wrong. The person may have actually run for a DIFFERENT office or
+  in a DIFFERENT town in the same state. If you find them running/winning ANY race in the
+  state, that is NOT a non-candidate — capture the real office in `actual_office`.
+- If `any_office` is populated, explicitly check whether that DDHQ office is the SAME PERSON
+  (same locality/region, plausible) or a NAMESAKE (different part of the state, common name).
+
+## Decide, per record
+- ran: did this person actually run for office in the 2026 cycle anywhere in the state?
+- made_ballot: did they appear on an actual ballot (vs only exploring / never filed)?
+- result: won | lost | withdrew | not_on_ballot | unknown
+- office_level: federal | state | county | municipal | school | special_district | local | unknown.
+  Descriptive only, for auditing. Do NOT use it to guess whether DDHQ covers the race —
+  whether DDHQ has the race is determined separately and empirically (we contract DDHQ to
+  cover small races, so size does not predict coverage).
+- name_found_elsewhere_in_state: yes | no — did the broad state-wide name search find this
+  same person under a different office/town than the one we have?
+
+Do NOT decide whether DDHQ "should" cover the race. That is resolved upstream from DDHQ
+staging, not from your judgment of office size.
+
+## final_category (pick exactly one — candidacy status / outcome only, coverage-agnostic)
+- `WON`            ran and WON. Requires a source naming THIS person as winner of THIS race.
+- `LOST`           ran and on the ballot, confirmed lost.
+- `ON_BALLOT`      confirmed on the ballot, outcome unknown / not yet decided.
+- `NOT_ON_BALLOT`  filed / declared / campaigned but withdrew or missed filing; never on a ballot.
+- `NON_CANDIDATE`  no evidence anywhere that this person ran. Likely a product signup who never filed.
+
+## Output
+Write a JSON array (one object per input record) to the results path given in your prompt,
+AND return that same JSON array as your final message. Object shape:
+```json
+{
+  "unique_id": "gp_api|123",
+  "ran": "yes|no|unknown",
+  "made_ballot": "yes|no|unknown",
+  "result": "won|lost|withdrew|not_on_ballot|unknown",
+  "office_level": "federal|state|county|municipal|school|special_district|local|unknown",
+  "name_found_elsewhere_in_state": "yes|no",
+  "actual_office": "real office if different from ours, else null",
+  "actual_election_date": "real date if known and different from ours, else null",
+  "final_category": "WON|LOST|ON_BALLOT|NOT_ON_BALLOT|NON_CANDIDATE",
+  "source_url": "https://...",
+  "confidence": "high|med|low",
+  "notes": "one line of evidence"
+}
+```
+
+## Rules
+- Never guess a win. `result=won` requires a source naming THIS person as the winner of THIS
+  (or a confirmed equivalent) race.
+- Common names collide. Confirm locality/office before trusting a hit. A different person with
+  the same name winning elsewhere is NOT a win for this record.
+- If after all tiers (including the broad state-wide search) you find nothing, return
+  ran=unknown, final_category=NON_CANDIDATE, confidence=low. Do not invent a result.
+- Return ONLY the JSON array as your final message. No prose outside it.


### PR DESCRIPTION
## What

Adds a reusable Claude Code skill, `ddhq-miss-audit`, that audits and quantifies gp_api product campaigns with no matching DDHQ election result over a given election-date window.

Invoke with `/ddhq-miss-audit`. It supersedes the older worktree-only `ddhq-miss-classifier`.

## How it works

1. Deterministic SQL pre-pass (`classify.sql`) against DDHQ staging, fixture-gated on four known cases. Includes a name-anywhere-in-state signal so no one is called "absent" without a statewide name check.
2. Web-verification fan-out: one subagent per ~20-record batch, following `verify_contract.md`, writing structured JSON results.
3. Aggregation (`aggregate.py`) into a candidacy_stage-correct decomposition, emitting an external summary CSV, an office-level breakdown, a confirmed-winners list, and an internal per-record detail CSV.

## Design decisions baked in

- The matching entity is a candidacy_stage (person + office + election_date). A person appearing in DDHQ under a different office or date is a different entity, so not matching it is correct by design rather than a matcher failure.
- DDHQ coverage is empirical: whether a race appears in staging, never predicted from office size, since we contract DDHQ to cover smaller races.
- Verification subagents run on a small model to control cost.

## Notes

- Lives under `.claude/skills/`, alongside the existing skills.
- Audit output CSVs are written to `analytics/ad_hoc/` (gitignored); none are included here. The per-record detail file labels named individuals and is internal only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive documentation/scripts and new dbt staging models with tests; no runtime product or matcher pipeline code paths are modified.
> 
> **Overview**
> Adds a reusable **`ddhq-miss-audit`** Claude Code skill (invoke via `/ddhq-miss-audit`) to quantify why **gp_api** campaigns in an election window lack a **DDHQ** match, using a **candidacy_stage** lens (person + office + election_date).
> 
> The workflow is: run **`classify.sql`** on Databricks against `clustered_candidacy_stages` and DDHQ staging (fixture-gated categories, two-tier office tokens, statewide name signal); fan out **web verification** batches per **`verify_contract.md`** (small model); merge with **`aggregate.py`** into stakeholder summary CSVs, office-level breakdown, confirmed winners, and an internal per-person detail file.
> 
> **Separately**, the PR registers **nine new `gp_api_db` Airbyte sources** (annotations, notes, bug reports, chat, meeting briefings, artifact feedback) and adds matching **`stg_airbyte_source__gp_api_db_*`** models plus column tests in **`stg_airbyte_source__gp_api_db.yaml`** for EO Meeting Briefing analytics—not used by the audit SQL itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba3aa8cb4fd35c9f4fb8824251cb2c0c682ffa6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->