### PR TITLE
[DATA-1359] Add active serve-user cohort to People Served

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3160,6 +3160,45 @@ models:
           arguments:
             combination_of_columns: [source_name, gp_election_stage_id]
 
+  - name: int__serve_active_user
+    description: >
+      The single source of truth for the "active serve user" behavioral
+      definition (epic DATA-1359), one row per user. A user is an active serve
+      user when they completed Serve onboarding by sending an SMS poll AND have
+      pledged. This is the behavioral half of the People Served cohort; the office
+      half (Serve-ICP) and the internal-email exclusion are applied at
+      int__serve_district_resolution, where the office and owner email live. Reads
+      staging + intermediate only (never an analytics mart) so the cohort flag it
+      feeds stays below the analytics layer, with no dependency cycle into
+      int__serve_block_coverage. "Pledged" is any pledged campaign from
+      source-staging campaigns, which on the serve cohort is identical to the
+      stricter "latest candidacy pledged" notion (proven: zero membership delta).
+    columns:
+      - name: user_id
+        description: Product-DB user id (primary key).
+        data_tests:
+          - unique
+          - not_null
+      - name: has_sent_sms_poll
+        description: >
+          Sent at least one 'Serve Onboarding - SMS Poll Sent' event (the final
+          onboarding step), from int__amplitude_user_milestones.
+        data_tests:
+          - not_null
+      - name: has_pledged
+        description: >
+          Owns at least one pledged campaign (details:pledged) in source-staging
+          campaigns.
+        data_tests:
+          - not_null
+      - name: is_active_serve_user
+        description: >
+          has_sent_sms_poll AND has_pledged: the behavioral gate of the People
+          Served active cohort (combined with Serve-ICP and non-internal email
+          downstream at the resolver).
+        data_tests:
+          - not_null
+
   - name: int__serve_district_resolution
     description: >
       Resolves each serve org to its L2 district: the serve-cohort entry point
@@ -3178,6 +3217,10 @@ models:
       is_statewide (reported separately downstream), and is_internal_email.
       Rows are never excluded here; pending cohort decisions are var-driven
       filters plus flags, and flagged rows flow through for downstream review.
+      Carries in_people_served_cohort (epic DATA-1359): the active People Served
+      cohort gate -- active serve user (int__serve_active_user) AND Serve-ICP
+      office (int__icp_offices, a unique join) AND not internal email -- as a flag,
+      never a row exclusion.
     columns:
       - name: organization_slug
         description: Serve org identifier (primary key)
@@ -3296,6 +3339,29 @@ models:
           count toward the public metric is a pending product decision, so
           flag, never exclude (the serve_cohort_exclude_internal_email_orgs
           var flips the filter).
+        data_tests:
+          - not_null
+      - name: is_active_serve_user
+        description: >
+          Carried from int__serve_active_user: the owner sent an SMS poll AND
+          pledged (the behavioral half of the cohort). False when the owner has no
+          active-user row.
+        data_tests:
+          - not_null
+      - name: icp_office_serve
+        description: >
+          Carried from int__icp_offices (unique join on ballotready_position_id):
+          the office meets Serve ICP. False when the position id is null, stale, or
+          missing -- an observable non-ICP miss, never a silent drop.
+        data_tests:
+          - not_null
+      - name: in_people_served_cohort
+        description: >
+          The active People Served cohort gate: is_active_serve_user AND
+          icp_office_serve AND not is_internal_email. Flag only -- out-of-cohort
+          officials still flow through. Drives both count_once
+          (int__serve_block_coverage active union) and the count-multiple variants
+          (people_served district_level filter).
         data_tests:
           - not_null
     data_tests:
@@ -3427,7 +3493,9 @@ models:
       district types as the substrate (get_l2_major_district_columns), so count-once <=
       count-multiple holds. served_set is 'all' (served by any cohort district) or one
       of the substrate's L2 district types; statewide officials are read from the exact T5
-      'State' rows in people_served, not here.
+      'State' rows in people_served, not here. served_voters_active is the same count
+      restricted to the active cohort (in_people_served_cohort on the resolver); active
+      <= all block-for-block.
     columns:
       - name: block_geoid
         description: 15-char zero-padded 2020 census block GEOID
@@ -3441,6 +3509,17 @@ models:
           - not_null
       - name: served_voters
         description: Distinct cohort-served voters in this block for this served_set
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: served_voters_active
+        description: >
+          Distinct ACTIVE-cohort-served voters in this block for this served_set
+          (in_people_served_cohort). A subset of served_voters, so <= served_voters
+          and <= total_voters.
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
@@ -3467,3 +3546,7 @@ models:
           name: serve_block_coverage_served_le_total
           arguments:
             expression: "served_voters <= total_voters"
+      - dbt_utils.expression_is_true:
+          name: serve_block_coverage_active_le_served
+          arguments:
+            expression: "served_voters_active <= served_voters"

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3198,6 +3198,11 @@ models:
           downstream at the resolver).
         data_tests:
           - not_null
+    data_tests:
+      - dbt_utils.expression_is_true:
+          name: serve_active_user_flag_matches_components
+          arguments:
+            expression: "is_active_serve_user = (has_sent_sms_poll and has_pledged)"
 
   - name: int__serve_district_resolution
     description: >

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3356,8 +3356,19 @@ models:
       - name: icp_office_serve
         description: >
           Carried from int__icp_offices (unique join on ballotready_position_id):
-          the office meets Serve ICP. False when the position id is null, stale, or
-          missing -- an observable non-ICP miss, never a silent drop.
+          the office meets Serve ICP. False when the office is confirmed non-ICP, when
+          the position id is null/missing (no linked office), or when the office's L2
+          voter count is unknown (that last case is also flagged by
+          icp_office_serve_unknown).
+        data_tests:
+          - not_null
+      - name: icp_office_serve_unknown
+        description: >
+          The org has a BallotReady position that matched int__icp_offices but the
+          office's L2 voter count is absent, so int__icp_offices returned a null
+          serve-ICP determination (unknown, not confirmed non-ICP). icp_office_serve
+          coalesces this to false (conservative exclusion); this flag keeps the data
+          gap observable so a cohort miss is diagnosable as unknown vs true non-ICP.
         data_tests:
           - not_null
       - name: in_people_served_cohort

