### PR TITLE
[DATA-2079] Expose Amplitude event taxonomy on amplitude_events

### DIFF
--- a/dbt/project/models/marts/analytics/amplitude_events.sql
+++ b/dbt/project/models/marts/analytics/amplitude_events.sql
@@ -1,12 +1,19 @@
 {{ config(materialized="view") }}
 
 /*
-    Passthrough exposure of stg_airbyte_source__amplitude_api_events into
-    mart_analytics for Sigma BI POV consumption. View materialization (not
-    table) because this is a thin alias and storage duplication isn't
-    justified. Promote to a transformed table model if Sigma usage patterns
-    warrant it post-POV. Sigma SP access to mart_analytics is provisioned
-    in thegoodparty/gp-terraform-dataplatform#29.
+    Exposure of stg_airbyte_source__amplitude_api_events into mart_analytics
+    (Sigma reads marts only). View, not table: a thin projection over a large
+    staging table doesn't justify storage duplication.
+
+    family / is_win / is_recurrent come from the amplitude_event_taxonomy
+    macros so classification has a single source of truth shared with
+    int__amplitude_event_catalog; consumers must not re-derive product
+    classification from event_type strings.
 */
-select *
+select
+    *,
+    {{ amplitude_event_family("event_type") }} as family,
+    family like 'win_%' as is_win,
+    -- null-safe: IN-list yields null (not false) on a null event_type
+    coalesce({{ amplitude_event_is_recurrent("event_type") }}, false) as is_recurrent
 from {{ ref("stg_airbyte_source__amplitude_api_events") }}

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1486,9 +1486,14 @@ models:
 
   - name: amplitude_events
     description: >
-      Passthrough exposure of stg_airbyte_source__amplitude_api_events
-      into mart_analytics for Sigma BI POV. View materialization, no
-      transformations. Columns documented at the upstream staging model.
+      Exposure of stg_airbyte_source__amplitude_api_events into
+      mart_analytics (Sigma reads marts only), enriched with the governed
+      event taxonomy: family, is_win, and is_recurrent derive from the
+      amplitude_event_taxonomy macros so BI consumers never re-derive
+      serve/win classification from event_type strings. Passthrough columns
+      are documented at the upstream staging model; the event_type-grain
+      catalog (volume, recency, Govern metadata) is
+      int__amplitude_event_catalog, built from the same macros.
 
       Source: stg_airbyte_source__amplitude_api_events.
     columns:
@@ -1497,6 +1502,35 @@ models:
         data_tests:
           - not_null
           - unique
+
+      - name: family
+        description: >
+          Product-feature bucket from the amplitude_event_family macro. Win
+          families are prefixed `win_`; non-Win buckets cover serve,
+          auth/settings, navigation, and anonymous noise. Unmatched
+          event_types fall through to 'other' for triage. Closed set by
+          construction; the accepted_values contract is tested on
+          int__amplitude_event_catalog, which derives from the same macro.
+        data_tests:
+          - not_null
+
+      - name: is_win
+        description: >
+          True for Win-product candidate-attributed families (family like
+          'win_%'); false for serve / cross-product / noise. Event-level
+          filter only — user-level "Win active" questions belong on
+          users_win_activity / users_win_base, not on raw event counts.
+        data_tests:
+          - not_null
+
+      - name: is_recurrent
+        description: >
+          True for recurrent-activity events (vs one-off lifecycle
+          milestones) — exactly the events the Win activity rollups count.
+          Event-level allowlist (amplitude_event_is_recurrent macro), not a
+          pattern. False, never null, when event_type is null.
+        data_tests:
+          - not_null
 
   - name: hubspot_contacts
     description: >


### PR DESCRIPTION
## What

Adds three classification columns to the `mart_analytics.amplitude_events` view — `family`, `is_win`, `is_recurrent` — compiled from the existing `amplitude_event_taxonomy` macros. YAML docs and `not_null` tests included. No other model or macro changes.

## Why

The only events surface Sigma (and the Sigma agent) can read was a raw passthrough with no product classification, so downstream consumers re-derived serve/win classification from `event_type` strings and got it wrong (shared app events counted as Win activity — reported by the analytics owner, diagnosed 2026-07-06). The governed taxonomy already existed in the intermediate layer; this exposes it where marts-only consumers can use it. Same thin-gold-surface pattern as `users_serve_active` (DATA-2063).

Deliberate scope choices:
- `int__amplitude_event_catalog` is NOT additionally exposed as gold: inline columns solve the reported failure mode with zero joins; revisit only if a concrete Sigma need for the event-grain catalog appears.
- The closed-set `accepted_values` on `family` stays on `int__amplitude_event_catalog` (same macro, cheap event_type-grain scan) rather than duplicating the 25-value list here.
- `is_recurrent` is coalesced to false at the call site because Spark `NULL IN (...)` yields NULL; a null `event_type` row already classifies in-band as `family = 'other'`.

## Verification (CI preview)

- [x] Exact `event_type → family/is_win/is_recurrent` parity vs `int__amplitude_event_catalog` (0 mismatches; event_types newer than the nightly catalog reported separately)
- [x] 0 nulls in the three new columns; `is_win` matches `family like 'win_%'` row-for-row
- [x] Family distribution sanity read (shared/noise families dominate; win_* families present)

Results posted as a PR comment (all PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin mart enrichment on a view using existing macros; no auth, infra, or macro definition changes in this diff.
> 
> **Overview**
> **`mart_analytics.amplitude_events`** stops being a raw `select *` passthrough and now projects **`family`**, **`is_win`**, and **`is_recurrent`** from the shared **`amplitude_event_taxonomy`** macros (same logic as **`int__amplitude_event_catalog`**). **`is_recurrent`** is **`coalesce(..., false)`** so null **`event_type`** rows are never null on that flag.
> 
> **`m_analytics.yaml`** documents the three columns, states that BI must not re-derive Win/Serve classification from **`event_type`**, and adds **`not_null`** tests on each new field. The model stays a **view** over staging—no new gold catalog exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e74503a47d879563df7147ab35835b29a1e47e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
