### PR TITLE
Fix Dexter MI mayor filing address (DATA-2019)

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -64,7 +64,14 @@ with
 select
     tbl_race.id,
     tbl_race.created_at,
-    tbl_race.updated_at,
+    -- Bump updated_at when a filing-address override applies so the election-api
+    -- write model's incremental upsert (gated on updated_at) actually picks up
+    -- the corrected value; BallotReady's own updated_at does not change.
+    case
+        when filing_overrides.br_database_id is not null
+        then current_timestamp()
+        else tbl_race.updated_at
+    end as updated_at,
     tbl_race.br_hash_id,
     tbl_race.br_database_id,
     tbl_race.election_date,
@@ -75,7 +82,9 @@ select
         tbl_race.normalized_position_name, '//', '-'
     ) as normalized_position_name,
     tbl_race.position_description,
-    tbl_race.filing_office_address,
+    coalesce(
+        filing_overrides.filing_office_address, tbl_race.filing_office_address
+    ) as filing_office_address,
     tbl_race.filing_phone_number,
     tbl_race.paperwork_instructions,
     tbl_race.filing_requirements,
@@ -118,6 +127,9 @@ left join
 left join
     {{ ref("m_election_api__position") }} as tbl_position
     on tbl_race.br_position_database_id = tbl_position.br_database_id
+left join
+    {{ ref("election_api_race_filing_address_overrides") }} as filing_overrides
+    on tbl_race.br_database_id = filing_overrides.br_database_id
 where
     tbl_race.place_id in (select id from {{ ref("m_election_api__place") }})
     and tbl_race.election_date

--- a/dbt/project/seeds/election_api_race_filing_address_overrides.csv
+++ b/dbt/project/seeds/election_api_race_filing_address_overrides.csv
@@ -1,0 +1,2 @@
+br_database_id,slug,filing_office_address,reason
+2252382,mi/dexter/city-executive-mayor,"3515 Broad Street, Dexter, MI 48130","BallotReady filing address (8123 Main Street, 2nd Floor) is wrong; correct Dexter city offices address confirmed by the MI filing office (DATA-2019)"

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -176,18 +176,6 @@ seeds:
                 select br_database_id
                 from {{ ref('m_election_api__race') }}
               )
-      - name: slug
-        description: election-api race slug (for documentation only, not used in joins)
-        data_tests:
-          - not_null
-      - name: filing_office_address
-        description: Corrected filing office address
-        data_tests:
-          - not_null
-      - name: reason
-        description: Why this override is needed
-        data_tests:
-          - not_null
 
   - name: icp_normalized_position_names
     description: >

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -168,6 +168,26 @@ seeds:
         description: Why this override is needed
         data_tests:
           - not_null
+    data_tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              br_database_id in (
+                select br_database_id
+                from {{ ref('m_election_api__race') }}
+              )
+      - name: slug
+        description: election-api race slug (for documentation only, not used in joins)
+        data_tests:
+          - not_null
+      - name: filing_office_address
+        description: Corrected filing office address
+        data_tests:
+          - not_null
+      - name: reason
+        description: Why this override is needed
+        data_tests:
+          - not_null
 
   - name: icp_normalized_position_names
     description: >

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -137,6 +137,38 @@ seeds:
                 from {{ ref('m_election_api__district') }}
               )
 
+  - name: election_api_race_filing_address_overrides
+    description: >
+      Manual overrides for the filing office address shown on election-api race
+      pages. BallotReady sometimes supplies the wrong filing address for a
+      position; add a row here keyed on the race br_database_id with the correct
+      address and it takes precedence over the BallotReady value in the
+      election-api race mart. Keyed at race grain (one row per BallotReady race)
+      to match the mart and the displayed page; a future election for the same
+      office gets a new br_database_id and would need its own row.
+    columns:
+      - name: br_database_id
+        description: BallotReady race database ID to override
+        data_tests:
+          - unique
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('int__enhanced_race')
+                field: br_database_id
+      - name: slug
+        description: election-api race slug (for documentation only, not used in joins)
+        data_tests:
+          - not_null
+      - name: filing_office_address
+        description: Corrected filing office address
+        data_tests:
+          - not_null
+      - name: reason
+        description: Why this override is needed
+        data_tests:
+          - not_null
+
   - name: icp_normalized_position_names
     description: >
       BallotReady normalized position names that qualify for ICP flags.


### PR DESCRIPTION
## Problem

DATA-2019: the elections page for Dexter, MI mayor shows the wrong filing office address. BallotReady supplies `8123 Main Street, 2nd Floor, Dexter, MI 48130` for race `br_database_id` 2252382 (`mi/dexter/city-executive-mayor`). The correct address is `3515 Broad Street, Dexter, MI 48130`, confirmed by the MI filing office.

The displayed value comes from election-api `Race.filing_office_address`, which `m_election_api__race` populates from the BallotReady position's `filing_address`.

## Fix

- New seed `election_api_race_filing_address_overrides.csv`, keyed on race `br_database_id`, holding the corrected address (mirrors the existing `l2_br_match_overrides` pattern).
- `m_election_api__race` `coalesce`s the override over the BallotReady value.
- The mart bumps `updated_at` for overridden rows. The election-api Postgres write upserts incrementally gated on `updated_at`, and BallotReady's own `updated_at` does not change when we override, so without this the corrected row would be skipped.
- Seed documented in `seeds_schema.yaml` with `unique` / `not_null` / `relationships`-to-`int__enhanced_race` tests.

## Verification

- Seed data tests pass (6/6).
- Built the mart in `dbt_dball`; the row reads `3515 Broad Street, Dexter, MI 48130`.
- Ran `write__election_api_db` against the dev election-api DB and confirmed the `Race` row now returns the corrected address.

## Adding future overrides

Add a row to the seed with the race `br_database_id` and corrected address, rebuild the mart, and the change flows to election-api on the next sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-data correction with a small, tested seed pattern; no auth or broad schema changes beyond one mart column and sync timestamp behavior for overridden rows.
> 
> **Overview**
> Adds a **manual override path** for wrong BallotReady filing office addresses on election-api race pages, starting with Dexter MI mayor (DATA-2019).
> 
> A new seed `election_api_race_filing_address_overrides` is keyed by race `br_database_id`. **`m_election_api__race`** left-joins it and **`coalesce`s** the override over `filing_office_address`. For rows with an override, **`updated_at` is set to `current_timestamp()`** so the election-api Postgres incremental upsert (which keys off `updated_at`) still ships the fix when BallotReady’s timestamp is unchanged.
> 
> The seed is documented in **`seeds_schema.yaml`** with uniqueness, not-null, and relationship tests to `int__enhanced_race`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be17c0716c9fd026002ac9528e287c67b4534fe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->