### PR TITLE
[DATA-2056] Disambiguate election-api place slug collisions

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -172,6 +172,17 @@ models:
         tests:
           - not_null
           - unique
+      - name: source_updated_at
+        description: >
+          Un-bumped source updated_at, carried separately from updated_at so
+          the model's incremental watermark stays in the source-time domain.
+          updated_at is bumped to wall-clock when a row is new to the mart or
+          its slug changed (the election-api write model's publish gate);
+          gating ingestion on those bumped values would skip later source
+          updates whose BallotReady stamps lag wall-clock. Not published to
+          election-api (the writer's Place upsert selects explicit columns).
+        tests:
+          - not_null
 
   - name: m_election_api__position
     description: "Mart model that serves the Election API"

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -150,7 +150,13 @@ models:
           - unique
           - is_uuid
       - name: slug
-        description: "Slug of the place"
+        description: >
+          URL slug of the place, globally unique (election-api Place.slug is
+          a unique routing key). When distinct geographies share a raw slug
+          (e.g. a city and a same-named school district), one canonical owner
+          keeps the clean slug — an incorporated place (mtfcc G4110) wins,
+          otherwise the latest-updated row — and every other member carries a
+          deterministic '-<geoid>' suffix instead of being dropped.
         tests:
           - not_null
           - unique
@@ -300,6 +306,28 @@ models:
               arguments:
                 to: ref('int__enhanced_race')
                 field: br_database_id
+      - name: place_id
+        description: >
+          UUID of the place the race belongs to. Foreign key to
+          m_election_api__place: the race mart inner-joins the place mart, so
+          every emitted race resolves to a served place (races whose place is
+          not served are dropped rather than shipped with a dangling FK).
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('m_election_api__place')
+                field: id
+      - name: slug
+        description: >
+          Race slug, <place slug>/<position slug>, built from the
+          disambiguated m_election_api__place slug so it always extends the
+          place slug election-api serves. Indexed but not unique in
+          election-api; the place slug is the unique routing key. Consistency
+          with the place slug is guarded by
+          assert_race_slug_prefix_matches_place_slug.
+        tests:
+          - not_null
       - name: position_id
         description: >
           UUID of the BallotReady position the race is for. Foreign key to

--- a/dbt/project/models/marts/election_api/m_election_api__place.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__place.sql
@@ -3,6 +3,7 @@
         materialized="incremental",
         incremental_strategy="merge",
         unique_key="id",
+        on_schema_change="append_new_columns",
         auto_liquid_cluster=true,
     )
 }}
@@ -129,12 +130,23 @@ select
     tbl_place.income_household_median,
     tbl_place.unemployment_rate,
     tbl_place.home_value,
-    tbl_place.parent_id
+    tbl_place.parent_id,
+    -- The un-bumped source timestamp, kept separate so the incremental
+    -- watermark below stays in the source-time domain: bumped updated_at
+    -- values are wall-clock (ahead of BallotReady's event-time stamps by
+    -- days), and gating on them would silently skip later source updates
+    -- whose stamps land inside that gap. Not published: the election-api
+    -- writer's Place upsert selects its columns explicitly.
+    tbl_place.updated_at as source_updated_at
 from slug_disambiguated as tbl_place
 {% if is_incremental() %}
     left join {{ this }} as tbl_prev on tbl_place.id = tbl_prev.id
     where
         tbl_prev.id is null
         or tbl_place.slug <> tbl_prev.slug
-        or tbl_place.updated_at > (select max(updated_at) from {{ this }})
+        -- Per-row coalesce: rows written before source_updated_at existed
+        -- carry their (never-bumped) updated_at; bumped rows contribute
+        -- their source stamp, not the wall-clock bump.
+        or tbl_place.updated_at
+        > (select max(coalesce(source_updated_at, updated_at)) from {{ this }})
 {% endif %}

