### PR TITLE
Event provenance: instrumentation-context matcher + re-baseline

### DIFF
--- a/analytics/data/amplitude_event_provenance.csv
+++ b/analytics/data/amplitude_event_provenance.csv
@@ -1,438 +1,442 @@
 event_type,event_type_slug,instrumented_commit,instrumented_pr,instrumented_date,retired_commit,retired_pr,retired_date,last_code_change_date,updated_at
-10 DLC Compliance - PIN Verification Completed,10_dlc_compliance_pin_verification_completed,ecf326d35c1db1bd0af368b87a335b47286e8716,1049,2025-10-06,,,,2025-10-06,2026-06-23T16:53:54
-10 DLC Compliance - Registration Submitted,10_dlc_compliance_registration_submitted,ecf326d35c1db1bd0af368b87a335b47286e8716,1049,2025-10-06,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,2026-06-05,2026-06-23T16:53:54
-AI Assistant - Chat History: Click delete,ai_assistant_chat_history_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant - Chat History: Click menu,ai_assistant_chat_history_click_menu,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant - Chat: Click copy,ai_assistant_chat_click_copy,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant - Chat: Click regenerate,ai_assistant_chat_click_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant - Chat: Click thumbs down,ai_assistant_chat_click_thumbs_down,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant - Chat: Click thumbs up,ai_assistant_chat_click_thumbs_up,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant - Response Completed,ai_assistant_response_completed,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-23T16:53:54
-AI Assistant: Ask a question,ai_assistant_ask_a_question,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant: Click new chat,ai_assistant_click_new_chat,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-AI Assistant: Click view chat history,ai_assistant_click_view_chat_history,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Account - Password Reset Completed,account_password_reset_completed,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-23T16:53:54
-Account - Password Reset Requested,account_password_reset_requested,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-27,2026-06-23T16:53:54
-Account - Password Set Completed,account_password_set_completed,2fc365543df992198d512fbe2d6053a6d38a1aa7,888,2025-08-18,,,,2025-08-18,2026-06-23T16:53:54
-Account - Pro Subscription Canceled,account_pro_subscription_canceled,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
-Account - Pro Subscription Confirmed,account_pro_subscription_confirmed,ac3e04fb428f001d0ab7bcc471c5c85ef726e2b5,319,2025-06-27,,,,2025-06-27,2026-06-23T16:53:54
-Account - User Deleted,account_user_deleted,9582a5844f58fb5a53304f8a8dfef0ef25ffb532,1487,2026-04-20,,,,2026-04-20,2026-06-23T16:53:54
-Briefing Assistant - Agenda Created,briefing_assistant_agenda_created,acb9d347d9513d1aa6f49c97e9fbb14f6d581b28,1676,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - Agenda Not Created,briefing_assistant_agenda_not_created,5b8b5d6d70a84b9178fc66152cda021a6b4a1c03,30,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
-Briefing Assistant - Agenda Submission Failed,briefing_assistant_agenda_submission_failed,c339b19dec1b846127f34a99f0c6cf406e42a982,30,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
-Briefing Assistant - Agenda Submitted,briefing_assistant_agenda_submitted,c339b19dec1b846127f34a99f0c6cf406e42a982,30,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
-Briefing Assistant - Briefing Viewed,briefing_assistant_briefing_viewed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - Download Clicked,briefing_assistant_download_clicked,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - Feedback Completed,briefing_assistant_feedback_completed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - List Viewed,briefing_assistant_list_viewed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - Share Completed,briefing_assistant_share_completed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - Share Drawer Opened,briefing_assistant_share_drawer_opened,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - Sources Expanded,briefing_assistant_sources_expanded,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefing Assistant - TOC Item Clicked,briefing_assistant_toc_item_clicked,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-23T16:53:54
-Briefings - Briefing Viewed,briefings_briefing_viewed,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
-Briefings - Click Download,briefings_click_download,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
-Briefings - Click Read Full Briefing,briefings_click_read_full_briefing,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
-Briefings - Feedback: Helpful,briefings_feedback_helpful,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
-Briefings - Feedback: Not Helpful,briefings_feedback_not_helpful,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
-Briefings - Issue Detail Viewed,briefings_issue_detail_viewed,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-23T16:53:54
-Campaign - Follow-On Created,campaign_follow_on_created,d55fa245190deb34c93bd32b863b7c776bbff190,152,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
-Campaign Plan - Weekly Tasks Digest,campaign_plan_weekly_tasks_digest,61d552cc6974dfbb0696f8aad51563686e07e814,1472,2026-04-21,,,,2026-04-21,2026-06-23T16:53:54
-Campaign Plan V2 - Community Events Generation Completed,campaign_plan_v2_community_events_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Community Events Generation Started,campaign_plan_v2_community_events_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Media Generation Completed,campaign_plan_v2_media_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Media Generation Started,campaign_plan_v2_media_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Opportunities & Challenges Generation Completed,campaign_plan_v2_opportunities_challenges_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Opportunities & Challenges Generation Started,campaign_plan_v2_opportunities_challenges_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Opposition Research Generation Completed,campaign_plan_v2_opposition_research_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Opposition Research Generation Started,campaign_plan_v2_opposition_research_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Campaign Plan V2 - Strategy Race Changed,campaign_plan_v2_strategy_race_changed,f920787b11cffc31ae84b70f9b148a89f9431466,104,2026-06-12,,,,2026-06-12,2026-06-23T16:53:54
-Campaign Verify Token Status Update,campaign_verify_token_status_update,362c9b448065c166e4f742836d508cafc825054b,593,2025-10-07,,,,2025-10-07,2026-06-23T16:53:54
-Candidacy - Campaign Completed,candidacy_campaign_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
-Candidacy - Debrief Clicked,candidacy_debrief_clicked,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-23T16:53:54
-Candidacy - Did You Win Modal Completed,candidacy_did_you_win_modal_completed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-23T16:53:54
-Candidacy - Did You Win Modal Viewed,candidacy_did_you_win_modal_viewed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-23T16:53:54
-Candidate Website - Continued,candidate_website_continued,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
-Candidate Website - Edited,candidate_website_edited,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
-Candidate Website - Published,candidate_website_published,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2026-03-03,2026-06-23T16:53:54
-Candidate Website - Purchased domain,candidate_website_purchased_domain,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2026-03-03,2026-06-23T16:53:54
-Candidate Website - Selected domain,candidate_website_selected_domain,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
-Candidate Website - Started,candidate_website_started,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
-Candidate Website - Started domain selection,candidate_website_started_domain_selection,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
-Candidate Website - Unpublished,candidate_website_unpublished,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-23T16:53:54
-Click to Call CTA Clicked,click_to_call_cta_clicked,,,,,,,,2026-06-23T16:53:54
-Click to Call CTA Viewed,click_to_call_cta_viewed,,,,,,,,2026-06-23T16:53:54
-Click to Call Phone Submitted,click_to_call_phone_submitted,,,,,,,,2026-06-23T16:53:54
-Contacts - Column Edited,contacts_column_edited,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
-Contacts - Contacts Viewed,contacts_contacts_viewed,89f97d0c41382d4c48e72db3ffe591be4694d12a,194,2026-06-17,,,,2026-06-17,2026-06-23T16:53:54
-Contacts - Download,contacts_download,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2026-06-17,2026-06-23T16:53:54
-Contacts - Segment Created,contacts_segment_created,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
-Contacts - Segment Deleted,contacts_segment_deleted,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
-Contacts - Segment Updated,contacts_segment_updated,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
-Contacts - Segment Viewed,contacts_segment_viewed,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-23T16:53:54
-Content Builder - Editor: Click Copy,content_builder_editor_click_copy,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Click Delete,content_builder_editor_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Click Regenerate,content_builder_editor_click_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Click Rename,content_builder_editor_click_rename,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Click Translate,content_builder_editor_click_translate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Open Kebab Menu,content_builder_editor_open_kebab_menu,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Open Version Picker,content_builder_editor_open_version_picker,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Select Version,content_builder_editor_select_version,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Submit Regenerate,content_builder_editor_submit_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder - Editor: Submit Translate,content_builder_editor_submit_translate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Click Content,content_builder_click_content,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Click Continue Questions,content_builder_click_continue_questions,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Click Generate,content_builder_click_generate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Close Additional Inputs,content_builder_close_additional_inputs,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Generation Completed,content_builder_generation_completed,3968af2dffa446ff83c6625da709ebb45c5ef31e,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Generation Started,content_builder_generation_started,3968af2dffa446ff83c6625da709ebb45c5ef31e,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Select Template,content_builder_select_template,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Content Builder: Submit Additional Inputs,content_builder_submit_additional_inputs,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Custom Voter file created,custom_voter_file_created,93fabd843cdc5e60795b99327819517c76426f3a,,2024-06-07,,,,2024-06-07,2026-06-23T16:53:54
-Daily Ad Metrics,daily_ad_metrics,,,,,,,,2026-06-23T16:53:54
-Dashboard - Campaign Plan Generation Completed,dashboard_campaign_plan_generation_completed,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-07,2026-06-23T16:53:54
-Dashboard - Campaign Plan Task CTA Clicked,dashboard_campaign_plan_task_cta_clicked,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-03,2026-06-23T16:53:54
-Dashboard - Campaign Plan View Mode Toggled,dashboard_campaign_plan_view_mode_toggled,99a9be2e39794c5d3eaeb2b897be4eea422ecc92,1720,2026-04-17,,,,2026-04-17,2026-06-23T16:53:54
-Dashboard - Campaign Plan Viewed,dashboard_campaign_plan_viewed,329017f7e2c2ecd299b09f81f081db9a2168722f,,2026-01-28,,,,2026-04-03,2026-06-23T16:53:54
-Dashboard - Campaign Plan Week Navigated,dashboard_campaign_plan_week_navigated,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-03,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Campaign Manager Clicked,dashboard_campaign_plan_campaign_manager_clicked,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Community Events Displayed,dashboard_campaign_plan_community_events_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Community Events Requested,dashboard_campaign_plan_community_events_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Community Events Results Received,dashboard_campaign_plan_community_events_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Media Displayed,dashboard_campaign_plan_media_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Media Requested,dashboard_campaign_plan_media_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Media Results Received,dashboard_campaign_plan_media_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Plan Downloaded,dashboard_campaign_plan_plan_downloaded,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Strategic Landscape Displayed,dashboard_campaign_plan_strategic_landscape_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Strategic Landscape Requested,dashboard_campaign_plan_strategic_landscape_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Plan: Strategic Landscape Results Received,dashboard_campaign_plan_strategic_landscape_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Dashboard - Campaign Task Status Updated,dashboard_campaign_task_status_updated,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-03,2026-06-23T16:53:54
-Dashboard - Candidate Dashboard Viewed,dashboard_candidate_dashboard_viewed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2025-06-18,2026-06-23T16:53:54
-Dashboard - Path to Victory: Exit Understand Path to Victory,dashboard_path_to_victory_exit_understand_path_to_victory,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Download Voter File Failure,download_voter_file_failure,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-23T16:53:54
-Download Voter File Success,download_voter_file_success,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-23T16:53:54
-Download Voter File attempt,download_voter_file_attempt,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-23T16:53:54
-Experiment Viewed,experiment_viewed,,,,,,,,2026-06-23T16:53:54
-Invalid Party,invalid_party,f4290f167ee16aaaed0299d64c48ae8a3452eeb3,,2024-06-13,85954771b6d545e35af77bf5ca3ae86e9cbdb80d,1790,2026-05-05,2026-05-05,2026-06-23T16:53:54
-Navigation - Dashboard: Click AI Assistant,navigation_dashboard_click_ai_assistant,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation - Dashboard: Click Briefings,navigation_dashboard_click_briefings,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,,,,2026-04-09,2026-06-23T16:53:54
-Navigation - Dashboard: Click Campaign Plan,navigation_dashboard_click_campaign_plan,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-23T16:53:54
-Navigation - Dashboard: Click Community,navigation_dashboard_click_community,ab19165b23e99ec39c1dbe8feef281ba6d1bc284,576,2025-04-03,,,,2026-06-19,2026-06-23T16:53:54
-Navigation - Dashboard: Click Contacts,navigation_dashboard_click_contacts,b54392a3217e2e427dc5c39f86b98d70a94289c0,938,2025-09-04,,,,2025-09-04,2026-06-23T16:53:54
-Navigation - Dashboard: Click Content Builder,navigation_dashboard_click_content_builder,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation - Dashboard: Click Dashboard,navigation_dashboard_click_dashboard,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation - Dashboard: Click Door Knocking,navigation_dashboard_click_door_knocking,27bef878da7c3238d22d65e27e4b37afee213ed7,522,2025-03-09,,,,2025-03-09,2026-06-23T16:53:54
-Navigation - Dashboard: Click Free Resources,navigation_dashboard_click_free_resources,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,2025-10-14,2026-06-23T16:53:54
-Navigation - Dashboard: Click Issues,navigation_dashboard_click_issues,d4a6c5feef4c178a4619e51f79c3090c9191e7dd,733,2025-07-01,,,,2025-07-01,2026-06-23T16:53:54
-Navigation - Dashboard: Click My Profile,navigation_dashboard_click_my_profile,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation - Dashboard: Click Polls,navigation_dashboard_click_polls,405a687410467f5dc4b89616f282135384a421e8,,2025-10-08,,,,2025-10-08,2026-06-23T16:53:54
-Navigation - Dashboard: Click Resources,navigation_dashboard_click_resources,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,3f6a11a2d717831603f3640b481d6ce9ca6c6698,1459,2026-02-23,2026-02-23,2026-06-23T16:53:54
-Navigation - Dashboard: Click Text Messaging,navigation_dashboard_click_text_messaging,fdf692bfb6171d2436153dff317c995684c94770,,2025-03-22,70a5c952c7fc6b985b062d1b7d9ceb8707bc7dd5,923,2025-08-27,2025-08-27,2026-06-23T16:53:54
-Navigation - Dashboard: Click Voter Data,navigation_dashboard_click_voter_data,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation - Dashboard: Click Voter Outreach,navigation_dashboard_click_voter_outreach,2a9e9929d18f38be852ff8233c76f644cfc6bff6,900,2025-08-20,,,,2025-08-20,2026-06-23T16:53:54
-Navigation - Dashboard: Click Website,navigation_dashboard_click_website,9b740f9d306dba90477c9d2860876585bce07ea4,,2025-06-19,,,,2025-06-19,2026-06-23T16:53:54
-Navigation - Top - Avatar Dropdown: Close Dropdown,navigation_top_avatar_dropdown_close_dropdown,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation - Top: Click Avatar Dropdown,navigation_top_click_avatar_dropdown,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation - Top: Click Logo,navigation_top_click_logo,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation Top - Avatar Dropdown: Click Logout,navigation_top_avatar_dropdown_click_logout,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Navigation Top - Avatar Dropdown: Click Profile,navigation_top_avatar_dropdown_click_profile,a747931b6d3aa7b74f3b331bf53c423d81b641ad,1524,2026-04-16,,,,2026-04-16,2026-06-23T16:53:54
-Navigation Top - Avatar Dropdown: Click Settings,navigation_top_avatar_dropdown_click_settings,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Ballot Status Completed,onboarding_ballot_status_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
-Onboarding - Candidate Affiliation Completed,onboarding_candidate_affiliation_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
-Onboarding - Candidate Office Completed,onboarding_candidate_office_completed,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-23T16:53:54
-Onboarding - Candidate Office Searched,onboarding_candidate_office_searched,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-23T16:53:54
-Onboarding - Candidate Pledge Completed,onboarding_candidate_pledge_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-23T16:53:54
-Onboarding - Complete Step: Click Go to Dashboard,onboarding_complete_step_click_go_to_dashboard,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Know Your Voters Completed,onboarding_know_your_voters_completed,712fb71051988420909b538f89ea4da4703c1b8b,1804,2026-05-07,,,,2026-05-07,2026-06-23T16:53:54
-Onboarding - Office Selection Completed,onboarding_office_selection_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
-Onboarding - Office Step: Click Can't See Office,onboarding_office_step_click_cant_see_office,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Office Step: Click Next,onboarding_office_step_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Office Step: Office Selected,onboarding_office_step_office_selected,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Party Selection Completed,onboarding_party_selection_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
-Onboarding - Party Step: Click Submit,onboarding_party_step_click_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Path To Victory Completed,onboarding_path_to_victory_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
-Onboarding - Path To Victory Errored,onboarding_path_to_victory_errored,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
-Onboarding - Path To Victory Updated,onboarding_path_to_victory_updated,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
-Onboarding - Pledge Completed,onboarding_pledge_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-06-24,2026-06-24T18:31:10
-Onboarding - Pledge Step: Click Ask a Question,onboarding_pledge_step_click_ask_a_question,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Pledge Step: Click Submit,onboarding_pledge_step_click_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Onboarding - Registration Completed,onboarding_registration_completed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2025-06-18,2026-06-23T16:53:54
-Onboarding - User Created,onboarding_user_created,ac3e04fb428f001d0ab7bcc471c5c85ef726e2b5,319,2025-06-27,,,,2025-06-27,2026-06-23T16:53:54
-Onboarding - Welcome Completed,onboarding_welcome_completed,85954771b6d545e35af77bf5ca3ae86e9cbdb80d,1790,2026-05-05,,,,2026-05-05,2026-06-23T16:53:54
-Onboarding V2 - Ballot Status Completed,onboarding_v2_ballot_status_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Ballot Status Viewed,onboarding_v2_ballot_status_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Campaign Manager Clicked,onboarding_v2_campaign_manager_clicked,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Community Events Displayed,onboarding_v2_community_events_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Community Events Requested,onboarding_v2_community_events_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Community Events Results Received,onboarding_v2_community_events_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Media Displayed,onboarding_v2_media_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Media Requested,onboarding_v2_media_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Media Results Received,onboarding_v2_media_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - New Campaign Context Completed,onboarding_v2_new_campaign_context_completed,9cd8b68a5e50b3eec249595ea4d927de286b9680,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
-Onboarding V2 - New Campaign Context Viewed,onboarding_v2_new_campaign_context_viewed,9cd8b68a5e50b3eec249595ea4d927de286b9680,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
-Onboarding V2 - Office Completed,onboarding_v2_office_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Office Next Clicked,onboarding_v2_office_next_clicked,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
-Onboarding V2 - Office Viewed,onboarding_v2_office_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Party Designation Blocked,onboarding_v2_party_designation_blocked,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Party Designation Completed,onboarding_v2_party_designation_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Party Designation Viewed,onboarding_v2_party_designation_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Plan Downloaded,onboarding_v2_plan_downloaded,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Plan Shared,onboarding_v2_plan_shared,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-23T16:53:54
-Onboarding V2 - Pledge Completed,onboarding_v2_pledge_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Pledge Submit Clicked,onboarding_v2_pledge_submit_clicked,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
-Onboarding V2 - Pledge Viewed,onboarding_v2_pledge_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Resources Completed,onboarding_v2_resources_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Resources Viewed,onboarding_v2_resources_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Strategic Landscape Displayed,onboarding_v2_strategic_landscape_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Strategic Landscape Requested,onboarding_v2_strategic_landscape_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Strategic Landscape Results Received,onboarding_v2_strategic_landscape_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Voter Insights Completed,onboarding_v2_voter_insights_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Voter Insights Viewed,onboarding_v2_voter_insights_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Votes Needed Calculated,onboarding_v2_votes_needed_calculated,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
-Onboarding V2 - Votes Needed Completed,onboarding_v2_votes_needed_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Votes Needed Failed,onboarding_v2_votes_needed_failed,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-23T16:53:54
-Onboarding V2 - Votes Needed Viewed,onboarding_v2_votes_needed_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Onboarding V2 - Welcome Completed,onboarding_v2_welcome_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-10,2026-06-23T16:53:54
-Onboarding V2 - Welcome Viewed,onboarding_v2_welcome_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-10,2026-06-23T16:53:54
-Onboarding: Click Finish Later,onboarding_click_finish_later,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Org Switcher - Organization Switched,org_switcher_organization_switched,7d6668ba391fe68eb744fd6f98f4fdcf4377a295,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
-Org Switcher - Run For Office Clicked,org_switcher_run_for_office_clicked,7d6668ba391fe68eb744fd6f98f4fdcf4377a295,151,2026-06-15,,,,2026-06-15,2026-06-23T16:53:54
-Outreach - Action Clicked,outreach_action_clicked,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
-Outreach - Click Create,outreach_click_create,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
-Outreach - Door Knocking: Complete,outreach_door_knocking_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
-Outreach - Phone Banking: Complete,outreach_phone_banking_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
-Outreach - Social Media: Complete,outreach_social_media_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
-Outreach - View Accessed,outreach_view_accessed,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-23T16:53:54
-P2P Upgrade - Modal: Click Button,p2p_upgrade_modal_click_button,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
-P2P Upgrade - Modal: Exit,p2p_upgrade_modal_exit,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
-P2P Upgrade - Modal: Modal Shown,p2p_upgrade_modal_modal_shown,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
-Page,page,a1e5ff46199301c71153b531950bc30ee11bf791,,2024-06-08,,,,2026-06-24,2026-06-24T18:31:10
-Page Viewed,page_viewed,,,,,,,,2026-06-23T16:53:54
-Payment - Completed,payment_completed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2026-02-08,2026-06-23T16:53:54
-Payment - Review and Pay Screen Viewed,payment_review_and_pay_screen_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
-Payment - Schedule and Pay Viewed,payment_schedule_and_pay_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Poll - Results Synthesis Complete,poll_results_synthesis_complete,8293df56527c17f0fa9e42c99caf625438dd7242,636,2025-10-13,,,,2025-10-15,2026-06-23T16:53:54
-Polls - Add Image Completed,polls_add_image_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Add Image Viewed,polls_add_image_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Audience Selection Completed,polls_audience_selection_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Audience Selection Viewed,polls_audience_selection_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Create Poll Clicked,polls_create_poll_clicked,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Expand Poll Recommendations Completed,polls_expand_poll_recommendations_completed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
-Polls - Expand Poll Recommendations Viewed,polls_expand_poll_recommendations_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
-Polls - Expand Poll Review Viewed,polls_expand_poll_review_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-23T16:53:54
-Polls - Low Confidence Modal Clicked,polls_low_confidence_modal_clicked,907174177b76b62992ff33439ebcd8b1d59d5e0a,1382,2026-03-09,,,,2026-03-09,2026-06-23T16:53:54
-Polls - Poll Bias Detection Shown,polls_poll_bias_detection_shown,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Poll Preview Completed,polls_poll_preview_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Poll Preview Viewed,polls_poll_preview_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Poll Question Completed,polls_poll_question_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Poll Question Optimized,polls_poll_question_optimized,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Poll Question Viewed,polls_poll_question_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Poll Results Issue Details Viewed,polls_poll_results_issue_details_viewed,24d9f8f48bfc6f173af3257d28bb7c35fc2d5c0f,1135,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
-Polls - Poll Results Overview Viewed,polls_poll_results_overview_viewed,24d9f8f48bfc6f173af3257d28bb7c35fc2d5c0f,1135,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
-Polls - Schedule Poll Completed,polls_schedule_poll_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Polls - Schedule Poll Viewed,polls_schedule_poll_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-23T16:53:54
-Pro Upgrade - Banner Viewed,pro_upgrade_banner_viewed,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Pro Upgrade - Banner: Click Get Pro,pro_upgrade_banner_click_get_pro,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Pro Upgrade - Candidate Profile Submitted,pro_upgrade_candidate_profile_submitted,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,,,,2026-06-05,2026-06-23T16:53:54
-Pro Upgrade - Candidate Profile Viewed,pro_upgrade_candidate_profile_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-23T16:53:54
-Pro Upgrade - Committee Check Page: Click Upload,pro_upgrade_committee_check_page_click_upload,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Pro Upgrade - Committee Check Page: Click back,pro_upgrade_committee_check_page_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Pro Upgrade - Committee Check Page: Click next,pro_upgrade_committee_check_page_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-"Pro Upgrade - Committee Check Page: Hover ""EIN number"" help",pro_upgrade_committee_check_page_hover_ein_number_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
-"Pro Upgrade - Committee Check Page: Hover ""Name of Campaign Committee"" help",pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
-"Pro Upgrade - Committee Check Page: Hover ""Upload"" help",pro_upgrade_committee_check_page_hover_upload_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-23T16:53:54
-Pro Upgrade - Committee Check Page: Hover “EIN number” help,pro_upgrade_committee_check_page_hover_ein_number_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-23T16:53:54
-Pro Upgrade - Committee Check Page: Hover “Name of Campaign Committee” help,pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-23T16:53:54
-Pro Upgrade - Committee Check Page: Hover “Upload” help,pro_upgrade_committee_check_page_hover_upload_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-23T16:53:54
-Pro Upgrade - Committee Check Page: Toggle EIN requirement,pro_upgrade_committee_check_page_toggle_ein_requirement,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Pro Upgrade - EIN Viewed,pro_upgrade_ein_viewed,c1183769c51e92e8e7177d09c9604c083f3b8454,1987,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - EIN: Click continue,pro_upgrade_ein_click_continue,c1183769c51e92e8e7177d09c9604c083f3b8454,1987,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - EIN: Hover help,pro_upgrade_ein_hover_help,0b66488415b7ecbcf217d96901a9a5c15ad50b0c,1987,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Filing Details Submitted,pro_upgrade_filing_details_submitted,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,,,,2026-06-05,2026-06-23T16:53:54
-Pro Upgrade - Filing Details Viewed,pro_upgrade_filing_details_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-23T16:53:54
-Pro Upgrade - Filing Instructions Viewed,pro_upgrade_filing_instructions_viewed,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Filing Instructions: Click continue to dashboard,pro_upgrade_filing_instructions_click_continue_to_dashboard,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Filing Instructions: Click email this to me,pro_upgrade_filing_instructions_click_email_this_to_me,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Filing Status Viewed,pro_upgrade_filing_status_viewed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Filing Status: Click already filed,pro_upgrade_filing_status_click_already_filed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Filing Status: Click not yet filed,pro_upgrade_filing_status_click_not_yet_filed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Guidance Viewed,pro_upgrade_guidance_viewed,7f6db6f25fc3e3277698af890bce5a7e3bd7de36,1986,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Guidance: Click let's go,pro_upgrade_guidance_click_lets_go,7f6db6f25fc3e3277698af890bce5a7e3bd7de36,1986,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Locked Item: Click,pro_upgrade_locked_item_click,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Pro Upgrade - Modal: Click Button,pro_upgrade_modal_click_button,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade - Modal: Exit,pro_upgrade_modal_exit,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade - Modal: Modal Shown,pro_upgrade_modal_modal_shown,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade - PIN Entry Viewed,pro_upgrade_pin_entry_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-23T16:53:54
-Pro Upgrade - Payment Viewed,pro_upgrade_payment_viewed,c465ade2992cad108b60684aa48d84e57b125f6e,1990,2026-06-07,,,,2026-06-07,2026-06-23T16:53:54
-Pro Upgrade - Service Agreement Page: Click back,pro_upgrade_service_agreement_page_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Pro Upgrade - Service Agreement Page: Click finish,pro_upgrade_service_agreement_page_click_finish,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Pro Upgrade - Splash Page: Click upgrade,pro_upgrade_splash_page_click_upgrade,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade - Splash Page: Exit,pro_upgrade_splash_page_exit,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade - Success Viewed,pro_upgrade_success_viewed,9a3d5e1de57e975a9a194e681e4f216a63c642d6,1992,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Pro Upgrade - Success: Click continue,pro_upgrade_success_click_continue,9a3d5e1de57e975a9a194e681e4f216a63c642d6,1992,2026-06-08,,,,2026-06-08,2026-06-23T16:53:54
-Pro Upgrade - Value Prop Viewed,pro_upgrade_value_prop_viewed,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-23T16:53:54
-Pro Upgrade - Value Prop: Click Get Pro,pro_upgrade_value_prop_click_get_pro,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-23T16:53:54
-Pro Upgrade - Value Prop: Click Maybe later,pro_upgrade_value_prop_click_maybe_later,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-23T16:53:54
-Pro Upgrade: Click Go to Stripe,pro_upgrade_click_go_to_stripe,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Pro Upgrade: Click exit top nav,pro_upgrade_click_exit_top_nav,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade: Confirm office,pro_upgrade_confirm_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade: Edit office,pro_upgrade_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade: Exit edit office,pro_upgrade_exit_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro Upgrade: Submit edit office,pro_upgrade_submit_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-23T16:53:54
-Pro user can not download voter file page,pro_user_can_not_download_voter_file_page,7d03f67f7ae53ade7b5894b5841fccbb35e16dcc,,2024-06-30,,,,2024-06-30,2026-06-23T16:53:54
-Profile - Campaign Details: Click Save,profile_campaign_details_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Candidate Profile: Click Submit,profile_candidate_profile_click_submit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Candidate Profile: Submit Success,profile_candidate_profile_submit_success,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,2026-06-05,2026-06-23T16:53:54
-Profile - Fun Fact: Click Save,profile_fun_fact_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Office Details: Click Edit,profile_office_details_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Office Details: Click Save,profile_office_details_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Policy Priorities: Cancel Add,profile_policy_priorities_cancel_add,e2e5ed9386a69f3cfa83791cd0de5adce47f9413,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Policy Priorities: Cancel Edit,profile_policy_priorities_cancel_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Policy Priorities: Click Add,profile_policy_priorities_click_add,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Policy Priorities: Click Delete,profile_policy_priorities_click_delete,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Policy Priorities: Click Edit,profile_policy_priorities_click_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Policy Priorities: Click Save,profile_policy_priorities_click_save,e1371f746f1db7146bb55de165e8725613e3d6aa,1778,2026-04-30,,,,2026-04-30,2026-06-23T16:53:54
-Profile - Policy Priorities: Submit Add,profile_policy_priorities_submit_add,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Policy Priorities: Submit Delete,profile_policy_priorities_submit_delete,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Policy Priorities: Submit Edit,profile_policy_priorities_submit_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-23T16:53:54
-Profile - Running Against: Cancel Add New,profile_running_against_cancel_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Running Against: Cancel Edit,profile_running_against_cancel_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Running Against: Click Add New,profile_running_against_click_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Running Against: Click Delete,profile_running_against_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Running Against: Click Edit,profile_running_against_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Running Against: Click Save,profile_running_against_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Running Against: Submit Add New,profile_running_against_submit_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Running Against: Submit Edit,profile_running_against_submit_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Top Issues: Cancel Delete,profile_top_issues_cancel_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Top Issues: Cancel Edit,profile_top_issues_cancel_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Top Issues: Click Delete,profile_top_issues_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Top Issues: Click Edit,profile_top_issues_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Top Issues: Click Finish Entering Issues,profile_top_issues_click_finish_entering_issues,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Top Issues: Submit Delete,profile_top_issues_submit_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Top Issues: Submit Edit,profile_top_issues_submit_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Profile - Why Running: Click Save,profile_why_running_click_save,e1371f746f1db7146bb55de165e8725613e3d6aa,1778,2026-04-30,,,,2026-04-30,2026-06-23T16:53:54
-Profile - Why Section: Click Save,profile_why_section_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Resources - Resource Clicked,resources_resource_clicked,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,3f6a11a2d717831603f3640b481d6ce9ca6c6698,1459,2026-02-23,2026-02-23,2026-06-23T16:53:54
-Schedule Text Campaign - Audience: Check Age,schedule_text_campaign_audience_check_age,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Audience: Check Audience,schedule_text_campaign_audience_check_audience,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Audience: Check Gender,schedule_text_campaign_audience_check_gender,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Audience: Check Political Party,schedule_text_campaign_audience_check_political_party,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Audience: Enter Audience Request,schedule_text_campaign_audience_enter_audience_request,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Script: Click Add your own script,schedule_text_campaign_script_click_add_your_own_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Script: Click Generate a new script,schedule_text_campaign_script_click_generate_a_new_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Script: Click Use a saved script,schedule_text_campaign_script_click_use_a_saved_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Script: Select Saved Script,schedule_text_campaign_script_select_saved_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign - Script: Submit added script,schedule_text_campaign_script_submit_added_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign: Back,schedule_text_campaign_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign: Exit,schedule_text_campaign_exit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign: Next,schedule_text_campaign_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Schedule Text Campaign: Submit,schedule_text_campaign_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Scroll Depth,scroll_depth,,,,,,,,2026-06-23T16:53:54
-Segment Consent Preference Updated,segment_consent_preference_updated,,,,,,,,2026-06-23T16:53:54
-Serve Onboarding - Add Image Viewed,serve_onboarding_add_image_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - BR Suggestion Changed,serve_onboarding_br_suggestion_changed,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,,,,2026-06-18,2026-06-24T18:31:10
-Serve Onboarding - Constituency Profile Viewed,serve_onboarding_constituency_profile_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - Getting Started Viewed,serve_onboarding_getting_started_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - Magic Link Activated,serve_onboarding_magic_link_activated,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,,,,2026-06-18,2026-06-23T16:53:54
-Serve Onboarding - Magic Link Sent,serve_onboarding_magic_link_sent,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,0457c312a51f110b32f82d85c2b2103969f8e8a5,349,2026-06-24,2026-06-24,2026-06-24T18:31:10
-Serve Onboarding - Meet Your Constituents Viewed,serve_onboarding_meet_your_constituents_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - Net New Completed,serve_onboarding_net_new_completed,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,,,,2026-06-24,2026-06-24T18:31:10
-Serve Onboarding - Poll Image Uploaded,serve_onboarding_poll_image_uploaded,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - Poll Preview Viewed,serve_onboarding_poll_preview_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - Poll Strategy Viewed,serve_onboarding_poll_strategy_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - Poll Value Props Viewed,serve_onboarding_poll_value_props_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - SMS Poll Creation Failed,serve_onboarding_sms_poll_creation_failed,4537360b9cd5f5071c5b1f99364e310e0b225620,1374,2026-02-04,,,,2026-02-04,2026-06-23T16:53:54
-Serve Onboarding - SMS Poll Sent,serve_onboarding_sms_poll_sent,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-23T16:53:54
-Serve Onboarding - Success Page Viewed,serve_onboarding_success_page_viewed,33f319823719eb25aef1fe2812184a61b23a41f6,1098,2025-10-29,,,,2025-10-29,2026-06-23T16:53:54
-Serve Onboarding - Sworn In Completed,serve_onboarding_sworn_in_completed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-23T16:53:54
-Serve Onboarding - Sworn In Viewed,serve_onboarding_sworn_in_viewed,33f319823719eb25aef1fe2812184a61b23a41f6,1098,2025-10-29,,,,2025-10-29,2026-06-23T16:53:54
-Set Password: Click Set Password,set_password_click_set_password,aeb23786b697e849c6684f4fc08acb0964fae1fe,513,2025-03-06,,,,2025-03-06,2026-06-23T16:53:54
-Settings - Account Settings: Click Manage Pro Subscription,settings_account_settings_click_manage_pro_subscription,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Account Settings: Click Send Email,settings_account_settings_click_send_email,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Account Settings: Click Upgrade,settings_account_settings_click_upgrade,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Delete Account: Cancel Delete,settings_delete_account_cancel_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Delete Account: Click Delete,settings_delete_account_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Delete Account: Submit Delete,settings_delete_account_submit_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Notifications: Toggle Email,settings_notifications_toggle_email,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Password: Click Save,settings_password_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Personal Info: Click Save,settings_personal_info_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Settings - Personal Info: Click Upload,settings_personal_info_click_upload,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Sign In: Click Create Account,sign_in_click_create_account,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Sign In: Click Forgot Password,sign_in_click_forgot_password,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Sign Up Clicked,sign_up_clicked,,,,,,,,2026-06-23T16:53:54
-Sign Up: Click Login,sign_up_click_login,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Viewed,viewed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2026-06-24,2026-06-24T18:31:10
-Viewed /elections/ak/tanana-city-school-district,viewed_elections_ak_tanana_city_school_district,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/chippewa-county-clerk/145f1d,viewed_elections_chippewa_county_clerk_145f1d,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/ia/red-oak-community-school-district,viewed_elections_ia_red_oak_community_school_district,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/mi/monroe-county/monroe/position/city-clerk-ward-officer,viewed_elections_mi_monroe_county_monroe_position_city_clerk_ward_officer,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/nv/elko/point-of-rocks,viewed_elections_nv_elko_point_of_rocks,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/pa,viewed_elections_pa,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/tx/borger-independent-school-district,viewed_elections_tx_borger_independent_school_district,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/tx/gray/hoover,viewed_elections_tx_gray_hoover,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/tx/saint-jo-independent-school-district,viewed_elections_tx_saint_jo_independent_school_district,,,,,,,,2026-06-23T16:53:54
-Viewed /elections/va/wise/dixiana,viewed_elections_va_wise_dixiana,,,,,,,,2026-06-23T16:53:54
-Voter Data - Custom Voter File - Audience: Click Back,voter_data_custom_voter_file_audience_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Custom Voter File: Click Create,voter_data_custom_voter_file_click_create,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Custom Voter File: Click Next,voter_data_custom_voter_file_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Custom Voter File: Exit modal,voter_data_custom_voter_file_exit_modal,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Custom Voter File: Select Channel,voter_data_custom_voter_file_select_channel,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Custom Voter File: Select Purpose,voter_data_custom_voter_file_select_purpose,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail - Learn & Take Action: Click Read More,voter_data_file_detail_learn_take_action_click_read_more,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail - Learn & Take Action: Click Schedule,voter_data_file_detail_learn_take_action_click_schedule,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail - Learn & Take Action: Click Write Script,voter_data_file_detail_learn_take_action_click_write_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail - Recommended Partners: Click Read More,voter_data_file_detail_recommended_partners_click_read_more,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail: Click Back,voter_data_file_detail_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail: Click Custom File Info Icon,voter_data_file_detail_click_custom_file_info_icon,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail: Click Download CSV,voter_data_file_detail_click_download_csv,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - File Detail: Click View Audience Filters,voter_data_file_detail_click_view_audience_filters,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Need Help: Exit modal,voter_data_need_help_exit_modal,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Need Help: Select Voter File type,voter_data_need_help_select_voter_file_type,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data - Need Help: Submit,voter_data_need_help_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data: Click Create Custom Voter File,voter_data_click_create_custom_voter_file,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data: Click Detail View,voter_data_click_detail_view,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Data: Click Need Help,voter_data_click_need_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-23T16:53:54
-Voter Outreach - 10DLC Compliance Completed,voter_outreach_10dlc_compliance_completed,a52bc1af5ee58f5b2492165ff4d973a76cf4db8b,457,2025-08-19,,,,2026-02-02,2026-06-23T16:53:54
-Voter Outreach - 10DLC Compliance Form Submitted,voter_outreach_10dlc_compliance_form_submitted,8434d128fc9812dcdde58effacd26458fccd95cc,894,2025-08-20,,,,2026-03-03,2026-06-23T16:53:54
-Voter Outreach - 10DLC Compliance Modal Viewed,voter_outreach_10dlc_compliance_modal_viewed,3f45b71a832475c190658d02e61151e16b0c6e65,1497,2026-03-03,,,,2026-03-03,2026-06-23T16:53:54
-Voter Outreach - 10DLC Compliance PIN Submitted,voter_outreach_10dlc_compliance_pin_submitted,8434d128fc9812dcdde58effacd26458fccd95cc,894,2025-08-20,,,,2026-03-03,2026-06-23T16:53:54
-Voter Outreach - 10DLC Compliance Started,voter_outreach_10dlc_compliance_started,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
-Voter Outreach - Campaign Completed,voter_outreach_campaign_completed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2026-06-10,2026-06-23T16:53:54
-Voter Outreach - Free Texts Offer Redeemed,voter_outreach_free_texts_offer_redeemed,aa90af3d789823511f82e9d81dee84417a82b0c2,520,2025-09-08,,,,2025-09-08,2026-06-23T16:53:54
-Voter Outreach - Payment Started,voter_outreach_payment_started,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-23T16:53:54
-[AI Visibility] Brand Snapshot,ai_visibility_brand_snapshot,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Dead Click,amplitude_dead_click,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Element Changed,amplitude_element_changed,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Element Clicked,amplitude_element_clicked,,,,,,,,2026-06-23T16:53:54
-[Amplitude] File Downloaded,amplitude_file_downloaded,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Form Started,amplitude_form_started,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Form Submitted,amplitude_form_submitted,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Network Request,amplitude_network_request,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Page Viewed,amplitude_page_viewed,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Rage Click,amplitude_rage_click,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Replay Captured,amplitude_replay_captured,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Viewport Content Updated,amplitude_viewport_content_updated,,,,,,,,2026-06-23T16:53:54
-[Amplitude] Web Vitals,amplitude_web_vitals,,,,,,,,2026-06-23T16:53:54
-[Experiment] Assignment,experiment_assignment,,,,,,,,2026-06-23T16:53:54
-[Experiment] Exposure,experiment_exposure,,,,,,,,2026-06-23T16:53:54
-[Experiment] Impression,experiment_impression,,,,,,,,2026-06-23T16:53:54
-ai_content_generation_start,ai_content_generation_start,a295f87f437a729b81c86adc2dc789ad9f1e3d18,316,2024-10-18,,,,2024-10-18,2026-06-23T16:53:54
-campaign_assistant_chatbot_input,campaign_assistant_chatbot_input,505dda0aafa691533330bcc405dd3d1bc796335d,315,2024-10-18,,,,2024-10-18,2026-06-23T16:53:54
-candidate CTA cancelled,candidate_cta_cancelled,5a9f8ed2d3b00f846e0d28fbb264d38e930d31f7,,2024-06-10,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-23T16:53:54
-candidate CTA clicked,candidate_cta_clicked,c0a574c0e56c270af68bf4cf82729bc30f967bf0,,2024-06-08,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-23T16:53:54
-candidate CTA selected,candidate_cta_selected,5a9f8ed2d3b00f846e0d28fbb264d38e930d31f7,,2024-06-10,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-23T16:53:54
-gtm.dom,gtm_dom,,,,,,,,2026-06-23T16:53:54
-gtm.init,gtm_init,,,,,,,,2026-06-23T16:53:54
-gtm.init_consent,gtm_init_consent,,,,,,,,2026-06-23T16:53:54
-gtm.js,gtm_js,,,,,,,,2026-06-23T16:53:54
-likelihood-to-cancel,likelihood_to_cancel,,,,,,,,2026-06-23T16:53:54
-onboarding_complete,onboarding_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2026-06-18,2026-06-23T16:53:54
-page,page,bcc9c195b46c214cb83ce829a49c8ab2b1fdffbf,,2024-06-05,,,,2026-06-24,2026-06-24T18:31:10
-page viewed,page_viewed,,,,,,,,2026-06-23T16:53:54
-page_view,page_view,abc192c40633b5bb1a9da10936bfcd433f621366,1268,2025-12-18,3ea4ebae6647d4a36c2e78cfb5da7eb706749b57,1551,2026-03-12,2026-03-12,2026-06-23T16:53:54
-pro_upgrade_complete,pro_upgrade_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2026-05-08,2026-06-23T16:53:54
-question_complete,question_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2025-12-17,2026-06-23T16:53:54
-schedule_campaign_image_too_large,schedule_campaign_image_too_large,4bed7aad64c8a8212e618db564bcb28ad2b9be5e,338,2024-10-30,,,,2024-10-30,2026-06-23T16:53:54
-screen,screen,a53d6050d2cf19c71a89fcbbef716951cdd12c22,,2024-06-13,,,,2026-06-24,2026-06-24T18:31:10
-session_end,session_end,,,,,,,,2026-06-23T16:53:54
-session_start,session_start,,,,,,,,2026-06-23T16:53:54
-usersnap_submission,usersnap_submission,634a1c354de73cca6e6a0393dbdd0ac6dc3c7ae2,293,2024-10-04,e256bd33a54df1a412dcbe055be41d284f5ce195,1495,2026-03-02,2026-03-02,2026-06-23T16:53:54
+10 DLC Compliance - PIN Verification Completed,10_dlc_compliance_pin_verification_completed,ecf326d35c1db1bd0af368b87a335b47286e8716,1049,2025-10-06,,,,2025-10-06,2026-06-25T01:35:48
+10 DLC Compliance - Registration Submitted,10_dlc_compliance_registration_submitted,ecf326d35c1db1bd0af368b87a335b47286e8716,1049,2025-10-06,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,2026-06-05,2026-06-25T01:35:48
+AI Assistant - Chat History: Click delete,ai_assistant_chat_history_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant - Chat History: Click menu,ai_assistant_chat_history_click_menu,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant - Chat: Click copy,ai_assistant_chat_click_copy,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant - Chat: Click regenerate,ai_assistant_chat_click_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant - Chat: Click thumbs down,ai_assistant_chat_click_thumbs_down,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant - Chat: Click thumbs up,ai_assistant_chat_click_thumbs_up,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant - Response Completed,ai_assistant_response_completed,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-25T01:35:48
+AI Assistant: Ask a question,ai_assistant_ask_a_question,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant: Click new chat,ai_assistant_click_new_chat,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+AI Assistant: Click view chat history,ai_assistant_click_view_chat_history,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Account - Password Reset Completed,account_password_reset_completed,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-25T01:35:48
+Account - Password Reset Requested,account_password_reset_requested,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-27,2026-06-25T01:35:48
+Account - Password Set Completed,account_password_set_completed,2fc365543df992198d512fbe2d6053a6d38a1aa7,888,2025-08-18,,,,2025-08-18,2026-06-25T01:35:48
+Account - Pro Subscription Canceled,account_pro_subscription_canceled,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-25T01:35:48
+Account - Pro Subscription Confirmed,account_pro_subscription_confirmed,ac3e04fb428f001d0ab7bcc471c5c85ef726e2b5,319,2025-06-27,,,,2025-06-27,2026-06-25T01:35:48
+Account - User Deleted,account_user_deleted,9582a5844f58fb5a53304f8a8dfef0ef25ffb532,1487,2026-04-20,,,,2026-04-20,2026-06-25T01:35:48
+Briefing Assistant - Agenda Created,briefing_assistant_agenda_created,acb9d347d9513d1aa6f49c97e9fbb14f6d581b28,1676,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - Agenda Not Created,briefing_assistant_agenda_not_created,5b8b5d6d70a84b9178fc66152cda021a6b4a1c03,30,2026-06-09,,,,2026-06-09,2026-06-25T01:35:48
+Briefing Assistant - Agenda Submission Failed,briefing_assistant_agenda_submission_failed,c339b19dec1b846127f34a99f0c6cf406e42a982,30,2026-06-09,,,,2026-06-09,2026-06-25T01:35:48
+Briefing Assistant - Agenda Submitted,briefing_assistant_agenda_submitted,c339b19dec1b846127f34a99f0c6cf406e42a982,30,2026-06-09,,,,2026-06-09,2026-06-25T01:35:48
+Briefing Assistant - Briefing Viewed,briefing_assistant_briefing_viewed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - Dictation Started,briefing_assistant_dictation_started,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - Download Clicked,briefing_assistant_download_clicked,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - Feedback Completed,briefing_assistant_feedback_completed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - List Viewed,briefing_assistant_list_viewed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - Share Completed,briefing_assistant_share_completed,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - Share Drawer Opened,briefing_assistant_share_drawer_opened,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - Sources Expanded,briefing_assistant_sources_expanded,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefing Assistant - TOC Item Clicked,briefing_assistant_toc_item_clicked,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,,,,2026-05-28,2026-06-25T01:35:48
+Briefings - Briefing Viewed,briefings_briefing_viewed,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-25T01:35:48
+Briefings - Click Download,briefings_click_download,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-25T01:35:48
+Briefings - Click Read Full Briefing,briefings_click_read_full_briefing,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-25T01:35:48
+Briefings - Feedback: Helpful,briefings_feedback_helpful,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-25T01:35:48
+Briefings - Feedback: Not Helpful,briefings_feedback_not_helpful,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-25T01:35:48
+Briefings - Issue Detail Viewed,briefings_issue_detail_viewed,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,ac4612dcdd10e768290c04d2f3c5f9511b9d64ad,1892,2026-05-28,2026-05-28,2026-06-25T01:35:48
+Campaign - Follow-On Created,campaign_follow_on_created,d55fa245190deb34c93bd32b863b7c776bbff190,152,2026-06-15,,,,2026-06-15,2026-06-25T01:35:48
+Campaign Plan - Weekly Tasks Digest,campaign_plan_weekly_tasks_digest,61d552cc6974dfbb0696f8aad51563686e07e814,1472,2026-04-21,,,,2026-04-21,2026-06-25T01:35:48
+Campaign Plan V2 - Community Events Generation Completed,campaign_plan_v2_community_events_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Community Events Generation Started,campaign_plan_v2_community_events_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Media Generation Completed,campaign_plan_v2_media_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Media Generation Started,campaign_plan_v2_media_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Opportunities & Challenges Generation Completed,campaign_plan_v2_opportunities_challenges_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Opportunities & Challenges Generation Started,campaign_plan_v2_opportunities_challenges_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Opposition Research Generation Completed,campaign_plan_v2_opposition_research_generation_completed,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Opposition Research Generation Started,campaign_plan_v2_opposition_research_generation_started,e1baf36df65d4f548f05b1ce39753ac57f886b57,1774,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Campaign Plan V2 - Strategy Race Changed,campaign_plan_v2_strategy_race_changed,f920787b11cffc31ae84b70f9b148a89f9431466,104,2026-06-12,,,,2026-06-12,2026-06-25T01:35:48
+Campaign Story - Rewrite Accepted,campaign_story_rewrite_accepted,3cc0a94448eed49c31647c436402f1f160113182,233,2026-06-18,,,,2026-06-18,2026-06-25T01:35:48
+Campaign Story - Rewrite Discarded,campaign_story_rewrite_discarded,3cc0a94448eed49c31647c436402f1f160113182,233,2026-06-18,,,,2026-06-18,2026-06-25T01:35:48
+Campaign Story - Rewrite Requested,campaign_story_rewrite_requested,3cc0a94448eed49c31647c436402f1f160113182,233,2026-06-18,,,,2026-06-18,2026-06-25T01:35:48
+Campaign Verify Token Status Update,campaign_verify_token_status_update,362c9b448065c166e4f742836d508cafc825054b,593,2025-10-07,,,,2025-10-07,2026-06-25T01:35:48
+Candidacy - Campaign Completed,candidacy_campaign_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-25T01:35:48
+Candidacy - Debrief Clicked,candidacy_debrief_clicked,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-25T01:35:48
+Candidacy - Did You Win Modal Completed,candidacy_did_you_win_modal_completed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-25T01:35:48
+Candidacy - Did You Win Modal Viewed,candidacy_did_you_win_modal_viewed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-25T01:35:48
+Candidate Website - Continued,candidate_website_continued,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-25T01:35:48
+Candidate Website - Edited,candidate_website_edited,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-25T01:35:48
+Candidate Website - Published,candidate_website_published,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2026-03-09,2026-06-25T01:35:48
+Candidate Website - Purchased domain,candidate_website_purchased_domain,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2026-03-09,2026-06-25T01:35:48
+Candidate Website - Selected domain,candidate_website_selected_domain,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-25T01:35:48
+Candidate Website - Started,candidate_website_started,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-25T01:35:48
+Candidate Website - Started domain selection,candidate_website_started_domain_selection,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-25T01:35:48
+Candidate Website - Unpublished,candidate_website_unpublished,b036da272037bd58ede583cfe854a0fa515b20d0,788,2025-07-24,,,,2025-07-24,2026-06-25T01:35:48
+Click to Call CTA Clicked,click_to_call_cta_clicked,,,,,,,,2026-06-25T01:35:48
+Click to Call CTA Viewed,click_to_call_cta_viewed,,,,,,,,2026-06-25T01:35:48
+Click to Call Phone Submitted,click_to_call_phone_submitted,,,,,,,,2026-06-25T01:35:48
+Contacts - Column Edited,contacts_column_edited,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-25T01:35:48
+Contacts - Contacts Viewed,contacts_contacts_viewed,89f97d0c41382d4c48e72db3ffe591be4694d12a,194,2026-06-17,,,,2026-06-17,2026-06-25T01:35:48
+Contacts - Download,contacts_download,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-25T01:35:48
+Contacts - Segment Created,contacts_segment_created,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-25T01:35:48
+Contacts - Segment Deleted,contacts_segment_deleted,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-25T01:35:48
+Contacts - Segment Updated,contacts_segment_updated,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-25T01:35:48
+Contacts - Segment Viewed,contacts_segment_viewed,e54c02097e3c70880d05b8a7479f7889f87cdd99,958,2025-09-14,,,,2025-09-14,2026-06-25T01:35:48
+Content Builder - Editor: Click Copy,content_builder_editor_click_copy,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Click Delete,content_builder_editor_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Click Regenerate,content_builder_editor_click_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Click Rename,content_builder_editor_click_rename,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Click Translate,content_builder_editor_click_translate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Open Kebab Menu,content_builder_editor_open_kebab_menu,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Open Version Picker,content_builder_editor_open_version_picker,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Select Version,content_builder_editor_select_version,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Submit Regenerate,content_builder_editor_submit_regenerate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder - Editor: Submit Translate,content_builder_editor_submit_translate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder: Click Content,content_builder_click_content,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder: Click Continue Questions,content_builder_click_continue_questions,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder: Click Generate,content_builder_click_generate,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder: Close Additional Inputs,content_builder_close_additional_inputs,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder: Generation Completed,content_builder_generation_completed,3968af2dffa446ff83c6625da709ebb45c5ef31e,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder: Generation Started,content_builder_generation_started,a52bc1af5ee58f5b2492165ff4d973a76cf4db8b,457,2025-08-19,,,,2025-08-19,2026-06-25T01:35:48
+Content Builder: Select Template,content_builder_select_template,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Content Builder: Submit Additional Inputs,content_builder_submit_additional_inputs,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Custom Voter file created,custom_voter_file_created,93fabd843cdc5e60795b99327819517c76426f3a,,2024-06-07,,,,2024-06-07,2026-06-25T01:35:48
+Daily Ad Metrics,daily_ad_metrics,,,,,,,,2026-06-25T01:35:48
+Dashboard - Campaign Plan Generation Completed,dashboard_campaign_plan_generation_completed,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-01,2026-06-25T01:35:48
+Dashboard - Campaign Plan Task CTA Clicked,dashboard_campaign_plan_task_cta_clicked,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-01,2026-06-25T01:35:48
+Dashboard - Campaign Plan View Mode Toggled,dashboard_campaign_plan_view_mode_toggled,99a9be2e39794c5d3eaeb2b897be4eea422ecc92,1720,2026-04-17,,,,2026-04-17,2026-06-25T01:35:48
+Dashboard - Campaign Plan Viewed,dashboard_campaign_plan_viewed,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-01,2026-06-25T01:35:48
+Dashboard - Campaign Plan Week Navigated,dashboard_campaign_plan_week_navigated,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-01,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Campaign Manager Clicked,dashboard_campaign_plan_campaign_manager_clicked,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Community Events Displayed,dashboard_campaign_plan_community_events_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Community Events Requested,dashboard_campaign_plan_community_events_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Community Events Results Received,dashboard_campaign_plan_community_events_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Media Displayed,dashboard_campaign_plan_media_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Media Requested,dashboard_campaign_plan_media_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Media Results Received,dashboard_campaign_plan_media_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Plan Downloaded,dashboard_campaign_plan_plan_downloaded,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Strategic Landscape Displayed,dashboard_campaign_plan_strategic_landscape_displayed,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Strategic Landscape Requested,dashboard_campaign_plan_strategic_landscape_requested,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Plan: Strategic Landscape Results Received,dashboard_campaign_plan_strategic_landscape_results_received,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Dashboard - Campaign Task Status Updated,dashboard_campaign_task_status_updated,f428f0fcfe56bfbf293ead4ed896393bd2a7bb15,,2026-04-01,,,,2026-04-01,2026-06-25T01:35:48
+Dashboard - Candidate Dashboard Viewed,dashboard_candidate_dashboard_viewed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2025-06-18,2026-06-25T01:35:48
+Dashboard - Path to Victory: Exit Understand Path to Victory,dashboard_path_to_victory_exit_understand_path_to_victory,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Download Voter File Failure,download_voter_file_failure,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-25T01:35:48
+Download Voter File Success,download_voter_file_success,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-25T01:35:48
+Download Voter File attempt,download_voter_file_attempt,66519ef3b964345000414bc3cb8b3e1b71e1e8fd,,2024-07-10,,,,2024-08-30,2026-06-25T01:35:48
+Experiment Viewed,experiment_viewed,,,,,,,,2026-06-25T01:35:48
+Invalid Party,invalid_party,f4290f167ee16aaaed0299d64c48ae8a3452eeb3,,2024-06-13,85954771b6d545e35af77bf5ca3ae86e9cbdb80d,1790,2026-05-05,2026-05-05,2026-06-25T01:35:48
+Navigation - Dashboard: Click AI Assistant,navigation_dashboard_click_ai_assistant,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation - Dashboard: Click Briefings,navigation_dashboard_click_briefings,78fc2e5a4d266437bd11d674cc5a10c5c841a44d,1683,2026-04-09,,,,2026-04-09,2026-06-25T01:35:48
+Navigation - Dashboard: Click Campaign Plan,navigation_dashboard_click_campaign_plan,cf6bb487eb93a12b82b9ed9191693db58f3810f4,54,2026-06-10,,,,2026-06-10,2026-06-25T01:35:48
+Navigation - Dashboard: Click Community,navigation_dashboard_click_community,ab19165b23e99ec39c1dbe8feef281ba6d1bc284,576,2025-04-03,,,,2025-04-03,2026-06-25T01:35:48
+Navigation - Dashboard: Click Contacts,navigation_dashboard_click_contacts,b54392a3217e2e427dc5c39f86b98d70a94289c0,938,2025-09-04,,,,2025-09-04,2026-06-25T01:35:48
+Navigation - Dashboard: Click Content Builder,navigation_dashboard_click_content_builder,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation - Dashboard: Click Dashboard,navigation_dashboard_click_dashboard,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation - Dashboard: Click Door Knocking,navigation_dashboard_click_door_knocking,27bef878da7c3238d22d65e27e4b37afee213ed7,522,2025-03-09,,,,2025-03-09,2026-06-25T01:35:48
+Navigation - Dashboard: Click Free Resources,navigation_dashboard_click_free_resources,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,2025-10-14,2026-06-25T01:35:48
+Navigation - Dashboard: Click Issues,navigation_dashboard_click_issues,d4a6c5feef4c178a4619e51f79c3090c9191e7dd,733,2025-07-01,,,,2025-07-01,2026-06-25T01:35:48
+Navigation - Dashboard: Click My Profile,navigation_dashboard_click_my_profile,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation - Dashboard: Click Polls,navigation_dashboard_click_polls,405a687410467f5dc4b89616f282135384a421e8,,2025-10-08,,,,2025-10-08,2026-06-25T01:35:48
+Navigation - Dashboard: Click Resources,navigation_dashboard_click_resources,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,3f6a11a2d717831603f3640b481d6ce9ca6c6698,1459,2026-02-23,2026-02-23,2026-06-25T01:35:48
+Navigation - Dashboard: Click Text Messaging,navigation_dashboard_click_text_messaging,fdf692bfb6171d2436153dff317c995684c94770,,2025-03-22,70a5c952c7fc6b985b062d1b7d9ceb8707bc7dd5,923,2025-08-27,2025-08-27,2026-06-25T01:35:48
+Navigation - Dashboard: Click Voter Data,navigation_dashboard_click_voter_data,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation - Dashboard: Click Voter Outreach,navigation_dashboard_click_voter_outreach,2a9e9929d18f38be852ff8233c76f644cfc6bff6,900,2025-08-20,,,,2025-08-20,2026-06-25T01:35:48
+Navigation - Dashboard: Click Website,navigation_dashboard_click_website,9b740f9d306dba90477c9d2860876585bce07ea4,,2025-06-19,,,,2025-06-19,2026-06-25T01:35:48
+Navigation - Top - Avatar Dropdown: Close Dropdown,navigation_top_avatar_dropdown_close_dropdown,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation - Top: Click Avatar Dropdown,navigation_top_click_avatar_dropdown,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation - Top: Click Logo,navigation_top_click_logo,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation Top - Avatar Dropdown: Click Logout,navigation_top_avatar_dropdown_click_logout,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Navigation Top - Avatar Dropdown: Click Profile,navigation_top_avatar_dropdown_click_profile,a747931b6d3aa7b74f3b331bf53c423d81b641ad,1524,2026-04-16,,,,2026-04-16,2026-06-25T01:35:48
+Navigation Top - Avatar Dropdown: Click Settings,navigation_top_avatar_dropdown_click_settings,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Ballot Status Completed,onboarding_ballot_status_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding - Candidate Affiliation Completed,onboarding_candidate_affiliation_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-25T01:35:48
+Onboarding - Candidate Office Completed,onboarding_candidate_office_completed,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-25T01:35:48
+Onboarding - Candidate Office Searched,onboarding_candidate_office_searched,b03a053aa73e223181f07083df44be9d819bfc7f,710,2025-06-23,,,,2025-06-23,2026-06-25T01:35:48
+Onboarding - Candidate Pledge Completed,onboarding_candidate_pledge_completed,a91befe9f1d10ad7c1319b0066b2f2a8035d8d70,920,2025-09-17,,,,2025-09-17,2026-06-25T01:35:48
+Onboarding - Complete Step: Click Go to Dashboard,onboarding_complete_step_click_go_to_dashboard,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Know Your Voters Completed,onboarding_know_your_voters_completed,712fb71051988420909b538f89ea4da4703c1b8b,1804,2026-05-07,,,,2026-05-07,2026-06-25T01:35:48
+Onboarding - Office Selection Completed,onboarding_office_selection_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding - Office Step: Click Can't See Office,onboarding_office_step_click_cant_see_office,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Office Step: Click Next,onboarding_office_step_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Office Step: Office Selected,onboarding_office_step_office_selected,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Party Selection Completed,onboarding_party_selection_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding - Party Step: Click Submit,onboarding_party_step_click_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Path To Victory Completed,onboarding_path_to_victory_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding - Path To Victory Errored,onboarding_path_to_victory_errored,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding - Path To Victory Updated,onboarding_path_to_victory_updated,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding - Pledge Completed,onboarding_pledge_completed,37bdbd6185ef7e74127482d6f2c69943a0fc2bfc,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding - Pledge Step: Click Ask a Question,onboarding_pledge_step_click_ask_a_question,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Pledge Step: Click Submit,onboarding_pledge_step_click_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Onboarding - Registration Completed,onboarding_registration_completed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2025-06-18,2026-06-25T01:35:48
+Onboarding - User Created,onboarding_user_created,ac3e04fb428f001d0ab7bcc471c5c85ef726e2b5,319,2025-06-27,,,,2025-06-27,2026-06-25T01:35:48
+Onboarding - Welcome Completed,onboarding_welcome_completed,85954771b6d545e35af77bf5ca3ae86e9cbdb80d,1790,2026-05-05,,,,2026-05-05,2026-06-25T01:35:48
+Onboarding V2 - Ballot Status Completed,onboarding_v2_ballot_status_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Ballot Status Viewed,onboarding_v2_ballot_status_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Campaign Manager Clicked,onboarding_v2_campaign_manager_clicked,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Community Events Displayed,onboarding_v2_community_events_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Community Events Requested,onboarding_v2_community_events_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Community Events Results Received,onboarding_v2_community_events_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Media Displayed,onboarding_v2_media_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Media Requested,onboarding_v2_media_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Media Results Received,onboarding_v2_media_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - New Campaign Context Completed,onboarding_v2_new_campaign_context_completed,9cd8b68a5e50b3eec249595ea4d927de286b9680,151,2026-06-15,,,,2026-06-15,2026-06-25T01:35:48
+Onboarding V2 - New Campaign Context Viewed,onboarding_v2_new_campaign_context_viewed,9cd8b68a5e50b3eec249595ea4d927de286b9680,151,2026-06-15,,,,2026-06-15,2026-06-25T01:35:48
+Onboarding V2 - Office Completed,onboarding_v2_office_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Office Next Clicked,onboarding_v2_office_next_clicked,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-25T01:35:48
+Onboarding V2 - Office Viewed,onboarding_v2_office_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Party Designation Blocked,onboarding_v2_party_designation_blocked,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Party Designation Completed,onboarding_v2_party_designation_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Party Designation Viewed,onboarding_v2_party_designation_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Plan Downloaded,onboarding_v2_plan_downloaded,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Plan Shared,onboarding_v2_plan_shared,3ca192ba46e2cb82bcf8e84ee0ebce7fe856793a,171,2026-06-16,,,,2026-06-16,2026-06-25T01:35:48
+Onboarding V2 - Pledge Completed,onboarding_v2_pledge_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Pledge Submit Clicked,onboarding_v2_pledge_submit_clicked,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-25T01:35:48
+Onboarding V2 - Pledge Viewed,onboarding_v2_pledge_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Resources Completed,onboarding_v2_resources_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Resources Viewed,onboarding_v2_resources_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Strategic Landscape Displayed,onboarding_v2_strategic_landscape_displayed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Strategic Landscape Requested,onboarding_v2_strategic_landscape_requested,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Strategic Landscape Results Received,onboarding_v2_strategic_landscape_results_received,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Voter Insights Completed,onboarding_v2_voter_insights_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Voter Insights Viewed,onboarding_v2_voter_insights_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Votes Needed Calculated,onboarding_v2_votes_needed_calculated,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-25T01:35:48
+Onboarding V2 - Votes Needed Completed,onboarding_v2_votes_needed_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Votes Needed Failed,onboarding_v2_votes_needed_failed,649d14e2bcffef78ea08c0063c0905fe3369dc4a,22,2026-06-09,,,,2026-06-09,2026-06-25T01:35:48
+Onboarding V2 - Votes Needed Viewed,onboarding_v2_votes_needed_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Onboarding V2 - Welcome Completed,onboarding_v2_welcome_completed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-10,2026-06-25T01:35:48
+Onboarding V2 - Welcome Viewed,onboarding_v2_welcome_viewed,7168448e9bf8ec252d9ad7ed5068bfff62d6769a,2002,2026-06-08,,,,2026-06-10,2026-06-25T01:35:48
+Onboarding: Click Finish Later,onboarding_click_finish_later,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Org Switcher - Organization Switched,org_switcher_organization_switched,7d6668ba391fe68eb744fd6f98f4fdcf4377a295,151,2026-06-15,,,,2026-06-15,2026-06-25T01:35:48
+Org Switcher - Run For Office Clicked,org_switcher_run_for_office_clicked,7d6668ba391fe68eb744fd6f98f4fdcf4377a295,151,2026-06-15,,,,2026-06-15,2026-06-25T01:35:48
+Outreach - Action Clicked,outreach_action_clicked,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-25T01:35:48
+Outreach - Click Create,outreach_click_create,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-25T01:35:48
+Outreach - Door Knocking: Complete,outreach_door_knocking_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-25T01:35:48
+Outreach - Phone Banking: Complete,outreach_phone_banking_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-25T01:35:48
+Outreach - Social Media: Complete,outreach_social_media_complete,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-25T01:35:48
+Outreach - View Accessed,outreach_view_accessed,334568cc8a740eadaa6578acb4699e660b18437f,743,2025-07-03,,,,2025-07-03,2026-06-25T01:35:48
+P2P Upgrade - Modal: Click Button,p2p_upgrade_modal_click_button,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-25T01:35:48
+P2P Upgrade - Modal: Exit,p2p_upgrade_modal_exit,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-25T01:35:48
+P2P Upgrade - Modal: Modal Shown,p2p_upgrade_modal_modal_shown,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-25T01:35:48
+Page,page,,,,,,,,2026-06-25T01:35:48
+Page Viewed,page_viewed,,,,,,,,2026-06-25T01:35:48
+Payment - Completed,payment_completed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2026-02-08,2026-06-25T01:35:48
+Payment - Review and Pay Screen Viewed,payment_review_and_pay_screen_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-25T01:35:48
+Payment - Schedule and Pay Viewed,payment_schedule_and_pay_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Poll - Results Synthesis Complete,poll_results_synthesis_complete,8293df56527c17f0fa9e42c99caf625438dd7242,636,2025-10-13,,,,2025-10-15,2026-06-25T01:35:48
+Polls - Add Image Completed,polls_add_image_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Add Image Viewed,polls_add_image_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Audience Selection Completed,polls_audience_selection_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Audience Selection Viewed,polls_audience_selection_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Create Poll Clicked,polls_create_poll_clicked,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Expand Poll Recommendations Completed,polls_expand_poll_recommendations_completed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-25T01:35:48
+Polls - Expand Poll Recommendations Viewed,polls_expand_poll_recommendations_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-25T01:35:48
+Polls - Expand Poll Review Viewed,polls_expand_poll_review_viewed,25a465774e01692e3283ad7eb15abc7452d75fc5,1113,2025-11-04,,,,2025-11-04,2026-06-25T01:35:48
+Polls - Low Confidence Modal Clicked,polls_low_confidence_modal_clicked,907174177b76b62992ff33439ebcd8b1d59d5e0a,1382,2026-03-09,,,,2026-03-09,2026-06-25T01:35:48
+Polls - Poll Bias Detection Shown,polls_poll_bias_detection_shown,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Poll Preview Completed,polls_poll_preview_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Poll Preview Viewed,polls_poll_preview_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Poll Question Completed,polls_poll_question_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Poll Question Optimized,polls_poll_question_optimized,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Poll Question Viewed,polls_poll_question_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Poll Results Issue Details Viewed,polls_poll_results_issue_details_viewed,24d9f8f48bfc6f173af3257d28bb7c35fc2d5c0f,1135,2025-11-11,,,,2025-11-11,2026-06-25T01:35:48
+Polls - Poll Results Overview Viewed,polls_poll_results_overview_viewed,24d9f8f48bfc6f173af3257d28bb7c35fc2d5c0f,1135,2025-11-11,,,,2025-11-11,2026-06-25T01:35:48
+Polls - Schedule Poll Completed,polls_schedule_poll_completed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Polls - Schedule Poll Viewed,polls_schedule_poll_viewed,446ad6a04274cf3799c0d7cd0347e596cb313a49,1230,2025-12-10,,,,2026-02-08,2026-06-25T01:35:48
+Pro Upgrade - Banner Viewed,pro_upgrade_banner_viewed,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Pro Upgrade - Banner: Click Get Pro,pro_upgrade_banner_click_get_pro,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Pro Upgrade - Candidate Profile Submitted,pro_upgrade_candidate_profile_submitted,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,,,,2026-06-05,2026-06-25T01:35:48
+Pro Upgrade - Candidate Profile Viewed,pro_upgrade_candidate_profile_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-25T01:35:48
+Pro Upgrade - Committee Check Page: Click Upload,pro_upgrade_committee_check_page_click_upload,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Pro Upgrade - Committee Check Page: Click back,pro_upgrade_committee_check_page_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Pro Upgrade - Committee Check Page: Click next,pro_upgrade_committee_check_page_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+"Pro Upgrade - Committee Check Page: Hover ""EIN number"" help",pro_upgrade_committee_check_page_hover_ein_number_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-25T01:35:48
+"Pro Upgrade - Committee Check Page: Hover ""Name of Campaign Committee"" help",pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-25T01:35:48
+"Pro Upgrade - Committee Check Page: Hover ""Upload"" help",pro_upgrade_committee_check_page_hover_upload_help,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,,,,2025-11-11,2026-06-25T01:35:48
+Pro Upgrade - Committee Check Page: Hover “EIN number” help,pro_upgrade_committee_check_page_hover_ein_number_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-25T01:35:48
+Pro Upgrade - Committee Check Page: Hover “Name of Campaign Committee” help,pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-25T01:35:48
+Pro Upgrade - Committee Check Page: Hover “Upload” help,pro_upgrade_committee_check_page_hover_upload_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,1c56e4c5094fa0dfdbbfe55fbaf0e43a2ca9e475,1132,2025-11-11,2025-11-11,2026-06-25T01:35:48
+Pro Upgrade - Committee Check Page: Toggle EIN requirement,pro_upgrade_committee_check_page_toggle_ein_requirement,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Pro Upgrade - EIN Viewed,pro_upgrade_ein_viewed,c1183769c51e92e8e7177d09c9604c083f3b8454,1987,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - EIN: Click continue,pro_upgrade_ein_click_continue,c1183769c51e92e8e7177d09c9604c083f3b8454,1987,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - EIN: Hover help,pro_upgrade_ein_hover_help,0b66488415b7ecbcf217d96901a9a5c15ad50b0c,1987,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Filing Details Submitted,pro_upgrade_filing_details_submitted,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,,,,2026-06-05,2026-06-25T01:35:48
+Pro Upgrade - Filing Details Viewed,pro_upgrade_filing_details_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-25T01:35:48
+Pro Upgrade - Filing Instructions Viewed,pro_upgrade_filing_instructions_viewed,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Filing Instructions: Click continue to dashboard,pro_upgrade_filing_instructions_click_continue_to_dashboard,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Filing Instructions: Click email this to me,pro_upgrade_filing_instructions_click_email_this_to_me,ecd2a35fadc270c7d5c4b5234ec6223962991f2a,1985,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Filing Status Viewed,pro_upgrade_filing_status_viewed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Filing Status: Click already filed,pro_upgrade_filing_status_click_already_filed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Filing Status: Click not yet filed,pro_upgrade_filing_status_click_not_yet_filed,6dfb6b9f0034b4b4e8caf8c7fad46d362c21f1fb,1984,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Guidance Viewed,pro_upgrade_guidance_viewed,7f6db6f25fc3e3277698af890bce5a7e3bd7de36,1986,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Guidance: Click let's go,pro_upgrade_guidance_click_lets_go,7f6db6f25fc3e3277698af890bce5a7e3bd7de36,1986,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Locked Item: Click,pro_upgrade_locked_item_click,54770c93280dd2e2b0febcaa23ac3d73028287f7,2001,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Pro Upgrade - Modal: Click Button,pro_upgrade_modal_click_button,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade - Modal: Exit,pro_upgrade_modal_exit,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade - Modal: Modal Shown,pro_upgrade_modal_modal_shown,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade - PIN Entry Viewed,pro_upgrade_pin_entry_viewed,001203d930501b41ed0b51c7a3551620d2ede502,1939,2026-06-03,,,,2026-06-03,2026-06-25T01:35:48
+Pro Upgrade - Payment Viewed,pro_upgrade_payment_viewed,c465ade2992cad108b60684aa48d84e57b125f6e,1990,2026-06-07,,,,2026-06-07,2026-06-25T01:35:48
+Pro Upgrade - Service Agreement Page: Click back,pro_upgrade_service_agreement_page_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Pro Upgrade - Service Agreement Page: Click finish,pro_upgrade_service_agreement_page_click_finish,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Pro Upgrade - Splash Page: Click upgrade,pro_upgrade_splash_page_click_upgrade,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade - Splash Page: Exit,pro_upgrade_splash_page_exit,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade - Success Viewed,pro_upgrade_success_viewed,9a3d5e1de57e975a9a194e681e4f216a63c642d6,1992,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Pro Upgrade - Success: Click continue,pro_upgrade_success_click_continue,9a3d5e1de57e975a9a194e681e4f216a63c642d6,1992,2026-06-08,,,,2026-06-08,2026-06-25T01:35:48
+Pro Upgrade - Value Prop Viewed,pro_upgrade_value_prop_viewed,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-25T01:35:48
+Pro Upgrade - Value Prop: Click Get Pro,pro_upgrade_value_prop_click_get_pro,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-25T01:35:48
+Pro Upgrade - Value Prop: Click Maybe later,pro_upgrade_value_prop_click_maybe_later,4d37796a8d006151b6b85118974c80afa5fd7320,1983,2026-06-06,,,,2026-06-06,2026-06-25T01:35:48
+Pro Upgrade: Click Go to Stripe,pro_upgrade_click_go_to_stripe,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Pro Upgrade: Click exit top nav,pro_upgrade_click_exit_top_nav,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade: Confirm office,pro_upgrade_confirm_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade: Edit office,pro_upgrade_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade: Exit edit office,pro_upgrade_exit_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro Upgrade: Submit edit office,pro_upgrade_submit_edit_office,8b0426df16c5949c469f122beaaf70b859ba0d1f,,2025-03-10,,,,2025-03-10,2026-06-25T01:35:48
+Pro user can not download voter file page,pro_user_can_not_download_voter_file_page,7d03f67f7ae53ade7b5894b5841fccbb35e16dcc,,2024-06-30,,,,2024-06-30,2026-06-25T01:35:48
+Profile - Campaign Details: Click Save,profile_campaign_details_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Candidate Profile: Click Submit,profile_candidate_profile_click_submit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Candidate Profile: Submit Success,profile_candidate_profile_submit_success,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,fd74078f7caa3d32df9f6d362ab5d18d10340452,1970,2026-06-05,2026-06-05,2026-06-25T01:35:48
+Profile - Fun Fact: Click Save,profile_fun_fact_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Office Details: Click Edit,profile_office_details_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Office Details: Click Save,profile_office_details_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Policy Priorities: Cancel Add,profile_policy_priorities_cancel_add,e2e5ed9386a69f3cfa83791cd0de5adce47f9413,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Policy Priorities: Cancel Edit,profile_policy_priorities_cancel_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Policy Priorities: Click Add,profile_policy_priorities_click_add,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Policy Priorities: Click Delete,profile_policy_priorities_click_delete,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Policy Priorities: Click Edit,profile_policy_priorities_click_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Policy Priorities: Click Save,profile_policy_priorities_click_save,e1371f746f1db7146bb55de165e8725613e3d6aa,1778,2026-04-30,,,,2026-04-30,2026-06-25T01:35:48
+Profile - Policy Priorities: Submit Add,profile_policy_priorities_submit_add,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Policy Priorities: Submit Delete,profile_policy_priorities_submit_delete,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Policy Priorities: Submit Edit,profile_policy_priorities_submit_edit,3a9eda2435a50c733d461fffb4c31cade6a4670f,1769,2026-04-29,,,,2026-04-29,2026-06-25T01:35:48
+Profile - Running Against: Cancel Add New,profile_running_against_cancel_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Running Against: Cancel Edit,profile_running_against_cancel_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Running Against: Click Add New,profile_running_against_click_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Running Against: Click Delete,profile_running_against_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Running Against: Click Edit,profile_running_against_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Running Against: Click Save,profile_running_against_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Running Against: Submit Add New,profile_running_against_submit_add_new,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Running Against: Submit Edit,profile_running_against_submit_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Top Issues: Cancel Delete,profile_top_issues_cancel_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Top Issues: Cancel Edit,profile_top_issues_cancel_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Top Issues: Click Delete,profile_top_issues_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Top Issues: Click Edit,profile_top_issues_click_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Top Issues: Click Finish Entering Issues,profile_top_issues_click_finish_entering_issues,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Top Issues: Submit Delete,profile_top_issues_submit_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Top Issues: Submit Edit,profile_top_issues_submit_edit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Profile - Why Running: Click Save,profile_why_running_click_save,e1371f746f1db7146bb55de165e8725613e3d6aa,1778,2026-04-30,,,,2026-04-30,2026-06-25T01:35:48
+Profile - Why Section: Click Save,profile_why_section_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Resources - Resource Clicked,resources_resource_clicked,4e16c164e0a629ba6c5ea08b302c880de1df2b5c,1040,2025-10-14,3f6a11a2d717831603f3640b481d6ce9ca6c6698,1459,2026-02-23,2026-02-23,2026-06-25T01:35:48
+Schedule Text Campaign - Audience: Check Age,schedule_text_campaign_audience_check_age,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Audience: Check Audience,schedule_text_campaign_audience_check_audience,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Audience: Check Gender,schedule_text_campaign_audience_check_gender,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Audience: Check Political Party,schedule_text_campaign_audience_check_political_party,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Audience: Enter Audience Request,schedule_text_campaign_audience_enter_audience_request,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Script: Click Add your own script,schedule_text_campaign_script_click_add_your_own_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Script: Click Generate a new script,schedule_text_campaign_script_click_generate_a_new_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Script: Click Use a saved script,schedule_text_campaign_script_click_use_a_saved_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Script: Select Saved Script,schedule_text_campaign_script_select_saved_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign - Script: Submit added script,schedule_text_campaign_script_submit_added_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign: Back,schedule_text_campaign_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign: Exit,schedule_text_campaign_exit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign: Next,schedule_text_campaign_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Schedule Text Campaign: Submit,schedule_text_campaign_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Scroll Depth,scroll_depth,,,,,,,,2026-06-25T01:35:48
+Segment Consent Preference Updated,segment_consent_preference_updated,,,,,,,,2026-06-25T01:35:48
+Serve Onboarding - Add Image Viewed,serve_onboarding_add_image_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - BR Suggestion Changed,serve_onboarding_br_suggestion_changed,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,,,,2026-06-18,2026-06-25T01:35:48
+Serve Onboarding - Constituency Profile Viewed,serve_onboarding_constituency_profile_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - Getting Started Viewed,serve_onboarding_getting_started_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - Magic Link Activated,serve_onboarding_magic_link_activated,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,b2f1f6c21a0949156b851cf80326878d990a5950,323,2026-06-24,2026-06-24,2026-06-25T01:35:48
+Serve Onboarding - Magic Link Sent,serve_onboarding_magic_link_sent,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,b2f1f6c21a0949156b851cf80326878d990a5950,323,2026-06-24,2026-06-24,2026-06-25T01:35:48
+Serve Onboarding - Meet Your Constituents Viewed,serve_onboarding_meet_your_constituents_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - Net New Completed,serve_onboarding_net_new_completed,4cc1cb142febe9084e5dde6771d6bdbd29f25e46,198,2026-06-18,,,,2026-06-18,2026-06-25T01:35:48
+Serve Onboarding - Poll Image Uploaded,serve_onboarding_poll_image_uploaded,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - Poll Preview Viewed,serve_onboarding_poll_preview_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - Poll Strategy Viewed,serve_onboarding_poll_strategy_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - Poll Value Props Viewed,serve_onboarding_poll_value_props_viewed,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - SMS Poll Creation Failed,serve_onboarding_sms_poll_creation_failed,4537360b9cd5f5071c5b1f99364e310e0b225620,1374,2026-02-04,,,,2026-02-04,2026-06-25T01:35:48
+Serve Onboarding - SMS Poll Sent,serve_onboarding_sms_poll_sent,3f61c919fcb19db7270362a4767ab98ed1a10a88,1022,2025-10-09,,,,2025-10-09,2026-06-25T01:35:48
+Serve Onboarding - Success Page Viewed,serve_onboarding_success_page_viewed,33f319823719eb25aef1fe2812184a61b23a41f6,1098,2025-10-29,,,,2025-10-29,2026-06-25T01:35:48
+Serve Onboarding - Sworn In Completed,serve_onboarding_sworn_in_completed,20a7ac0f8561471fa493aab7be2b3a8cd0c014de,1103,2025-10-30,,,,2025-10-30,2026-06-25T01:35:48
+Serve Onboarding - Sworn In Viewed,serve_onboarding_sworn_in_viewed,33f319823719eb25aef1fe2812184a61b23a41f6,1098,2025-10-29,,,,2025-10-29,2026-06-25T01:35:48
+Set Password: Click Set Password,set_password_click_set_password,aeb23786b697e849c6684f4fc08acb0964fae1fe,513,2025-03-06,,,,2025-03-06,2026-06-25T01:35:48
+Settings - Account Settings: Click Manage Pro Subscription,settings_account_settings_click_manage_pro_subscription,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Account Settings: Click Send Email,settings_account_settings_click_send_email,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Account Settings: Click Upgrade,settings_account_settings_click_upgrade,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Delete Account: Cancel Delete,settings_delete_account_cancel_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Delete Account: Click Delete,settings_delete_account_click_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Delete Account: Submit Delete,settings_delete_account_submit_delete,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Notifications: Toggle Email,settings_notifications_toggle_email,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Password: Click Save,settings_password_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Personal Info: Click Save,settings_personal_info_click_save,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Settings - Personal Info: Click Upload,settings_personal_info_click_upload,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Sign In: Click Create Account,sign_in_click_create_account,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Sign In: Click Forgot Password,sign_in_click_forgot_password,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Sign Up Clicked,sign_up_clicked,,,,,,,,2026-06-25T01:35:48
+Sign Up: Click Login,sign_up_click_login,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Viewed,viewed,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/ak/tanana-city-school-district,viewed_elections_ak_tanana_city_school_district,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/chippewa-county-clerk/145f1d,viewed_elections_chippewa_county_clerk_145f1d,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/ia/red-oak-community-school-district,viewed_elections_ia_red_oak_community_school_district,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/mi/monroe-county/monroe/position/city-clerk-ward-officer,viewed_elections_mi_monroe_county_monroe_position_city_clerk_ward_officer,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/nv/elko/point-of-rocks,viewed_elections_nv_elko_point_of_rocks,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/pa,viewed_elections_pa,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/tx/borger-independent-school-district,viewed_elections_tx_borger_independent_school_district,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/tx/gray/hoover,viewed_elections_tx_gray_hoover,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/tx/saint-jo-independent-school-district,viewed_elections_tx_saint_jo_independent_school_district,,,,,,,,2026-06-25T01:35:48
+Viewed /elections/va/wise/dixiana,viewed_elections_va_wise_dixiana,,,,,,,,2026-06-25T01:35:48
+Voter Data - Custom Voter File - Audience: Click Back,voter_data_custom_voter_file_audience_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Custom Voter File: Click Create,voter_data_custom_voter_file_click_create,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Custom Voter File: Click Next,voter_data_custom_voter_file_click_next,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Custom Voter File: Exit modal,voter_data_custom_voter_file_exit_modal,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Custom Voter File: Select Channel,voter_data_custom_voter_file_select_channel,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Custom Voter File: Select Purpose,voter_data_custom_voter_file_select_purpose,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail - Learn & Take Action: Click Read More,voter_data_file_detail_learn_take_action_click_read_more,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail - Learn & Take Action: Click Schedule,voter_data_file_detail_learn_take_action_click_schedule,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail - Learn & Take Action: Click Write Script,voter_data_file_detail_learn_take_action_click_write_script,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail - Recommended Partners: Click Read More,voter_data_file_detail_recommended_partners_click_read_more,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail: Click Back,voter_data_file_detail_click_back,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail: Click Custom File Info Icon,voter_data_file_detail_click_custom_file_info_icon,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail: Click Download CSV,voter_data_file_detail_click_download_csv,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - File Detail: Click View Audience Filters,voter_data_file_detail_click_view_audience_filters,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Need Help: Exit modal,voter_data_need_help_exit_modal,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Need Help: Select Voter File type,voter_data_need_help_select_voter_file_type,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data - Need Help: Submit,voter_data_need_help_submit,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data: Click Create Custom Voter File,voter_data_click_create_custom_voter_file,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data: Click Detail View,voter_data_click_detail_view,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Data: Click Need Help,voter_data_click_need_help,1170c2777b41a1baf9f50650655aa705fdf7bbb3,,2025-02-26,,,,2025-02-26,2026-06-25T01:35:48
+Voter Outreach - 10DLC Compliance Completed,voter_outreach_10dlc_compliance_completed,a52bc1af5ee58f5b2492165ff4d973a76cf4db8b,457,2025-08-19,,,,2025-08-19,2026-06-25T01:35:48
+Voter Outreach - 10DLC Compliance Form Submitted,voter_outreach_10dlc_compliance_form_submitted,8434d128fc9812dcdde58effacd26458fccd95cc,894,2025-08-20,,,,2026-03-09,2026-06-25T01:35:48
+Voter Outreach - 10DLC Compliance Modal Viewed,voter_outreach_10dlc_compliance_modal_viewed,3f45b71a832475c190658d02e61151e16b0c6e65,1497,2026-03-03,,,,2026-03-03,2026-06-25T01:35:48
+Voter Outreach - 10DLC Compliance PIN Submitted,voter_outreach_10dlc_compliance_pin_submitted,8434d128fc9812dcdde58effacd26458fccd95cc,894,2025-08-20,,,,2026-03-09,2026-06-25T01:35:48
+Voter Outreach - 10DLC Compliance Started,voter_outreach_10dlc_compliance_started,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-25T01:35:48
+Voter Outreach - Campaign Completed,voter_outreach_campaign_completed,703131cfff639170bd836b12c6d00c13e1fc1432,708,2025-06-18,,,,2025-06-18,2026-06-25T01:35:48
+Voter Outreach - Free Texts Offer Redeemed,voter_outreach_free_texts_offer_redeemed,aa90af3d789823511f82e9d81dee84417a82b0c2,520,2025-09-08,,,,2025-09-08,2026-06-25T01:35:48
+Voter Outreach - Payment Started,voter_outreach_payment_started,2b9f22689ccc9e29678a4482de65a62db2e1d322,946,2025-09-09,,,,2025-09-09,2026-06-25T01:35:48
+[AI Visibility] Brand Snapshot,ai_visibility_brand_snapshot,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Dead Click,amplitude_dead_click,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Element Changed,amplitude_element_changed,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Element Clicked,amplitude_element_clicked,,,,,,,,2026-06-25T01:35:48
+[Amplitude] File Downloaded,amplitude_file_downloaded,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Form Started,amplitude_form_started,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Form Submitted,amplitude_form_submitted,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Network Request,amplitude_network_request,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Page Viewed,amplitude_page_viewed,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Rage Click,amplitude_rage_click,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Replay Captured,amplitude_replay_captured,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Viewport Content Updated,amplitude_viewport_content_updated,,,,,,,,2026-06-25T01:35:48
+[Amplitude] Web Vitals,amplitude_web_vitals,,,,,,,,2026-06-25T01:35:48
+[Experiment] Assignment,experiment_assignment,,,,,,,,2026-06-25T01:35:48
+[Experiment] Exposure,experiment_exposure,,,,,,,,2026-06-25T01:35:48
+[Experiment] Impression,experiment_impression,,,,,,,,2026-06-25T01:35:48
+ai_content_generation_start,ai_content_generation_start,a295f87f437a729b81c86adc2dc789ad9f1e3d18,316,2024-10-18,,,,2024-10-18,2026-06-25T01:35:48
+campaign_assistant_chatbot_input,campaign_assistant_chatbot_input,505dda0aafa691533330bcc405dd3d1bc796335d,315,2024-10-18,,,,2024-10-18,2026-06-25T01:35:48
+candidate CTA cancelled,candidate_cta_cancelled,5a9f8ed2d3b00f846e0d28fbb264d38e930d31f7,,2024-06-10,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-25T01:35:48
+candidate CTA clicked,candidate_cta_clicked,c0a574c0e56c270af68bf4cf82729bc30f967bf0,,2024-06-08,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-25T01:35:48
+candidate CTA selected,candidate_cta_selected,5a9f8ed2d3b00f846e0d28fbb264d38e930d31f7,,2024-06-10,ce8a2d7cb62e2543a880af29fcaba66486e159c7,862,2025-08-13,2025-08-13,2026-06-25T01:35:48
+gtm.dom,gtm_dom,,,,,,,,2026-06-25T01:35:48
+gtm.init,gtm_init,,,,,,,,2026-06-25T01:35:48
+gtm.init_consent,gtm_init_consent,,,,,,,,2026-06-25T01:35:48
+gtm.js,gtm_js,,,,,,,,2026-06-25T01:35:48
+likelihood-to-cancel,likelihood_to_cancel,,,,,,,,2026-06-25T01:35:48
+onboarding_complete,onboarding_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,85954771b6d545e35af77bf5ca3ae86e9cbdb80d,1790,2026-05-05,2026-05-05,2026-06-25T01:35:48
+page,page,25e499d086229c3ef5ed89d240d3432a608c9a01,,2025-03-23,,,,2026-02-08,2026-06-25T01:35:48
+page viewed,page_viewed,,,,,,,,2026-06-25T01:35:48
+page_view,page_view,,,,,,,,2026-06-25T01:35:48
+pro_upgrade_complete,pro_upgrade_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2026-05-08,2026-06-25T01:35:48
+question_complete,question_complete,650f61b4990c565bb4dff96419754e338ab088c2,,2024-08-26,,,,2025-12-17,2026-06-25T01:35:48
+schedule_campaign_image_too_large,schedule_campaign_image_too_large,4bed7aad64c8a8212e618db564bcb28ad2b9be5e,338,2024-10-30,,,,2024-10-30,2026-06-25T01:35:48
+screen,screen,,,,,,,,2026-06-25T01:35:48
+session_end,session_end,,,,,,,,2026-06-25T01:35:48
+session_start,session_start,,,,,,,,2026-06-25T01:35:48
+usersnap_submission,usersnap_submission,634a1c354de73cca6e6a0393dbdd0ac6dc3c7ae2,293,2024-10-04,e256bd33a54df1a412dcbe055be41d284f5ce195,1495,2026-03-02,2026-03-02,2026-06-25T01:35:48

