### PR TITLE
[DATA-1938] Surface broad civics viability via candidacy_scored

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3566,3 +3566,61 @@ models:
           name: serve_block_coverage_active_le_served
           arguments:
             expression: "served_voters_active <= served_voters"
+
+  - name: int__civics_viability_scoring
+    description: >
+      Viability scores for all candidacies in the civics mart, produced by an
+      MLflow model waterfall (best-available model wins via COALESCE). Reads the
+      candidacy + election marts as leaves; its output is joined onto the
+      downstream candidacy_scored mart, never back onto candidacy (acyclic).
+      Models load by latest registered version from model_predictions (no @prod
+      alias). Grain: one row per gp_candidacy_id.
+    columns:
+      - name: gp_candidacy_id
+        description: Primary key — foreign key to the candidacy mart.
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+      - name: viability_rating_2_0
+        description: Viability score on a 0–5 scale (null where no waterfall model could score the row).
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 5
+      - name: score_viability_automated
+        description: Human-readable viability label derived from viability_rating_2_0.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - No Chance
+                  - Unlikely to Win
+                  - Has a Chance
+                  - Likely to Win
+                  - Frontrunner
+      - name: scoring_model
+        description: >
+          Which waterfall model produced this row's surviving (coalesced) score —
+          i.e. the feature-completeness tier (viabilitywithopponentdata = the full
+          9-feature model; the rest are progressively more missing-tolerant
+          fallbacks). Internal provenance; not surfaced on candidacy_scored.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - viabilitywithopponentdata
+                  - viabilitywithoutopenseat
+                  - viabilitynoopponentdata
+                  - viabilitynoincumbency
+                  - viabilitynocandidatedatahs
+      - name: model_version
+        description: >
+          Resolved model_predictions registered version of scoring_model for this
+          row. Latest-version load is a moving pointer, so this records the exact
+          version that scored the row for traceability and a code-pin rollback target.
+      - name: updated_at
+        description: Timestamp when the score was last computed (the dbt run time).
+        data_tests:
+          - not_null