--- a/dbt/project/models/marts/election_api/m_election_api__place.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__place.sql
@@ -82,17 +82,18 @@ with
     -- points at them. Instead, keep one canonical owner on the clean slug
     -- and give every other member a deterministic, stable '-<geoid>' suffix.
     -- Ownership: an incorporated place (mtfcc G4110) wins its slug (the
-    -- place-page URL a user expects); collisions with no incorporated place
-    -- keep the previous winner (latest updated_at) so already-published
-    -- slugs do not churn.
+    -- place-page URL a user expects); all other ties break on the immutable
+    -- id, so ownership never drifts when BallotReady re-touches a member
+    -- (updated_at is a sync timestamp, not a claim to the slug). One-time
+    -- rollout consequence: a contested slug's canonical owner may differ
+    -- from the previously published winner.
     slug_disambiguated as (
         select
             * except (slug),
             case
                 when
                     row_number() over (
-                        partition by slug
-                        order by (mtfcc = 'G4110') desc, updated_at desc, id
+                        partition by slug order by (mtfcc = 'G4110') desc, id
                     )
                     = 1
                 then slug

--- a/dbt/project/models/marts/election_api/m_election_api__place.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__place.sql
@@ -26,6 +26,10 @@ with
         from {{ ref("int__enhanced_place_w_parent") }} as tbl_parent
         where tbl_parent.id in (select grandparent_id from grandparent_ids)
     ),
+    -- The full place universe, deliberately not incremental-sliced: slug
+    -- ownership below is a global property of the universe, so it must be
+    -- recomputed over all rows every run. The incremental filter is applied
+    -- to the outcome instead (see the final select).
     enriched_place_and_lineage as (
         select
             tbl_place.id,
@@ -57,41 +61,80 @@ with
                 or tbl_place.id
                 in (select greatgrandparent_id from greatgrandparent_ids)
             )
-            {% if is_incremental() %}
-                and tbl_place.updated_at > (select max(updated_at) from {{ this }})
-            {% endif %}
     ),
-    deduped_by_slug as (
+    -- One row per geography: the upstream place-with-parent model can carry a
+    -- geoid more than once (e.g. fanned out across parent rows). The old
+    -- slug-level dedup collapsed those incidentally; keep that guarantee
+    -- explicit now that slug-collision losers are no longer dropped.
+    deduped_by_geoid as (
         select *
         from enriched_place_and_lineage
-        qualify row_number() over (partition by slug order by updated_at desc) = 1
-    )
-/* may need to also remove parents of the removed places
-    parent_of_removed_places as (
+        qualify
+            row_number() over (
+                partition by geoid order by updated_at desc, id, parent_id
+            )
+            = 1
+    ),
+    -- Distinct geographies can share a slug (e.g. a city and a same-named
+    -- school district). election-api requires Place.slug to be globally
+    -- unique, but dropping the collision losers orphans every race that
+    -- points at them. Instead, keep one canonical owner on the clean slug
+    -- and give every other member a deterministic, stable '-<geoid>' suffix.
+    -- Ownership: an incorporated place (mtfcc G4110) wins its slug (the
+    -- place-page URL a user expects); collisions with no incorporated place
+    -- keep the previous winner (latest updated_at) so already-published
+    -- slugs do not churn.
+    slug_disambiguated as (
         select
-            parent_id
-        from enriched_place_and_lineage
-        qualify row_number() over (partition by parent_id order by updated_at desc) = 1
+            * except (slug),
+            case
+                when
+                    row_number() over (
+                        partition by slug
+                        order by (mtfcc = 'G4110') desc, updated_at desc, id
+                    )
+                    = 1
+                then slug
+                else concat(slug, '-', geoid)
+            end as slug
+        from deduped_by_geoid
     )
-    and add to the final select statement:
-    where id not in (select parent_id from parent_of_removed_places)
-    */
+
 select
-    id,
-    created_at,
-    updated_at,
-    br_database_id,
-    name,
-    slug,
-    geoid,
-    mtfcc,
-    state,
-    city_largest,
-    county_name,
-    population,
-    density,
-    income_household_median,
-    unemployment_rate,
-    home_value,
-    parent_id
-from deduped_by_slug
+    tbl_place.id,
+    tbl_place.created_at,
+    -- Bump updated_at when a row is new to the mart or its slug changed, so
+    -- the election-api write model's incremental filter (updated_at greater
+    -- than the postgres max) actually publishes it: recovered collision
+    -- losers and re-slugged rows keep a source updated_at that predates the
+    -- watermark and would otherwise never land.
+    {% if is_incremental() %}
+        case
+            when tbl_prev.id is null or tbl_place.slug <> tbl_prev.slug
+            then current_timestamp()
+            else tbl_place.updated_at
+        end as updated_at,
+    {% else %} tbl_place.updated_at,
+    {% endif %}
+    tbl_place.br_database_id,
+    tbl_place.name,
+    tbl_place.slug,
+    tbl_place.geoid,
+    tbl_place.mtfcc,
+    tbl_place.state,
+    tbl_place.city_largest,
+    tbl_place.county_name,
+    tbl_place.population,
+    tbl_place.density,
+    tbl_place.income_household_median,
+    tbl_place.unemployment_rate,
+    tbl_place.home_value,
+    tbl_place.parent_id
+from slug_disambiguated as tbl_place
+{% if is_incremental() %}
+    left join {{ this }} as tbl_prev on tbl_place.id = tbl_prev.id
+    where
+        tbl_prev.id is null
+        or tbl_place.slug <> tbl_prev.slug
+        or tbl_place.updated_at > (select max(updated_at) from {{ this }})
+{% endif %}

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -64,11 +64,15 @@ with
 select
     tbl_race.id,
     tbl_race.created_at,