--- a/analytics/data/amplitude_event_provenance_state.json
+++ b/analytics/data/amplitude_event_provenance_state.json
@@ -1,7 +1,7 @@
 {
   "job_name": "amplitude_event_provenance_backfill",
-  "last_processed_sha": "7c1c10378c5c08d994d7cf094ca9172dea95b04b",
+  "last_processed_sha": "3837c4d0b2e811166f9151bf49b89c38419519d6",
   "head_ref": "origin/develop",
-  "commit_count": 10069,
-  "last_run_at": "2026-06-24T18:31:10"
+  "commit_count": 7397,
+  "last_run_at": "2026-06-25T01:35:48"
 }

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -41,16 +41,21 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-# Source roots walked for instrumentation, with test files excluded so a test-only
-# reference to an event (e.g. expect(track).toHaveBeenCalledWith('E'), a call-arg
-# context match) does not register as an instrumentation change. git log and git grep
-# both honor :(exclude) magic pathspecs.
+# Source roots walked for instrumentation, with test files and seed-data CSVs excluded.
+# Test files are excluded so a test-only reference to an event (e.g.
+# expect(track).toHaveBeenCalledWith('E'), a call-arg context match) does not register
+# as an instrumentation change. Seed-data CSV rows (e.g. ``"Page","Page",...`` for the
+# city named Page) are line-leading quoted literals and would otherwise be mistaken for
+# instrumentation by the widened matcher; event instrumentation never lives in .csv, so
+# excluding them is safe and surgical. git log and git grep both honor :(exclude) magic
+# pathspecs.
 INSTRUMENTATION_PATHS = [
     "packages/gp-webapp",
     "packages/gp-api",
     ":(exclude,glob)packages/**/*.test.*",
     ":(exclude,glob)packages/**/*.spec.*",
     ":(exclude,glob)packages/**/__tests__/**",
+    ":(exclude,glob)packages/**/*.csv",
 ]
 
 # Events came online in Amplitude ~2025-05; the EVENTS map + segment wiring landed
