### PR TITLE
Warn on isolated civics not_null orphans; error above 20

### DIFF
--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -165,7 +165,11 @@ models:
       - name: user_id
         description: Foreign key to user table - the user who owns this campaign
         data_tests:
-          - not_null
+          # A few orphaned user_ids (user deleted in product) are expected
+          - not_null:
+              config:
+                warn_if: ">0"
+                error_if: ">20"
 
       - name: user_email
         description: User's email address (primary contact)
@@ -347,7 +351,11 @@ models:
           Whether this organization is a Win (campaign) or Serve (elected office)
           organization.
         data_tests:
-          - not_null
+          # Orgs with no campaign or elected office (incomplete/abandoned) leave this null
+          - not_null:
+              config:
+                warn_if: ">0"
+                error_if: ">20"
           - accepted_values:
               arguments:
                 values: ["win", "serve"]
@@ -559,14 +567,7 @@ models:
         data_tests:
           - accepted_values:
               arguments:
-                values:
-                  [
-                    "Won",
-                    "Lost",
-                    "Runoff",
-                    "Withdrew",
-                    "Not on Ballot",
-                  ]
+                values: ["Won", "Lost", "Runoff", "Withdrew", "Not on Ballot"]
 
       - name: latest_stage_reached
         description: >
@@ -599,14 +600,7 @@ models:
         data_tests:
           - accepted_values:
               arguments:
-                values:
-                  [
-                    "Won",
-                    "Lost",
-                    "Runoff",
-                    "Withdrew",
-                    "Not on Ballot",
-                  ]
+                values: ["Won", "Lost", "Runoff", "Withdrew", "Not on Ballot"]
 
       - name: is_pledged
         description: >
@@ -1852,7 +1846,16 @@ models:
         data_tests:
           - accepted_values:
               arguments:
-                values: ["City", "Local", "County", "Township", "State", "Regional", "Federal"]
+                values:
+                  [
+                    "City",
+                    "Local",
+                    "County",
+                    "Township",
+                    "State",
+                    "Regional",
+                    "Federal",
+                  ]
               config:
                 severity: warn
 
@@ -1904,7 +1907,16 @@ models:
         data_tests:
           - accepted_values:
               arguments:
-                values: ["Independent", "Nonpartisan", "Democrat", "Republican", "Libertarian", "Green", "Other"]
+                values:
+                  [
+                    "Independent",
+                    "Nonpartisan",
+                    "Democrat",
+                    "Republican",
+                    "Libertarian",
+                    "Green",
+                    "Other",
+                  ]
               config:
                 severity: warn
 
@@ -2153,7 +2165,16 @@ models:
         data_tests:
           - accepted_values:
               arguments:
-                values: ["City", "Local", "County", "Township", "State", "Regional", "Federal"]
+                values:
+                  [
+                    "City",
+                    "Local",
+                    "County",
+                    "Township",
+                    "State",
+                    "Regional",
+                    "Federal",
+                  ]
               config:
                 severity: warn
 
@@ -2201,7 +2222,16 @@ models:
         data_tests:
           - accepted_values:
               arguments:
-                values: ["Independent", "Nonpartisan", "Democrat", "Republican", "Libertarian", "Green", "Other"]
+                values:
+                  [
+                    "Independent",
+                    "Nonpartisan",
+                    "Democrat",
+                    "Republican",
+                    "Libertarian",
+                    "Green",
+                    "Other",
+                  ]
               config:
                 severity: warn
 
@@ -2741,7 +2771,8 @@ models:
     data_tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
-            combination_of_columns: [state_postal_code, district_type, district_name]
+            combination_of_columns:
+              [state_postal_code, district_type, district_name]
     columns:
       - name: state_postal_code
         description: Two-letter state postal code, derived from the census geoid FIPS prefix (authoritative).


### PR DESCRIPTION
## Problem

Scheduled `dbt build` was failing on two civics not_null tests, each on exactly one real upstream row:

- `not_null_organizations_organization_type` — org `campaign-325541` has neither a campaign nor an elected office, so the `case` in `organizations.sql` returns null.
- `not_null_campaigns_user_id` — campaign `325586` references user `341540`, which was deleted in the product, so the left join to users yields null.

Both rows persist after fresh syncs (sources extracted same-day), so these are genuine product states, not sync lag. A resync will not clear them.

## Change

Set `warn_if: ">0"` / `error_if: ">20"` on both not_null tests in `m_civics.yaml`. A handful of these orphans is expected and now warns; a systemic break (>20) still errors. Scheduled builds go green while keeping the signal.

Verified locally: both tests now WARN at the current count of 1 instead of ERROR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema YAML and dbt test severity thresholds only; no SQL or runtime pipeline logic changes.
> 
> **Overview**
> Scheduled **`dbt build`** was failing on two **`m_civics.yaml`** **`not_null`** tests that each hit a single persistent upstream row (orphaned **`campaigns.user_id`** after a deleted user; null **`organizations.organization_type`** when an org has neither campaign nor elected office).
> 
> Those tests now use **`warn_if: ">0"`** and **`error_if: ">20"`**, with inline comments documenting why a small number of nulls is expected. Isolated product-data orphans warn instead of erroring; more than 20 still fails as a systemic break.
> 
> The rest of the diff is YAML-only: **`accepted_values`** lists and **`combination_of_columns`** are reformatted for readability—no semantic test changes there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e7598cf507f8b818f50f608e41dd5bbeb6e2af. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->