### PR TITLE
[DATA-2055] Widen election-api race date window to 2-month grace period

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -133,9 +133,9 @@ left join
 where
     tbl_race.place_id in (select id from {{ ref("m_election_api__place") }})
     -- 2-month grace period keeps recently-passed races serveable (the campaign
-    -- plan reads races after election day). Keep anchored to the same bounds as
+    -- plan reads races after election day). Keep the lower bound in sync with
     -- the race filter in write__election_api_db.py, which otherwise re-narrows
-    -- this window (boundary-day membership differs: between vs strict >)
+    -- this window
     and tbl_race.election_date
     between current_date() - interval '2 months' and current_date() + interval '2 years'
     -- Race -> Position -> District -> ProjectedTurnout is the chain the API

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -42,8 +42,9 @@ with
     -- election cycle. win_number is carried here too but has no live source:
     -- BallotReady supplies no win number, and the only values that exist come
     -- from the 2023-2025 HubSpot archive (int__civics_candidacy_2025), whose
-    -- past elections fall outside this mart's forward-looking date filter, so
-    -- win_number is null for every row this mart emits, and consumers fall back
+    -- past elections fall well outside this mart's date window (a 2-month
+    -- grace period at the oldest), so win_number is null for every row this
+    -- mart emits, and consumers fall back
     -- to a computed estimate. Aggregate with any non-null value; downstream Race
     -- rows that share a gp_election_id (i.e. multiple BR race stages for the
     -- same election cycle) will all carry the same values.
@@ -132,8 +133,9 @@ left join
 where
     tbl_race.place_id in (select id from {{ ref("m_election_api__place") }})
     -- 2-month grace period keeps recently-passed races serveable (the campaign
-    -- plan reads races after election day); must match the race filter in
-    -- write__election_api_db.py, which otherwise re-narrows this window
+    -- plan reads races after election day). Keep anchored to the same bounds as
+    -- the race filter in write__election_api_db.py, which otherwise re-narrows
+    -- this window (boundary-day membership differs: between vs strict >)
     and tbl_race.election_date
     between current_date() - interval '2 months' and current_date() + interval '2 years'
     -- Race -> Position -> District -> ProjectedTurnout is the chain the API

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -131,8 +131,11 @@ left join
     on tbl_race.br_database_id = filing_overrides.br_database_id
 where
     tbl_race.place_id in (select id from {{ ref("m_election_api__place") }})
+    -- 2-month grace period keeps recently-passed races serveable (the campaign
+    -- plan reads races after election day); must match the race filter in
+    -- write__election_api_db.py, which otherwise re-narrows this window
     and tbl_race.election_date