--- a/dbt/project/models/intermediate/civics/int__serve_active_user.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_active_user.sql
@@ -1,0 +1,47 @@
+{{ config(materialized="table", tags=["intermediate", "civics", "serve"]) }}
+
+-- int__serve_active_user (epic DATA-1359): the single source of truth for the
+-- "active serve user" BEHAVIORAL definition, one row per user. A user is an
+-- active serve user when they completed Serve onboarding by sending an SMS poll
+-- AND have pledged. This is the behavioral half of the People Served cohort; the
+-- office half (Serve-ICP) and the internal-email exclusion are applied downstream
+-- at int__serve_district_resolution, where the office and the owner email live,
+-- so this model stays a pure user-grain behavioral table.
+--
+-- Reads staging + intermediate ONLY, never an analytics mart: the cohort flag it
+-- feeds is consumed by int__serve_block_coverage, which sits below the analytics
+-- layer, so sourcing from a mart would risk a dependency cycle.
+--
+-- "Pledged" is "any pledged campaign" from source-staging campaigns. On the serve
+-- cohort this is identical to the stricter "latest candidacy pledged" notion
+-- (proven: zero membership delta), so the simpler source-staging read is canonical.
+with
+    sms_poll as (
+        -- int__amplitude_user_milestones is already one non-null row per user_id
+        select user_id, (first_sms_poll_sent_at is not null) as has_sent_sms_poll
+        from {{ ref("int__amplitude_user_milestones") }}
+    ),
+
+    pledged as (
+        select
+            user_id, bool_or(coalesce(details:pledged::boolean, false)) as has_pledged
+        from {{ ref("stg_airbyte_source__gp_api_db_campaign") }}
+        where user_id is not null
+        group by user_id
+    ),
+
+    combined as (
+        select
+            coalesce(s.user_id, p.user_id) as user_id,
+            coalesce(s.has_sent_sms_poll, false) as has_sent_sms_poll,
+            coalesce(p.has_pledged, false) as has_pledged
+        from sms_poll s
+        full outer join pledged p on s.user_id = p.user_id
+    )
+
+select
+    user_id,
+    has_sent_sms_poll,
+    has_pledged,
+    has_sent_sms_poll and has_pledged as is_active_serve_user
+from combined

--- a/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_block_coverage.sql
@@ -29,14 +29,27 @@
 -- exact T5
 -- 'State'
 -- rows in people_served and reported separately (TDD 4.5), avoiding a basis mix.
+--
+-- ACTIVE COHORT (epic DATA-1359): served_voters_active is the parallel
+-- distinct-served-voter count restricted to the active People Served cohort
+-- (in_people_served_cohort on the resolver) -- the SAME single L2 scan, just a second
+-- membership flag carried through. Active cohort districts are a subset of all cohort
+-- districts, so served_voters_active <= served_voters block-for-block. people_served
+-- reads served_voters for cohort='all' and served_voters_active for cohort='active'.
 with
     cohort_districts as (
-        select distinct
+        -- one row per cohort district; is_active_district = 1 when ANY active org
+        -- (in_people_served_cohort) resolves to it
+        select
             state,
             l2_district_type as district_type,
-            normalized_district_name as district_name
+            normalized_district_name as district_name,
+            max(
+                case when in_people_served_cohort then 1 else 0 end
+            ) as is_active_district
         from {{ ref("int__serve_district_resolution") }}
         where resolution_path != 'unresolved' and not is_statewide
+        group by state, l2_district_type, normalized_district_name
     ),
 
     state_fips as (
@@ -76,7 +89,8 @@ with
             and trim({{ normalize_l2_district_name("district_value") }}) != ''
     ),
 
-    -- per (block, voter, type): is this voter in a cohort district of this type?
+    -- per (block, voter, type): is this voter in a cohort district of this type, and
+    -- in an ACTIVE cohort district of this type?
     voter_type as (
         select
             u.block_geoid,
@@ -84,7 +98,10 @@ with
             u.district_type,
             max(
                 case when c.district_type is not null then 1 else 0 end
-            ) as served_this_type
+            ) as served_this_type,
+            max(
+                case when c.is_active_district = 1 then 1 else 0 end
+            ) as served_this_type_active
         from unpivoted u
         join state_fips sf on left(u.block_geoid, 2) = sf.fips_code
         left join
@@ -95,42 +112,61 @@ with
         group by u.block_geoid, u.lalvoterid, u.district_type
     ),
 
-    -- per (block, voter): served by ANY cohort district (the cross-type union)
+    -- per (block, voter): served by ANY cohort district / any ACTIVE cohort district
     voter_any as (
-        select block_geoid, lalvoterid, max(served_this_type) as served_any
+        select
+            block_geoid,
+            lalvoterid,
+            max(served_this_type) as served_any,
+            max(served_this_type_active) as served_any_active
         from voter_type
         group by block_geoid, lalvoterid
     ),
 
-    -- block denominator + the cohort-wide served-voter union
+    -- block denominator + the cohort-wide served-voter unions (all + active)
     block_all as (
-        select block_geoid, count(*) as total_voters, sum(served_any) as served_voters
+        select
+            block_geoid,
+            count(*) as total_voters,
+            sum(served_any) as served_voters,
+            sum(served_any_active) as served_voters_active
         from voter_any
         group by block_geoid
     ),
 