-    -- Bump updated_at when a filing-address override applies so the election-api
-    -- write model's incremental upsert (gated on updated_at) actually picks up
-    -- the corrected value; BallotReady's own updated_at does not change.
+    -- Bump updated_at when a filing-address override applies, or when the
+    -- place mart re-slugged this race's place (slug disambiguation), so the
+    -- election-api write model's incremental upsert (gated on updated_at)
+    -- actually picks up the corrected value; BallotReady's own updated_at
+    -- does not change in either case.
     case
         when filing_overrides.br_database_id is not null
+        then current_timestamp()
+        when tbl_place.slug <> replace(tbl_race.place_name_slug, '-ccd', '')
         then current_timestamp()
         else tbl_race.updated_at
     end as updated_at,
@@ -100,14 +104,15 @@ select
     tbl_race.sub_area_value,
     tbl_race.frequency,
     tbl_race.place_id,
-    replace(
-        concat(
-            tbl_race.place_name_slug,
-            '/',
-            {{ slugify("tbl_race.normalized_position_name") }}
-        ),
-        '-ccd',
-        ''
+    -- Build the race slug from the place mart's (slug-disambiguated) place
+    -- slug rather than the raw upstream place_name_slug, so the race slug
+    -- always extends the place slug election-api actually serves. The
+    -- '-ccd' strip on the position part preserves the previous derivation,
+    -- which stripped it from the whole concatenated slug.
+    concat(
+        tbl_place.slug,
+        '/',
+        replace({{ slugify("tbl_race.normalized_position_name") }}, '-ccd', '')
     ) as slug,
     tbl_race.position_names,
     tbl_position.id as position_id,
@@ -118,6 +123,11 @@ select
     tbl_civics.official_office_name,
     tbl_civics.office_level
 from {{ ref("int__enhanced_race") }} as tbl_race
+-- Inner join: a race whose place is absent from the place mart cannot be
+-- served (Race.placeId must resolve), and this is also where the race picks
+-- up the disambiguated place slug.
+inner join
+    {{ ref("m_election_api__place") }} as tbl_place on tbl_race.place_id = tbl_place.id
 left join
     stage_per_br_race as tbl_stage
     on cast(tbl_race.br_database_id as string) = tbl_stage.br_race_id
@@ -131,12 +141,11 @@ left join
     {{ ref("election_api_race_filing_address_overrides") }} as filing_overrides
     on tbl_race.br_database_id = filing_overrides.br_database_id
 where
-    tbl_race.place_id in (select id from {{ ref("m_election_api__place") }})
     -- 2-month grace period keeps recently-passed races serveable (the campaign
     -- plan reads races after election day). Keep the lower bound in sync with
     -- the race filter in write__election_api_db.py, which otherwise re-narrows
     -- this window
-    and tbl_race.election_date
+    tbl_race.election_date
     between current_date() - interval '2 months' and current_date() + interval '2 years'
     -- Race -> Position -> District -> ProjectedTurnout is the chain the API
     -- depends on; a Race with no matching Position can't serve the

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -64,17 +64,18 @@ with
 select
     tbl_race.id,
     tbl_race.created_at,
-    -- Bump updated_at when a filing-address override applies, or when the
-    -- place mart re-slugged this race's place (slug disambiguation), so the
-    -- election-api write model's incremental upsert (gated on updated_at)
-    -- actually picks up the corrected value; BallotReady's own updated_at
-    -- does not change in either case.
+    -- Bump updated_at when a filing-address override applies (BallotReady's
+    -- own updated_at does not change), and otherwise ride the place row's
+    -- updated_at: the place mart bumps it whenever a slug changes
+    -- (disambiguation in either direction), so every dependent race clears
+    -- the election-api write model's incremental gate (updated_at greater
+    -- than the postgres max) in the same run and republishes its rebuilt
+    -- slug and place_id. Comparing slugs instead would miss a place moving
+    -- back from a suffixed slug to a clean one.
     case
         when filing_overrides.br_database_id is not null
         then current_timestamp()
