### PR TITLE
[DATA-2063] Codify active serve users as a gold mart model

### DIFF
--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -580,6 +580,31 @@ models:
           arguments:
             expression: "last_activity_at >= first_activity_at"
 
+  - name: users_serve_active
+    description: >
+      Canonical gold-layer membership table for "active serve users" (epic
+      DATA-1359): one row per user who completed Serve onboarding by sending
+      an SMS poll AND has pledged. Thin projection of int__serve_active_user,
+      which owns the definition; exists so dashboards read the definition
+      from a gold schema (Sigma is losing staging/intermediate access).
+
+      Grain: one row per user_id, active serve users only — joining this
+      model IS the active-user filter.
+
+      For component flags and correct funnel denominators over all users,
+      use users_serve_base (same upstream definition). For the "empowered
+      elected officials" dashboard cohort, join users_win_candidacy and
+      apply icp_office_serve and the internal-email exclusion there.
+
+    columns:
+      - name: user_id
+        description: >
+          Product-DB user id (primary key). Joins to users_serve_base.user_id,
+          users_win_candidacy.user_id, and mart_civics.users.user_id.
+        data_tests:
+          - unique
+          - not_null
+
   - name: users_serve_base
     description: >
       User-grain snapshot for Serve product metrics and onboarding funnel.

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -582,7 +582,7 @@ models:
 
   - name: users_serve_active
     description: >
-      Canonical gold-layer membership table for "active serve users" (epic
+      Canonical gold-layer membership view for "active serve users" (epic
       DATA-1359): one row per user who completed Serve onboarding by sending
       an SMS poll AND has pledged. Thin projection of int__serve_active_user,
       which owns the definition; exists so dashboards read the definition

--- a/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
@@ -55,9 +55,11 @@ metrics:
     description: >
       Count of active serve users: completed Serve onboarding by sending an
       SMS poll AND pledged. Definition owned by int__serve_active_user,
-      surfaced through users_serve_base; the gold membership table
+      surfaced through users_serve_base; the gold membership view
       users_serve_active exposes the same population for direct dashboard
-      reads.
+      reads. Time series bucket by onboarding-completion date (the metric's
+      aggregation time is first_sms_poll_sent_at), not by pledge or account
+      registration date.
     type: simple
     type_params:
       measure: active_serve_user_count

--- a/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
@@ -9,14 +9,19 @@ semantic_models:
       the columns.
     model: ref('users_serve_base')
     defaults:
-      agg_time_dimension: registered_at
+      agg_time_dimension: first_sms_poll_sent_at
     entities:
       - name: user
         type: primary
         expr: user_id
     dimensions:
-      - name: registered_at
-        description: When the user account was created.
+      # Serve-native aggregation time. Not registered_at: MetricFlow requires a
+      # (primary entity, dimension) pairing to be unique across semantic models,
+      # and user__registered_at is already owned by users_win. Every user who
+      # contributes to the active count has this timestamp (sending the SMS poll
+      # is a component of the definition).
+      - name: first_sms_poll_sent_at
+        description: When the user completed Serve onboarding by sending their first SMS poll.
         type: time
         type_params:
           time_granularity: day

--- a/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
@@ -1,0 +1,58 @@
+semantic_models:
+  - name: users_serve
+    description: >
+      Semantic model over the users_serve_base mart. One row per user (the
+      mart keeps all users so funnel denominators stay correct). Surfaces
+      the governed Serve engagement flags as dimensions. The flag
+      *definitions* are owned by users_serve_base and its upstreams (the
+      active-user flag by int__serve_active_user); this model only exposes
+      the columns.
+    model: ref('users_serve_base')
+    defaults:
+      agg_time_dimension: registered_at
+    entities:
+      - name: user
+        type: primary
+        expr: user_id
+    dimensions:
+      - name: registered_at
+        description: When the user account was created.
+        type: time
+        type_params:
+          time_granularity: day
+      # Governed flags surfaced straight from the mart (definition lives there).
+      - name: is_serve_user
+        description: Serve product user (completed a poll through an elected office).
+        type: categorical
+      - name: is_active_eo
+        description: Viewed the Serve polls dashboard in the trailing 30 days.
+        type: categorical
+      - name: has_sent_sms_poll
+        description: Completed Serve onboarding by sending an SMS poll.
+        type: categorical
+      - name: has_pledged
+        description: Owns at least one pledged campaign.
+        type: categorical
+      - name: is_active_serve_user
+        description: >
+          Active serve user (sent an SMS poll AND pledged) — the behavioral
+          gate of the People Served active cohort.
+        type: categorical
+    measures:
+      - name: active_serve_user_count
+        description: Count of active serve users (sent an SMS poll AND pledged).
+        agg: sum
+        expr: "case when is_active_serve_user then 1 else 0 end"
+
+metrics:
+  - name: active_serve_users
+    label: Active Serve Users
+    description: >
+      Count of active serve users: completed Serve onboarding by sending an
+      SMS poll AND pledged. Definition owned by int__serve_active_user,
+      surfaced through users_serve_base; the gold membership table
+      users_serve_active exposes the same population for direct dashboard
+      reads.
+    type: simple
+    type_params:
+      measure: active_serve_user_count

--- a/dbt/project/models/marts/analytics/users_serve_active.sql
+++ b/dbt/project/models/marts/analytics/users_serve_active.sql
@@ -3,7 +3,7 @@
 /*
     mart_analytics.users_serve_active
 
-    Canonical gold-layer membership table for "active serve users" (epic
+    Canonical gold-layer membership view for "active serve users" (epic
     DATA-1359): one row per user who completed Serve onboarding by sending an
     SMS poll AND has pledged. A thin projection of int__serve_active_user,
     which owns the definition — no logic lives here, so this mart cannot

--- a/dbt/project/models/marts/analytics/users_serve_active.sql
+++ b/dbt/project/models/marts/analytics/users_serve_active.sql
@@ -1,0 +1,27 @@
+{{ config(materialized="view") }}
+
+/*
+    mart_analytics.users_serve_active
+
+    Canonical gold-layer membership table for "active serve users" (epic
+    DATA-1359): one row per user who completed Serve onboarding by sending an
+    SMS poll AND has pledged. A thin projection of int__serve_active_user,
+    which owns the definition — no logic lives here, so this mart cannot
+    drift from the single source of truth.
+
+    Exists so dashboards read the definition from a gold schema instead of
+    re-deriving it from staging/intermediate tables (Sigma is losing access
+    to those schemas, and business logic belongs in dbt, not dashboard SQL).
+
+    Grain: one row per user_id, active serve users only — joining this model
+    IS the active-user filter.
+
+    Related surfaces: users_serve_base carries the component flags
+    (has_sent_sms_poll, has_pledged, is_active_serve_user) over ALL users for
+    funnel denominators. For the "empowered elected officials" dashboard
+    cohort, join users_win_candidacy and apply icp_office_serve and the
+    internal-email exclusion there.
+*/
+select user_id
+from {{ ref("int__serve_active_user") }}
+where is_active_serve_user


### PR DESCRIPTION
## What

Adds `users_serve_active` (mart_analytics): the canonical gold-layer membership table for "active serve users" — one row per user who completed Serve onboarding by sending an SMS poll AND has pledged. It is a thin, filtered projection of `int__serve_active_user`, which owns the definition (DATA-1359). Also adds a `users_serve` semantic model + `active_serve_users` metric (mirror of `sem_analytics__users_win.yml`), so the count exists in the metric layer as well.

Why now: the dashboard tool is about to lose access to staging/intermediate schemas, and the active-user definition is currently re-derived in dashboard SQL that mixes mart + staging + intermediate tables. This gives dashboards one gold-schema source of truth; the analytics owner repoints the dashboard query after this lands (handoff note prepared separately).

## Why it is safe

- Purely additive: no existing model changes. The resolver (`int__serve_district_resolution`) and `users_serve_base` keep reading the intermediate, exactly as before — no dependency cycle.
- The model body is a projection with a flag filter; it cannot express a second definition of "active", so it cannot drift from the intermediate.
- View materialization (like `users_serve_base`): zero-copy over the intermediate table, always consistent within a build.
- The semantic model only exposes existing `users_serve_base` columns; the measure is a case-when count over the governed flag.
- Definitional note: the model's pledge notion is "any pledged campaign" (owned by `int__serve_active_user`, proven equivalent to the dashboard's latest-candidacy pledge on this cohort with zero membership delta). The model is canonical going forward.
- Access-model assumption for the DE lead: Unity Catalog views read underlying tables with owner rights, so the dashboard principal needs SELECT only on `mart_analytics` (same mechanism `users_serve_base` relies on today). Flagging explicitly since the Sigma schema-access cut is the motivation — please confirm the dashboard principal retains `mart_analytics` SELECT under the new grants.

