### PR TITLE
[DATA-2015] Wire even_year_primary into inference routing

### DIFF
--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -116,12 +116,12 @@ models:
                 min_value: 2024
                 max_value: 2035
       - name: election_code
-        description: "General or Local_or_Municipal (the only codes this model emits)."
+        description: "General, Local_or_Municipal, or Primary (the codes this model emits)."
         tests:
           - not_null
           - accepted_values:
               arguments:
-                values: ["General", "Local_or_Municipal"]
+                values: ["General", "Local_or_Municipal", "Primary"]
       - name: state
         description: >
           State postal code. The full-nationwide set is asserted so a partial

--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -174,6 +174,7 @@ _SLUG_ELECTION_CODE = {
     "midterm": "General",
     "even_year_local": "Local_or_Municipal",
     "off_year_local_lag2": "Local_or_Municipal",
+    "even_year_primary": "Primary",
 }
 
 
@@ -182,9 +183,9 @@ def _year_to_model_slugs(year):
     if year % 2 != 0:
         return ["off_year_local_lag2"]
     elif year % 4 == 2:
-        return ["midterm", "even_year_local"]
+        return ["midterm", "even_year_local", "even_year_primary"]
     else:
-        return ["presidential_lag3", "even_year_local"]
+        return ["presidential_lag3", "even_year_local", "even_year_primary"]
 
 
 def _detect_election_cols(l2_columns, max_vote_history_year):

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -275,7 +275,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ["General", "LocalOrMunicipal", "ConsolidatedGeneral"]
+                values: ["General", "LocalOrMunicipal", "ConsolidatedGeneral", "Primary"]
       - name: model_version
         description: The model version
         tests:

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 from dbt.project.models.intermediate.l2.int__voter_turnout_lgbm_inference import (
     _OPP_STATES_SQL,
+    _SLUG_ELECTION_CODE,
     _assert_consistent_model_family,
     _build_district_membership_sql,
     _build_precinct_features_sql,
@@ -59,14 +60,22 @@ _ELECTION_COLS = [
 @pytest.mark.parametrize(
     "year,expected",
     [
-        (2026, ["midterm", "even_year_local"]),  # even, year % 4 == 2
-        (2028, ["presidential_lag3", "even_year_local"]),  # even, year % 4 == 0
+        (2026, ["midterm", "even_year_local", "even_year_primary"]),  # even, year % 4 == 2
+        (2028, ["presidential_lag3", "even_year_local", "even_year_primary"]),  # even, year % 4 == 0
         (2027, ["off_year_local_lag2"]),  # odd
         (2025, ["off_year_local_lag2"]),  # odd
     ],
 )
 def test_year_to_model_slugs(year, expected):
     assert _year_to_model_slugs(year) == expected
+
+
+@pytest.mark.parametrize("year", [2024, 2025, 2026, 2027, 2028, 2029, 2030])
+def test_every_routed_slug_has_an_election_code(year):
+    # Every slug _year_to_model_slugs can return must have an entry in
+    # _SLUG_ELECTION_CODE, or _predict_precinct KeyErrors in production.
+    for slug in _year_to_model_slugs(year):
+        assert slug in _SLUG_ELECTION_CODE, f"{slug} (routed for {year}) has no election_code mapping"
 
 
 def test_detect_election_cols_filters_future_years():


### PR DESCRIPTION
## What this does

`even_year_primary` (the new statewide-primary turnout model, trained alongside the `OtherElection_` fix from #560) was built but never actually connected to this inference pipeline - it had no routing and no output label. This wires it in:

- Added `even_year_primary` to both even-year branches of `_year_to_model_slugs` (midterm and presidential cycles - it's even-year-only regardless of which 4-year position, so it belongs in both)
- Added `"Primary"` as its `election_code` in `_SLUG_ELECTION_CODE`

No feature-building changes needed - the existing feature SQL already builds `Primary_` lag features generically for every slug, this was purely a routing and labeling gap.

## Test plan
- [x] Added a regression test asserting every slug `_year_to_model_slugs` can return has an `election_code` mapping (a missing one would `KeyError` in `_predict_precinct` at runtime, not at import time, so this is worth guarding explicitly)
- [x] Full test suite passes (48 tests)
- [x] ruff check + format clean (pinned v0.7.4, matches CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which ML models run in production inference and adds a new `election_code` in aggregated turnout output; failure modes are guarded by tests and intentional hard-fail if `@production` model is missing.
> 
> **Overview**
> Connects the existing **`even_year_primary`** LightGBM model to the nationwide turnout inference pipeline so even-year runs actually load it and label outputs correctly.
> 
> **`_year_to_model_slugs`** now includes **`even_year_primary`** on both even-year branches (midterm and presidential cycles). **`_SLUG_ELECTION_CODE`** maps that slug to **`Primary`**, which **`_predict_precinct`** stamps on each row for downstream district aggregation.
> 
> Tests expect the expanded slug lists for 2026/2028 and add **`test_every_routed_slug_has_an_election_code`** so a future routed slug without a mapping fails in CI instead of **`KeyError`** at inference time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94000d6274e96fe48635ceab63a7dd05b9e286e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->