### PR TITLE
[DATA-2077] Add int__civics_record_first_seen

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3682,3 +3682,55 @@ models:
         description: Timestamp when the score was last computed (the dbt run time).
         data_tests:
           - not_null
+
+  - name: int__civics_record_first_seen
+    description: >
+      One row per source-native person identifier with the earliest timestamp at
+      which that person is evidenced in the source. The person layer mints a
+      stable gp_person_id from the earliest member of each cluster, so this model
+      decides which member wins. first_seen_at prefers each source's native
+      created timestamp, falling back to Airbyte extraction time only for DDHQ
+      (no native created field). BallotReady has no first-class person record in
+      the S3 feeds, so a BR person's first_seen is the min created timestamp
+      across their candidacy and office-holder rows.
+    columns:
+      - name: source_name
+        description: >
+          Source system and record type. TechSpeed candidates and office holders
+          are distinct native id spaces, so they get distinct source_names.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - ballotready
+                  - gp_api
+                  - hubspot
+                  - techspeed_candidate
+                  - techspeed_officeholder
+                  - ddhq
+      - name: source_id
+        description: Source-native person identifier (string), unique within source_name.
+        data_tests:
+          - not_null
+      - name: first_seen_at
+        description: Earliest timestamp the person is evidenced in the source.
+        data_tests:
+          - not_null
+      - name: ingested_at
+        description: >
+          Min Airbyte extraction time; used only for the first_seen sanity test.
+          Null for HubSpot, whose staging drops _airbyte_extracted_at.
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - source_name
+              - source_id
+      - dbt_utils.expression_is_true:
+          name: int__civics_record_first_seen_first_seen_at_lte_ingested_at
+          arguments:
+            expression: "first_seen_at <= ingested_at"
+          config:
+            where: "ingested_at is not null"
+            severity: warn

--- a/dbt/project/models/intermediate/civics/int__civics_record_first_seen.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_record_first_seen.sql
@@ -1,0 +1,150 @@
+-- One row per source-native person identifier with the earliest timestamp at
+-- which that person is evidenced in the source. The person layer mints a stable
+-- gp_person_id from the earliest member of each cluster (canonical-person plan,
+-- decision 4), so this model decides which member wins. Fully re-derivable and
+-- safe under full refresh: for a fixed set of source rows the min is stable.
+--
+-- first_seen_at prefers each source's native created timestamp, falling back to
+-- Airbyte extraction time where none exists (DDHQ). The plan's middle
+-- "source-file date" tier is omitted: pre-work found native created fields are
+-- ~100% populated for every source except DDHQ, so it would cover nothing.
+--
+-- BallotReady has no first-class person record in the S3 feeds; a BR person is
+-- reconstructed from their candidacy and office-holder rows, so first_seen is
+-- the min created timestamp across both. TechSpeed candidates and office
+-- holders are distinct native id spaces, so they get distinct source_names.
+--
+-- ingested_at (min Airbyte extraction time) exists only for the sanity test
+-- first_seen_at <= ingested_at. HubSpot staging drops _airbyte_extracted_at, so
+-- it is null there.
+with
+    ballotready_rows as (
+        select
+            cast(br_candidate_id as string) as source_id,
+            candidacy_created_at as created_at,
+            _airbyte_extracted_at
+        from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
+        where br_candidate_id is not null
+
+        union all
+
+        select
+            cast(br_candidate_id as string) as source_id,
+            office_holder_created_at as created_at,
+            _airbyte_extracted_at
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+        where br_candidate_id is not null
+    ),
+
+    ballotready as (
+        select
+            'ballotready' as source_name,
+            source_id,
+            cast(
+                min(coalesce(created_at, _airbyte_extracted_at)) as timestamp
+            ) as first_seen_at,
+            cast(min(_airbyte_extracted_at) as timestamp) as ingested_at
+        from ballotready_rows
+        group by source_id
+    ),
+
+    gp_api as (
+        select
+            'gp_api' as source_name,
+            cast(id as string) as source_id,
+            cast(
+                min(coalesce(created_at, _airbyte_extracted_at)) as timestamp
+            ) as first_seen_at,
+            cast(min(_airbyte_extracted_at) as timestamp) as ingested_at
+        from {{ ref("stg_airbyte_source__gp_api_db_user") }}
+        where id is not null
+        group by id
+    ),
+
+    hubspot as (
+        select
+            'hubspot' as source_name,
+            cast(id as string) as source_id,
+            cast(min(contact_created_at) as timestamp) as first_seen_at,
+            cast(null as timestamp) as ingested_at
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
+        where id is not null and contact_created_at is not null
+        group by id
+    ),
+
+    techspeed_candidate_rows as (
+        select
+            {{
+                generate_candidate_code(
+                    "first_name", "last_name", "state", "office_type", "city"
+                )
+            }} as source_id,
+            coalesce(
+                try_cast(date_processed as date),
+                try_to_date(date_processed, 'MM/dd/yyyy'),
+                try_to_date(date_processed, 'M/d/yyyy')
+            ) as created_date,
+            _airbyte_extracted_at
+        from {{ ref("stg_airbyte_source__techspeed_gdrive_candidates") }}
+    ),
+
+    techspeed_candidate as (
+        select
+            'techspeed_candidate' as source_name,
+            source_id,
+            cast(
+                min(
+                    coalesce(cast(created_date as timestamp), _airbyte_extracted_at)
+                ) as timestamp
+            ) as first_seen_at,
+            cast(min(_airbyte_extracted_at) as timestamp) as ingested_at
+        from techspeed_candidate_rows
+        where source_id is not null
+        group by source_id
+    ),
+
+    techspeed_officeholder as (
+        select
+            'techspeed_officeholder' as source_name,
+            cast(ts_officeholder_id as string) as source_id,
+            cast(
+                min(
+                    coalesce(
+                        cast(date_processed_date as timestamp), _airbyte_extracted_at
+                    )
+                ) as timestamp
+            ) as first_seen_at,
+            cast(min(_airbyte_extracted_at) as timestamp) as ingested_at
+        from {{ ref("stg_airbyte_source__techspeed_gdrive_officeholders") }}
+        where ts_officeholder_id is not null
+        group by ts_officeholder_id
+    ),
+
+    ddhq as (
+        select
+            'ddhq' as source_name,
+            cast(candidate_id as string) as source_id,
+            cast(min(_airbyte_extracted_at) as timestamp) as first_seen_at,
+            cast(min(_airbyte_extracted_at) as timestamp) as ingested_at
+        from {{ ref("stg_airbyte_source__ddhq_gdrive_election_results") }}
+        where candidate_id is not null
+        group by candidate_id
+    )
+
+select source_name, source_id, first_seen_at, ingested_at
+from ballotready
+union all
+select source_name, source_id, first_seen_at, ingested_at
+from gp_api
+union all
+select source_name, source_id, first_seen_at, ingested_at
+from hubspot
+union all
+select source_name, source_id, first_seen_at, ingested_at
+from techspeed_candidate
+union all
+select source_name, source_id, first_seen_at, ingested_at
+from techspeed_officeholder
+union all
+select source_name, source_id, first_seen_at, ingested_at
+from ddhq