--- a/dbt/project/models/intermediate/civics/int__civics_viability_scoring.py
+++ b/dbt/project/models/intermediate/civics/int__civics_viability_scoring.py
@@ -1,0 +1,271 @@
+"""
+dbt Python model: int__civics_viability_scoring
+
+Scores all candidacies in the civics mart using the viability MLflow model
+waterfall. Produces a score for every candidacy that has enough data to
+run at least the most-permissive model.
+
+Waterfall (best available wins via COALESCE):
+  1. ViabilityWithOpponentData    — all 9 features
+  2. ViabilityWithoutOpenSeat     — drops open_seat
+  3. ViabilityNoOpponentData      — drops open_seat + log_n_losers
+  4. ViabilityNoIncumbency        — drops open_seat + is_incumbent
+  5. ViabilityNoCandidateDataHS   — most resilient to missingness: multi_seat, partisan_contest, is_unexpired, office_type_woe, state_woe, level_woe
+
+Output key: gp_candidacy_id
+Joins to mart output: mart_civics.candidacy.viability_score (via int__civics_candidacy_*)
+"""
+
+import mlflow
+import numpy as np
+import pandas as pd
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.functions import (
+    coalesce,
+    col,
+    count,
+    current_timestamp,
+    isnan,
+    lit,
+    log,
+    lower,
+    round,
+    when,
+)
+
+
+def _resolve_latest_version(modelname: str) -> str:
+    """Latest registered version of an MLflow model in model_predictions.
+
+    Mirrors the sibling int__techspeed_viability_scoring.py, but sorts versions
+    NUMERICALLY: MLflow's ModelVersion.version is a string, so the sibling's
+    max(..., key=lambda x: x.version) picks the wrong version once a model
+    reaches v10 ("9" > "10" lexicographically) -- viabilitywithopponentdata is
+    already at v5. No @prod alias is used: these models load by latest version
+    because setting @prod needs apply_tag, which is gated by design.
+    """
+    client = mlflow.tracking.MlflowClient()
+    versions = client.search_model_versions(f"name='goodparty_data_catalog.model_predictions.{modelname}'")
+    if not versions:
+        raise ValueError(
+            f"No registered versions found for goodparty_data_catalog.model_predictions.{modelname}; "
+            "the model must be copied into model_predictions before this scorer runs."
+        )
+    return max(versions, key=lambda mv: int(mv.version)).version
+
+
+def _score_using_model(df: pd.DataFrame, modelname: str, score_col: str) -> tuple[pd.DataFrame, str]:
+    version = _resolve_latest_version(modelname)
+    model = mlflow.sklearn.load_model(
+        f"models:/goodparty_data_catalog.model_predictions.{modelname}/{version}"
+    )
+    # Subset preflight: the fallback models intentionally use fewer than the 9
+    # inputs, so require the model's features to be a SUBSET of what we provide
+    # (an exact-9 check would wrongly reject valid fallbacks). A missing feature
+    # would otherwise surface as an opaque KeyError on the df[...] selection.
+    missing = set(model.feature_names_in_) - set(df.columns)
+    if missing:
+        raise KeyError(f"{modelname} needs features absent from the scoring frame: {sorted(missing)}")
+    df[score_col] = np.nan
+    valid_rows = df[model.feature_names_in_].notnull().all(axis=1)
+    if valid_rows.sum() > 0:
+        df.loc[valid_rows, score_col] = model.predict_proba(df.loc[valid_rows, model.feature_names_in_])[:, 1]
+    return df, version
+
+
+def _join_woe(df: DataFrame, col_name: str, spark: SparkSession) -> DataFrame:
+    woe_df = spark.table(f"goodparty_data_catalog.model_predictions.viability_br_{col_name}_woe")
+    valid_cats = [r["cat_grouped"] for r in woe_df.select("cat_grouped").distinct().collect()]
+    df = df.withColumn(
+        "grouped_col",
+        when(col(col_name).isin(valid_cats), col(col_name)).otherwise(lit("Other")),
+    )
+    df = df.join(
+        woe_df.select(col("cat_grouped").alias("grouped_col"), col(f"{col_name}_woe")),
+        on="grouped_col",
+        how="left",
+    ).drop("grouped_col")
+    return df
+
+
+def model(dbt, session: SparkSession) -> DataFrame:
+    spark = session
+
+    dbt.config(
+        submission_method="all_purpose_cluster",
+        http_path="sql/protocolv1/o/3578414625112071/0409-211859-6hzpukya",
+        materialized="table",
+        auto_liquid_cluster=True,
+        tags=["intermediate", "civics", "viability"],
+    )
+
+    candidacy = dbt.ref("candidacy")
+    election = dbt.ref("election")
+
+    # bring in state, seats_available, and number_of_opponents fallback from election table
+    # (state is not on the candidacy mart; election.state is already a 2-letter abbreviation)
+    election_fields = election.select(
+        col("gp_election_id"),
+        col("state"),
+        col("seats_available"),
+        col("number_of_opponents").alias("raw_n_opponents"),
+    )
+
+    # count candidacies per election from the mart (~75% fill vs ~2.6% for the pre-computed column)
+    # only trust this count when > 1: a count of 1 may mean we only ingested one candidate,
+    # not that the race is genuinely uncontested
+    n_candidates_per_election = (
+        candidacy.filter(col("gp_election_id").isNotNull())
+        .groupBy("gp_election_id")
+        .agg(count("*").alias("n_candidates_mart"))
+    )
+
+    df = candidacy.join(election_fields, on="gp_election_id", how="left").join(
+        n_candidates_per_election, on="gp_election_id", how="left"
+    )
+
+    df = (
+        df.withColumn("level", lower(col("office_level")))
+        # seats
+        .withColumn(
+            "n_seats",
+            when(col("seats_available").isNull(), None)
+            .when(col("seats_available") == 0, None)
+            .otherwise(col("seats_available").cast("int")),
+        )
+        # n_candidates: trust mart count when > 1, else fall back to election column, else null
+        .withColumn(
+            "n_candidates",
+            when(col("n_candidates_mart") > 1, col("n_candidates_mart"))
+            .when(
+                col("raw_n_opponents").isNotNull() & (col("raw_n_opponents") != ""),
+                when(col("raw_n_opponents") == "10+", lit(11)).otherwise(
+                    col("raw_n_opponents").cast("int") + 1
+                ),
+            )
+            .otherwise(None),
+        )
+        # derived features
+        .withColumn(
+            "multi_seat",
+            when(col("n_seats").isNull(), None).when(col("n_seats") > 1, lit(1)).otherwise(lit(0)),
+        )
+        .withColumn(
+            "partisan_contest",
+            when(col("is_partisan").isNotNull(), when(col("is_partisan"), lit(1)).otherwise(lit(0)))
+            .when(col("level").isin("federal", "state"), lit(1))
+            .otherwise(lit(0)),
+        )
+        .withColumn("is_unexpired", lit(False))
+        .withColumn(
+            "log_n_losers",
+            when(col("n_candidates").isNull() | col("n_seats").isNull(), None)
+            .when(col("n_seats") >= col("n_candidates"), log(lit(0.001)))
+            .otherwise(log(col("n_candidates") - col("n_seats"))),
+        )
+        # open_seat: boolean → keep as-is (pandas will cast to float 0/1/NaN)
+        .withColumnRenamed("is_open_seat", "open_seat")
+    )
+
+    # WoE encoding
+    for c in ["state", "level", "office_type"]:
+        df = _join_woe(df, c, spark)
+
+    all_features = [
+        "multi_seat",
+        "partisan_contest",
+        "is_unexpired",
+        "office_type_woe",
+        "state_woe",
+        "level_woe",
+        "is_incumbent",
+        "open_seat",
+        "log_n_losers",
+    ]
+
+    df_pd = df.select(["gp_candidacy_id", *all_features]).toPandas()
+    df_pd[all_features] = df_pd[all_features].astype(float)
+
+    # waterfall — each model scores the rows it can; COALESCE picks best available
+    waterfall = [
+        ("viabilitywithopponentdata", "y_score0a"),
+        ("viabilitywithoutopenseat", "y_score0b"),
+        ("viabilitynoopponentdata", "y_score2"),
+        ("viabilitynoincumbency", "y_score3"),
+        ("viabilitynocandidatedatahs", "y_score1a"),
+    ]
+    resolved_versions: dict[str, str] = {}
+    for modelname, score_col in waterfall:
+        df_pd, resolved_versions[modelname] = _score_using_model(df_pd, modelname, score_col)
+
+    score_cols = ["y_score0a", "y_score0b", "y_score2", "y_score3", "y_score1a"]
+
+    df_scored = spark.createDataFrame(df_pd.to_dict("records"))
+
+    # pandas NaN survives as float NaN in Spark (not null) — convert explicitly
+    # so COALESCE and comparisons behave correctly
+    for s in score_cols:
+        df_scored = df_scored.withColumn(s, when(col(s).isNull() | isnan(col(s)), None).otherwise(col(s)))
+
+    df_scored = (
+        df_scored.withColumn(
+            "viability_rating_2_0",
+            round(
+                5
+                * coalesce(
+                    col("y_score0a"),
+                    col("y_score0b"),
+                    col("y_score2"),
+                    col("y_score3"),
+                    col("y_score1a"),
+                ),
+                2,
+            ),
+        )
+        .withColumn(
+            "score_viability_automated",
+            when(col("viability_rating_2_0").isNull(), None)
+            .when(col("viability_rating_2_0") < 1, "No Chance")
+            .when(col("viability_rating_2_0") < 2, "Unlikely to Win")
+            .when(col("viability_rating_2_0") < 3, "Has a Chance")
+            .when(col("viability_rating_2_0") < 4, "Likely to Win")
+            .otherwise("Frontrunner"),
+        )
+        .withColumn("updated_at", current_timestamp())
+    )
+
+    # Per-row provenance: which waterfall model produced the surviving (coalesced)
+    # score, and that model's resolved version. The waterfall order IS the coalesce
+    # order, so the first non-null score column is the winning model. Build the
+    # when-chain back-to-front so the earliest model is the outermost (highest
+    # priority) branch, matching the coalesce above. Internal traceability + a
+    # code-pin rollback target; NOT surfaced on candidacy_scored (sales is
+    # provenance-free by decision).
+    waterfall_provenance = [
+        ("y_score0a", "viabilitywithopponentdata"),
+        ("y_score0b", "viabilitywithoutopenseat"),
+        ("y_score2", "viabilitynoopponentdata"),
+        ("y_score3", "viabilitynoincumbency"),
+        ("y_score1a", "viabilitynocandidatedatahs"),
+    ]
+    scoring_model_expr = lit(None).cast("string")
+    model_version_expr = lit(None).cast("string")
+    for prov_score_col, prov_modelname in reversed(waterfall_provenance):
+        scoring_model_expr = when(col(prov_score_col).isNotNull(), lit(prov_modelname)).otherwise(
+            scoring_model_expr
+        )
+        model_version_expr = when(
+            col(prov_score_col).isNotNull(), lit(resolved_versions[prov_modelname])
+        ).otherwise(model_version_expr)
+    df_scored = df_scored.withColumn("scoring_model", scoring_model_expr).withColumn(
+        "model_version", model_version_expr
+    )
+
+    return df_scored.select(
+        "gp_candidacy_id",
+        "viability_rating_2_0",
+        "score_viability_automated",
+        "scoring_model",
+        "model_version",
+        "updated_at",
+    )