@@ -126,12 +131,18 @@ def slugify_event(name: str) -> str:
 # --------------------------------------------------------------------------- #
 
 
-# An event literal counts as instrumentation only when it is a quoted string in a
-# map-value position (``Key: 'Event'``) or a call-argument position (``track('Event')``)
-# -- i.e. immediately preceded by ``:`` or ``(`` (with optional whitespace) and a quote.
-# This excludes the bare-token false positives (Playwright ``page``/``Page``, testing-
-# library ``screen``, ARIA values, route arrays, comment prose) that a substring match hit.
-_INSTRUMENTATION_PREFIX = r"[:(]\s*"
+# An event literal counts as instrumentation when it is a quoted string that is either
+# (a) in a map-value / call-argument position -- immediately preceded by ``:`` or ``(``
+# (``Key: 'Event'``, ``track('Event')``) -- or (b) line-leading (only whitespace before the
+# opening quote). Case (b) is required because Prettier wraps long declarations so the literal
+# sits on its own line (``Key:\n  'Event'``, ``track(\n  userId,\n  'Event',``); the ``:``/``(``
+# is then on the previous line, invisible to a per-line match. ``re.MULTILINE`` makes ``^``
+# match each line start in the multi-line git-grep dump ``present_at_head`` passes in.
+# The bare-token false positives (Playwright ``page``/``Page``, testing-library ``screen``,
+# ARIA values, route arrays, comment prose) are never a line-leading quoted literal, so they
+# stay excluded. Seed-data CSV rows (``"Page","Page",...``) ARE line-leading quoted literals;
+# they are excluded at the path level (see INSTRUMENTATION_PATHS), not here.
+_INSTRUMENTATION_PREFIX = r"(?:[:(]\s*|^\s*)"
 _QUOTE_CLASS = "['\"`]"  # straight single, double, backtick
 
 