## Review and verification

- Independent adversarial review (a different model) was run on the implementation plan; its findings (prod-gate before the dashboard handoff, metric verification beyond YAML parse, YAML anchor placement) are incorporated. A diff-level pass runs after CI builds.
- After the CI preview builds, these checks will be posted below: membership parity (preview view vs prod intermediate, exact match expected), dashboard-cohort reconciliation (rewritten mart-only query vs the current staging-based dashboard query, anti-join both directions, zero diff expected), and metric-expression equivalence (case-when count over `users_serve_base` == membership count).
- dbt tests: `unique` + `not_null` on `user_id`.

Refs DATA-1359, DATA-2063 (https://app.clickup.com/t/86ajb360m). Related: #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics views and YAML only; definition stays in `int__serve_active_user`, so no change to upstream business logic or existing marts.
> 
> **Overview**
> Adds **`users_serve_active`** in `mart_analytics`: a view that lists one `user_id` per **active serve user** (SMS poll sent **and** pledged), by filtering `int__serve_active_user`—so dashboards can use gold schema only instead of re-deriving the rule from staging/intermediate SQL as Sigma loses those grants.
> 
> Also adds **`sem_analytics__users_serve.yml`**: a semantic model on `users_serve_base` with Serve engagement dimensions and the **`active_serve_users`** metric (sum of `is_active_serve_user`), aligned with the Win semantic-layer pattern.
> 
> **`m_analytics.yaml`** documents the new mart (`unique` / `not_null` on `user_id`) and how it relates to `users_serve_base` and `users_win_candidacy` for funnel vs empowered-EO cohorts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5139e9fc6c0db31e4612a2297684ea99537c519. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->