-        when tbl_place.slug <> replace(tbl_race.place_name_slug, '-ccd', '')
-        then current_timestamp()
-        else tbl_race.updated_at
+        else greatest(tbl_race.updated_at, tbl_place.updated_at)
     end as updated_at,
     tbl_race.br_hash_id,
     tbl_race.br_database_id,

--- a/dbt/project/tests/assert_race_slug_prefix_matches_place_slug.sql
+++ b/dbt/project/tests/assert_race_slug_prefix_matches_place_slug.sql
@@ -1,0 +1,10 @@
+-- Every race slug must extend its resolved place's slug: the race mart
+-- derives slug as <place slug>/<position slug> from m_election_api__place,
+-- and election-api routes race pages under the place page. A failing row
+-- means the two marts disagree about a place's canonical slug (e.g. a race
+-- slug still built from a raw, un-disambiguated place slug).
+select tbl_race.id, tbl_race.slug as race_slug, tbl_place.slug as place_slug
+from {{ ref("m_election_api__race") }} as tbl_race
+inner join
+    {{ ref("m_election_api__place") }} as tbl_place on tbl_race.place_id = tbl_place.id
+where not startswith(tbl_race.slug, concat(tbl_place.slug, '/'))


### PR DESCRIPTION
## Problem

Races whose place loses a slug dedup to a same-named geography are dropped from election-api entirely. `m_election_api__place` enforces one row per `slug` (election-api `Place.slug` is a globally unique routing key) by keeping only the most-recently-updated row per slug; every other geography sharing that slug is dropped, and `m_election_api__race` then drops all races pointing at the dropped places. ~307 future races are orphaned this way across 62 slugs; in 159 of them an incorporated city loses its slug to a same-named school district (e.g. both Portland ME city-council races: the city loses `me/portland` to a Portland school district).

## Fix (scoped to the election-api marts; the shared upstream slug source is deliberately untouched)

**`m_election_api__place`** — stop dropping slug-collision losers; disambiguate instead:
- Slug ownership is computed over the full place universe every run. It is a global property: the old code applied the incremental filter before the dedup, so on incremental runs a new collision partner could never see the standing owner already in the mart.
- One canonical owner keeps the clean slug: an incorporated place (mtfcc G4110) wins its slug; all other ties break on the immutable `id`, so ownership never drifts when BallotReady re-touches a collision member (`updated_at` is a sync timestamp, not a claim to the slug — the review bot caught that an `updated_at` tiebreak would let any re-synced loser steal the clean slug later).
- Every other member gets a deterministic, stable `-<geoid>` suffix, defined on the final transformed slug (after the `-ccd` strip). `slug` stays globally unique.
- The incremental filter moves to the outcome: merge rows whose source `updated_at` advanced, whose computed slug differs from the stored slug, or which are new to the mart. New/re-slugged rows get `updated_at = current_timestamp()` so the write model's incremental filter (`updated_at >` postgres max) actually publishes them — same pattern as the race mart's existing filing-override bump.
- The mart's own incremental gate does NOT use those bumped values: a separate `source_updated_at` column (not published; the writer's Place upsert selects explicit columns) keeps the watermark in the source-time domain via `max(coalesce(source_updated_at, updated_at))`. BallotReady stamps event times that lag wall-clock by days, so gating ingestion on a wall-clock bump would silently skip later source updates landing inside that gap.
- A one-row-per-geoid pre-dedup keeps the mart's existing `id`/`geoid` uniqueness guarantees, which the old slug dedup was providing incidentally.

**`m_election_api__race`** — build the race slug from the disambiguated place slug:
- Inner join `m_election_api__place` on `place_id` (replaces the `IN` subquery; same filter semantics, and null `place_id` races stay excluded) and derive `slug = place.slug || '/' || <position slug>` so the race slug always extends the place slug election-api serves. For non-collision places the result is byte-identical to the previous derivation (the `-ccd` strip on the position part preserves the old whole-string strip).
- Race `updated_at` rides the place row: `greatest(race.updated_at, place.updated_at)` (filing-override bump unchanged). The place mart bumps its `updated_at` whenever a slug changes in either direction, so every dependent race clears the writer's incremental gate in the same run and republishes its rebuilt slug and `place_id` — including a place moving back from a suffixed slug to a clean one, which a slug-comparison bump would miss. Historic place timestamps sit below the Postgres watermark, so this adds no republish volume in steady state.

