### PR TITLE
[DATA-1938] Carry TechSpeed opponent count into civics election

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -663,10 +663,6 @@ models:
           null, which forced solo-ingested TechSpeed candidacies onto the
           weaker viabilitynoopponentdata fallback in
           int__civics_viability_scoring.
-        data_tests:
-          - dbt_utils.expression_is_true:
-              arguments:
-                expression: "number_of_opponents is null or try_cast(number_of_opponents as int) >= 0"
 
       - name: has_ddhq_match
         description: Whether there is a DDHQ match (always false for TechSpeed)
@@ -684,6 +680,16 @@ models:
       - name: updated_at
         data_tests:
           - not_null
+
+    data_tests:
+      # Well-formedness of the DATA-1938 opponent count: null or a non-negative
+      # integer string (opponents = number_of_candidates - 1, so >= 0). Model
+      # level rather than column level so the expression can reference the
+      # column by name without the column-test macro prepending the column.
+      - dbt_utils.expression_is_true:
+          name: civics_election_techspeed_opponents_well_formed
+          arguments:
+            expression: "number_of_opponents is null or try_cast(number_of_opponents as int) >= 0"
 
   - name: int__civics_candidacy_stage_techspeed
     description: >

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -654,6 +654,20 @@ models:
               arguments:
                 min_value: 0
 
+      - name: number_of_opponents
+        description: >
+          Opponent count for the race (number_of_candidates - 1 from the
+          TechSpeed source), stored as a string to match the BR/DDHQ/2025
+          election models and the scorer's parsing. Null when the source count
+          is missing, non-numeric, or < 1. DATA-1938: previously hardcoded
+          null, which forced solo-ingested TechSpeed candidacies onto the
+          weaker viabilitynoopponentdata fallback in
+          int__civics_viability_scoring.
+        data_tests:
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: "number_of_opponents is null or try_cast(number_of_opponents as int) >= 0"
+
       - name: has_ddhq_match
         description: Whether there is a DDHQ match (always false for TechSpeed)
 

--- a/dbt/project/models/intermediate/civics/int__civics_election_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_techspeed.sql
@@ -148,7 +148,20 @@ with
             cast(null as date) as term_start_date,
             -- Keep boolean type to match BallotReady election intermediate
             is_uncontested,
-            cast(null as string) as number_of_opponents,
+            -- DATA-1938: carry the TechSpeed opponent count instead of
+            -- hardcoding null. number_of_candidates is the count of candidates
+            -- in the race from the TechSpeed source; opponents = candidates - 1.
+            -- Kept as a string to match the BR/DDHQ/2025 election models and the
+            -- scorer's string handling (int__civics_viability_scoring). Empty,
+            -- non-numeric, and < 1 counts fall to null (a race has >= 1
+            -- candidate). The representative-row pick already collapses to one
+            -- row per election, so this is per-election with no fan-out.
+            cast(
+                case
+                    when try_cast(number_of_candidates as int) >= 1
+                    then try_cast(number_of_candidates as int) - 1
+                end as string
+            ) as number_of_opponents,
             is_open_seat,
             false as has_ddhq_match,
             -- BR-derived from br_race_id when TS captures one. Surfaces the

--- a/dbt/project/tests/assert_civics_election_techspeed_opponent_coverage_floor.sql
+++ b/dbt/project/tests/assert_civics_election_techspeed_opponent_coverage_floor.sql
@@ -1,0 +1,17 @@
+-- Regression guard on the TechSpeed opponent count (DATA-1938).
+-- int__civics_election_techspeed must CARRY the opponent count derived from
+-- the TechSpeed source (number_candidates - 1), not hardcode number_of_opponents
+-- to null. The hardcoded null starved int__civics_viability_scoring of the
+-- log_n_losers feature, forcing solo-ingested TechSpeed candidacies onto the
+-- weaker viabilitynoopponentdata fallback.
+--
+-- Fails when the populated share drops below the floor, or when the model is
+-- empty (count(*) = 0, a total upstream break). A share floor, not a fixed
+-- count, so TechSpeed volume changes never trip it on their own. TechSpeed's
+-- number_candidates is ~fully populated at source, so a real drop here means a
+-- revert to the hardcoded null or a break in the source mapping. `* 1.0` keeps
+-- the ratio an explicit float per the sibling coverage tests, and
+-- nullif(count(*), 0) guards the empty model from an ANSI divide-by-zero.
+select count(*) as total_ts_elections, count(number_of_opponents) as populated_opponents
+from {{ ref("int__civics_election_techspeed") }}
+having count(*) = 0 or count(number_of_opponents) * 1.0 / nullif(count(*), 0) < 0.90


### PR DESCRIPTION
## What

