### PR TITLE
[DATA-2077] Add person source projections for civics vendors (B1)

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3685,11 +3685,9 @@ models:
 
   - name: int__civics_person_source_ballotready
     description: >
-      BallotReady person projection for the canonical-person layer. One row per
-      br_candidate_id, reconstructed from the S3 candidacy and office-holder
-      feeds. first_seen_at is the earliest created timestamp across both and
-      drives the earliest-member gp_person_id mint. All-time. The BR API Person
-      object layers in as the attribute authority once its staging lands (A2).
+      BallotReady person projection. One row per br_candidate_id, reconstructed
+      from the S3 candidacy and office-holder feeds. first_seen_at is the
+      earliest created timestamp across both. All-time.
     columns:
       - name: source_name
         description: Constant 'ballotready'.

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3682,3 +3682,105 @@ models:
         description: Timestamp when the score was last computed (the dbt run time).
         data_tests:
           - not_null
+
+  - name: int__civics_person_source_ballotready
+    description: >
+      BallotReady person projection for the canonical-person layer. One row per
+      br_candidate_id, reconstructed from the S3 candidacy and office-holder
+      feeds. first_seen_at is the earliest created timestamp across both and
+      drives the earliest-member gp_person_id mint. All-time. The BR API Person
+      object layers in as the attribute authority once its staging lands (A2).
+    columns:
+      - name: source_name
+        description: Constant 'ballotready'.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["ballotready"]
+      - name: source_id
+        description: Native BR person id (br_candidate_id, as string).
+        data_tests:
+          - not_null
+          - unique
+      - name: br_candidate_id
+        description: Native BR person id; equal to source_id.
+        data_tests:
+          - not_null
+      - name: first_seen_at
+        description: Earliest created timestamp across the person's candidacy and term rows.
+        data_tests:
+          - not_null
+
+  - name: int__civics_person_source_techspeed_candidate
+    description: >
+      TechSpeed candidate person projection. One row per candidate identity code
+      (generate_candidate_code, 5-arg). TechSpeed has no native candidate id, so
+      the code fragments a person across offices/cities by construction;
+      cross-code identity is resolved by the probabilistic person layer.
+      All-time. first_seen_at is the earliest parsed date_processed.
+    columns:
+      - name: source_name
+        description: Constant 'techspeed_candidate'.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["techspeed_candidate"]
+      - name: source_id
+        description: TechSpeed candidate identity code; equal to techspeed_candidate_code.
+        data_tests:
+          - not_null
+          - unique
+      - name: first_seen_at
+        description: Earliest parsed date_processed across the code's rows.
+        data_tests:
+          - not_null
+
+  - name: int__civics_person_source_techspeed_officeholder
+    description: >
+      TechSpeed office-holder person projection. One row per ts_officeholder_id.
+      br_candidate_id carries the deterministic BR person link, suppressed for
+      ids flagged reused across different people. All-time; first_seen_at is the
+      earliest parsed date_processed.
+    columns:
+      - name: source_name
+        description: Constant 'techspeed_officeholder'.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["techspeed_officeholder"]
+      - name: source_id
+        description: Native TechSpeed office-holder id (ts_officeholder_id).
+        data_tests:
+          - not_null
+          - unique
+      - name: first_seen_at
+        description: Earliest parsed date_processed across the id's rows.
+        data_tests:
+          - not_null
+
+  - name: int__civics_person_source_ddhq
+    description: >
+      DDHQ candidate person projection. One row per DDHQ candidate_id, which is
+      per-race/per-cycle rather than a durable person id; cross-cycle identity is
+      resolved by the probabilistic person layer. All-time. DDHQ has no native
+      created field, so first_seen_at falls back to the Airbyte extraction time.
+    columns:
+      - name: source_name
+        description: Constant 'ddhq'.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["ddhq"]
+      - name: source_id
+        description: Native DDHQ candidate id (candidate_id, as string).
+        data_tests:
+          - not_null
+          - unique
+      - name: first_seen_at
+        description: Earliest Airbyte extraction time across the candidate_id's rows.
+        data_tests:
+          - not_null