@@ -142,13 +153,17 @@ def compile_event_pattern(events: Iterable[str]) -> re.Pattern[str]:
     contains (regex alternation is ordered + non-overlapping left-to-right),
     which stops a short literal from being double-counted inside a longer one.
 
-    Each alternate must appear as a quoted string in an instrumentation context
-    (map value ``Key: 'Event'`` or call argument ``track('Event')``); the event
-    name is capture group 1 so ``find_events`` returns the name, not the quotes.
+    Each alternate must appear as a quoted string in an instrumentation context:
+    either a map-value / call-argument position (immediately preceded by ``:`` or
+    ``(``) or a line-leading position (only whitespace before the opening quote).
+    The line-leading case is needed because Prettier wraps long declarations so the
+    literal sits on its own line with the ``:``/``(`` on the previous line.
+    ``re.MULTILINE`` makes ``^`` match each line start in multi-line git-grep dumps.
+    The event name is capture group 1 so ``find_events`` returns the name, not the quotes.
     """
     ordered = sorted(set(events), key=len, reverse=True)
     alternation = "|".join(re.escape(e) for e in ordered)
-    return re.compile(rf"{_INSTRUMENTATION_PREFIX}{_QUOTE_CLASS}({alternation}){_QUOTE_CLASS}")
+    return re.compile(rf"{_INSTRUMENTATION_PREFIX}{_QUOTE_CLASS}({alternation}){_QUOTE_CLASS}", re.MULTILINE)
 
 
 def find_events(text: str, pattern: re.Pattern[str]) -> set[str]:

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -117,6 +117,15 @@ def slugify_event(name: str) -> str:
 # --------------------------------------------------------------------------- #
 
 
+# An event literal counts as instrumentation only when it is a quoted string in a
+# map-value position (``Key: 'Event'``) or a call-argument position (``track('Event')``)
+# -- i.e. immediately preceded by ``:`` or ``(`` (with optional whitespace) and a quote.
+# This excludes the bare-token false positives (Playwright ``page``/``Page``, testing-
+# library ``screen``, ARIA values, route arrays, comment prose) that a substring match hit.
+_INSTRUMENTATION_PREFIX = r"[:(]\s*"
+_QUOTE_CLASS = "['\"`]"  # straight single, double, backtick
+
+
 def compile_event_pattern(events: Iterable[str]) -> re.Pattern[str]:
     """Compile one alternation regex over the known event_type literals.
 
@@ -124,17 +133,13 @@ def compile_event_pattern(events: Iterable[str]) -> re.Pattern[str]:
     contains (regex alternation is ordered + non-overlapping left-to-right),
     which stops a short literal from being double-counted inside a longer one.
 
-    Each alternate is bounded by non-alphanumeric lookarounds so a single-word
-    literal (``page``, ``screen``, ``Viewed``) does not match as a substring of a
-    compound identifier (``pageTitle``, ``screenWidth``, ``isViewed``). The
-    surrounding quote delimiters of a real event literal satisfy the bounds; the
-    bound is alphanumeric (not ``\\b``) so literals that begin or end with
-    punctuation still match. The single-word-inside-snake_case case (``page`` in
-    ``page_view``) stays handled by the longest-first, non-overlapping ordering.
+    Each alternate must appear as a quoted string in an instrumentation context
+    (map value ``Key: 'Event'`` or call argument ``track('Event')``); the event
+    name is capture group 1 so ``find_events`` returns the name, not the quotes.
     """
     ordered = sorted(set(events), key=len, reverse=True)
-    anchored = (rf"(?<![A-Za-z0-9]){re.escape(e)}(?![A-Za-z0-9])" for e in ordered)
-    return re.compile("|".join(anchored))
+    alternation = "|".join(re.escape(e) for e in ordered)
+    return re.compile(rf"{_INSTRUMENTATION_PREFIX}{_QUOTE_CLASS}({alternation}){_QUOTE_CLASS}")
 
 
 def find_events(text: str, pattern: re.Pattern[str]) -> set[str]:

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -138,6 +138,9 @@ def slugify_event(name: str) -> str:
 # sits on its own line (``Key:\n  'Event'``, ``track(\n  userId,\n  'Event',``); the ``:``/``(``
 # is then on the previous line, invisible to a per-line match. ``re.MULTILINE`` makes ``^``
 # match each line start in the multi-line git-grep dump ``present_at_head`` passes in.
+# Note (b) matches ANY line-leading quoted literal, not only wrapped declarations -- a
+# Prettier-wrapped array element or a leading-quote comment line can also match; this is
+# accepted because the full-rebuild validation gate re-checks every event's attribution.
 # The bare-token false positives (Playwright ``page``/``Page``, testing-library ``screen``,
 # ARIA values, route arrays, comment prose) are never a line-leading quoted literal, so they
 # stay excluded. Seed-data CSV rows (``"Page","Page",...``) ARE line-leading quoted literals;

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -41,8 +41,17 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-# Instrumentation packages whose history defines when an event was added/removed.
-INSTRUMENTATION_PATHS = ["packages/gp-webapp", "packages/gp-api"]
+# Source roots walked for instrumentation, with test files excluded so a test-only
+# reference to an event (e.g. expect(track).toHaveBeenCalledWith('E'), a call-arg
+# context match) does not register as an instrumentation change. git log and git grep
+# both honor :(exclude) magic pathspecs.
+INSTRUMENTATION_PATHS = [
+    "packages/gp-webapp",
+    "packages/gp-api",
+    ":(exclude,glob)packages/**/*.test.*",
+    ":(exclude,glob)packages/**/*.spec.*",
+    ":(exclude,glob)packages/**/__tests__/**",
+]
 
 # Events came online in Amplitude ~2025-05; the EVENTS map + segment wiring landed
 # ~2025-02. Bounding the walk here skips the large pre-2024 scaffold-era diffs while

--- a/analytics/lib/amplitude_event_provenance_backfill.py
+++ b/analytics/lib/amplitude_event_provenance_backfill.py
@@ -144,6 +144,7 @@ def slugify_event(name: str) -> str:
 # they are excluded at the path level (see INSTRUMENTATION_PATHS), not here.
 _INSTRUMENTATION_PREFIX = r"(?:[:(]\s*|^\s*)"
 _QUOTE_CLASS = "['\"`]"  # straight single, double, backtick
+_INQUOTE_PAD = r"[ \t]*"  # tolerate stray spaces/tabs inside the quotes from source typos
 
 
 def compile_event_pattern(events: Iterable[str]) -> re.Pattern[str]:
@@ -159,11 +160,21 @@ def compile_event_pattern(events: Iterable[str]) -> re.Pattern[str]:
     The line-leading case is needed because Prettier wraps long declarations so the
     literal sits on its own line with the ``:``/``(`` on the previous line.
     ``re.MULTILINE`` makes ``^`` match each line start in multi-line git-grep dumps.
-    The event name is capture group 1 so ``find_events`` returns the name, not the quotes.
+
+    The capture group wraps only the alternation (not the padding), so the returned
+    name is always the trimmed taxonomy name -- not the typo'd source literal. The
+    ``_INQUOTE_PAD`` (``[ \\t]*``) around the capture group tolerates stray leading/
+    trailing horizontal whitespace inside the quotes from source typos (e.g.
+    ``analyticsHelper.ts``: ``'Pro Upgrade - Committee Check Page: Click Upload '``
+    with a trailing space). ``[ \\t]*`` (horizontal only) is used instead of ``\\s*``
+    so it never spans newlines and matches across lines in a multi-line git-grep dump.
     """
     ordered = sorted(set(events), key=len, reverse=True)
     alternation = "|".join(re.escape(e) for e in ordered)
-    return re.compile(rf"{_INSTRUMENTATION_PREFIX}{_QUOTE_CLASS}({alternation}){_QUOTE_CLASS}", re.MULTILINE)
+    return re.compile(
+        rf"{_INSTRUMENTATION_PREFIX}{_QUOTE_CLASS}{_INQUOTE_PAD}({alternation}){_INQUOTE_PAD}{_QUOTE_CLASS}",
+        re.MULTILINE,
+    )
 
 
 def find_events(text: str, pattern: re.Pattern[str]) -> set[str]:

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -124,6 +124,41 @@ def test_find_events_matches_double_quoted_and_multiple():
     assert find_events(line, pattern) == {"pro_upgrade_complete", "onboarding_complete"}
 
 
+def test_find_events_matches_map_value_and_call_arg_contexts():
+    pattern = compile_event_pattern(["page", "Onboarding Started"])
+    map_line = "  PageEvent: 'page',"
+    call_line = "  trackEvent('Onboarding Started')"
+    assert find_events(map_line, pattern) == {"page"}
+    assert find_events(call_line, pattern) == {"Onboarding Started"}
+
+
+def test_find_events_ignores_non_instrumentation_token_positions():
+    # The real-world false positives that motivated this change.
+    pattern = compile_event_pattern(["page", "Page", "screen", "Viewed"])
+    lines = [
+        "      page.getByText('Filing Address')",  # Playwright call receiver
+        "  fireEvent.click(screen.getByTestId('x'))",  # testing-library
+        "import { type Page } from '@playwright/test'",  # type import
+        '      aria-current="page"',  # ARIA value (preceded by =)
+        "      path: ['page'],",  # route array (: then [)
+        '  // the "Viewed" event fires once on view',  # comment prose
+    ]
+    for line in lines:
+        assert find_events(line, pattern) == set(), line
+
+
+def test_find_events_context_still_prefers_longest():
+    pattern = compile_event_pattern(["Completed", "Pledge Completed"])
+    line = "  pledge: 'Pledge Completed',"
+    assert find_events(line, pattern) == {"Pledge Completed"}
+
+
+def test_find_events_context_matches_multiple_on_one_line():
+    pattern = compile_event_pattern(["pro_upgrade_complete", "onboarding_complete"])
+    line = '  PRO: "pro_upgrade_complete", ONB: "onboarding_complete",'
+    assert find_events(line, pattern) == {"pro_upgrade_complete", "onboarding_complete"}
+
+
 def test_find_events_ignores_single_word_literal_inside_compound_identifier():
     pattern = compile_event_pattern(["page", "screen", "Viewed"])
     line = "  const pageTitle = screenWidth; const ok = isViewed;"
@@ -430,12 +465,12 @@ def test_run_backfill_writes_csv_and_state(monkeypatch, tmp_path):
     cur = FakeCursor(["Event A", "Event B"])
     stream = [
         _header("a1", "a1", "2025-02-01", "feat: add A (#1)"),
-        '+  trackEvent(EVENTS.X)  // "Event A"',
+        '+  X: "Event A",',
         _header("b1", "b1", "2025-03-01", "feat: add B (#2)"),
-        '+  trackEvent(EVENTS.Y)  // "Event B"',
+        '+  Y: "Event B",',
     ]
     monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter(stream))
-    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '"Event A" "Event B"')
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '  X: "Event A",\n  Y: "Event B",')
     monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "headsha")
     monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
     monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 7)
