### PR TITLE
Accept all experiment_run status values in staging test

### DIFF
--- a/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db.yaml
+++ b/dbt/project/models/staging/airbyte_source/gp_api_db/stg_airbyte_source__gp_api_db.yaml
@@ -289,11 +289,16 @@ models:
       - name: stage
         description: "Pipeline stage the run reached"
       - name: status
-        description: "Terminal status of the run (e.g. COMPLETED, FAILED)"
+        description: >
+          Status of the run. Accepted values are the union of the current
+          ExperimentRunStatus enum (QUEUED, RUNNING, AWAITING_RESUME, COMPLETED,
+          FAILED) plus SUPERSEDED, a legacy value dropped from the enum but still
+          present on historical rows.
         data_tests:
           - accepted_values:
               arguments:
-                values: ["COMPLETED", "FAILED"]
+                values:
+                  ["QUEUED", "RUNNING", "AWAITING_RESUME", "COMPLETED", "FAILED", "SUPERSEDED"]
       - name: priority
         description: "Scheduling priority of the run"
       - name: data_quality


### PR DESCRIPTION
## What

The `accepted_values` test on `stg_airbyte_source__gp_api_db_experiment_run.status` was failing in the scheduled `dbt build` run — it only allowed `COMPLETED` and `FAILED`, but the source now emits more states.

## Fix

Expanded the accepted set to the union of:
- the current `ExperimentRunStatus` enum: `QUEUED`, `RUNNING`, `AWAITING_RESUME`, `COMPLETED`, `FAILED`
- `SUPERSEDED` — a legacy value that has been dropped from the enum but is still present on historical rows in the source.

## Verification

Confirmed the live distinct values in Databricks with `dbt show`:

| status     |    n |
| ---------- | ---- |
| COMPLETED  | 6232 |
| FAILED     | 4025 |
| SUPERSEDED |   33 |
| RUNNING    |    1 |

`dbt build --select stg_airbyte_source__gp_api_db_experiment_run` now passes (PASS=8, ERROR=0), including the previously-failing test.

## Note

`SUPERSEDED` is present in the data (33 rows) but is not in any current `ExperimentRunStatus` enum definition. Worth a quick confirmation from the app team that it's an intentional legacy state and not a data-quality issue.