## Tests
- Race `place_id`: `not_null` + `relationships` to `m_election_api__place.id` (guards the exact regression class).
- Race `slug`: `not_null`.
- New singular test `assert_race_slug_prefix_matches_place_slug`: every race slug must extend its resolved place's slug.
- Existing place `slug`/`geoid` uniqueness tests keep guarding the disambiguation.

## Rollout (one manual step after merge)

Recovered rows carry old source `updated_at`, so incremental writer runs would skip them (the write model filters every table to `updated_at > MAX(updated_at)` already in Postgres; recovered candidacies/stances have no bump path at all). After merge, trigger one full-refresh run:

```
dbt build --full-refresh --select "m_election_api__place m_election_api__race m_election_api__candidacy m_election_api__stance write__election_api_db"
```

- `--full-refresh` on `m_election_api__place` reprocesses existing collision-loser rows (its incremental filter otherwise skips rows whose source timestamps never advanced).
- `write__election_api_db` under full refresh has `dbt.is_incremental = False`, which bypasses the per-table `updated_at` filter, so recovered places, races, candidacies, and stances all publish once. Steady-state incremental publishing resumes on the next scheduled run.
- Rebuild order (place -> race -> candidacy -> stance -> write) falls out of the DAG.
- To state the churn plainly: **38 already-published place slugs change owner or form at rollout** — 13 incorporated cities take their canonical slug back from same-named school districts (the intended fix), and 25 non-city collision groups settle onto the immutable-id owner (one-time consequence of the drift-proof tiebreak; measured vs 26 under the previous `updated_at` rule). The 77 recovered places are additions.

## Writer behaviors this change interacts with (called out, not silently relied on)

- **Slug dedup-delete + `ON DELETE SET NULL`:** when a slug's owner flips (the school district held `me/portland`; the city takes it), the writer deletes the published loser row (same slug, different id) and re-inserts it suffixed via the upsert. Those are two separate commits; `Race.placeId` / `Position.placeId` are `ON DELETE SET NULL`, and the same run's race upsert re-sets `place_id` (re-slugged races are bumped, so they are included in the incremental slice). A failure between the two commits can leave a transient null `place_id` until the next successful run — pre-existing writer behavior, unchanged here.
- **Watermark note:** the mart ingests on a pure source-time watermark (`source_updated_at`), so bumps can never make it miss source updates. One bounded residual sits at the writer: after a future ownership flip publishes wall-clock-bumped rows, the Postgres `MAX(updated_at)` gate is ahead of source time, so a place-attribute-only update whose BallotReady stamp lands inside that gap reaches the mart but republishes only when the row is next re-stamped (or on a writer `--full-refresh`). Slug and FK changes always bump, so they always publish; the residual affects only near-static attribute columns of the Place table, as a delay, not a loss.

## Verification (on the CI preview schema; results will follow as a PR comment)
- No `m_election_api__place.slug` maps to >1 row.
- Portland city (`bd1c9721…`) present at `me/portland`; both ME city-council races (br 2935694, 2935699) present with resolving `place_id` and a race slug extending the place slug.
- The 159 G4110-vs-school-district city races recover; colliding school districts remain (suffixed) with their races resolving.
- Full place-slug delta vs prod measured and reviewed (expected: bounded to colliding slugs, not the 27.7k source-universe figure).

Scope: DATA-2056a (slug collisions) only. Place-less offices (~4.8k races with null `place_id`) are DATA-2056b, deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core election-api routing slugs and incremental publish semantics; rollout needs a one-time full-refresh and will change a bounded set of published place URLs.
> 
> **Overview**
> **`m_election_api__place`** no longer drops geographies that lose a slug dedup. Slug ownership is recomputed over the full place universe each run; one row keeps the clean slug (incorporated **G4110** wins, else latest `updated_at`), and colliders get a stable `-<geoid>` suffix. Incremental logic moves to the final output: merge on new rows, slug changes, or source `updated_at` advances, with wall-clock **`updated_at`** bumps for publish while **`source_updated_at`** preserves the ingestion watermark. **`deduped_by_geoid`** replaces slug-level dedup so `id`/`geoid` uniqueness is explicit.
> 
> **`m_election_api__race`** inner-joins the place mart, builds **`slug`** from the disambiguated place slug, and sets **`updated_at`** to `greatest(race, place)` (plus filing overrides) so slug changes republish dependent races in the same run.
> 
> Schema/docs add **`place_id`**, **`slug`**, and **`source_updated_at`** tests; new singular test **`assert_race_slug_prefix_matches_place_slug`** guards race/place slug alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b6cd35dafa8eb1005826d69bc2d1f5a3941821. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