-    -- per (block, type): voters served by a cohort district of that type
+    -- per (block, type): voters served by a cohort district of that type (all + active)
     block_by_type as (
         select
             block_geoid,
             district_type as served_set,
-            sum(served_this_type) as served_voters
+            sum(served_this_type) as served_voters,
+            sum(served_this_type_active) as served_voters_active
         from voter_type
         group by block_geoid, district_type
         having sum(served_this_type) > 0
     ),
 
     coverage as (
-        select block_geoid, 'all' as served_set, served_voters, total_voters
+        select
+            block_geoid,
+            'all' as served_set,
+            served_voters,
+            served_voters_active,
+            total_voters
         from block_all
         where served_voters > 0
 
         union all
 
-        select t.block_geoid, t.served_set, t.served_voters, b.total_voters
+        select
+            t.block_geoid,
+            t.served_set,
+            t.served_voters,
+            t.served_voters_active,
+            b.total_voters
         from block_by_type t
         join block_all b on t.block_geoid = b.block_geoid
     )
 
-select block_geoid, served_set, served_voters, total_voters
+select block_geoid, served_set, served_voters, served_voters_active, total_voters
 from coverage

--- a/dbt/project/models/intermediate/civics/int__serve_district_resolution.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_district_resolution.sql
@@ -43,6 +43,19 @@ with
         where is_matched
     ),
 
+    -- the active People Served cohort's two non-email inputs. active_user is the
+    -- behavioral half (unique by user_id, so the join cannot fan out the org
+    -- grain); icp_offices is the office half (unique by br_database_position_id,
+    -- verified in int__icp.yaml, so it cannot fan out either).
+    active_user as (
+        select user_id, is_active_serve_user from {{ ref("int__serve_active_user") }}
+    ),
+
+    icp_offices as (
+        select br_database_position_id, icp_office_serve
+        from {{ ref("int__icp_offices") }}
+    ),
+
     resolved as (
         select
             o.organization_slug,
@@ -75,10 +88,14 @@ with
                     coalesce(o.custom_position_name, '')
                 )
             ) as title_text,
-            o.user_email
+            o.user_email,
+            coalesce(au.is_active_serve_user, false) as is_active_serve_user,
+            coalesce(i.icp_office_serve, false) as icp_office_serve
         from serve_orgs o
         left join districts d on coalesce(o.override_district_id, o.district_id) = d.id
         left join crosswalk x on o.ballotready_position_id = x.br_database_id
+        left join active_user au on o.user_id = au.user_id
+        left join icp_offices i on o.ballotready_position_id = i.br_database_position_id
     ),
 
     final as (
@@ -185,7 +202,25 @@ with
 
             -- internal/test accounts; whether they count toward the public
             -- metric is a pending product decision, so flag, never exclude
-            coalesce(user_email ilike '%goodparty%', false) as is_internal_email
+            coalesce(user_email ilike '%goodparty%', false) as is_internal_email,
+
+            -- behavioral + office components of the cohort, carried for
+            -- observability so a cohort miss is debuggable rather than silent
+            is_active_serve_user,
+            icp_office_serve,
+
+            -- in_people_served_cohort (epic DATA-1359): the active People Served
+            -- cohort gate -- active serve user (sent SMS poll AND pledged) AND a
+            -- Serve-ICP office AND not an internal/test account. Flag only, never a
+            -- row exclusion: out-of-cohort officials still flow through for the
+            -- broad 'all' rollups and the per-official surface. A null/stale/missing
+            -- BallotReady position id leaves icp_office_serve false (an observable
+            -- non-ICP miss); a user with no active-user row is non-active. Drives
+            -- both count_once (block-coverage active union) and the count-multiple
+            -- variants (people_served district_level filter).
+            (
+                is_active_serve_user and icp_office_serve and not is_internal_email
+            ) as in_people_served_cohort
         from resolved
     )
 

--- a/dbt/project/models/intermediate/civics/int__serve_district_resolution.sql
+++ b/dbt/project/models/intermediate/civics/int__serve_district_resolution.sql
@@ -90,7 +90,16 @@ with
             ) as title_text,
             o.user_email,
             coalesce(au.is_active_serve_user, false) as is_active_serve_user,
-            coalesce(i.icp_office_serve, false) as icp_office_serve
+            coalesce(i.icp_office_serve, false) as icp_office_serve,
+            -- int__icp_offices returns NULL icp_office_serve for a MATCHED position
+            -- whose L2 district has no voter count in the aggregations table (unknown,
+            -- not confirmed non-ICP). The coalesce above treats unknown as non-ICP
+            -- (conservative: an unconfirmed office is not admitted to the cohort), so
+            -- carry the distinction here for observability -- an excluded official can
+            -- then be diagnosed as a data gap vs a true non-ICP.
+            (
+                o.ballotready_position_id is not null and i.icp_office_serve is null
+            ) as icp_office_serve_unknown
         from serve_orgs o
         left join districts d on coalesce(o.override_district_id, o.district_id) = d.id
         left join crosswalk x on o.ballotready_position_id = x.br_database_id
@@ -208,14 +217,19 @@ with
             -- observability so a cohort miss is debuggable rather than silent
             is_active_serve_user,
             icp_office_serve,
+            icp_office_serve_unknown,
 
             -- in_people_served_cohort (epic DATA-1359): the active People Served
             -- cohort gate -- active serve user (sent SMS poll AND pledged) AND a
             -- Serve-ICP office AND not an internal/test account. Flag only, never a
             -- row exclusion: out-of-cohort officials still flow through for the