### PR DESCRIPTION
First model of Track B in the canonical-person rework (parent: DATA-2075).

## What

`int__civics_record_first_seen`: one row per source-native person identifier `(source_name, source_id)` with a `first_seen_at` timestamp. The person layer mints a stable `gp_person_id` from the earliest member of each cluster, so this model decides which member wins. It is fully re-derivable and safe under `dbt full-refresh`: for a fixed set of source rows the min is stable.

## Contract

`first_seen_at` prefers each source's native created timestamp, falling back to Airbyte extraction time only where none exists.

| source_name | source_id | first_seen_at |
|---|---|---|
| ballotready | br_candidate_id | min(candidacy_created_at, office_holder_created_at) |
| gp_api | user id | created_at |
| hubspot | contact id | contact_created_at (createdate) |
| techspeed_candidate | candidate_code | min(date_processed) |
| techspeed_officeholder | ts_officeholder_id | min(date_processed_date) |
| ddhq | candidate_id | min(_airbyte_extracted_at) |

Notes:
- BallotReady has no first-class person record in the S3 feeds; a BR person is reconstructed from candidacy + office-holder rows, so first_seen is the min created timestamp across both. The GraphQL People table (Track A) is a person-attributes source, not a timing source.
- TechSpeed candidates and office holders are distinct native id spaces, so they get distinct source_names.
- The plan's middle "source-file date" precedence tier is omitted: native created fields are ~100% populated for every source except DDHQ, so it would cover nothing.
- DDHQ has no native created field and candidate_id is per-cycle (reused ~1.5%); this only affects which timestamp a reused id carries. Cross-cycle identity is the probabilistic layer's job.

## Validation

Row counts match the pre-work findings exactly: ballotready 460,669, ddhq 96,791, hubspot 328,584, techspeed_officeholder 30,375, techspeed_candidate 72,345, gp_api 69,474. Grain is unique within every source; zero null first_seen_at.

## Tests

- `unique_combination_of_columns` on (source_name, source_id)
- `not_null` on source_name, source_id, first_seen_at
- `accepted_values` on source_name
- warn-severity `first_seen_at <= ingested_at` sanity check. 4 gp_api rows trip it (product `created_at` a few moments after extraction — clock skew), so it warns rather than errors. HubSpot staging drops `_airbyte_extracted_at`, so `ingested_at` is null there and those rows are excluded from the check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New intermediate logic drives which cluster member wins stable person ids; wrong min timestamps would skew canonical-person resolution, though the model is isolated until downstream Track B models consume it.
> 
> **Overview**
> Adds **`int__civics_record_first_seen`**, the first Track B model in the canonical-person rework: one row per `(source_name, source_id)` with **`first_seen_at`** (and optional **`ingested_at`** for QA).
> 
> The SQL unions six person-id spaces—BallotReady (`br_candidate_id` from candidacies + office holders), gp_api users, HubSpot contacts, TechSpeed candidates (`generate_candidate_code`), TechSpeed officeholders, and DDHQ `candidate_id`—each with source-specific rules: native created/processed timestamps where available, **`_airbyte_extracted_at`** only as fallback (DDHQ uses extraction time for `first_seen_at`).
> 
> **`int__civics.yaml`** documents the contract and adds tests: grain uniqueness, `not_null` / `accepted_values`, and a warn-level check that `first_seen_at <= ingested_at` when ingestion time exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cf1512a37a3ed416dc3540529e6b239c8900317. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->