### PR TITLE
[DATA-1523] Add durable feed-invariant tests for reverse-ETL feeds

### DIFF
--- a/dbt/project/tests/assert_candidacy_hubspot_non_major_party.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_non_major_party.sql
@@ -1,0 +1,8 @@
+{{ config(tags=["feed_invariant", "sales_reverse_etl"]) }}
+-- DATA-1523 / DATA-2011 cutover guard (non-major-party).
+-- candidacy_hubspot must not include major-party candidates (inherited verbatim from
+-- the legacy
+-- feeds). Zero tolerance.
+select gp_candidacy_id
+from {{ ref("candidacy_hubspot") }}
+where `Party Affiliation` ilike '%democrat%' or `Party Affiliation` ilike '%republican%'

--- a/dbt/project/tests/assert_candidacy_hubspot_not_already_in_hubspot.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_not_already_in_hubspot.sql
@@ -1,0 +1,28 @@
+{{ config(tags=["feed_invariant", "sales_reverse_etl"]) }}
+-- DATA-1523 / DATA-2011 cutover guard (not-already-in-HubSpot anti-join).
+-- candidacy_hubspot must exclude anyone already in HubSpot by email, 10+digit phone, or
+-- br_candidacy_id. This guards the NOT EXISTS anti-join in candidacy_hubspot.sql
+-- against
+-- int__hubspot_contacts. Zero tolerance: any row is a duplicate lead re-uploaded to
+-- HubSpot.
+select h.gp_candidacy_id
+from {{ ref("candidacy_hubspot") }} as h
+where
+    exists (
+        select 1
+        from {{ ref("int__hubspot_contacts") }} as hs
+        where
+            (
+                nullif(trim(h.`Email`), '') is not null
+                and lower(trim(hs.email)) = lower(trim(h.`Email`))
+            )
+            or (
+                length(regexp_replace(h.`Phone Number`, '[^0-9]', '')) >= 10
+                and regexp_replace(hs.phone_number, '[^0-9]', '')
+                = regexp_replace(h.`Phone Number`, '[^0-9]', '')
+            )
+            or (
+                nullif(h.candidacy_id, '') is not null
+                and hs.br_candidacy_id = try_cast(h.candidacy_id as int)
+            )
+    )

--- a/dbt/project/tests/assert_candidacy_hubspot_usable_contact.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_usable_contact.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        severity="warn",
+        warn_if=">0",
+        error_if=">20",
+        tags=["feed_invariant", "sales_reverse_etl"],
+    )
+}}
+-- DATA-1523 / DATA-2011 guard (usable contact).
+-- Every candidacy_hubspot row should be reachable: a real email OR a 10+digit phone.
+-- The feed's
+-- eligibility currently accepts ANY non-empty phone (the >=10-digit check only gates
+-- the anti-join),
+-- so a sub-10-digit phone with no email is an unusable lead. Known small edge today;
+-- warn on any,
+-- error on a material regression. Tightening feed eligibility would let this go to
+-- strict error.
+select gp_candidacy_id
+from {{ ref("candidacy_hubspot") }}
+where
+    nullif(trim(`Email`), '') is null
+    and (
+        nullif(regexp_replace(`Phone Number`, '[^0-9]', ''), '') is null
+        or length(regexp_replace(`Phone Number`, '[^0-9]', '')) < 10
+    )

--- a/dbt/project/tests/assert_candidacy_hubspot_within_window.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_within_window.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        severity="warn",
+        warn_if=">0",
+        error_if=">20",
+        tags=["feed_invariant", "sales_reverse_etl"],
+    )
+}}
+-- DATA-1523 / DATA-2011 cutover guard (30-day rolling window).
+-- candidacy_hubspot keeps candidacies active in the last 30 days on
+-- greatest(created_at, updated_at).
+-- A few boundary rows can appear between the model build and the test run, so warn on
+-- any and error
+-- only on a material breach (a removed/broken window predicate).
+select gp_candidacy_id
+from {{ ref("candidacy_hubspot") }}
+where last_activity_at < current_date() - interval 30 day