-            -- broad 'all' rollups and the per-official surface. A null/stale/missing
-            -- BallotReady position id leaves icp_office_serve false (an observable
-            -- non-ICP miss); a user with no active-user row is non-active. Drives
+            -- broad 'all' rollups and the per-official surface. A missing BallotReady
+            -- position id (no linked office) or a confirmed non-ICP office leaves
+            -- icp_office_serve false; a matched office whose L2 voter count is unknown
+            -- is also excluded but flagged via icp_office_serve_unknown (a data gap,
+            -- not
+            -- a confirmed non-ICP); a user with no active-user row is non-active.
+            -- Drives
             -- both count_once (block-coverage active union) and the count-multiple
             -- variants (people_served district_level filter).
             (

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -646,6 +646,22 @@ models:
         data_tests:
           - not_null
 
+      - name: has_pledged
+        description: >
+          TRUE if the user owns at least one pledged campaign. From
+          int__serve_active_user (epic DATA-1359).
+        data_tests:
+          - not_null
+
+      - name: is_active_serve_user
+        description: >
+          TRUE if the user is an active serve user (sent an SMS poll AND pledged):
+          the behavioral gate of the People Served active cohort, shared with the
+          epic via int__serve_active_user. Combine with Serve-ICP and non-internal
+          email (applied at the resolver) for the full cohort.
+        data_tests:
+          - not_null
+
       - name: serve_getting_started_at
         description: >
           Earliest timestamp for 'Serve Onboarding - Getting Started Viewed'.
@@ -1473,6 +1489,20 @@ models:
       official_constituents; the conservative reading excludes them. Thin by design;
       variants may migrate to the dbt semantic layer.
     columns:
+      - name: cohort
+        description: >
+          'all' (every resolved serve org -- the broad reading) or 'active' (the
+          active People Served cohort: in_people_served_cohort = active serve user
+          AND Serve-ICP office AND not internal). 'active' is the canonical North
+          Star; 'all' is retained for comparison. No statewide office is Serve-ICP,
+          so cohort='active' carries no office_type='State' rows.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - all
+                  - active
       - name: metric_variant
         description: >
           count_once (distinct people) or count_multiple_per_district / per_seat / per_org.
@@ -1506,15 +1536,26 @@ models:
       - dbt_utils.unique_combination_of_columns:
           name: people_served_unique_key
           arguments:
-            combination_of_columns: [metric_variant, office_type]
+            combination_of_columns: [cohort, metric_variant, office_type]
       - dbt_utils.expression_is_true:
-          name: people_served_north_star_sanity_band
+          name: people_served_north_star_sanity_band_all
           arguments:
             expression: "people_served between 30000000 and 90000000"
           config:
-            # wide catastrophic-breakage guard on the local North Star (currently ~56M);
-            # the ordering invariant (singular test) is the hard correctness check.
-            where: "metric_variant = 'count_once' and office_type = 'all'"
+            # wide catastrophic-breakage guard on the BROAD local North Star
+            # (currently ~65M); the ordering invariant (singular test) is the hard
+            # correctness check.
+            where: "cohort = 'all' and metric_variant = 'count_once' and office_type = 'all'"
+            severity: warn
+      - dbt_utils.expression_is_true:
+          name: people_served_north_star_sanity_band_active
+          arguments:
+            expression: "people_served between 5000000 and 25000000"
+          config:
+            # wide catastrophic-breakage guard on the ACTIVE local North Star
+            # (count_once, de-duplicated, below the ~14.1M additive per_district);
+            # headline HELD until DATA-2018, so this is only a breakage guard.
+            where: "cohort = 'active' and metric_variant = 'count_once' and office_type = 'all'"
             severity: warn
 
   - name: official_constituents
@@ -1558,6 +1599,13 @@ models:
           - not_null
       - name: is_geo_seat
         description: Carried from the resolver (the jurisdiction-vs-electoral-seat flag).
+      - name: in_people_served_cohort
+        description: >
+          Carried from the resolver: the official is in the active People Served
+          cohort (active serve user AND Serve-ICP office AND not internal). Flag
+          only -- every official is kept regardless.
+        data_tests:
+          - not_null
       - name: constituents
         description: >
           The district population the official serves

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1476,9 +1476,13 @@ models:
   - name: people_served
     description: >
       The People Served metrics (DATA-1993, epic DATA-1359): one row per
-      (metric_variant, office_type). count_once is the distinct-person union (from
-      int__serve_block_coverage); the count_multiple variants are sums off the substrate
-      via district_census_stats. Ordering holds within every office_type: count_once <=
+      (cohort, metric_variant, office_type). cohort is 'all' (every resolved serve
+      org) or 'active' (the active People Served cohort: in_people_served_cohort);
+      'active' is the canonical North Star and BOTH are present, so BI consumers MUST
+      filter or group by cohort -- omitting it double-counts. count_once is the
+      distinct-person union (from int__serve_block_coverage); the count_multiple
+      variants are sums off the substrate via district_census_stats. Ordering holds
+      within every (cohort, office_type): count_once <=
       count_multiple_per_district <= per_seat <= per_org. office_type is 'all' (the local
       cohort-wide North Star headline) or one of the substrate's L2 district types, PLUS 'State'
       for statewide officials, which are read from the EXACT T5 'State' census totals and

--- a/dbt/project/models/marts/analytics/official_constituents.sql
+++ b/dbt/project/models/marts/analytics/official_constituents.sql
@@ -40,6 +40,7 @@ select
     r.resolution_path,
     r.requires_review,
     r.is_geo_seat,
+    r.in_people_served_cohort,
     coalesce(s.district_population, sw.district_population) as constituents,
     coalesce(s.registered_voters, sw.registered_voters) as registered_voters,
     coalesce(s.district_population, sw.district_population)

--- a/dbt/project/models/marts/analytics/people_served.sql
+++ b/dbt/project/models/marts/analytics/people_served.sql
@@ -1,13 +1,21 @@
 {{ config(materialized="table", tags=["marts", "analytics", "serve"]) }}
 
--- people_served (DATA-1993): the People Served metrics, one row per
--- (metric_variant, office_type). count-once is the distinct-person union from
+-- people_served (DATA-1993, epic DATA-1359): the People Served metrics, one row per
+-- (cohort, metric_variant, office_type). count-once is the distinct-person union from
 -- int__serve_block_coverage; count-multiple variants are pure sums off the substrate
 -- via district_census_stats. Scoped to the substrate's office-bearing district types,
 -- so
 -- count-once <= count_multiple_per_district <= per_seat <= per_org by construction
 -- (a distinct union is <= a sum; a per-district sum <= per-seat <= per-org because
 -- 1 <= n_seats <= n_orgs per district).
+--
+-- cohort: 'all' (every resolved serve org -- the broad reading) or 'active' (the active
+-- People Served cohort: in_people_served_cohort = active serve user AND Serve-ICP
+-- office
+-- AND not internal). 'active' is the canonical North Star; 'all' is retained for the
+-- broad comparison. The single resolver flag in_people_served_cohort drives BOTH paths:
+-- count-once reads served_voters_active from block-coverage, count-multiple adds the
+-- flag to the district_level filter, so all four variants share one active universe.
 --
 -- office_type: 'all' (the cohort-wide local rollup -- the North Star headline) or one
 -- of
@@ -18,14 +26,16 @@
 -- local 'all' rollup (which would mix population bases and swamp the local story). The
 -- deduped local+statewide union is intentionally not a stored column (set-relative; a
 -- fresh
--- query -- TDD 4.2).
+-- query -- TDD 4.2). No statewide office is Serve-ICP, so cohort='active' has no
+-- 'State'
+-- rows.
 --
 -- The live 'all' numbers include population from a few known wrong-scope matches
 -- (requires_review, pending the DATA-1989 upstream overrides); the conservative reading
 -- excludes them. Those rows are carried + flagged on official_constituents for the
 -- product
 -- to caveat; they are NOT filtered here (fix upstream, not in the model -- TDD 7.3).
