### PR TITLE
[DATA-2015] Fix even-year local election data to allow for "no election happened" precincts

### DIFF
--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -610,9 +610,7 @@ def model(dbt, session):
     for inference_year in inference_years:
         op_years = _op_years(election_cols, l2_col_set, inference_year)
         if op_years:
-            session.sql(_opp_view_sql(op_years, catalog, precincts_schema)).createOrReplaceTempView(
-                "_hp_opp"
-            )
+            session.sql(_opp_view_sql(op_years, catalog, precincts_schema)).createOrReplaceTempView("_hp_opp")
         # ~206k precincts per year (~150 MB) — toPandas is safe; eagerly materialized here so
         # the per-year _hp_opp view is consumed before the next year overwrites it.
         pdf = session.sql(

--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -9,9 +9,17 @@ ballots_projected. Output feeds int__model_prediction_voter_turnout.
 Collapse-specific changes vs the per-state macro (all verified against the
 nationwide table on 2026-06-29):
   - State comes from the real `state_postal_code` column (no lit(state_code)).
-  - The odd-year opportunity logic is ROW-LEVEL (state_postal_code IN (...)).
+  - The odd-year (`AnyElection`) opportunity logic is ROW-LEVEL (state_postal_code IN (...)).
   - The vote-history "voted" test is BOOLEAN (cols are BooleanType nationwide),
     not = 'Y'.
+
+Even-year (`OtherElection`, local) eligibility is guided solely by per-precinct
+opportunity presence in `turnout_historical_precincts` — no state-list shortcut,
+since local election incidence varies precinct-by-precinct, not by state. This
+mirrors the training-side fix (see the training notebook's vote_history_sql).
+Previously this branched on `year % 2 == 0` and blanket-zeroed every even-year
+eligible non-voter nationwide, inflating the `even_year_local` target/feature
+denominator everywhere.
 
 The SQL-building helpers are pure (return SQL strings) so they are unit-tested
 without Spark/MLflow; `model()` executes them. `import mlflow` is deferred into
@@ -181,23 +189,24 @@ def _safe_date(column_name):
     )
 
 
-def _odd_op_years(election_cols, l2_col_set, inference_year):
-    """Odd years (in lag range) with AnyElection/OtherElection cols. For these,
-    NON-opportunity states need a per-precinct opportunity flag; opportunity states
-    short-circuit to 0.0. (Was gated on a scalar per-state flag in the macro.)"""
+def _op_years(election_cols, l2_col_set, inference_year):
+    """Years (in lag range) needing a per-precinct opportunity flag: odd-year
+    AnyElection (non-opportunity-state precincts) and even-year OtherElection
+    (all precincts, no state shortcut). AnyElection is always odd and
+    OtherElection is always even in the nationwide L2 schema, so no explicit
+    parity filter is needed here — the prefix already implies it."""
     return sorted(
         {
             year
             for col_name, prefix, year in election_cols
             if col_name in l2_col_set
             and prefix in ("AnyElection", "OtherElection")
-            and year % 2 == 1
             and 1 <= inference_year - year <= 12
         }
     )
 
 
-def _opp_view_sql(odd_op_years, catalog, precincts_schema):
+def _opp_view_sql(op_years, catalog, precincts_schema):
     """Nationwide opportunity-flag table over ALL states (was WHERE State = one state).
 
     precincts_schema = where turnout_historical_precincts lives. PROD default is
@@ -207,10 +216,10 @@ def _opp_view_sql(odd_op_years, catalog, precincts_schema):
     opp_col_exprs = ", ".join(
         f"MAX(CASE WHEN election_year_str IN ('AnyElection_{y}', 'OtherElection_{y}') "
         f"THEN 1 ELSE 0 END) AS opp_{y}"
-        for y in odd_op_years
+        for y in op_years
     )
     year_filter = " OR ".join(
-        f"election_year_str IN ('AnyElection_{y}', 'OtherElection_{y}')" for y in odd_op_years
+        f"election_year_str IN ('AnyElection_{y}', 'OtherElection_{y}')" for y in op_years
     )
     return f"""
         SELECT State, County, Precinct, {opp_col_exprs}
@@ -225,13 +234,14 @@ def _build_precinct_features_sql(l2_col_set, election_cols, inference_year, l2_c
 
     Collapse changes vs the per-state macro:
       - State from the real `state_postal_code` column (no lit()).
-      - Vote-history eligibility (branches 7/8) is ROW-LEVEL via state_postal_code IN (...).
+      - Odd-year (AnyElection) eligibility is ROW-LEVEL via state_postal_code IN (...).
+      - Even-year (OtherElection) eligibility is precinct-opportunity-only, no state list.
       - The vote-history "voted" test is BOOLEAN (cols are BooleanType), not = 'Y'.
     """
-    odd_op_years = _odd_op_years(election_cols, l2_col_set, inference_year)
-    if odd_op_years:
+    op_years = _op_years(election_cols, l2_col_set, inference_year)
+    if op_years:
         # Enrich _l2 with per-precinct opportunity flags via a (State, County, Precinct) join.
-        opp_select = ", ".join(f"COALESCE(hp.opp_{y}, 0) AS opp_{y}" for y in odd_op_years)
+        opp_select = ", ".join(f"COALESCE(hp.opp_{y}, 0) AS opp_{y}" for y in op_years)
         from_clause = (
             f"(SELECT l2.*, {opp_select} FROM _l2 AS l2"
             f" LEFT JOIN _hp_opp AS hp"
@@ -321,8 +331,13 @@ def _build_precinct_features_sql(l2_col_set, election_cols, inference_year, l2_c
         if column_name in l2_col_set:
             exprs.append(f"mode(`{column_name}`) AS `{column_name}`")
 
-    # Vote-history columns: replicates training's 8-branch eligibility CASE. Branch 1
-    # (voted) is now a BOOLEAN test; branches 7/8 (odd-year opportunity) are ROW-LEVEL.
+    # Vote-history columns: replicates training's eligibility CASE. The "voted" test is
+    # a BOOLEAN (not = 'Y'). Non-voter eligibility branches by prefix, not year parity:
+    #   - General/Primary: always held, eligible non-voter -> 0.
+    #   - AnyElection (odd-year local): opportunity-state shortcut, then per-precinct
+    #     opportunity check, ROW-LEVEL.
+    #   - OtherElection (even-year local): per-precinct opportunity only, no state
+    #     shortcut — local election incidence varies precinct-by-precinct, not by state.
     for col_name, prefix, year in election_cols:
         if col_name not in l2_col_set:
             continue
@@ -331,14 +346,13 @@ def _build_precinct_features_sql(l2_col_set, election_cols, inference_year, l2_c
             continue
 
         if prefix in ("General", "Primary"):
-            eligible_nonvoter_sql = "ELSE 0.0"  # branch 5: always held
-        elif year % 2 == 0:
-            eligible_nonvoter_sql = "ELSE 0.0"  # branch 6: even-year local opportunity assumed
-        else:
-            # branch 7 (opportunity state) then branch 8 (non-op precinct check) — row-level
+            eligible_nonvoter_sql = "ELSE 0.0"
+        elif prefix == "AnyElection":
             eligible_nonvoter_sql = (
                 f"WHEN state_postal_code IN {_OPP_STATES_SQL} THEN 0.0 WHEN opp_{year} = 1 THEN 0.0 ELSE NULL"
             )
+        else:  # OtherElection
+            eligible_nonvoter_sql = f"WHEN opp_{year} = 1 THEN 0.0 ELSE NULL"
 
         exprs.append(
             f"CAST(AVG("
@@ -594,9 +608,9 @@ def model(dbt, session):
 
     pred_dfs = []
     for inference_year in inference_years:
-        odd_op_years = _odd_op_years(election_cols, l2_col_set, inference_year)
-        if odd_op_years:
-            session.sql(_opp_view_sql(odd_op_years, catalog, precincts_schema)).createOrReplaceTempView(
+        op_years = _op_years(election_cols, l2_col_set, inference_year)
+        if op_years:
+            session.sql(_opp_view_sql(op_years, catalog, precincts_schema)).createOrReplaceTempView(
                 "_hp_opp"
             )
         # ~206k precincts per year (~150 MB) — toPandas is safe; eagerly materialized here so

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -9,7 +9,6 @@ must stay inside `model()` (the dbt test env has pyspark + pandas, not mlflow).
 import numpy as np
 import pandas as pd
 import pytest
-
 from dbt.project.models.intermediate.l2.int__voter_turnout_lgbm_inference import (
     _OPP_STATES_SQL,
     _assert_consistent_model_family,

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -180,10 +180,10 @@ def test_predict_precinct_encodes_categoricals_and_outputs_contract():
             "Precinct": ["1", "2"],
             "n_voters": [10.0, 20.0],
             "age": [40.0, 50.0],
-            "Parties_Description": ["D", "R"],  # categorical, integer-encoded via cat_map
+            "Parties_Description": ["Democratic", "Republican"],  # categorical, integer-encoded via cat_map
         }
     )
-    cat_map = {"Parties_Description": ["D", "R", "I"]}
+    cat_map = {"Parties_Description": ["Democratic", "Republican", "Non-Partisan"]}
     booster = _FakeBooster(["age", "Parties_Description"])
     out = _predict_precinct(pdf, booster, cat_map, "midterm", "FamX", 2026)
     assert list(out["p_hat"]) == [0.5, 0.5]
@@ -216,7 +216,7 @@ def test_select_cat_map_path_raises_unless_exactly_one(paths):
 def test_read_model_family_tag_returns_value():
     tags = {
         "model_family": "precinct_level_lgbm_votehistory_socioecondemopolgeo",
-        "lightgbm_version": "4.6.0",
+        "lightgbm_version": "4.3.0",
     }
     assert (
         _read_model_family_tag(tags, "goodparty_data_catalog.model_predictions.voter_turnout_model_midterm")
@@ -224,7 +224,7 @@ def test_read_model_family_tag_returns_value():
     )
 
 
-@pytest.mark.parametrize("tags", [None, {}, {"lightgbm_version": "4.6.0"}, {"model_family": ""}])
+@pytest.mark.parametrize("tags", [None, {}, {"lightgbm_version": "4.3.0"}, {"model_family": ""}])
 def test_read_model_family_tag_raises_when_missing_or_empty(tags):
     with pytest.raises(ValueError):
         _read_model_family_tag(tags, "some.model.name")

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -9,13 +9,14 @@ must stay inside `model()` (the dbt test env has pyspark + pandas, not mlflow).
 import numpy as np
 import pandas as pd
 import pytest
+
 from dbt.project.models.intermediate.l2.int__voter_turnout_lgbm_inference import (
     _OPP_STATES_SQL,
     _assert_consistent_model_family,
     _build_district_membership_sql,
     _build_precinct_features_sql,
     _detect_election_cols,
-    _odd_op_years,
+    _op_years,
     _opp_view_sql,
     _parse_state_allowlist,
     _predict_precinct,
@@ -25,6 +26,8 @@ from dbt.project.models.intermediate.l2.int__voter_turnout_lgbm_inference import
 )
 
 # A representative L2 column set: vote-history (boolean nationwide) + keys + a few features.
+# AnyElection is always odd-year, OtherElection is always even-year in the real nationwide
+# schema — kept realistic here since the eligibility branch now routes by prefix, not parity.
 _L2_COLS = {
     "state_postal_code",
     "County",
@@ -42,14 +45,14 @@ _L2_COLS = {
     "General_2024",
     "Primary_2024",
     "AnyElection_2023",
-    "OtherElection_2023",
+    "OtherElection_2024",
     "ConsumerData_Donor_Political_Liberal",  # _Y_INDICATOR (STRING)
 }
 _ELECTION_COLS = [
     ("General_2024", "General", 2024),
     ("Primary_2024", "Primary", 2024),
     ("AnyElection_2023", "AnyElection", 2023),
-    ("OtherElection_2023", "OtherElection", 2023),
+    ("OtherElection_2024", "OtherElection", 2024),
 ]
 
 
@@ -96,20 +99,28 @@ def test_vote_history_uses_boolean_not_y_string():
 
 def test_odd_year_opportunity_is_row_level():
     sql = _build_precinct_features_sql(_L2_COLS, _ELECTION_COLS, 2026, 2026)
-    # odd-year AnyElection/OtherElection eligibility branches on the row's state,
-    # then the per-precinct opportunity flag — not a Python-resolved scalar.
-    assert f"WHEN state_postal_code IN {_OPP_STATES_SQL} THEN 0.0" in sql
-    assert "WHEN opp_2023 = 1 THEN 0.0" in sql
+    # AnyElection (odd-year local) eligibility branches on the row's state, then the
+    # per-precinct opportunity flag — not a Python-resolved scalar.
+    assert f"WHEN state_postal_code IN {_OPP_STATES_SQL} THEN 0.0 WHEN opp_2023 = 1 THEN 0.0 ELSE NULL" in sql
+
+
+def test_even_year_opportunity_has_no_state_shortcut():
+    sql = _build_precinct_features_sql(_L2_COLS, _ELECTION_COLS, 2026, 2026)
+    # OtherElection (even-year local) eligibility is precinct-opportunity-only — no
+    # state-list shortcut, since local election incidence varies precinct-by-precinct.
+    assert "WHEN opp_2024 = 1 THEN 0.0 ELSE NULL" in sql
+    assert f"state_postal_code IN {_OPP_STATES_SQL} THEN 0.0 WHEN opp_2024" not in sql
 
 
 def test_opp_years_and_view_sql():
-    years = _odd_op_years(_ELECTION_COLS, _L2_COLS, 2026)
-    assert years == [2023]
+    years = _op_years(_ELECTION_COLS, _L2_COLS, 2026)
+    assert years == [2023, 2024]
     view = _opp_view_sql(years, "goodparty_data_catalog", "model_predictions")
     assert "model_predictions.turnout_historical_precincts" in view
     assert "GROUP BY State, County, Precinct" in view
     assert "WHERE State =" not in view  # nationwide: no per-state filter
     assert "opp_2023" in view
+    assert "opp_2024" in view
 
 
 # ── Task 3: allowlist + membership ───────────────────────────────────────────


### PR DESCRIPTION
## What this fixes

The turnout model for even-year local elections (city council, school board, etc.
held the same year as a presidential or midterm election) couldn't tell the
difference between two very different situations:

1. A precinct really did have a local election that year, and a given voter
   chose not to vote
2. A precinct had no local election at all that year

Both cases were being counted the same way ("didn't vote"), which inflated
local-election turnout numbers everywhere - including in places that never
had a local race at all that year.

This fix uses whether a precinct actually recorded a vote in that type of
election as the signal for whether an opportunity to vote existed there in
the first place. If nobody in a precinct ever voted in that election type in
a given year, it's now treated as "no election happened" (excluded) rather
than counted as a missed vote.

This mirrors a fix already made and validated on the model-training side.

## Background

As part of the same effort, a new model, `even_year_primary`, was also built
and trained (on the training side) to predict turnout in statewide primary
elections, separate from local elections. That model is not wired into this
nationwide inference pipeline yet - this PR only covers the even-year local
election fix. Primary-election inference support (routing, feature building,
`election_code` mapping for `even_year_primary`) would be a follow-up PR.

## Test plan
- [x] Updated tests to check the new even-year-local behavior
- [x] All existing tests still pass (23 passed)
- [x] Code style checks (ruff) pass
- [ ] Not yet tested against real production data (no dbt Cloud CLI access in
      this session)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core vote-history SQL for `even_year_local` predictions nationwide; wrong opportunity logic would skew projected ballots, but behavior is aligned with training and covered by updated unit tests.
> 
> **Overview**
> Fixes **even-year local** (`OtherElection`) vote-history eligibility in nationwide LightGBM turnout inference so precincts with **no local race** are excluded instead of counted as eligible non-voters.
> 
> **Before:** eligibility used `year % 2 == 0` and treated every even-year eligible non-voter as `0.0`, which inflated `even_year_local` features/targets nationwide. **After:** routing is by column prefix (`AnyElection` vs `OtherElection`). `_odd_op_years` becomes `_op_years` and includes even years for `OtherElection`; `turnout_historical_precincts` supplies `opp_{year}` for both odd and even local years. `OtherElection` non-voters are eligible only when `opp_{year} = 1` (no odd-year state-list shortcut). Odd-year `AnyElection` behavior is unchanged.
> 
> Unit tests add `test_even_year_opportunity_has_no_state_shortcut` and update fixtures/assertions for `opp_2024` and combined opportunity years.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1dfa0ffb64673330bda086011296e99f6f8050c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->