--- a/dbt/project/models/intermediate/civics/int__civics_person_source_ballotready.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_source_ballotready.sql
@@ -1,16 +1,11 @@
--- BallotReady person projection for the canonical-person layer: one row per
--- br_candidate_id (the native BR person id). A BR person has no first-class
--- record in the S3 feeds, so identity is reconstructed from their candidacy
--- (candidacies_v3) and office-holder (office_holders_v3) rows. first_seen_at is
--- the earliest created timestamp across both, which drives the earliest-member
--- gp_person_id mint (canonical-person plan, decision 4).
+-- BallotReady person projection: one row per br_candidate_id, the native BR
+-- person id. BallotReady has no first-class person record in the S3 feeds, so
+-- identity is reconstructed from a person's candidacy (candidacies_v3) and
+-- office-holder (office_holders_v3) rows. first_seen_at is the earliest created
+-- timestamp across both.
 --
--- All-time: no election-day filter. A person's older candidacies and terms are
--- exactly the signal the person layer uses to resolve them (decision 9).
---
--- The BR API Person object (richer bio/contacts) is the intended authority for
--- these attributes; it layers in once its staging lands (track A2). Until then
--- attributes come from the S3 rows only.
+-- No election-day filter: a person's older candidacies and terms are useful
+-- signal when resolving them across sources.
 with
     candidacy_members as (
         select

--- a/dbt/project/models/intermediate/civics/int__civics_person_source_ballotready.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_source_ballotready.sql
@@ -1,0 +1,130 @@
+-- BallotReady person projection for the canonical-person layer: one row per
+-- br_candidate_id (the native BR person id). A BR person has no first-class
+-- record in the S3 feeds, so identity is reconstructed from their candidacy
+-- (candidacies_v3) and office-holder (office_holders_v3) rows. first_seen_at is
+-- the earliest created timestamp across both, which drives the earliest-member
+-- gp_person_id mint (canonical-person plan, decision 4).
+--
+-- All-time: no election-day filter. A person's older candidacies and terms are
+-- exactly the signal the person layer uses to resolve them (decision 9).
+--
+-- The BR API Person object (richer bio/contacts) is the intended authority for
+-- these attributes; it layers in once its staging lands (track A2). Until then
+-- attributes come from the S3 rows only.
+with
+    candidacy_members as (
+        select
+            cast(br_candidate_id as string) as br_candidate_id,
+            lower(trim(first_name)) as first_name,
+            lower(trim(last_name)) as last_name,
+            nullif(lower(trim(middle_name)), '') as middle_name,
+            upper(trim(state)) as state,
+            nullif(lower(trim(email)), '') as email,
+            nullif(trim(phone), '') as phone,
+            cast(null as string) as website_url,
+            cast(null as string) as facebook_url,
+            cast(null as string) as twitter_url,
+            cast(null as string) as linkedin_url,
+            cast(br_candidacy_id as string) as candidacy_source_id,
+            cast(br_race_id as string) as race_id,
+            nullif(trim(position_name), '') as office_name,
+            election_day as election_date,
+            coalesce(candidacy_created_at, _airbyte_extracted_at) as created_at,
+            coalesce(
+                candidacy_updated_at, candidacy_created_at, _airbyte_extracted_at
+            ) as sort_at
+        from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
+        where br_candidate_id is not null
+    ),
+
+    officeholder_members as (
+        select
+            cast(br_candidate_id as string) as br_candidate_id,
+            lower(trim(first_name)) as first_name,
+            lower(trim(last_name)) as last_name,
+            nullif(lower(trim(middle_name)), '') as middle_name,
+            upper(trim(state)) as state,
+            nullif(lower(trim(email)), '') as email,
+            nullif(trim(phone), '') as phone,
+            nullif(trim(website_url), '') as website_url,
+            nullif(trim(facebook_url), '') as facebook_url,
+            nullif(trim(twitter_url), '') as twitter_url,
+            nullif(trim(linkedin_url), '') as linkedin_url,
+            cast(br_candidacy_id as string) as candidacy_source_id,
+            cast(null as string) as race_id,
+            nullif(trim(coalesce(position_name, office_title)), '') as office_name,
+            cast(null as date) as election_date,
+            coalesce(office_holder_created_at, _airbyte_extracted_at) as created_at,
+            coalesce(
+                office_holder_updated_at,
+                office_holder_created_at,
+                _airbyte_extracted_at
+            ) as sort_at
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+        where br_candidate_id is not null
+    ),
+
+    members as (
+        select *
+        from candidacy_members
+        union all
+        select *
+        from officeholder_members
+    ),
+
+    -- Coherent name/state from the most recently updated member row.
+    representative as (
+        select br_candidate_id, first_name, last_name, middle_name, state
+        from members
+        qualify
+            row_number() over (partition by br_candidate_id order by sort_at desc) = 1
+    ),
+
+    aggregated as (
+        select
+            br_candidate_id,
+            cast(min(created_at) as timestamp) as first_seen_at,
+            -- Best non-null contact / social across all of a person's rows;
+            -- socials only appear on office-holder rows.
+            max(email) as email,
+            max(phone) as phone,
+            max(website_url) as website_url,
+            max(facebook_url) as facebook_url,
+            max(twitter_url) as twitter_url,
+            max(linkedin_url) as linkedin_url,
+            array_sort(collect_set(candidacy_source_id)) as candidacy_source_ids,
+            array_sort(collect_set(race_id)) as race_ids,
+            array_sort(collect_set(office_name)) as office_names,
+            array_sort(collect_set(election_date)) as election_dates
+        from members
+        group by br_candidate_id
+    )
+
+select
+    'ballotready' as source_name,
+    r.br_candidate_id as source_id,
+    r.br_candidate_id,
+    cast(null as string) as ts_officeholder_id,
+    cast(null as string) as techspeed_candidate_code,
+    cast(null as string) as ddhq_candidate_id,
+    r.first_name,
+    r.last_name,
+    r.middle_name,
+    nullif(
+        trim(concat_ws(' ', r.first_name, r.middle_name, r.last_name)), ''
+    ) as full_name,
+    a.email,
+    a.phone,
+    r.state,
+    cast(null as date) as birth_date,
+    a.website_url,
+    a.facebook_url,
+    a.twitter_url,
+    a.linkedin_url,
+    a.candidacy_source_ids,
+    a.race_ids,
+    a.office_names,
+    a.election_dates,
+    a.first_seen_at
+from representative as r
+join aggregated as a using (br_candidate_id)

--- a/dbt/project/models/intermediate/civics/int__civics_person_source_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_source_ddhq.sql
@@ -1,9 +1,9 @@
 -- DDHQ candidate person projection: one row per DDHQ candidate_id. candidate_id
--- is per-race/per-cycle, not a durable person id (pre-work finding 1): it can
--- span several races within a cycle and is occasionally reused across people,
--- so cross-cycle person identity is left to the probabilistic layer. DDHQ has
--- no native created field, so first_seen_at falls back to the Airbyte
--- extraction time (canonical-person plan, decision 4). All-time.
+-- is per-race/per-cycle rather than a durable person id: it can span several
+-- races within a cycle and is occasionally reused across people, so cross-cycle
+-- person identity is resolved by the probabilistic person layer, not here. DDHQ
+-- has no native created field, so first_seen_at falls back to the Airbyte
+-- extraction time.
 with
     ddhq as (
         select

--- a/dbt/project/models/intermediate/civics/int__civics_person_source_ddhq.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_source_ddhq.sql
@@ -1,0 +1,76 @@
+-- DDHQ candidate person projection: one row per DDHQ candidate_id. candidate_id
+-- is per-race/per-cycle, not a durable person id (pre-work finding 1): it can
+-- span several races within a cycle and is occasionally reused across people,
+-- so cross-cycle person identity is left to the probabilistic layer. DDHQ has
+-- no native created field, so first_seen_at falls back to the Airbyte
+-- extraction time (canonical-person plan, decision 4). All-time.
+with
+    ddhq as (
+        select
+            cast(candidate_id as string) as ddhq_candidate_id,
+            lower(trim(candidate_first_name)) as first_name,
+            lower(trim(candidate_last_name)) as last_name,
+            nullif(lower(trim(candidate_middle_name)), '') as middle_name,
+            upper(trim(state_postal_code)) as state,
+            nullif(lower(trim(official_office_name)), '') as office_name,
+            cast(ddhq_race_id as string) as race_id,
+            cast(candidate_id as string)
+            || '_'
+            || cast(ddhq_race_id as string) as candidacy_source_id,
+            election_date,
+            _airbyte_extracted_at
+        from {{ ref("stg_airbyte_source__ddhq_gdrive_election_results") }}
+        where candidate_id is not null
+    ),
+
+    representative as (
+        select ddhq_candidate_id, first_name, last_name, middle_name, state
+        from ddhq
+        qualify
+            row_number() over (
+                partition by ddhq_candidate_id
+                order by election_date desc nulls last, race_id desc
+            )
+            = 1
+    ),
+
+    aggregated as (
+        select
+            ddhq_candidate_id,
+            cast(min(_airbyte_extracted_at) as timestamp) as first_seen_at,
+            array_sort(collect_set(candidacy_source_id)) as candidacy_source_ids,
+            array_sort(collect_set(race_id)) as race_ids,
+            array_sort(collect_set(office_name)) as office_names,
+            array_sort(collect_set(election_date)) as election_dates
+        from ddhq
+        group by ddhq_candidate_id
+    )
+
+select
+    'ddhq' as source_name,
+    r.ddhq_candidate_id as source_id,
+    cast(null as string) as br_candidate_id,
+    cast(null as string) as ts_officeholder_id,
+    cast(null as string) as techspeed_candidate_code,
+    r.ddhq_candidate_id,
+    r.first_name,
+    r.last_name,
+    r.middle_name,
+    nullif(
+        trim(concat_ws(' ', r.first_name, r.middle_name, r.last_name)), ''
+    ) as full_name,
+    cast(null as string) as email,
+    cast(null as string) as phone,
+    r.state,
+    cast(null as date) as birth_date,
+    cast(null as string) as website_url,
+    cast(null as string) as facebook_url,
+    cast(null as string) as twitter_url,
+    cast(null as string) as linkedin_url,
+    a.candidacy_source_ids,
+    a.race_ids,
+    a.office_names,
+    a.election_dates,
+    a.first_seen_at
+from representative as r
+join aggregated as a using (ddhq_candidate_id)

--- a/dbt/project/models/intermediate/civics/int__civics_person_source_techspeed_candidate.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_source_techspeed_candidate.sql
@@ -1,11 +1,10 @@
 -- TechSpeed candidate person projection: one row per candidate identity code.
 -- TechSpeed exposes no native candidate id, so identity keys off
--- generate_candidate_code (same 5-arg form the candidacy-stage prematch uses),
--- which makes candidacy_source_ids join back to the candidacy-stage layer.
--- The code fragments a person across offices and cities by construction;
--- cross-code person identity is left to the probabilistic person layer
--- (canonical-person plan, pre-work finding 4). All-time. first_seen_at is the
--- earliest date_processed (parsed inline; candidate staging keeps it raw).
+-- generate_candidate_code (the same 5-arg form the candidacy-stage models use),
+-- which keeps candidacy_source_ids joinable to the candidacy-stage layer. The
+-- code varies by office and city, so a person running for multiple offices
+-- resolves to several codes here. first_seen_at is the earliest date_processed
+-- (parsed inline; candidate staging keeps it raw).
 with
     ts as (
         select

--- a/dbt/project/models/intermediate/civics/int__civics_person_source_techspeed_candidate.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_source_techspeed_candidate.sql
@@ -1,0 +1,106 @@
+-- TechSpeed candidate person projection: one row per candidate identity code.
+-- TechSpeed exposes no native candidate id, so identity keys off
+-- generate_candidate_code (same 5-arg form the candidacy-stage prematch uses),
+-- which makes candidacy_source_ids join back to the candidacy-stage layer.
+-- The code fragments a person across offices and cities by construction;
+-- cross-code person identity is left to the probabilistic person layer
+-- (canonical-person plan, pre-work finding 4). All-time. first_seen_at is the
+-- earliest date_processed (parsed inline; candidate staging keeps it raw).
+with
+    ts as (
+        select
+            {{
+                generate_candidate_code(
+                    "first_name", "last_name", "state", "office_type", "city"
+                )
+            }} as techspeed_candidate_code,
+            lower(trim(first_name)) as first_name,
+            lower(trim(last_name)) as last_name,
+            upper(trim(state_postal_code)) as state,
+            nullif(lower(trim(email)), '') as email,
+            nullif(trim(phone), '') as phone,
+            birth_date_parsed as birth_date,
+            nullif(trim(website_url), '') as website_url,
+            nullif(trim(facebook_url), '') as facebook_url,
+            nullif(trim(linkedin_url), '') as linkedin_url,
+            nullif(lower(trim(official_office_name)), '') as office_name,
+            cast(br_race_id as string) as race_id,
+            election_date,
+            case
+                when primary_election_date_parsed is not null
+                then 'primary'
+                else 'general'
+            end as election_stage,
+            coalesce(
+                try_cast(date_processed as date),
+                try_to_date(date_processed, 'MM/dd/yyyy'),
+                try_to_date(date_processed, 'M/d/yyyy')
+            ) as processed_date,
+            _airbyte_extracted_at
+        from {{ ref("stg_airbyte_source__techspeed_gdrive_candidates") }}
+    ),
+
+    coded as (select * from ts where techspeed_candidate_code is not null),
+
+    representative as (
+        select techspeed_candidate_code, first_name, last_name, state
+        from coded
+        qualify
+            row_number() over (
+                partition by techspeed_candidate_code
+                order by processed_date desc nulls last, _airbyte_extracted_at desc
+            )
+            = 1
+    ),
+
+    aggregated as (
+        select
+            techspeed_candidate_code,
+            cast(
+                min(
+                    coalesce(cast(processed_date as timestamp), _airbyte_extracted_at)
+                ) as timestamp
+            ) as first_seen_at,
+            max(email) as email,
+            max(phone) as phone,
+            max(birth_date) as birth_date,
+            max(website_url) as website_url,
+            max(facebook_url) as facebook_url,
+            max(linkedin_url) as linkedin_url,
+            array_sort(
+                collect_set(techspeed_candidate_code || '__' || election_stage)
+            ) as candidacy_source_ids,
+            array_sort(collect_set(race_id)) as race_ids,
+            array_sort(collect_set(office_name)) as office_names,
+            array_sort(collect_set(election_date)) as election_dates
+        from coded
+        group by techspeed_candidate_code
+    )
+
+select
+    'techspeed_candidate' as source_name,
+    r.techspeed_candidate_code as source_id,
+    cast(null as string) as br_candidate_id,
+    cast(null as string) as ts_officeholder_id,
+    r.techspeed_candidate_code,
+    cast(null as string) as ddhq_candidate_id,
+    r.first_name,
+    r.last_name,
+    cast(null as string) as middle_name,
+    nullif(trim(concat_ws(' ', r.first_name, r.last_name)), '') as full_name,
+    a.email,
+    a.phone,
+    r.state,
+    a.birth_date,
+    a.website_url,
+    a.facebook_url,
+    -- TechSpeed stores twitter/instagram as handles, not URLs; left null here.
+    cast(null as string) as twitter_url,
+    a.linkedin_url,
+    a.candidacy_source_ids,
+    a.race_ids,
+    a.office_names,
+    a.election_dates,
+    a.first_seen_at
+from representative as r
+join aggregated as a using (techspeed_candidate_code)

--- a/dbt/project/models/intermediate/civics/int__civics_person_source_techspeed_officeholder.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_source_techspeed_officeholder.sql
@@ -1,0 +1,90 @@
+-- TechSpeed office-holder person projection: one row per ts_officeholder_id.
+-- The deterministic link to a BallotReady person (ts_officeholder_id ==
+-- br_office_holder_id) is carried as br_candidate_id, but suppressed for the
+-- ids flagged reused across different people (the existing reuse guard in
+-- int__civics_elected_official_canonical_ids). Reused ids still project as
+-- office-holder persons, just without a false deterministic BR link. All-time;
+-- first_seen_at is the earliest parsed date_processed.
+with
+    ts as (
+        select
+            cast(ts_officeholder_id as string) as ts_officeholder_id,
+            lower(trim(first_name)) as first_name,
+            lower(trim(last_name)) as last_name,
+            upper(trim(state)) as state,
+            nullif(lower(trim(email)), '') as email,
+            nullif(trim(phone), '') as phone,
+            nullif(lower(trim(office_name)), '') as office_name,
+            date_processed_date as processed_date,
+            _airbyte_extracted_at
+        from {{ ref("stg_airbyte_source__techspeed_gdrive_officeholders") }}
+        where ts_officeholder_id is not null
+    ),
+
+    crosswalk as (
+        select
+            cast(ts_officeholder_id as string) as ts_officeholder_id,
+            cast(br_candidate_id as string) as br_candidate_id,
+            ts_officeholder_id_is_reused
+        from {{ ref("int__civics_elected_official_canonical_ids") }}
+    ),
+
+    representative as (
+        select ts_officeholder_id, first_name, last_name, state
+        from ts
+        qualify
+            row_number() over (
+                partition by ts_officeholder_id
+                order by processed_date desc nulls last, _airbyte_extracted_at desc
+            )
+            = 1
+    ),
+
+    aggregated as (
+        select
+            ts_officeholder_id,
+            cast(
+                min(
+                    coalesce(cast(processed_date as timestamp), _airbyte_extracted_at)
+                ) as timestamp
+            ) as first_seen_at,
+            max(email) as email,
+            max(phone) as phone,
+            array_sort(collect_set(office_name)) as office_names,
+            -- Office-holder rows carry no candidacy or race ids; typed empties.
+            collect_set(cast(null as string)) as candidacy_source_ids,
+            collect_set(cast(null as string)) as race_ids,
+            collect_set(cast(null as date)) as election_dates
+        from ts
+        group by ts_officeholder_id
+    )
+
+select
+    'techspeed_officeholder' as source_name,
+    r.ts_officeholder_id as source_id,
+    case
+        when not coalesce(x.ts_officeholder_id_is_reused, false) then x.br_candidate_id
+    end as br_candidate_id,
+    r.ts_officeholder_id,
+    cast(null as string) as techspeed_candidate_code,
+    cast(null as string) as ddhq_candidate_id,
+    r.first_name,
+    r.last_name,
+    cast(null as string) as middle_name,
+    nullif(trim(concat_ws(' ', r.first_name, r.last_name)), '') as full_name,
+    a.email,
+    a.phone,
+    r.state,
+    cast(null as date) as birth_date,
+    cast(null as string) as website_url,
+    cast(null as string) as facebook_url,
+    cast(null as string) as twitter_url,
+    cast(null as string) as linkedin_url,
+    a.candidacy_source_ids,
+    a.race_ids,
+    a.office_names,
+    a.election_dates,
+    a.first_seen_at
+from representative as r
+join aggregated as a using (ts_officeholder_id)
+left join crosswalk as x using (ts_officeholder_id)


### PR DESCRIPTION
First models of the canonical-person layer (track B, item B1). One person projection per source-native person id, all sharing a uniform schema so the downstream person prematch and id mint can union them directly. All-time, no election-day gate.

Each row carries: the native person id + cross-source FK columns, person attributes (name, email, phone, state, birth_date, socials), candidacy/term context arrays (`candidacy_source_ids`, `race_ids`, `office_names`, `election_dates`), and `first_seen_at`. `first_seen_at` is the earliest timestamp the person is evidenced in the source and drives the earliest-member `gp_person_id` mint.

## Models

| Model | Grain | first_seen_at | Rows |
|---|---|---|---|
| `int__civics_person_source_ballotready` | `br_candidate_id` | min(candidacy_created_at, office_holder_created_at) | 460,669 |
| `int__civics_person_source_techspeed_candidate` | `generate_candidate_code` (5-arg) | min(parsed date_processed) | 73,189 |
| `int__civics_person_source_techspeed_officeholder` | `ts_officeholder_id` | min(date_processed_date) | 30,375 |
| `int__civics_person_source_ddhq` | `candidate_id` | min(_airbyte_extracted_at) | 96,791 |

Row counts match the pre-work baselines.

## Notes

- BallotReady is one merged projection keyed on `br_candidate_id`, reconstructed from the S3 candidacy and office-holder feeds. The BR API Person attribute overlay is deferred to track A2 (its staging is not landed yet); noted in the model header.
- TechSpeed office-holders carry the deterministic BR person link (`ts_officeholder_id == br_office_holder_id`) as `br_candidate_id`, suppressed for the 86 ids flagged reused across different people. 30,289/30,375 resolve to a BR person.
- TechSpeed has no native candidate id, so the candidate projection keys off `generate_candidate_code` (same 5-arg form the candidacy-stage prematch uses), which keeps `candidacy_source_ids` joinable to the candidacy-stage layer.
- DDHQ `candidate_id` is per-race/per-cycle rather than a durable person id; cross-cycle person identity is left to the probabilistic person layer.

## Tests

Per model: uniqueness and not_null on the native key, `first_seen_at` not_null, accepted `source_name`. All 25 pass; sqlfmt/pre-commit clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New identity-layer models affect how persons are keyed and linked across vendors; incorrect `first_seen_at`, crosswalk suppression, or TS/DDHQ grain assumptions could mis-mint or mis-merge `gp_person_id` downstream, though scope is additive intermediate tables with dbt tests.
> 
> **Overview**
> Introduces **track B1** of the canonical-person layer: four new intermediate models that each project **one row per source-native person id**, using a **uniform column layout** so later steps can union them for person prematch and `gp_person_id` minting. Coverage is **all-time** (no election-day filter).
> 
> **BallotReady** (`int__civics_person_source_ballotready`) rebuilds people from S3 candidacy and office-holder feeds keyed on `br_candidate_id`, with `first_seen_at` as the earliest created timestamp across both. **TechSpeed candidate** keys on the same `generate_candidate_code` used in candidacy prematch; **TechSpeed officeholder** keys on `ts_officeholder_id` and sets `br_candidate_id` from the existing elected-official crosswalk except when `ts_officeholder_id_is_reused`. **DDHQ** keys on `candidate_id` with `first_seen_at` from Airbyte extraction when there is no native created time.
> 
> Each model rolls up attributes (names, contacts, arrays of candidacy/race/office/election context) and documents/tests grain via `int__civics.yaml` (`source_name`, unique `source_id`, `first_seen_at` not null).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bea8d0b1dfb9ae704d7c4ea5c29163ed83aeaaca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->