--- seat =
+-- Tightening to cohort='active' drops most wrong-scope matches on its own. seat =
 -- a distinct namespaced position/office id with an org_slug fallback, guaranteeing
 -- 1 <= n_seats <= n_orgs per district. Thin by design: variants may migrate to the dbt
 -- semantic layer.
@@ -36,39 +46,78 @@ with
 
     coverage as (select * from {{ ref("int__serve_block_coverage") }}),
 
-    -- count-once per served_set (local: 'all' = the North Star, plus per type)
+    -- count-once per (cohort, served_set): 'all' reads served_voters, 'active' reads
+    -- served_voters_active. 'all' = the North Star headline at office_type 'all'.
     count_once_local as (
         select
+            'all' as cohort,
             c.served_set as office_type,
             sum(c.served_voters * 1.0 / c.total_voters * p.population) as people_served
         from coverage c
         join block_pop p on c.block_geoid = p.block_geoid
         group by c.served_set
+
+        union all
+
+        select
+            'active' as cohort,
+            c.served_set as office_type,
+            sum(
+                c.served_voters_active * 1.0 / c.total_voters * p.population
+            ) as people_served
+        from coverage c
+        join block_pop p on c.block_geoid = p.block_geoid
+        group by c.served_set
+        -- drop types with no active voters so the active office_type set matches
+        -- the count-multiple active set (the ordering invariant needs all four
+        -- variants present per (cohort, office_type))
+        having sum(c.served_voters_active) > 0
     ),
 
-    -- one row per cohort district (local + statewide), with seat/org multipliers.
-    -- seat id is namespaced so a BallotReady id never collides with an office id; the
-    -- org_slug fallback guarantees every org contributes >=1 distinct seat.
+    -- one row per resolved serve org, with its seat id and cohort flag. seat id is
+    -- namespaced so a BallotReady id never collides with an office id; the org_slug
+    -- fallback guarantees every org contributes >=1 distinct seat.
+    resolved_orgs as (
+        select
+            organization_slug,
+            state,
+            l2_district_type,
+            normalized_district_name,
+            is_statewide,
+            in_people_served_cohort,
+            coalesce(
+                'br:' || cast(ballotready_position_id as string),
+                'eo:' || cast(elected_office_id as string),
+                'org:' || organization_slug
+            ) as seat_id
+        from {{ ref("int__serve_district_resolution") }}
+        where resolution_path != 'unresolved'
+    ),
+
+    -- one row per cohort district (local + statewide), carrying both all-cohort and
+    -- active-cohort seat/org multipliers in one pass.
     district_level as (
         select
             co.l2_district_type as office_type,
             s.district_population,
-            count(distinct co.organization_slug) as n_orgs,
+            count(distinct co.organization_slug) as n_orgs_all,
+            count(distinct co.seat_id) as n_seats_all,
             count(
-                distinct coalesce(
-                    'br:' || cast(co.ballotready_position_id as string),
-                    'eo:' || cast(co.elected_office_id as string),
-                    'org:' || co.organization_slug
-                )
-            ) as n_seats
-        from {{ ref("int__serve_district_resolution") }} co
+                distinct case
+                    when co.in_people_served_cohort then co.organization_slug
+                end
+            ) as n_orgs_active,
+            count(
+                distinct case when co.in_people_served_cohort then co.seat_id end
+            ) as n_seats_active
+        from resolved_orgs co
         join
             {{ ref("district_census_stats") }} s
             on co.state = s.state_postal_code
             and co.l2_district_type = s.district_type
             and co.normalized_district_name = s.district_name
             and s.district_type != 'State'
-        where co.resolution_path != 'unresolved' and not co.is_statewide
+        where not co.is_statewide
         group by
             co.l2_district_type,
             s.state_postal_code,
@@ -80,46 +129,72 @@ with
         select
             'State' as office_type,
             s.district_population,
-            count(distinct co.organization_slug) as n_orgs,
+            count(distinct co.organization_slug) as n_orgs_all,
+            count(distinct co.seat_id) as n_seats_all,
             count(
-                distinct coalesce(
-                    'br:' || cast(co.ballotready_position_id as string),
-                    'eo:' || cast(co.elected_office_id as string),
-                    'org:' || co.organization_slug
-                )
-            ) as n_seats
-        from {{ ref("int__serve_district_resolution") }} co
+                distinct case
+                    when co.in_people_served_cohort then co.organization_slug
+                end
+            ) as n_orgs_active,
+            count(
+                distinct case when co.in_people_served_cohort then co.seat_id end
+            ) as n_seats_active
+        from resolved_orgs co
         join
             {{ ref("district_census_stats") }} s
             on co.state = s.state_postal_code
             and s.district_type = 'State'
-        where co.resolution_path != 'unresolved' and co.is_statewide
+        where co.is_statewide
         group by s.state_postal_code, s.district_population
     ),
 