@@ -831,10 +866,10 @@ def test_run_refresh_updates_affected_and_carries_forward_unaffected(monkeypatch
     # Window net-removes Event A only.
     stream = [
         _header("z9", "z9", "2026-06-18", "feat: remove A (#9)"),
-        '-  trackEvent(EVENTS.X)  // "Event A"',
+        '-  X: "Event A",',
     ]
     monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter(stream))
-    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '"Event B"')  # A gone, B present
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '  Y: "Event B",')  # A gone, B present
     monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")
     monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
     monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 11)
@@ -891,11 +926,11 @@ def test_run_refresh_onboards_new_universe_event_via_full_history(monkeypatch, t
     # historical add commit. present_at_head sees Event C in the code at HEAD.
     def fake_log(*a, **k):
         if k.get("pickaxe") == "Event C":
-            return iter([_header("c1", "c1", "2025-01-15", "feat: add C (#5)"), '+  EVENTS.C  // "Event C"'])
+            return iter([_header("c1", "c1", "2025-01-15", "feat: add C (#5)"), '+  C: "Event C",'])
         return iter([])
 
     monkeypatch.setattr(bf, "run_git_log", fake_log)
-    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '"Event C"')
+    monkeypatch.setattr(bf, "git_grep_present_text", lambda *a, **k: '  C: "Event C",')
     monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")
     monkeypatch.setattr(bf, "git_head_ref", lambda *a, **k: "origin/develop")
     monkeypatch.setattr(bf, "git_commit_count", lambda *a, **k: 10)