--- a/dbt/project/tests/assert_candidacy_techspeed_cost_guard.sql
+++ b/dbt/project/tests/assert_candidacy_techspeed_cost_guard.sql
@@ -1,0 +1,12 @@
+{{ config(tags=["feed_invariant", "sales_reverse_etl"]) }}
+-- DATA-1523 / DATA-2011 cutover guard (paid-enrichment cost guard).
+-- The TechSpeed enrichment feed must NEVER include a candidacy TechSpeed already knows
+-- (source_systems contains 'techspeed'); re-sending is paid re-enrichment. This
+-- guards the
+-- `AND NOT array_contains(cy.source_systems, 'techspeed')` predicate in
+-- candidacy_techspeed.sql.
+-- Zero tolerance: any row here is real money wasted.
+select t.gp_candidacy_id
+from {{ ref("candidacy_techspeed") }} as t
+join {{ ref("candidacy") }} as c on t.gp_candidacy_id = c.gp_candidacy_id
+where array_contains(c.source_systems, 'techspeed')


### PR DESCRIPTION
## What

Adds 5 durable dbt singular tests guarding the invariants of the new candidate-export feeds
(`candidacy_hubspot`, `candidacy_techspeed`), so the guarantees verified in the one-off old-vs-new
pipeline review become standing regression protection.

## Why

The DATA-2011 cutover moved the HubSpot + TechSpeed export feeds onto the civics pipeline. A
pre-announcement old-vs-new review confirmed the feeds are correct (zero genuine dropped leads on
both email and phone keys; all sendable filters clean; every announcement claim substantiated). An
independent Codex review found no data defect but flagged that the invariants were only checked by
one-off queries, not durable tests — a gap before the legacy marts are deleted (DATA-2012). These
tests close that gap so the deletion is safe.

## Tests

| Test | Guards | Severity |
|---|---|---|
| `assert_candidacy_techspeed_cost_guard` | TS feed never re-sends techspeed-known candidacies (paid re-enrichment) | error on any |
| `assert_candidacy_hubspot_not_already_in_hubspot` | HS feed excludes existing HubSpot contacts (email / 10+digit phone / br_candidacy_id) | error on any |
| `assert_candidacy_hubspot_non_major_party` | HS feed excludes major-party | error on any |
| `assert_candidacy_hubspot_within_window` | 30-day rolling window | warn>0, error>20 |
| `assert_candidacy_hubspot_usable_contact` | reachable by email OR 10+digit phone | warn>0, error>20 |

The warn/error thresholds on the last two match the repo's existing "warn on a few, error above N"
pattern; the boundary tolerance avoids false failures on rolling-window edge rows and the one known
loose-phone-eligibility row.

Score/label consistency is intentionally **not** re-tested here — it is already guarded upstream by
`candidacy_scored_score_label_consistent`, and `candidacy_hubspot` passes those columns through
unchanged; a re-derived copy would risk false positives on gap-filled rows.

## Current prod state (from the review)

First three tests return 0; window 0; usable-contact 1 (a single row with a sub-10-digit phone and
no email — the test warns, does not fail). Optional follow-up: tighten feed eligibility to
`length(digits(phone)) >= 10 OR email present`, then promote `usable_contact` to strict error.

## Verification

Local dbt is Fusion (cannot build); these invariants were verified against prod data via SQL during
the review, and will be confirmed on this PR's CI preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no changes to feed models or production export logic; failures would surface regressions before legacy mart deletion.
> 
> **Overview**
> Adds **five dbt singular tests** tagged `feed_invariant` / `sales_reverse_etl` so DATA-2011 cutover guarantees for `candidacy_hubspot` and `candidacy_techspeed` are enforced in CI instead of one-off review SQL.
> 
> **Strict (fail on any row):** TechSpeed must not re-send candidacies already in `source_systems` with `techspeed` (paid re-enrichment). HubSpot export must exclude major-party affiliations, and must not include contacts that already exist in `int__hubspot_contacts` by email, normalized 10+ digit phone, or `br_candidacy_id`.
> 
> **Graduated:** Rolling **30-day** activity window (`last_activity_at`) and **usable contact** (email or 10+ digit phone) use `warn_if=">0"` and `error_if=">20"` to tolerate boundary timing and the known single loose-phone edge without blocking on minor noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff091d631f041320935fa2aeb46976ff7965ac2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->