-    between current_date() - interval '1 day' and current_date() + interval '2 years'
+    between current_date() - interval '2 months' and current_date() + interval '2 years'
     -- Race -> Position -> District -> ProjectedTurnout is the chain the API
     -- depends on; a Race with no matching Position can't serve the
     -- campaign-strategy-context endpoint (no projected_turnout, no district

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -570,11 +570,11 @@ def model(dbt, session: SparkSession) -> DataFrame:
     position_df: DataFrame = dbt.ref("m_election_api__position")
     projected_turnout_df: DataFrame = dbt.ref("m_election_api__projected_turnout")
 
-    # keep races from a 2-month post-election grace period through ~2 years out.
-    # Keep anchored to the same bounds as the m_election_api__race window, which
-    # this otherwise re-narrows (boundary-day membership differs: strict > here)
+    # keep races from a 2-month post-election grace period through ~2 years out;
+    # the lower bound matches the m_election_api__race window exactly (keep them
+    # in sync, or this filter re-narrows what the mart emits)
     race_df = race_df.filter(
-        (race_df.election_date > add_months(current_date(), -2))
+        (race_df.election_date >= add_months(current_date(), -2))
         & (race_df.election_date < date_add(current_date(), 2 * 365))
     )
 

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import psycopg2
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.functions import current_date, date_add, date_sub
+from pyspark.sql.functions import add_months, current_date, date_add
 from pyspark.sql.types import (
     IntegerType,
     StringType,
@@ -570,9 +570,10 @@ def model(dbt, session: SparkSession) -> DataFrame:
     position_df: DataFrame = dbt.ref("m_election_api__position")
     projected_turnout_df: DataFrame = dbt.ref("m_election_api__projected_turnout")
 
-    # filter the race dataframe to only include races that are within 1 day of the current date and 2 years from the current date
+    # keep races from a 2-month post-election grace period through 2 years out;
+    # must match the date window in m_election_api__race, which this re-narrows otherwise
     race_df = race_df.filter(
-        (race_df.election_date > date_sub(current_date(), 1))
+        (race_df.election_date > add_months(current_date(), -2))
         & (race_df.election_date < date_add(current_date(), 2 * 365))
     )
 
@@ -687,7 +688,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
             db_schema=db_schema,
         )
 
-    # for the race db, drop rows that have `election_date` more than 1 day ago
+    # for the race db, drop rows with `election_date` more than 2 years past
     _execute_sql_query(
         f"DELETE FROM {db_schema}.\"Race\" WHERE election_date < current_date - interval '2 years'",
         db_host,

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -570,8 +570,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
     position_df: DataFrame = dbt.ref("m_election_api__position")
     projected_turnout_df: DataFrame = dbt.ref("m_election_api__projected_turnout")
 
-    # keep races from a 2-month post-election grace period through 2 years out;
-    # must match the date window in m_election_api__race, which this re-narrows otherwise
+    # keep races from a 2-month post-election grace period through ~2 years out.
+    # Keep anchored to the same bounds as the m_election_api__race window, which
+    # this otherwise re-narrows (boundary-day membership differs: strict > here)
     race_df = race_df.filter(
         (race_df.election_date > add_months(current_date(), -2))
         & (race_df.election_date < date_add(current_date(), 2 * 365))

--- a/dbt/project/tests/assert_election_api_race_retains_recent_past_races.sql
+++ b/dbt/project/tests/assert_election_api_race_retains_recent_past_races.sql
@@ -1,0 +1,8 @@
+-- The race mart must keep recently-passed races (2-month grace period):
+-- the campaign plan reads races after election day, so a future-only
+-- window breaks it the morning after an election. Local elections run
+-- year-round, so an empty past-race set means the window regressed.
+select count(*) as past_race_count
+from {{ ref("m_election_api__race") }}
+where election_date < current_date()
+having count(*) = 0

--- a/dbt/project/tests/assert_election_api_race_retains_recent_past_races.sql
+++ b/dbt/project/tests/assert_election_api_race_retains_recent_past_races.sql
@@ -1,8 +1,26 @@
--- The race mart must keep recently-passed races (2-month grace period):
--- the campaign plan reads races after election day, so a future-only
--- window breaks it the morning after an election. Local elections run
--- year-round, so an empty past-race set means the window regressed.
-select count(*) as past_race_count
-from {{ ref("m_election_api__race") }}
-where election_date < current_date()
-having count(*) = 0
+-- Every upstream race inside the 2-month grace period that passes the mart's
+-- other gates (place retained, position matched) must stay in
+-- m_election_api__race: the campaign plan reads races after election day, so
+-- dropping them breaks it the morning after an election. Both window edges
+-- are padded by a day to absorb build-vs-test-time date skew.
+with
+    eligible as (
+        select tbl_race.br_database_id
+        from {{ ref("int__enhanced_race") }} as tbl_race
+        where
+            tbl_race.br_database_id is not null
+            and tbl_race.election_date
+            between current_date()
+            - interval '2 months'
+            + interval '1 day' and current_date()
+            - interval '1 day'
+            and tbl_race.place_id in (select id from {{ ref("m_election_api__place") }})
+            and tbl_race.br_position_database_id
+            in (select br_database_id from {{ ref("m_election_api__position") }})
+    )
+select eligible.br_database_id
+from eligible
+left join
+    {{ ref("m_election_api__race") }} as tbl_mart
+    on eligible.br_database_id = tbl_mart.br_database_id
+where tbl_mart.br_database_id is null

--- a/dbt/project/tests/mart_election_api_race_win_number_estimate_coverage_warn.sql
+++ b/dbt/project/tests/mart_election_api_race_win_number_estimate_coverage_warn.sql
@@ -8,8 +8,8 @@
 
 -- win_number is structurally null on the election_api race mart: BallotReady
 -- supplies no win number, and the only values that ever existed are HubSpot
--- archive rows for 2023-2025 elections, which the mart's forward-looking date
--- filter excludes. So the win_number_effective the campaign-strategy-context
+-- archive rows for 2023-2025 elections, which the mart's date window
+-- excludes. So the win_number_effective the campaign-strategy-context
 -- endpoint serves is always win_number_estimate, and that estimate is null
 -- whenever a race has no positive Projected_Turnout for its election year.
 --
@@ -37,7 +37,11 @@ with
         left join
             {{ ref("m_election_api__position") }} as tbl_position
             on tbl_race.position_id = tbl_position.id
-        where tbl_position.district_id is not null
+        where
+            tbl_position.district_id is not null
+            -- the mart retains a 2-month grace window of recently-passed races;
+            -- keep this metric scoped to upcoming races as documented above
+            and tbl_race.election_date >= current_date()
     ),
 
     projected_turnout as (


### PR DESCRIPTION
## Summary

The election-api Race table loses a race the day after its election date because both dbt-side date filters only kept races from 1 day in the past forward. Campaign plan sections look a race up by `br_hash_id` with no date filter, so the lookup 404s the morning after an election (DATA-2055). Decision on the ticket: widen the lower bound to a 2-month grace period.

- `m_election_api__race.sql`: lower bound of the `election_date` window is now `current_date() - interval '2 months'` (was `- interval '1 day'`). Upper bound unchanged at 2 years out.
- `write__election_api_db.py`: race filter lower bound is now `add_months(current_date(), -2)` (was `date_sub(current_date(), 1)`). `add_months` keeps the lower bound on the same calendar-month arithmetic as the SQL interval rather than a day-count approximation. The lower bound is inclusive (`>=`), matching the mart's `between` exactly (tightened after review; the first revision used strict `>`). The writer's upper bound keeps its pre-existing 730-day cap vs the mart's calendar 2 years, harmless because the writer never deletes inside the 2-year retention. Comments in both files say to keep the lower bounds in sync.
- The 2-year retention DELETE is untouched; only its stale comment (which still said 1 day) is corrected.

election-api itself needs no change: it does not date-filter races by default, and the zip/onboarding search already defaults `electionDateFrom` to today app-side, so past races will not surface there.

## Tests

- New singular test `assert_election_api_race_retains_recent_past_races`: every upstream race inside the grace window that passes the mart's other gates (place retained, position matched) must be retained. This fails loudly if the window is ever re-narrowed, and passes vacuously if the upstream population is legitimately empty. Window edges padded a day against build-vs-test-time date skew.
- `mart_election_api_race_win_number_estimate_coverage_warn` now scopes explicitly to upcoming races. Its documented metric was always "upcoming races"; before this PR the mart window guaranteed that implicitly. The explicit filter keeps the metric and its 15/25 percent thresholds meaning the same thing after the widen.

## Verification (PR preview schema)

- Confirm the 11 known recently-passed races (May/June 2026 election dates) appear in the preview `m_election_api__race` by `br_database_id`.
- Confirm the row-count delta vs prod is bounded: recently-passed races added, no change to future rows.

Results will be posted as a PR comment after the CI build.

## Observation for a follow-up ticket (not changed here)

The writer's incremental `updated_at` gate is currently a no-op: the filtered dataframe inside the watermark loop is discarded (`df = df.filter(...)` rebinds only the loop-local name; the load loop uses the original dataframes). Every run therefore writes the full window, which is why no one-time backfill is needed after this merge: the missing recently-passed races reappear on the first prod run. Worth noting before anyone "fixes" that gate: activating it would skip rows whose BallotReady `updated_at` predates the Postgres watermark, exactly the backlog this PR recovers, so it needs a deliberate design pass rather than a drive-by repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