-    -- count-multiple per office_type (the substrate types + 'State'), and a
-    -- local-only 'all'
-    -- rollup
+    -- explode to one row per (cohort, district), picking the cohort-appropriate
+    -- multipliers. 'active' keeps only districts with >=1 active org.
+    district_by_cohort as (
+        select
+            'all' as cohort,
+            office_type,
+            district_population,
+            n_orgs_all as n_orgs,
+            n_seats_all as n_seats
+        from district_level
+
+        union all
+
+        select
+            'active' as cohort,
+            office_type,
+            district_population,
+            n_orgs_active as n_orgs,
+            n_seats_active as n_seats
+        from district_level
+        where n_orgs_active > 0
+    ),
+
+    -- count-multiple per (cohort, office_type), plus a local-only 'all' rollup
     cm_by_type as (
         select
+            cohort,
             office_type,
             sum(district_population) as per_district,
             sum(district_population * n_seats) as per_seat,
             sum(district_population * n_orgs) as per_org,
             count(*) as n_cohort_districts
-        from district_level
-        group by office_type
+        from district_by_cohort
+        group by cohort, office_type
     ),
 
     cm_all as (
         select
+            cohort,
             'all' as office_type,
             sum(district_population) as per_district,
             sum(district_population * n_seats) as per_seat,
             sum(district_population * n_orgs) as per_org,
             count(*) as n_cohort_districts
-        from district_level
+        from district_by_cohort
         where office_type != 'State'
+        group by cohort
     ),
 
     cm as (
@@ -134,7 +209,7 @@ with
     -- overlap),
     -- which equals statewide per_district -> add it so 'State' has all four variants.
     statewide_count_once as (
-        select 'State' as office_type, per_district as people_served
+        select cohort, 'State' as office_type, per_district as people_served
         from cm_by_type
         where office_type = 'State'
     ),
@@ -142,6 +217,7 @@ with
     final as (
         select
             'count_once' as metric_variant,
+            cohort,
             office_type,
             people_served,
             cast(null as bigint) as n_cohort_districts
@@ -149,21 +225,27 @@ with
 
         union all
 
-        select 'count_once', office_type, people_served, cast(null as bigint)
+        select 'count_once', cohort, office_type, people_served, cast(null as bigint)
         from statewide_count_once
 
         union all
 
         select
-            'count_multiple_per_district', office_type, per_district, n_cohort_districts
+            'count_multiple_per_district',
+            cohort,
+            office_type,
+            per_district,
+            n_cohort_districts
         from cm
         union all
-        select 'count_multiple_per_seat', office_type, per_seat, n_cohort_districts
+        select
+            'count_multiple_per_seat', cohort, office_type, per_seat, n_cohort_districts
         from cm
         union all
-        select 'count_multiple_per_org', office_type, per_org, n_cohort_districts
+        select
+            'count_multiple_per_org', cohort, office_type, per_org, n_cohort_districts
         from cm
     )
 
-select metric_variant, office_type, people_served, n_cohort_districts
+select cohort, metric_variant, office_type, people_served, n_cohort_districts
 from final

--- a/dbt/project/models/marts/analytics/people_served.sql
+++ b/dbt/project/models/marts/analytics/people_served.sql
@@ -69,9 +69,13 @@ with
         from coverage c
         join block_pop p on c.block_geoid = p.block_geoid
         group by c.served_set
-        -- drop types with no active voters so the active office_type set matches
-        -- the count-multiple active set (the ordering invariant needs all four
-        -- variants present per (cohort, office_type))
+        -- drop types with no active voters so the active office_type set matches the
+        -- count-multiple active set (the ordering invariant needs all four variants per
+        -- (cohort, office_type)). count_once and count-multiple gate office_type
+        -- independently but share one L2-unpivot lineage, so the two sets are identical
+        -- by construction; assert_people_served_cohort_contract verifies it and FAILS
+        -- CLOSED on any divergence. Do NOT instead subset count_once to the cm set --
+        -- that would silently drop real served population from the headline.
         having sum(c.served_voters_active) > 0
     ),
 

--- a/dbt/project/models/marts/analytics/people_served.sql
+++ b/dbt/project/models/marts/analytics/people_served.sql
@@ -47,7 +47,8 @@ with
     coverage as (select * from {{ ref("int__serve_block_coverage") }}),
 
     -- count-once per (cohort, served_set): 'all' reads served_voters, 'active' reads