`int__civics_election_techspeed` hardcoded `number_of_opponents = null`. This starved the broad-viability scorer (`int__civics_viability_scoring`) of the `log_n_losers` feature for **solo-ingested** TechSpeed races, forcing them onto the weaker `viabilitynoopponentdata` fallback model and scoring them too low. This is the dominant driver of the "downgrade-dominant" band-shift flagged after the DATA-1938 broad-viability rollout (PR #530).

This PR carries the opponent count through, so the scorer can use a `log_n_losers`-bearing model for those races.

## Root cause (code + data confirmed)

- The scorer derives the opponent count two ways: (A) count civics candidacies per election, trusted only when `> 1`; else (B) `election.number_of_opponents + 1`. For the affected races both fail — they are solo-ingested (count = 1) **and** `number_of_opponents` is null.
- All three live per-source civics election models hardcode the column null (`techspeed:151`, `ballotready:90`, `ddhq:47`); only the 2025 HubSpot archive carries a value. Prod: only **6,260 / 482,309** elections (1.3%) have an opponent count.
- The count **already exists** in the TechSpeed source the model reads: `stg_airbyte_source__techspeed_gdrive_candidates.number_of_candidates` (clean integers 1–61, essentially fully populated). It was simply dropped at the projection.

## The fix

Replace the hardcoded null with `number_of_candidates - 1` (string, to match the BR/DDHQ/2025 models and the scorer's parsing). Notes:

- **Source choice:** the prior TechSpeed scorer (`int__techspeed_viability_scoring`) derived its opponent count from this same `number_of_candidates` field, not from HubSpot. Sourcing TechSpeed-native (vs. a new HubSpot `properties_number_of_opponents` join) keeps it durable — no dependency on a HubSpot property continuing to be populated — and adds no new join. The model already reads this staging table.
- **No fan-out:** the model's `representative_row` CTE already collapses to one row per election.
- **Surgical blast radius:** the scorer prefers path (A) whenever the per-election candidacy count is `> 1`, so populating `number_of_opponents` can only change rows where that count is `1` (the solo-ingested set). Full-model / no-incumbency / unscored buckets are computed from path (A) or unrelated features and are provably unaffected.
- **Propagation:** the `election` mart surfaces `number_of_opponents` via `coalesce(br, ts, ddhq)`; since BR/DDHQ stay null, the TS value survives the coalesce. No mart change needed.

## Scope (v1: TechSpeed only)

Of the fallback population, the TechSpeed-solo rows lost a count that **exists** in source — genuine, recoverable data loss, and ~99% of the old-vs-new downgraders. The remaining BR/DDHQ-solo rows have no analogous dropped count field (their candidate counts come from counting candidacy rows, which path (A) already uses); filling their hardcoded null would mean manufacturing data, not restoring it. BR/DDHQ left as a documented follow-up.

## Tests

- `assert_civics_election_techspeed_opponent_coverage_floor.sql` — regression guard; fails if the populated share drops below the floor (catches a revert to the hardcoded null, which sits at 0%).
- Well-formedness contract test on the column (`number_of_opponents` is null or a non-negative integer string).

## Validation (on CI preview, then prod)

- [ ] `number_of_opponents` populated on `int__civics_election_techspeed` (was 0%).
- [ ] The affected solo-ingested TechSpeed candidacies leave `viabilitynoopponentdata` (via `scoring_model` provenance) and their scores rise.
- [ ] DATA-1938 prod-validation gates still pass (`.tickets/DATA-1938/2026-06-24-prod-validation-queries.sql`): parity, 34-col fidelity, coverage non-regression, `lost_score = 0`.

This informs the DATA-1938 owner sign-off and the announcement: the ~16k downgrade is largely this fixable mapping gap, not a model reassessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inputs to the civics viability ML waterfall for solo-ingested TechSpeed candidacies; scope is limited to elections where per-election candidacy count is 1, but scores and `scoring_model` provenance will shift for that population.
> 
> **Overview**
> **DATA-1938:** `int__civics_election_techspeed` no longer hardcodes `number_of_opponents` as null. It now sets the field from TechSpeed `number_of_candidates - 1` (cast to string, null when invalid or &lt; 1).
> 
> That restores opponent data for **solo-ingested** TechSpeed races so `int__civics_viability_scoring` can use `log_n_losers` instead of routing those candidacies to the weaker `viabilitynoopponentdata` waterfall tier.
> 
> **Tests:** Column contract in `int__civics.yaml` (null or non-negative integer string) plus `assert_civics_election_techspeed_opponent_coverage_floor` (≥90% populated share, catches reverts or empty model).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f66f2b61f2f6a230e200a00686d39f7b857fd3b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->