@@ -929,7 +964,7 @@ def test_attribute_events_from_history_finds_instrumentation_via_pickaxe(tmp_pat
     subprocess.run(
         ["git", "-C", repo, "commit", "-q", "-m", "base"], check=True, capture_output=True, env=env
     )
-    (tmp_path / "app.ts").write_text('trackEvent(EVENTS.X)  // "Event X"\n')
+    (tmp_path / "app.ts").write_text('  X: "Event X",\n')
     subprocess.run(["git", "-C", repo, "add", "."], check=True, capture_output=True, env=env)
     subprocess.run(
         ["git", "-C", repo, "commit", "-q", "-m", "feat: add X (#7)"],
@@ -961,15 +996,15 @@ def test_run_refresh_does_not_fabricate_instrumented_for_predates_window_event(m
     bf.write_watermark(str(state_path), "oldsha", "origin/develop", 10, "2025-04-01T00:00:00")
     stream = [
         _header("p1", "p1", "2026-06-10", "feat: edit P, add Q (#7)"),
-        '+  trackEvent(EVENTS.P)  // "Event P"',
-        '+  trackEvent(EVENTS.Q)  // "Event Q"',
+        '+  P: "Event P",',
+        '+  Q: "Event Q",',
     ]
     monkeypatch.setattr(bf, "run_git_log", lambda *a, **k: iter(stream))
 
     # The 4th positional arg is the grep ref: at the watermark (oldsha) P already exists and Q
     # does not; at HEAD both exist.
     def fake_grep(*a, **k):
-        return '"Event P"' if a[3] == "oldsha" else '"Event P" "Event Q"'
+        return '  P: "Event P",' if a[3] == "oldsha" else '  P: "Event P",\n  Q: "Event Q",'
 
     monkeypatch.setattr(bf, "git_grep_present_text", fake_grep)
     monkeypatch.setattr(bf, "git_head_sha", lambda *a, **k: "newsha")

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -381,14 +381,14 @@ def test_build_git_log_argv_adds_pickaxe_before_ref():
 
 def test_build_git_log_argv_excludes_test_files():
     argv = build_git_log_argv("/repo", None, INSTRUMENTATION_PATHS, ref="origin/develop")
-    joined = " ".join(argv)
     assert ":(exclude,glob)packages/**/*.test.*" in argv
+    assert ":(exclude,glob)packages/**/*.spec.*" in argv
     assert ":(exclude,glob)packages/**/__tests__/**" in argv
     # source roots still present
     assert "packages/gp-webapp" in argv
     assert "packages/gp-api" in argv
     # excludes come after the -- separator with the rest of the pathspec
-    assert "--" in joined
+    assert "--" in argv
 
 
 def test_present_at_head_marks_found_literals():

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -174,6 +174,28 @@ def test_find_events_matches_single_word_literal_at_quote_boundaries():
     assert find_events(line, pattern) == {"page", "Viewed"}
 
 
+def test_find_events_matches_line_leading_wrapped_literal():
+    # Prettier wraps long map values / call args so the literal sits on its own line,
+    # preceded only by whitespace -- the : or ( is on the previous line.
+    pattern = compile_event_pattern(["Campaign Plan V2 - Opposition Research Generation Started"])
+    line = "      'Campaign Plan V2 - Opposition Research Generation Started',"
+    assert find_events(line, pattern) == {"Campaign Plan V2 - Opposition Research Generation Started"}
+
+
+def test_find_events_matches_literal_in_multiline_dump():
+    # present_at_head feeds a multi-line git-grep dump; re.MULTILINE makes ^ match each
+    # line start, so a line-leading literal anywhere in the dump is found, while a bare
+    # (unquoted) token like Playwright's `page` receiver is not.
+    pattern = compile_event_pattern(["Briefing Assistant - Agenda Created", "page"])
+    dump = (
+        "      this.analytics.track(\n"
+        "        userId,\n"
+        "        'Briefing Assistant - Agenda Created',\n"
+        "      page.getByText('x')\n"
+    )
+    assert find_events(dump, pattern) == {"Briefing Assistant - Agenda Created"}
+
+
 # --------------------------------------------------------------------------- #
 # parse_git_log -- the single-pass history walk
 # --------------------------------------------------------------------------- #
@@ -389,6 +411,11 @@ def test_build_git_log_argv_excludes_test_files():
     assert "packages/gp-api" in argv
     # excludes come after the -- separator with the rest of the pathspec
     assert "--" in argv
+
+
+def test_build_git_log_argv_excludes_data_files():
+    argv = build_git_log_argv("/repo", None, INSTRUMENTATION_PATHS, ref="origin/develop")
+    assert ":(exclude,glob)packages/**/*.csv" in argv
 
 
 def test_present_at_head_marks_found_literals():

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import amplitude_event_provenance_backfill as bf
 import pytest
 from amplitude_event_provenance_backfill import (
+    INSTRUMENTATION_PATHS,
     build_git_log_argv,
     build_provenance_row,
     classify_code_status,
@@ -376,6 +377,18 @@ def test_build_git_log_argv_adds_pickaxe_before_ref():
     # -S<literal> is one argv element (fixed string), placed before the ref and the pathspec.
     assert '-SClick "Upload"' in argv
     assert argv.index('-SClick "Upload"') < argv.index("origin/develop") < argv.index("--")
+
+
+def test_build_git_log_argv_excludes_test_files():
+    argv = build_git_log_argv("/repo", None, INSTRUMENTATION_PATHS, ref="origin/develop")
+    joined = " ".join(argv)
+    assert ":(exclude,glob)packages/**/*.test.*" in argv
+    assert ":(exclude,glob)packages/**/__tests__/**" in argv
+    # source roots still present
+    assert "packages/gp-webapp" in argv
+    assert "packages/gp-api" in argv
+    # excludes come after the -- separator with the rest of the pathspec
+    assert "--" in joined
 
 
 def test_present_at_head_marks_found_literals():

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -148,14 +148,16 @@ def test_find_events_ignores_non_instrumentation_token_positions():
 
 
 def test_find_events_context_still_prefers_longest():
+    # Distinct from the map-value longest-first test: backtick-quoted call argument.
     pattern = compile_event_pattern(["Completed", "Pledge Completed"])
-    line = "  pledge: 'Pledge Completed',"
+    line = "  trackEvent(`Pledge Completed`)"
     assert find_events(line, pattern) == {"Pledge Completed"}
 
 
 def test_find_events_context_matches_multiple_on_one_line():
+    # Distinct from the double-quoted map test: a call-arg and a map-value on one line.
     pattern = compile_event_pattern(["pro_upgrade_complete", "onboarding_complete"])
-    line = '  PRO: "pro_upgrade_complete", ONB: "onboarding_complete",'
+    line = "  trackEvent('pro_upgrade_complete'); ONB: 'onboarding_complete',"
     assert find_events(line, pattern) == {"pro_upgrade_complete", "onboarding_complete"}
 
 

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -196,6 +196,22 @@ def test_find_events_matches_literal_in_multiline_dump():
     assert find_events(dump, pattern) == {"Briefing Assistant - Agenda Created"}
 
 
+def test_find_events_tolerates_whitespace_inside_quotes():
+    # A source typo can leave stray space inside the quotes (e.g. analyticsHelper.ts
+    # 'Pro Upgrade - Committee Check Page: Click Upload '); the literal still denotes the
+    # taxonomy event, so match it and return the trimmed taxonomy name (no trailing space).
+    pattern = compile_event_pattern(["Pro Upgrade - Committee Check Page: Click Upload"])
+    line = "      ClickUpload: 'Pro Upgrade - Committee Check Page: Click Upload ',"
+    assert find_events(line, pattern) == {"Pro Upgrade - Committee Check Page: Click Upload"}
+
+
+def test_find_events_whitespace_tolerance_does_not_overmatch_adjacent_text():
+    # The in-quote padding is horizontal whitespace only and must not let a short name
+    # match when the quoted literal actually contains additional words.
+    pattern = compile_event_pattern(["page"])
+    assert find_events("  EVT: 'page extra',", pattern) == set()
+
+
 # --------------------------------------------------------------------------- #
 # parse_git_log -- the single-pass history walk
 # --------------------------------------------------------------------------- #

--- a/analytics/tests/test_amplitude_event_provenance_backfill.py
+++ b/analytics/tests/test_amplitude_event_provenance_backfill.py
@@ -203,6 +203,16 @@ def test_find_events_tolerates_whitespace_inside_quotes():
     pattern = compile_event_pattern(["Pro Upgrade - Committee Check Page: Click Upload"])
     line = "      ClickUpload: 'Pro Upgrade - Committee Check Page: Click Upload ',"
     assert find_events(line, pattern) == {"Pro Upgrade - Committee Check Page: Click Upload"}
+    # leading whitespace inside the quotes is tolerated symmetrically
+    lead = "      ClickUpload: '  Pro Upgrade - Committee Check Page: Click Upload',"
+    assert find_events(lead, pattern) == {"Pro Upgrade - Committee Check Page: Click Upload"}
+
+
+def test_compile_event_pattern_has_single_capture_group():
+    # find_events relies on findall returning the event name, which holds only while the
+    # pattern has exactly one capturing group (the alternation). A second group would make
+    # findall return tuples and silently corrupt results.
+    assert compile_event_pattern(["Some Event", "page"]).groups == 1
 
 
 def test_find_events_whitespace_tolerance_does_not_overmatch_adjacent_text():


### PR DESCRIPTION
## What this does

Stops the event-provenance backfill from attributing instrumentation dates to event names that merely appear as ordinary code tokens. The matcher (`compile_event_pattern` / `find_events`) is the single gate every walk path funnels through, so tightening it fixes the windowed walk, the full-history pickaxe onboarding, and the present-at-head check at once.

An event literal now counts as instrumentation only when it is a quoted string in a real instrumentation position:
- preceded by `:` or `(` on the same line (map value `Key: 'Event'`, call argument `track('Event')`), or
- line-leading (only whitespace before the opening quote), because Prettier wraps long declarations and multi-line call arguments so the literal sits on its own line.

Stray horizontal whitespace inside the quotes is tolerated so a source typo still resolves to the taxonomy event. The walk also excludes test files (`*.test.*`, `*.spec.*`, `__tests__/**`) and data files (`*.csv`), so test-only references and seed-data rows are not mistaken for instrumentation.

## Why it is more than the original plan

The plan's first matcher required `:` or `(` on the same line as the literal. A full-rebuild validation gate showed this dropped 42 real hand-instrumented events whose literals are Prettier-wrapped onto their own line (the `:`/`(` is on the previous line, invisible to a per-line matcher). Widening to line-leading literals, excluding `*.csv` (a seed-data row for the city named Page leaked in), and tolerating in-quote whitespace (one event had a trailing-space typo in source) were added and verified against real data.

## Validation

Full rebuild against omni `origin/develop` under the final matcher:
- Exactly 4 events flip to `not_found_in_code`: `Page`, `Viewed`, `screen`, `page_view`. All confirmed to have zero instrumentation-context occurrences in source (genuinely auto-tracked, not in the EVENTS map).
- 41 previously-dropped real events recovered their `instrumented_date`.
- 0 spurious new attributions. 4 new universe events onboarded. 437 to 441 rows.
- Lib test suite: 92 passing.

## Files

- `analytics/lib/amplitude_event_provenance_backfill.py`: matcher and `INSTRUMENTATION_PATHS`.
- `analytics/tests/test_amplitude_event_provenance_backfill.py`: matcher and path tests.
- `analytics/data/amplitude_event_provenance.csv` and `..._state.json`: re-baselined dataset (generated output, gate-validated).

## Follow-up (separate, in omni)

`packages/gp-webapp/helpers/analyticsHelper.ts:386` has a trailing-space typo in the event literal: `'Pro Upgrade - Committee Check Page: Click Upload '`. The matcher now tolerates it, but the source literal should be cleaned up in a gp-webapp PR so the code and the Amplitude taxonomy name match exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes attribution logic for hundreds of analytics events and committed provenance data; incorrect matching would skew downstream taxonomy joins, though the PR describes gate-validated full rebuild results.
> 
> **Overview**
> Tightens how the Amplitude **event provenance backfill** decides that an event name was actually instrumented in omni, then re-runs a full rebuild and commits the updated dataset.
> 
> **Matcher (`compile_event_pattern` / `find_events`)** now only counts a taxonomy literal when it appears as a **quoted string** in a real instrumentation position: same-line map value or call argument (`Key: 'Event'`, `track('Event')`), or **line-leading** quotes (for Prettier-wrapped literals). Bare tokens like Playwright `page`, testing-library `screen`, and comment prose no longer match. In-quote horizontal whitespace is trimmed so a trailing-space typo still maps to the correct event name.
> 
> **Git walk scope** adds `:(exclude)` pathspecs so `git log` / `git grep` skip `*.test.*`, `*.spec.*`, `__tests__/**`, and `*.csv`, avoiding test-only references and seed-data rows (e.g. city name "Page") that look like line-leading quoted literals.
> 
> **Committed outputs** refresh `amplitude_event_provenance.csv` (441 rows, bulk `updated_at` plus new rows such as Briefing Assistant dictation and Campaign Story rewrite events) and advance `amplitude_event_provenance_state.json` to the new head SHA. Tests are expanded for the matcher and path exclusions; fixtures use map-value quoted literals instead of comment-style stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0241b83e948f340ba58d41b9919b6d9820a02f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->