-    -- served_voters_active. 'all' = the North Star headline at office_type 'all'.
+    -- served_voters_active. The North Star headline is (cohort='active',
+    -- office_type='all'); 'all' is the broad comparison reading.
     count_once_local as (
         select
             'all' as cohort,

--- a/dbt/project/models/marts/analytics/users_serve_base.sql
+++ b/dbt/project/models/marts/analytics/users_serve_base.sql
@@ -21,6 +21,7 @@
 with
     users as (select * from {{ ref("goodparty_data_catalog", "users") }}),
     milestones as (select * from {{ ref("int__amplitude_user_milestones") }}),
+    active_user as (select * from {{ ref("int__serve_active_user") }}),
 
     -- Get most recent Serve activity timestamp per user for Active EO flag.
     serve_latest as (
@@ -58,6 +59,13 @@ with
             -- Connect to Poll (DATA-1499)
             m.first_sms_poll_sent_at,
             (m.first_sms_poll_sent_at is not null) as has_sent_sms_poll,
+
+            -- Active People Served cohort definition (epic DATA-1359), sourced from
+            -- the single source of truth int__serve_active_user so the dashboard and
+            -- the epic share one definition. has_sent_sms_poll above is the same value
+            -- (same milestone upstream), kept on its funnel derivation.
+            coalesce(au.has_pledged, false) as has_pledged,
+            coalesce(au.is_active_serve_user, false) as is_active_serve_user,
 
             -- Serve Onboarding Funnel timestamps
             m.serve_getting_started_at,
@@ -109,6 +117,7 @@ with
 
         from users u
         left join milestones m on u.user_id = m.user_id
+        left join active_user au on u.user_id = au.user_id
         left join serve_latest s on u.user_id = s.user_id
     )
 

--- a/dbt/project/tests/assert_people_served_cohort_contract.sql
+++ b/dbt/project/tests/assert_people_served_cohort_contract.sql
@@ -1,4 +1,4 @@
--- People Served cohort contract (epic DATA-1359). Guards two invariants that the
+-- People Served cohort contract (epic DATA-1359). Guards three invariants that the
 -- ordering test and the warn-severity sanity bands cannot:
 -- (1) PRESENCE: each cohort ('all', 'active') must publish all four metric variants
 -- at office_type='all' (the North Star headline). A broken active join would
@@ -8,6 +8,20 @@
 -- (2) NO ACTIVE STATEWIDE: cohort='active' must carry no office_type='State' rows
 -- (no statewide office is Serve-ICP). Enforces the documented contract against a
 -- future data drift.
+-- (3) ENGINE ALIGNMENT: within each cohort, the office_type set carried by count_once
+-- (the int__serve_block_coverage L2 voter-scan engine) must equal the set carried
+-- by the count-multiple variants (the district_census_stats substrate engine). The
+-- two gate office_type independently (a served voter of that type vs a census
+-- district match), so in principle a type could land on one side only. They share
+-- one L2-unpivot lineage (block-coverage and the substrate both unpivot
+-- int__l2_nationwide_uniform via get_l2_major_district_columns +
+-- normalize_l2_district_name),
+-- so this cannot occur on correct data; this arm FAILS CLOSED and names the
+-- direction if an upstream regression ever forks that lineage, replacing the
+-- ordering test's cryptic 'missing_variant'. Deliberately does NOT subset count_once
+-- to the count-multiple set: that would silently drop a real served-population row
+-- from the leadership headline (a delegate-review suggestion, rejected for that
+-- reason -- a divergence must halt the build, not be hidden).
 -- Returns offending rows; empty = pass.
 with
     headline as (
@@ -38,6 +52,43 @@ with
         from {{ ref("people_served") }}
         where cohort = 'active' and office_type = 'State'
         group by cohort
+    ),
+
+    variant_sets as (
+        select
+            cohort,
+            office_type,
+            max(
+                case when metric_variant = 'count_once' then 1 else 0 end
+            ) as in_count_once,
+            max(
+                case
+                    when
+                        metric_variant in (
+                            'count_multiple_per_district',
+                            'count_multiple_per_seat',
+                            'count_multiple_per_org'
+                        )
+                    then 1
+                    else 0
+                end
+            ) as in_count_multiple
+        from {{ ref("people_served") }}
+        group by cohort, office_type
+    ),
+
+    set_alignment_failures as (
+        select
+            cohort,
+            count(*) as n_variants,
+            case
+                when in_count_once = 1 and in_count_multiple = 0
+                then 'count_once_office_type_absent_from_count_multiple'
+                else 'count_multiple_office_type_absent_from_count_once'
+            end as failure
+        from variant_sets
+        where in_count_once != in_count_multiple
+        group by cohort, in_count_once, in_count_multiple
     )
 
 select cohort, n_variants, failure
@@ -45,3 +96,6 @@ from presence_failures
 union all
 select cohort, n_variants, failure
 from active_state_failures
+union all
+select cohort, n_variants, failure
+from set_alignment_failures

--- a/dbt/project/tests/assert_people_served_cohort_contract.sql
+++ b/dbt/project/tests/assert_people_served_cohort_contract.sql
@@ -1,0 +1,47 @@
+-- People Served cohort contract (epic DATA-1359). Guards two invariants that the
+-- ordering test and the warn-severity sanity bands cannot:
+-- (1) PRESENCE: each cohort ('all', 'active') must publish all four metric variants
+-- at office_type='all' (the North Star headline). A broken active join would
+-- silently emit zero active rows -- the ordering test only checks
+-- (cohort, office_type) groups that already exist, so a wholesale-missing active
+-- cohort slips through, and the sanity band is warn-only.
+-- (2) NO ACTIVE STATEWIDE: cohort='active' must carry no office_type='State' rows
+-- (no statewide office is Serve-ICP). Enforces the documented contract against a
+-- future data drift.
+-- Returns offending rows; empty = pass.
+with
+    headline as (
+        select cohort, count(distinct metric_variant) as n_variants
+        from {{ ref("people_served") }}
+        where office_type = 'all'
+        group by cohort
+    ),
+
+    expected_cohorts as (
+        select 'all' as cohort
+        union all
+        select 'active' as cohort
+    ),
+
+    presence_failures as (
+        select
+            e.cohort,
+            coalesce(h.n_variants, 0) as n_variants,
+            'headline_missing_variants' as failure
+        from expected_cohorts e
+        left join headline h on e.cohort = h.cohort
+        where coalesce(h.n_variants, 0) != 4
+    ),
+
+    active_state_failures as (
+        select cohort, count(*) as n_variants, 'active_has_statewide' as failure
+        from {{ ref("people_served") }}
+        where cohort = 'active' and office_type = 'State'
+        group by cohort
+    )
+
+select cohort, n_variants, failure
+from presence_failures
+union all
+select cohort, n_variants, failure
+from active_state_failures

--- a/dbt/project/tests/assert_people_served_ordering_invariant.sql
+++ b/dbt/project/tests/assert_people_served_ordering_invariant.sql
@@ -1,15 +1,18 @@
--- The People Served invariant (DATA-1993): within every office_type, all four metric
--- variants are PRESENT and count_once <= count_multiple_per_district <= per_seat <=
--- per_org. count-once dedups people; each count-multiple variant can only re-count them
--- (a per-district sum >= a distinct union; per-seat >= per-district and per-org >=
--- per-seat because 1 <= n_seats <= n_orgs per district). Strict on presence too: every
--- office_type ('all', each L2 type, and 'State') carries all four variants by
--- construction, so a missing one is a build bug -- the null-tolerant form would hide
--- it.
--- Returns offending office_types; empty = pass.
+-- The People Served invariant (DATA-1993, epic DATA-1359): within every (cohort,
+-- office_type), all four metric variants are PRESENT and count_once <=
+-- count_multiple_per_district <= per_seat <= per_org. count-once dedups people; each
+-- count-multiple variant can only re-count them (a per-district sum >= a distinct
+-- union;
+-- per-seat >= per-district and per-org >= per-seat because 1 <= n_seats <= n_orgs per
+-- district). Strict on presence too: every (cohort, office_type) that appears carries
+-- all
+-- four variants by construction, so a missing one is a build bug -- the null-tolerant
+-- form would hide it.
+-- Returns offending (cohort, office_type)s; empty = pass.
 with
     p as (
         select
+            cohort,
             office_type,
             max(case when metric_variant = 'count_once' then people_served end) as co,
             max(
@@ -29,7 +32,7 @@ with
                 end
             ) as cmo
         from {{ ref("people_served") }}
-        group by office_type
+        group by cohort, office_type
     )
 
 select


### PR DESCRIPTION
## What & why

Wires the agreed **active serve-user cohort** into the People Served metric (epic DATA-1359). The North Star was reframed: it counts constituents (census population, de-duplicated `count_once`) over the *active* cohort — officials whose owner sent the onboarding SMS poll **and** is pledged **and** holds a Serve-ICP office **and** is not an internal account — not the broad "has a serve org" set. The active reading ships alongside the existing broad (`all`) reading as a new `cohort` dimension; one resolver flag drives both the count-once and count-multiple paths.

## What changed

- **`int__serve_active_user`** (new intermediate): the single source of truth for the behavioral active definition (`has_sent_sms_poll AND has_pledged`), one row per user. Reads staging + intermediate only, so it stays below the analytics layer (no dependency cycle into block-coverage).
- **`int__serve_district_resolution`**: carries `in_people_served_cohort` (`is_active_serve_user AND icp_office_serve AND not is_internal_email`) as a flag — never a row exclusion. The ICP and active-user joins are both unique, so they cannot fan out the org grain.
- **`int__serve_block_coverage`**: emits `served_voters_active` alongside `served_voters` in the **same single L2 scan** (active cohort districts are a subset, so `served_voters_active <= served_voters` block-for-block — enforced by a new test).
- **`people_served`**: adds a `cohort` (`all` | `active`) dimension orthogonal to `metric_variant` and `office_type`. `count_once` reads `served_voters`/`served_voters_active`; the count-multiple variants filter `district_level` on the cohort flag. Unique key and the ordering invariant are now per `(cohort, office_type)`; the North Star sanity band is split per cohort. No statewide office is Serve-ICP, so `cohort='active'` carries no `State` rows.
- **`official_constituents`**: carries the cohort flag (every official kept).
- **`users_serve_base`**: exposes `is_active_serve_user` / `has_pledged` from the shared `int__serve_active_user` so the dashboard and the epic share one definition.

## Validation

**Phase 0 (prove-before-build, against live prod)** — the reconstructed cohort reproduces the analytics team's cohort at user-id membership level: **718 officials**, ICP voter-proxy sum **8.45M** (matches the analytics ~8.48M within 0.4%). The pledged any-vs-latest delta the plan flagged is **zero** on this cohort (any-pledged, any-latest-version, and most-recent-campaign all select the identical 718). Resolver is strictly 1 org : 1 user (no fanout). Active count-multiple `per_district` = 14.14M across 680 districts (the de-duplicated `count_once` is below this by construction).

**To confirm on the CI preview schema after build:**
- `count_once` (`cohort='all'`, `office_type='all'`) unchanged (~65M) — the broad path is byte-identical.
- `count_once` (`cohort='active'`, `office_type='all'`) recompute, reconciled to the 8.45M voter proxy (constituents ≈ 1.6–1.8× voters; expected below the 14.14M additive bound).
- All tests green, especially the per-`(cohort, office_type)` ordering invariant and the substrate inequalities.

## Headline

**Held.** No leadership headline number is shared until the DATA-2018 Census-direct backtest passes (a deliberate ship-once decision). This PR is the metric mechanism, not the share-out.

## Test plan

- [ ] CI dbt build green (all 7 touched/added models + tests)
- [ ] CI preview: `count_once` all-cohort unchanged; active-cohort recompute reconciles to the voter proxy
- [ ] Ordering invariant holds per `(cohort, office_type)`; `served_voters_active <= served_voters`
- [ ] Independent adversarial review (codex, pr mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the published People Served grain and North Star definition for a core analytics metric; mitigated by retaining `cohort='all'`, flag-only filtering, and new contract tests, but downstream dashboards/SQL that omit `cohort` can misreport totals.
> 
> **Overview**
> Introduces the **active People Served cohort** (DATA-1359): owners who sent the Serve onboarding SMS poll **and** pledged, on a **Serve-ICP** office, excluding internal emails. The North Star is reframed to **`cohort='active'`**; the prior broad universe remains as **`cohort='all'`**.
> 
> **`int__serve_active_user`** is the new user-grain source for the behavioral gate (`has_sent_sms_poll` ∧ `has_pledged`), built from staging/intermediate only to avoid cycles into block coverage.
> 
> **`int__serve_district_resolution`** joins that model and **`int__icp_offices`**, exposing component flags plus **`in_people_served_cohort`** as a **flag only** (orgs are not dropped).
> 
> **`int__serve_block_coverage`** adds **`served_voters_active`** in the same L2 scan; **`people_served`** gains **`cohort`** (`all` | `active`) on the grain and splits count-once vs count-multiple logic off the shared resolver flag. **`official_constituents`** and **`users_serve_base`** surface the cohort / active-user fields for BI.
> 
> Tests/docs are extended: per-cohort ordering and sanity bands, `served_voters_active <= served_voters`, and **`assert_people_served_cohort_contract`** (headline variants present, no active statewide rows, count-once vs count-multiple office_type alignment). **BI must filter or group by `cohort`** or metrics double-count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bd5f4ae71b178ed86b7d985a9ec6fc6b7f05da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->