--- a/dbt/project/models/marts/analytics/leads_win_candidacy.sql
+++ b/dbt/project/models/marts/analytics/leads_win_candidacy.sql
@@ -69,7 +69,9 @@ with
             pro.election_result as primary_runoff_election_result,
             gro.election_result as general_runoff_election_result
 
-        from {{ ref("candidacy") }} cand
+        -- DATA-1938: candidacy_scored = candidacy + broad civics viability, so
+        -- viability_score reflects the new civics scorer.
+        from {{ ref("candidacy_scored") }} cand
 
         -- Candidate
         left join

--- a/dbt/project/models/marts/analytics/users_win_candidacy.sql
+++ b/dbt/project/models/marts/analytics/users_win_candidacy.sql
@@ -110,8 +110,10 @@ with
         -- version matches the candidacy from its own election cycle.
         -- Falls back to campaign_id alone when election_date is NULL to avoid
         -- silently dropping candidacy data for campaigns with missing dates.
+        -- DATA-1938: read candidacy_scored (candidacy + broad civics viability)
+        -- so viability_score reflects the new civics scorer.
         left join
-            {{ ref("candidacy") }} cand
+            {{ ref("candidacy_scored") }} cand
             on c.campaign_id = cand.product_campaign_id
             and (
                 c.election_date = cand.general_election_date or c.election_date is null

--- a/dbt/project/models/marts/civics/candidacy_scored.sql
+++ b/dbt/project/models/marts/civics/candidacy_scored.sql
@@ -1,7 +1,10 @@
 -- Civics mart `candidacy_scored`: the candidacy mart with broad civics
 -- viability layered on. This is the sales/Win-facing viability source going
 -- forward; consumers read `viability_score` / `score_viability_automated` here,
--- not on `candidacy`.
+-- not on `candidacy`. The analytics consumers (users_win_candidacy,
+-- leads_win_candidacy) read here as of this PR; the HubSpot reverse-ETL feed
+-- (sales_reverse_etl/candidacy_hubspot) migrates in a staged fast-follow once
+-- prod validation passes.
 --
 -- DATA-1938. The new civics scorer (int__civics_viability_scoring) is canonical
 -- and OVERWRITES the old candidacy value wherever it scored the row; the old

--- a/dbt/project/models/marts/civics/candidacy_scored.sql
+++ b/dbt/project/models/marts/civics/candidacy_scored.sql
@@ -1,0 +1,71 @@
+-- Civics mart `candidacy_scored`: the candidacy mart with broad civics
+-- viability layered on. This is the sales/Win-facing viability source going
+-- forward; consumers read `viability_score` / `score_viability_automated` here,
+-- not on `candidacy`.
+--
+-- DATA-1938. The new civics scorer (int__civics_viability_scoring) is canonical
+-- and OVERWRITES the old candidacy value wherever it scored the row; the old
+-- value gap-fills rows the new scorer could not score, so coverage never
+-- regresses. The scorer reads candidacy + election as leaves, so layering its
+-- output here (downstream) is ACYCLIC -- the score never flows back onto candidacy.
+--
+-- Column list mirrors candidacy.sql's final SELECT verbatim and in order; only
+-- the two viability columns are overridden. They are gated on the SAME condition
+-- so the numeric score and its label can never come from different sources.
+with
+    scored as (
+        select gp_candidacy_id, viability_rating_2_0, score_viability_automated
+        from {{ ref("int__civics_viability_scoring") }}
+    )
+
+select
+    cy.gp_candidacy_id,
+    cy.gp_candidate_id,
+    cy.gp_election_id,
+    cy.product_campaign_id,
+    cy.hubspot_contact_id,
+    cy.hubspot_company_ids,
+    cy.candidate_id_source,
+    cy.party_affiliation,
+    cy.is_incumbent,
+    cy.is_open_seat,
+    cy.candidate_office,
+    cy.official_office_name,
+    cy.office_level,
+    cy.office_type,
+    cy.candidacy_result,
+    cy.general_election_result,
+    cy.latest_stage_reached,
+    cy.latest_stage_result,
+    cy.is_pledged,
+    cy.is_verified,
+    cy.verification_status_reason,
+    cy.is_partisan,
+    cy.primary_election_date,
+    cy.primary_runoff_election_date,
+    cy.general_election_date,
+    cy.general_runoff_election_date,
+    cy.br_position_database_id,
+    -- Viability override: new civics scorer wins, old candidacy value gap-fills.
+    case
+        when scored.viability_rating_2_0 is not null
+        then scored.viability_rating_2_0
+        else cy.viability_score
+    end as viability_score,
+    cy.win_number,
+    cy.win_number_model,
+    cy.is_win_icp,
+    cy.is_serve_icp,
+    cy.is_win_supersize_icp,
+    -- Label gated on the SAME condition as the score above, so the pair is always
+    -- internally consistent (never a new number with an old label).
+    case
+        when scored.viability_rating_2_0 is not null
+        then scored.score_viability_automated
+        else cy.score_viability_automated
+    end as score_viability_automated,
+    cy.source_systems,
+    cy.created_at,
+    cy.updated_at
+from {{ ref("candidacy") }} as cy
+left join scored on cy.gp_candidacy_id = scored.gp_candidacy_id

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -807,11 +807,17 @@ models:
       - dbt_utils.expression_is_true:
           name: candidacy_scored_score_label_consistent
           arguments:
-            # The numeric score and its label must always agree on presence
-            # (both set or both null) -- guards against pairing a new score with
-            # an old label if the unit-gating ever breaks. Verified 0 violations
-            # on prod candidacy before adding this test.
-            expression: "(viability_score is null) = (score_viability_automated is null)"
+            # The label must match the numeric band (and both must be null
+            # together) -- guards against pairing a score with the wrong label
+            # if the unit-gating or a band cutoff ever drifts. Verified 0
+            # violations on prod candidacy before adding this test.
+            expression: >
+              (viability_score is null and score_viability_automated is null)
+              or (viability_score >= 0 and viability_score < 1 and score_viability_automated = 'No Chance')
+              or (viability_score >= 1 and viability_score < 2 and score_viability_automated = 'Unlikely to Win')
+              or (viability_score >= 2 and viability_score < 3 and score_viability_automated = 'Has a Chance')
+              or (viability_score >= 3 and viability_score < 4 and score_viability_automated = 'Likely to Win')
+              or (viability_score >= 4 and score_viability_automated = 'Frontrunner')
 
   - name: candidate
     description: >

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -671,6 +671,10 @@ models:
 
       - name: viability_score
         description: >
+          INTERNAL (DATA-1938): the legacy/base viability value. The sales- and
+          Win-facing BROAD viability lives on candidacy_scored -- read it there,
+          not here. This column stays because candidacy_scored coalesces it in as
+          a gap-filler for rows the new civics scorer cannot score.
           Numeric viability rating (0..5) from the TechSpeed-trained
           MLflow model (int__techspeed_viability_scoring.viability_rating_2_0).
           Populated for TS-sourced candidacies via join in
@@ -685,6 +689,8 @@ models:
 
       - name: score_viability_automated
         description: >
+          INTERNAL (DATA-1938): read the broad label on candidacy_scored, not
+          here (see viability_score above).
           String category derived from viability_score by the MLflow model.
           Values: "No Chance" (score < 1), "Unlikely to Win" (1..2),
           "Has a Chance" (2..3), "Likely to Win" (3..4), "Frontrunner"
@@ -752,6 +758,60 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "updated_at >= created_at"
+
+  - name: candidacy_scored
+    description: >
+      The candidacy mart with broad civics viability layered on (DATA-1938).
+      This is the sales / Win-facing viability source: consumers read
+      viability_score and score_viability_automated HERE, not on candidacy.
+      Every non-viability column passes through from candidacy unchanged and in
+      the same order (see the candidacy model for their docs). viability_score
+      and score_viability_automated are overridden as a unit -- the new civics
+      scorer (int__civics_viability_scoring) wins where it scored the row, the
+      old candidacy value gap-fills the rest so coverage never regresses. The
+      scorer reads candidacy + election as leaves, so this downstream layer is
+      acyclic.
+    columns:
+      - name: gp_candidacy_id
+        description: Primary key - inherited from candidacy (one row per candidacy).
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+      - name: viability_score
+        description: >
+          Numeric viability rating (0..5): the broad civics score
+          (int__civics_viability_scoring.viability_rating_2_0) where available,
+          else the prior candidacy value. NULL only where neither could score.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 5
+      - name: score_viability_automated
+        description: >
+          String category, always consistent with viability_score (same source
+          for a given row). Values: "No Chance" (<1), "Unlikely to Win" (1..2),
+          "Has a Chance" (2..3), "Likely to Win" (3..4), "Frontrunner" (4..5).
+          NULL where viability_score is NULL.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - "No Chance"
+                  - "Unlikely to Win"
+                  - "Has a Chance"
+                  - "Likely to Win"
+                  - "Frontrunner"
+    data_tests:
+      - dbt_utils.expression_is_true:
+          name: candidacy_scored_score_label_consistent
+          arguments:
+            # The numeric score and its label must always agree on presence
+            # (both set or both null) -- guards against pairing a new score with
+            # an old label if the unit-gating ever breaks. Verified 0 violations
+            # on prod candidacy before adding this test.
+            expression: "(viability_score is null) = (score_viability_automated is null)"
 
   - name: candidate
     description: >

--- a/scripts/promote_viability_models.py
+++ b/scripts/promote_viability_models.py
@@ -5,6 +5,13 @@ Run once after this PR merges, before the new dbt model is executed.
 Safe to re-run: skips copy if @prod alias already points at a version
 promoted from the same sandbox source URI (tracked via a model version tag).
 
+NOTE (DATA-1938): the dbt scorer int__civics_viability_scoring loads models by
+LATEST registered version, NOT by the @prod alias, so this script's essential
+job for that pipeline is the sandbox -> model_predictions COPY. The @prod alias
+it also sets is not required by the dbt scorer (kept for explicit-promotion
+consumers). How research-to-dbt model promotion should work going forward
+(copy + grant + versioning) is an open process question.
+
 Requires env vars: DATABRICKS_HOST, DATABRICKS_TOKEN
 """
 

--- a/scripts/promote_viability_models.py
+++ b/scripts/promote_viability_models.py
@@ -1,0 +1,101 @@
+"""
+Promote viability MLflow models from sandbox to model_predictions.
+
+Run once after this PR merges, before the new dbt model is executed.
+Safe to re-run: skips copy if @prod alias already points at a version
+promoted from the same sandbox source URI (tracked via a model version tag).
+
+Requires env vars: DATABRICKS_HOST, DATABRICKS_TOKEN
+"""
+
+import os
+
+import mlflow
+
+DATABRICKS_HOST = os.environ["DATABRICKS_HOST"]  # e.g. https://dbc-3d8ca484-79f3.cloud.databricks.com
+DATABRICKS_TOKEN = os.environ["DATABRICKS_TOKEN"]  # Databricks PAT — set in env before running
+
+mlflow.set_tracking_uri("databricks")
+
+client = mlflow.tracking.MlflowClient()
+
+# Maps sandbox model name → latest sandbox version to promote.
+# Update these version numbers if models are retrained before this script runs.
+MODELS_TO_PROMOTE = [
+    ("viabilitywithopponentdata", 5),
+    ("viabilitywithoutopenseat", 5),
+    ("viabilitynoincumbency", 2),
+    ("viabilitynoopponentdata", 2),
+    ("viabilitynocandidatedatahs", 2),
+]
+
+SANDBOX_CATALOG = "goodparty_data_catalog.sandbox"
+PROD_CATALOG = "goodparty_data_catalog.model_predictions"
+PROD_ALIAS = "prod"
+TAG_PROMOTED_FROM = "promoted_from"
+
+
+def _prod_alias_source_tag(prod_name: str) -> str | None:
+    """Return the promoted_from tag on the current @prod version, or None."""
+    try:
+        mv = client.get_model_version_by_alias(prod_name, PROD_ALIAS)
+        return mv.tags.get(TAG_PROMOTED_FROM)
+    except mlflow.exceptions.MlflowException as e:
+        if e.error_code == "RESOURCE_DOES_NOT_EXIST":
+            return None
+        raise
+
+
+def _ensure_registered_model(name: str) -> None:
+    """Create the destination registered model if it does not exist yet.
+
+    copy_model_version does not reliably auto-create the destination registered
+    model in Unity Catalog, so create it first (idempotently). Three of the five
+    viability models exist only in sandbox, not in model_predictions, on first run.
+    """
+    try:
+        client.create_registered_model(name)
+        print(f"  CREATE registered model {name}")
+    except mlflow.exceptions.MlflowException as e:
+        if e.error_code != "RESOURCE_ALREADY_EXISTS":
+            raise
+
+
+def promote(sandbox_model: str, sandbox_version: int) -> None:
+    src_uri = f"models:/{SANDBOX_CATALOG}.{sandbox_model}/{sandbox_version}"
+    dst_name = f"{PROD_CATALOG}.{sandbox_model}"
+
+    if _prod_alias_source_tag(dst_name) == src_uri:
+        print(f"  SKIP  {sandbox_model}: @prod already promoted from {src_uri}")
+        return
+
+    _ensure_registered_model(dst_name)
+    print(f"  COPY  {src_uri}  →  {dst_name}")
+    new_mv = client.copy_model_version(
+        src_model_uri=src_uri,
+        dst_name=dst_name,
+    )
+    new_version = new_mv.version
+    print(f"        created version {new_version} in {dst_name}")
+
+    client.set_model_version_tag(
+        name=dst_name,
+        version=new_version,
+        key=TAG_PROMOTED_FROM,
+        value=src_uri,
+    )
+
+    print(f"  ALIAS {dst_name}@{PROD_ALIAS}  →  v{new_version}")
+    client.set_registered_model_alias(
+        name=dst_name,
+        alias=PROD_ALIAS,
+        version=new_version,
+    )
+    print(f"  DONE  {sandbox_model}")
+
+
+if __name__ == "__main__":
+    print(f"Promoting {len(MODELS_TO_PROMOTE)} models to {PROD_CATALOG}\n")
+    for model_name, version in MODELS_TO_PROMOTE:
+        promote(model_name, version)
+    print("\nAll done.")


### PR DESCRIPTION
## What

Broadens Viability 2.0 coverage by feeding the scorer from the civics mart and surfacing the result on a new downstream mart, `candidacy_scored`. Supersedes #518 (incorporates the research team's civics scorer plus the integration #518 deliberately left to data engineering).

Plan: `.tickets/DATA-1938/2026-06-23-viability-integration-build-plan.md` (v6.1; codex-gated: NO-GO on v5 -> GO-WITH-CHANGES on v6 -> all findings folded in).

## Architecture (no cycle)

`int__civics_viability_scoring` reads `candidacy` + `election` as leaves and writes a per-`gp_candidacy_id` score. `candidacy_scored` = `candidacy` with `viability_score` / `score_viability_automated` overridden by the new score, coalesced over the old candidacy value (new wins; old gap-fills so coverage never regresses). The score lands on the downstream layer, never back on `candidacy`, so the graph stays acyclic: per-source ints -> candidacy/election -> scorer -> candidacy_scored -> consumers.

## In this PR

- **Scorer (`int__civics_viability_scoring`)**: load MLflow models by latest registered version (no `@prod`; matches the sibling `int__techspeed_viability_scoring`). Numeric version sort + missing-model guard + subset feature preflight. Records per-row provenance (`scoring_model`, `model_version`) on the intermediate.
- **`candidacy_scored`** mart (mart_civics): explicit column list mirroring `candidacy`; the two viability columns overridden as a unit so the score and its label never come from different sources. Full tests incl. a score/label presence-consistency invariant.
- **Repointed** `users_win_candidacy` and `leads_win_candidacy` to `candidacy_scored`.
- **`candidacy.viability_score` / `score_viability_automated`** docs marked INTERNAL (read `candidacy_scored`); they stay as the gap-filler source.

## NOT in this PR (staged)

- The **HubSpot reverse-ETL** feed (`sales_reverse_etl/candidacy_hubspot`) repoint is a separate fast-follow gated on prod validation (it is a manually-run, net-new view; bulk delivery to existing HubSpot records is the separate DATA-1523 export).

## Model registry preflight (verified)

All 5 viability models exist in `model_predictions` (`viabilitywithopponentdata` v1-5, the other four v1); none carries `@prod`, so latest-version loading is the only thing that resolves today.

## Validation

- Local: `pre-commit` (ruff, ruff-format, mypy, sqlfmt) green. Local dbt is Fusion, so the build is validated on the CI preview.
- Reconcile on the CI preview (pending): `candidacy_scored` row count == `candidacy`, non-viability columns null-safe-equal, viability coverage non-regression, plus the overlap band-shift report.
- Post-merge prod validation by segment (ICP, election year) gates the HubSpot fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sales-facing viability semantics and depends on latest MLflow model versions at runtime; mitigated by acyclic layering, coalesce gap-fill, and score/label consistency tests, but Win/lead reports will shift where the new scorer differs from legacy TS-only scores.
> 
> **Overview**
> **Broad civics viability (DATA-1938)** is introduced as a downstream layer so Win/sales consumers get ML-scored viability without writing scores back onto `candidacy`.
> 
> A new Python intermediate, `int__civics_viability_scoring`, scores every `gp_candidacy_id` from the `candidacy` and `election` marts using a five-model MLflow **waterfall** (best complete model wins via `COALESCE`). It builds features (WoE joins, opponent/seat logic), fixes numeric MLflow version resolution, and stores internal provenance (`scoring_model`, `model_version`).
> 
> The **`candidacy_scored`** mart mirrors `candidacy` but overrides `viability_score` and `score_viability_automated` as a **matched pair**: new civics scores win when present; legacy `candidacy` values gap-fill unscored rows so coverage does not regress. dbt tests document the model and enforce score/label consistency.
> 
> **`users_win_candidacy`** and **`leads_win_candidacy`** now read `candidacy_scored` instead of `candidacy` for viability. Base `candidacy` viability columns are documented as internal gap-fill only. A one-time **`scripts/promote_viability_models.py`** copies sandbox MLflow models into `model_predictions` before the scorer runs (HubSpot reverse-ETL repoint is explicitly out of scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d69cd773d39ac9865a55a9d3d759287adb097b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->