### PR TITLE
[DATA-2085] Person grouping: deterministic edges and person groups

### DIFF
--- a/dbt/project/macros/strip_ts_stage_suffix.sql
+++ b/dbt/project/macros/strip_ts_stage_suffix.sql
@@ -1,0 +1,3 @@
+{% macro strip_ts_stage_suffix(column) %}
+    regexp_replace({{ column }}, '__(primary|general|runoff)$', '')
+{% endmacro %}

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3182,6 +3182,35 @@ models:
           config:
             where: "gp_api_campaign_id is not null"
 
+  - name: int__civics_person_nodes
+    description: >
+      Person record universe. One row per record_key (source_name || '|' ||
+      source_id) participating in person identity: BR persons (all-time
+      candidacies + officeholder terms), gp_api users, HubSpot contacts,
+      non-reused TS officeholder ids, and TS/DDHQ candidacy-stage records.
+      Also unions in the cluster- and bridge-derived gp_api user ids so every
+      edge endpoint is guaranteed a label seed in the propagation. See
+      canonical-person-plan.md decision 1.
+    columns:
+      - name: record_key
+        description: Primary key.
+        data_tests:
+          - unique
+          - not_null
+      - name: source_name
+        description: Source system, parsed from record_key.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - ballotready
+                  - gp_api
+                  - hubspot
+                  - techspeed
+                  - techspeed_officeholder
+                  - ddhq
+
   - name: int__civics_person_edges
     description: >
       Deterministic person edges. One row per typed edge between two record
@@ -3216,7 +3245,7 @@ models:
           # silently drops a propagation neighbor in one direction.
           - relationships:
               arguments:
-                to: ref('int__civics_person_groups')
+                to: ref('int__civics_person_nodes')
                 field: record_key
       - name: record_key_2
         description: Higher of the two endpoint record keys.
@@ -3224,7 +3253,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: ref('int__civics_person_groups')
+                to: ref('int__civics_person_nodes')
                 field: record_key
       - name: edge_type
         description: Trust-ordered edge provenance.
@@ -3248,13 +3277,13 @@ models:
 
   - name: int__civics_person_groups
     description: >
-      Person groups. One row per record_key with its person_group_key: the min
-      record_key reachable over the non-conflicting edges, via min-label
-      propagation across 15 unrolled passes (Spark SQL, no recursion). Pass
-      count exceeds the largest component's diameter with headroom; convergence
-      is tested (penultimate pass == final). had_conflict rolls up E7 conflict
-      edges to the group (both endpoints). See canonical-person-plan.md
-      decision 1.
+      Person groups. One row per int__civics_person_nodes record_key with its
+      person_group_key: the min record_key reachable over the non-conflicting
+      edges, via min-label propagation across 15 unrolled passes (Spark SQL,
+      no recursion). Pass count exceeds the largest component's diameter with
+      headroom; convergence is tested (penultimate pass == final).
+      had_conflict rolls up E7 conflict edges to the group (both endpoints).
+      See canonical-person-plan.md decision 1.
     tests:
       # Propagation converged: the last two passes agree for every record.
       - dbt_utils.expression_is_true:

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3199,12 +3199,12 @@ models:
       # Conflict edges are E7 vendor keys spanning >1 distinct br_candidate_id
       # (DDHQ candidate_id reuse). Excluded from propagation and flagged. Warn
       # on any; error on a large jump that would signal an E7-keying regression.
+      # No severity override: severity warn would disable error_if entirely.
       - dbt_utils.expression_is_true:
           name: person_edges_conflict_count_warn
           arguments:
             expression: "not is_conflict"
           config:
-            severity: warn
             warn_if: ">0"
             error_if: ">200"
     columns:
@@ -3212,10 +3212,20 @@ models:
         description: Lower of the two endpoint record keys (source_name || '|' || source_id).
         data_tests:
           - not_null
+          # Every endpoint must exist in the node universe; a missing endpoint
+          # silently drops a propagation neighbor in one direction.
+          - relationships:
+              arguments:
+                to: ref('int__civics_person_groups')
+                field: record_key
       - name: record_key_2
         description: Higher of the two endpoint record keys.
         data_tests:
           - not_null
+          - relationships:
+              arguments:
+                to: ref('int__civics_person_groups')
+                field: record_key
       - name: edge_type
         description: Trust-ordered edge provenance.
         data_tests:
@@ -3240,16 +3250,17 @@ models:
     description: >
       Person groups. One row per record_key with its person_group_key: the min
       record_key reachable over the non-conflicting edges, via min-label
-      propagation across 12 unrolled passes (Spark SQL, no recursion). Pass
-      count exceeds the largest component's diameter; convergence is tested
-      (penultimate pass == final). had_conflict rolls up E7 conflict edges to
-      the group. See canonical-person-plan.md decision 1.
+      propagation across 15 unrolled passes (Spark SQL, no recursion). Pass
+      count exceeds the largest component's diameter with headroom; convergence
+      is tested (penultimate pass == final). had_conflict rolls up E7 conflict
+      edges to the group (both endpoints). See canonical-person-plan.md
+      decision 1.
     tests:
       # Propagation converged: the last two passes agree for every record.
       - dbt_utils.expression_is_true:
           name: person_groups_converged
           arguments:
-            expression: "pass_penultimate_key = pass_final_key"
+            expression: "person_group_key = pass_penultimate_key"
       # At most one distinct br_candidate_id per group. ~108 known cluster
       # conflicts resolve to the min br_candidate_id (plan decision 1); warn
       # on the known set, error on a regression. See the singular test

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3182,6 +3182,105 @@ models:
           config:
             where: "gp_api_campaign_id is not null"
 
+  - name: int__civics_person_edges
+    description: >
+      Deterministic person edges. One row per typed edge between two record
+      keys (record_key = source_name || '|' || source_id). Direction-agnostic
+      (record_key_1 <= record_key_2). No new matching: edges derive from native
+      ids (E1 HubSpot<->gp_api, E3 HubSpot->BR candidacy), the elected-official
+      linkages (E4 ts_officeholder->BR, E6 gp_api->BR bridge), candidacy-stage
+      Splink cluster co-membership (E5, hub to the cluster's min record key),
+      and within-source vendor keys (E7). See canonical-person-plan.md
+      decision 1.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [record_key_1, record_key_2, edge_type]
+      # Conflict edges are E7 vendor keys spanning >1 distinct br_candidate_id
+      # (DDHQ candidate_id reuse). Excluded from propagation and flagged. Warn
+      # on any; error on a large jump that would signal an E7-keying regression.
+      - dbt_utils.expression_is_true:
+          name: person_edges_conflict_count_warn
+          arguments:
+            expression: "not is_conflict"
+          config:
+            severity: warn
+            warn_if: ">0"
+            error_if: ">200"
+    columns:
+      - name: record_key_1
+        description: Lower of the two endpoint record keys (source_name || '|' || source_id).
+        data_tests:
+          - not_null
+      - name: record_key_2
+        description: Higher of the two endpoint record keys.
+        data_tests:
+          - not_null
+      - name: edge_type
+        description: Trust-ordered edge provenance.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - e1_hubspot_user
+                  - e3_hubspot_br_candidacy
+                  - e4_ts_officeholder
+                  - e5_cluster
+                  - e6_eo_bridge
+                  - e7_within_source
+      - name: is_conflict
+        description: >
+          true for E7 edges whose within-source key resolves to more than one
+          distinct br_candidate_id. Flagged and excluded from propagation.
+        data_tests:
+          - not_null
+
+  - name: int__civics_person_groups
+    description: >
+      Person groups. One row per record_key with its person_group_key: the min
+      record_key reachable over the non-conflicting edges, via min-label
+      propagation across 12 unrolled passes (Spark SQL, no recursion). Pass
+      count exceeds the largest component's diameter; convergence is tested
+      (penultimate pass == final). had_conflict rolls up E7 conflict edges to
+      the group. See canonical-person-plan.md decision 1.
+    tests:
+      # Propagation converged: the last two passes agree for every record.
+      - dbt_utils.expression_is_true:
+          name: person_groups_converged
+          arguments:
+            expression: "pass_penultimate_key = pass_final_key"
+      # At most one distinct br_candidate_id per group. ~108 known cluster
+      # conflicts resolve to the min br_candidate_id (plan decision 1); warn
+      # on the known set, error on a regression. See the singular test
+      # assert_person_group_single_br_candidate.
+    columns:
+      - name: record_key
+        description: Primary key. source_name || '|' || source_id for the source record.
+        data_tests:
+          - unique
+          - not_null
+      - name: source_name
+        description: Source system, parsed from record_key.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - ballotready
+                  - gp_api
+                  - hubspot
+                  - techspeed
+                  - techspeed_officeholder
+                  - ddhq
+      - name: person_group_key
+        description: Min record_key reachable over non-conflicting edges. Stable person label.
+        data_tests:
+          - not_null
+      - name: had_conflict
+        description: true when the group is touched by an E7 conflict edge.
+        data_tests:
+          - not_null
+
   - name: int__civics_er_canonical_election_stages
     description: >
       Direct election-stage ER crosswalk: maps DDHQ / TechSpeed election stages

--- a/dbt/project/models/intermediate/civics/int__civics_person_edges.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_edges.sql
@@ -19,7 +19,11 @@ with
     ),
 
     contacts as (
-        select id, goodparty_user_id, br_candidacy_id
+        select
+            id,
+            cast(id as string) as id_string,
+            goodparty_user_id,
+            cast(br_candidacy_id as string) as br_candidacy_id
         from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
     ),
 
@@ -30,8 +34,22 @@ with
     ),
 
     clustered as (
-        select cluster_id, source_id, source_name, br_candidacy_id
+        select
+            cluster_id,
+            source_id,
+            source_name,
+            br_candidacy_id,
+            split(source_id, '__')[0] as gp_api_campaign_id
         from {{ ref("stg_er_source__clustered_candidacy_stages") }}
+    ),
+
+    -- gp_api user <-> BR person via the elected-official bridge (E6 and the
+    -- E7 conflict pre-filter both consume this).
+    bridge as (
+        select distinct
+            gp_api_user_id, cast(br_candidate_id as string) as br_candidate_id
+        from {{ ref("int__civics_elected_official_gp_api_bridge") }}
+        where gp_api_user_id is not null and br_candidate_id is not null
     ),
 
     -- E1/E2: HubSpot contact <-> gp_api user via bidirectional native ids.
@@ -47,18 +65,16 @@ with
             'gp_api|' || cast(u.id as string),
             'hubspot|' || cast(u.hubspot_contact_id as string)
         from users as u
-        inner join contacts as c on cast(c.id as string) = u.hubspot_contact_id
+        inner join contacts as c on c.id_string = u.hubspot_contact_id
     ),
 
     -- E3: HubSpot contact br_candidacy_id -> BR candidacy -> br_candidate_id.
     e3 as (
         select
-            'hubspot|' || cast(c.id as string) as rk_a,
+            'hubspot|' || c.id_string as rk_a,
             'ballotready|' || cand.br_candidate_id as rk_b
         from contacts as c
-        inner join
-            candidacies as cand
-            on cand.br_candidacy_id = cast(c.br_candidacy_id as string)
+        inner join candidacies as cand on cand.br_candidacy_id = c.br_candidacy_id
     ),
 
     -- E4: ts_officeholder_id == br_office_holder_id -> br_candidate_id.
@@ -83,7 +99,7 @@ with
         union
         select cc.cluster_id, 'gp_api|' || cast(camp.user_id as string)
         from clustered as cc
-        inner join campaigns as camp on camp.campaign_id = split(cc.source_id, '__')[0]
+        inner join campaigns as camp on camp.campaign_id = cc.gp_api_campaign_id
         where cc.source_name = 'gp_api'
         union
         select cluster_id, 'techspeed|' || source_id
@@ -112,9 +128,8 @@ with
     e6 as (
         select
             'gp_api|' || cast(gp_api_user_id as string) as rk_a,
-            'ballotready|' || cast(br_candidate_id as string) as rk_b
-        from {{ ref("int__civics_elected_official_gp_api_bridge") }}
-        where gp_api_user_id is not null and br_candidate_id is not null
+            'ballotready|' || br_candidate_id as rk_b
+        from bridge
     ),
 
     -- E7: within-source vendor keys. TS records sharing a stage-stripped
@@ -127,7 +142,7 @@ with
         select
             'techspeed' as source_name,
             source_id,
-            regexp_replace(source_id, '__(primary|general|runoff)$', '') as e7_key
+            {{ strip_ts_stage_suffix("source_id") }} as e7_key
         from clustered
         where source_name = 'techspeed'
         union all
@@ -136,15 +151,27 @@ with
         where source_name = 'ddhq'
     ),
 
-    -- Distinct br_candidate_ids each vendor record reaches through its cluster.
+    -- Distinct br_candidate_ids each vendor record reaches through its
+    -- cluster: directly via a BR co-member, or via a gp_api co-member that
+    -- resolves to a BR person through the elected-official bridge.
     vendor_cluster_br as (
-        select distinct cc.source_name, cc.source_id, cand.br_candidate_id
+        select cc.source_name, cc.source_id, cand.br_candidate_id
         from clustered as cc
         inner join
             clustered as br
             on br.cluster_id = cc.cluster_id
             and br.source_name = 'ballotready'
         inner join candidacies as cand on cand.br_candidacy_id = br.br_candidacy_id
+        where cc.source_name in ('techspeed', 'ddhq')
+        union
+        select cc.source_name, cc.source_id, b.br_candidate_id
+        from clustered as cc
+        inner join
+            clustered as gp
+            on gp.cluster_id = cc.cluster_id
+            and gp.source_name = 'gp_api'
+        inner join campaigns as camp on camp.campaign_id = gp.gp_api_campaign_id
+        inner join bridge as b on b.gp_api_user_id = camp.user_id
         where cc.source_name in ('techspeed', 'ddhq')
     ),
 

--- a/dbt/project/models/intermediate/civics/int__civics_person_edges.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_edges.sql
@@ -1,0 +1,210 @@
+-- Deterministic person edges. One row per typed edge between two record keys
+-- (record_key = source_name || '|' || source_id). Edges are direction-agnostic
+-- (record_key_1 <= record_key_2). No new matching: every edge derives from
+-- native ids, candidacy-stage Splink cluster co-membership, or the
+-- elected-official bridge. See canonical-person-plan.md decision 1.
+with
+    -- br_candidacy_id -> br_candidate_id (person grain).
+    candidacies as (
+        select distinct
+            cast(br_candidacy_id as string) as br_candidacy_id,
+            cast(br_candidate_id as string) as br_candidate_id
+        from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
+        where br_candidacy_id is not null and br_candidate_id is not null
+    ),
+
+    users as (
+        select id, hubspot_contact_id
+        from {{ ref("stg_airbyte_source__gp_api_db_user") }}
+    ),
+
+    contacts as (
+        select id, goodparty_user_id, br_candidacy_id
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
+    ),
+
+    campaigns as (
+        select cast(campaign_id as string) as campaign_id, user_id
+        from {{ ref("campaigns") }}
+        where is_latest_version and user_id is not null
+    ),
+
+    clustered as (
+        select cluster_id, source_id, source_name, br_candidacy_id
+        from {{ ref("stg_er_source__clustered_candidacy_stages") }}
+    ),
+
+    -- E1/E2: HubSpot contact <-> gp_api user via bidirectional native ids.
+    -- Both directions collapse to one pair after normalization.
+    e1 as (
+        select
+            'hubspot|' || cast(c.id as string) as rk_a,
+            'gp_api|' || cast(c.goodparty_user_id as string) as rk_b
+        from contacts as c
+        inner join users as u on u.id = c.goodparty_user_id
+        union
+        select
+            'gp_api|' || cast(u.id as string),
+            'hubspot|' || cast(u.hubspot_contact_id as string)
+        from users as u
+        inner join contacts as c on cast(c.id as string) = u.hubspot_contact_id
+    ),
+
+    -- E3: HubSpot contact br_candidacy_id -> BR candidacy -> br_candidate_id.
+    e3 as (
+        select
+            'hubspot|' || cast(c.id as string) as rk_a,
+            'ballotready|' || cand.br_candidate_id as rk_b
+        from contacts as c
+        inner join
+            candidacies as cand
+            on cand.br_candidacy_id = cast(c.br_candidacy_id as string)
+    ),
+
+    -- E4: ts_officeholder_id == br_office_holder_id -> br_candidate_id.
+    -- Reused ts_officeholder_ids suppressed (they conflate distinct people).
+    e4 as (
+        select
+            'techspeed_officeholder|' || cast(ts_officeholder_id as string) as rk_a,
+            'ballotready|' || cast(br_candidate_id as string) as rk_b
+        from {{ ref("int__civics_elected_official_canonical_ids") }}
+        where not ts_officeholder_id_is_reused and br_candidate_id is not null
+    ),
+
+    -- E5: candidacy-stage cluster co-membership. Map each member to its record
+    -- key, then hub every member to the cluster's min record key (avoids a
+    -- pairwise cross join). BR members map via candidacy; gp_api members map
+    -- campaign -> user; TS/DDHQ members are their own keys.
+    cluster_members as (
+        select cc.cluster_id, 'ballotready|' || cand.br_candidate_id as record_key
+        from clustered as cc
+        inner join candidacies as cand on cand.br_candidacy_id = cc.br_candidacy_id
+        where cc.source_name = 'ballotready'
+        union
+        select cc.cluster_id, 'gp_api|' || cast(camp.user_id as string)
+        from clustered as cc
+        inner join campaigns as camp on camp.campaign_id = split(cc.source_id, '__')[0]
+        where cc.source_name = 'gp_api'
+        union
+        select cluster_id, 'techspeed|' || source_id
+        from clustered
+        where source_name = 'techspeed'
+        union
+        select cluster_id, 'ddhq|' || source_id
+        from clustered
+        where source_name = 'ddhq'
+    ),
+
+    cluster_hub as (
+        select cluster_id, min(record_key) as hub_key
+        from cluster_members
+        group by cluster_id
+    ),
+
+    e5 as (
+        select cm.record_key as rk_a, h.hub_key as rk_b
+        from cluster_members as cm
+        inner join cluster_hub as h using (cluster_id)
+        where cm.record_key <> h.hub_key
+    ),
+
+    -- E6: elected-official bridge. gp_api user <-> BR person.
+    e6 as (
+        select
+            'gp_api|' || cast(gp_api_user_id as string) as rk_a,
+            'ballotready|' || cast(br_candidate_id as string) as rk_b
+        from {{ ref("int__civics_elected_official_gp_api_bridge") }}
+        where gp_api_user_id is not null and br_candidate_id is not null
+    ),
+
+    -- E7: within-source vendor keys. TS records sharing a stage-stripped
+    -- candidate_code; DDHQ records sharing candidate_id. Guards a vendor-only
+    -- person's primary/general split. DDHQ candidate_id is reused across
+    -- people ~1.5% of the time, so pre-filter: if a key's records already
+    -- resolve (via clusters) to >1 distinct br_candidate_id, its E7 edges are
+    -- flagged is_conflict and excluded from propagation downstream.
+    e7_members as (
+        select
+            'techspeed' as source_name,
+            source_id,
+            regexp_replace(source_id, '__(primary|general|runoff)$', '') as e7_key
+        from clustered
+        where source_name = 'techspeed'
+        union all
+        select 'ddhq', source_id, split(source_id, '_')[0]
+        from clustered
+        where source_name = 'ddhq'
+    ),
+
+    -- Distinct br_candidate_ids each vendor record reaches through its cluster.
+    vendor_cluster_br as (
+        select distinct cc.source_name, cc.source_id, cand.br_candidate_id
+        from clustered as cc
+        inner join
+            clustered as br
+            on br.cluster_id = cc.cluster_id
+            and br.source_name = 'ballotready'
+        inner join candidacies as cand on cand.br_candidacy_id = br.br_candidacy_id
+        where cc.source_name in ('techspeed', 'ddhq')
+    ),
+
+    e7_key_stats as (
+        select
+            m.source_name,
+            m.e7_key,
+            count(distinct v.br_candidate_id) as distinct_br,
+            count(distinct m.source_id) as distinct_records
+        from e7_members as m
+        left join
+            vendor_cluster_br as v
+            on v.source_name = m.source_name
+            and v.source_id = m.source_id
+        group by m.source_name, m.e7_key
+    ),
+
+    e7_hub as (
+        select source_name, e7_key, min(source_name || '|' || source_id) as hub_key
+        from e7_members
+        group by source_name, e7_key
+    ),
+
+    e7 as (
+        select
+            m.source_name || '|' || m.source_id as rk_a,
+            h.hub_key as rk_b,
+            s.distinct_br > 1 as is_conflict
+        from e7_members as m
+        inner join e7_key_stats as s using (source_name, e7_key)
+        inner join e7_hub as h using (source_name, e7_key)
+        where
+            s.distinct_records > 1 and m.source_name || '|' || m.source_id <> h.hub_key
+    ),
+
+    all_edges as (
+        select rk_a, rk_b, 'e1_hubspot_user' as edge_type, false as is_conflict
+        from e1
+        union all
+        select rk_a, rk_b, 'e3_hubspot_br_candidacy', false
+        from e3
+        union all
+        select rk_a, rk_b, 'e4_ts_officeholder', false
+        from e4
+        union all
+        select rk_a, rk_b, 'e5_cluster', false
+        from e5
+        union all
+        select rk_a, rk_b, 'e6_eo_bridge', false
+        from e6
+        union all
+        select rk_a, rk_b, 'e7_within_source', is_conflict
+        from e7
+    )
+
+select
+    least(rk_a, rk_b) as record_key_1,
+    greatest(rk_a, rk_b) as record_key_2,
+    edge_type,
+    bool_or(is_conflict) as is_conflict
+from all_edges
+where rk_a is not null and rk_b is not null and rk_a <> rk_b
+group by 1, 2, 3

--- a/dbt/project/models/intermediate/civics/int__civics_person_groups.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_groups.sql
@@ -1,0 +1,80 @@
+-- Person groups. One row per record_key with its person_group_key: the min
+-- record_key reachable over the non-conflicting edge list, via min-label
+-- propagation across a fixed number of unrolled passes (Spark SQL, no
+-- recursion). Pass count exceeds the largest component's diameter; the
+-- convergence test (penultimate == final) proves it. See
+-- canonical-person-plan.md decision 1.
+{% set passes = 12 %}
+with
+    -- Node universe: every source record participating in person identity.
+    -- Superset of all edge endpoints (edges join the same source tables).
+    nodes as (
+        select distinct 'ballotready|' || cast(br_candidate_id as string) as record_key
+        from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
+        where br_candidate_id is not null
+        union
+        select distinct 'ballotready|' || cast(br_candidate_id as string)
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+        where br_candidate_id is not null
+        union
+        select 'gp_api|' || cast(id as string)
+        from {{ ref("stg_airbyte_source__gp_api_db_user") }}
+        union
+        select 'hubspot|' || cast(id as string)
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
+        union
+        select distinct 'techspeed_officeholder|' || cast(ts_officeholder_id as string)
+        from {{ ref("int__civics_elected_official_canonical_ids") }}
+        where not ts_officeholder_id_is_reused
+        union
+        select distinct source_name || '|' || source_id
+        from {{ ref("stg_er_source__clustered_candidacy_stages") }}
+        where source_name in ('techspeed', 'ddhq')
+    ),
+
+    -- Undirected adjacency with a self-loop per node, conflict edges excluded.
+    -- The self-loop lets each pass take min() over neighbors only (own label
+    -- included as a neighbor), so it references the prior pass exactly once —
+    -- a linear chain, not the exponential self+neighbor double reference.
+    adjacency as (
+        select record_key_1 as src, record_key_2 as dst
+        from {{ ref("int__civics_person_edges") }}
+        where not is_conflict
+        union all
+        select record_key_2, record_key_1
+        from {{ ref("int__civics_person_edges") }}
+        where not is_conflict
+        union all
+        select record_key, record_key
+        from nodes
+    ),
+
+    labels_0 as (select record_key, record_key as person_group_key from nodes),
+
+    {% for n in range(1, passes + 1) %}
+        labels_{{ n }} as (
+            select a.src as record_key, min(l.person_group_key) as person_group_key
+            from adjacency as a
+            inner join labels_{{ n - 1 }} as l on l.record_key = a.dst
+            group by a.src
+        ),
+    {% endfor %}
+
+    -- Groups touched by any conflict edge (E7 keys spanning >1 br person).
+    conflict_groups as (
+        select distinct f.person_group_key
+        from {{ ref("int__civics_person_edges") }} as ce
+        inner join labels_{{ passes }} as f on f.record_key = ce.record_key_1
+        where ce.is_conflict
+    )
+
+select
+    f.record_key,
+    substring_index(f.record_key, '|', 1) as source_name,
+    f.person_group_key,
+    prev.person_group_key as pass_penultimate_key,
+    f.person_group_key as pass_final_key,
+    cg.person_group_key is not null as had_conflict
+from labels_{{ passes }} as f
+inner join labels_{{ passes - 1 }} as prev using (record_key)
+left join conflict_groups as cg on cg.person_group_key = f.person_group_key

--- a/dbt/project/models/intermediate/civics/int__civics_person_groups.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_groups.sql
@@ -1,10 +1,10 @@
 -- Person groups. One row per record_key with its person_group_key: the min
 -- record_key reachable over the non-conflicting edge list, via min-label
 -- propagation across a fixed number of unrolled passes (Spark SQL, no
--- recursion). Pass count exceeds the largest component's diameter; the
--- convergence test (penultimate == final) proves it. See
--- canonical-person-plan.md decision 1.
-{% set passes = 12 %}
+-- recursion). Labels stop changing after pass 5 on current data (pass 6 ==
+-- pass 5, verified); 15 passes leaves headroom and the convergence test
+-- (penultimate == final) proves it. See canonical-person-plan.md decision 1.
+{% set passes = 15 %}
 with
     -- Node universe: every source record participating in person identity.
     -- Superset of all edge endpoints (edges join the same source tables).
@@ -61,11 +61,22 @@ with
     {% endfor %}
 
     -- Groups touched by any conflict edge (E7 keys spanning >1 br person).
+    -- Both endpoints: conflict edges are excluded from propagation, so the
+    -- two sides land in different groups and each group needs the flag.
+    conflict_endpoints as (
+        select record_key_1 as record_key
+        from {{ ref("int__civics_person_edges") }}
+        where is_conflict
+        union
+        select record_key_2
+        from {{ ref("int__civics_person_edges") }}
+        where is_conflict
+    ),
+
     conflict_groups as (
         select distinct f.person_group_key
-        from {{ ref("int__civics_person_edges") }} as ce
-        inner join labels_{{ passes }} as f on f.record_key = ce.record_key_1
-        where ce.is_conflict
+        from conflict_endpoints as ce
+        inner join labels_{{ passes }} as f using (record_key)
     )
 
 select
@@ -73,7 +84,6 @@ select
     substring_index(f.record_key, '|', 1) as source_name,
     f.person_group_key,
     prev.person_group_key as pass_penultimate_key,
-    f.person_group_key as pass_final_key,
     cg.person_group_key is not null as had_conflict
 from labels_{{ passes }} as f
 inner join labels_{{ passes - 1 }} as prev using (record_key)

--- a/dbt/project/models/intermediate/civics/int__civics_person_groups.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_groups.sql
@@ -6,30 +6,8 @@
 -- (penultimate == final) proves it. See canonical-person-plan.md decision 1.
 {% set passes = 15 %}
 with
-    -- Node universe: every source record participating in person identity.
-    -- Superset of all edge endpoints (edges join the same source tables).
     nodes as (
-        select distinct 'ballotready|' || cast(br_candidate_id as string) as record_key
-        from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
-        where br_candidate_id is not null
-        union
-        select distinct 'ballotready|' || cast(br_candidate_id as string)
-        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
-        where br_candidate_id is not null
-        union
-        select 'gp_api|' || cast(id as string)
-        from {{ ref("stg_airbyte_source__gp_api_db_user") }}
-        union
-        select 'hubspot|' || cast(id as string)
-        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
-        union
-        select distinct 'techspeed_officeholder|' || cast(ts_officeholder_id as string)
-        from {{ ref("int__civics_elected_official_canonical_ids") }}
-        where not ts_officeholder_id_is_reused
-        union
-        select distinct source_name || '|' || source_id
-        from {{ ref("stg_er_source__clustered_candidacy_stages") }}
-        where source_name in ('techspeed', 'ddhq')
+        select record_key, source_name from {{ ref("int__civics_person_nodes") }}
     ),
 
     -- Undirected adjacency with a self-loop per node, conflict edges excluded.
@@ -81,10 +59,11 @@ with
 
 select
     f.record_key,
-    substring_index(f.record_key, '|', 1) as source_name,
+    n.source_name,
     f.person_group_key,
     prev.person_group_key as pass_penultimate_key,
     cg.person_group_key is not null as had_conflict
 from labels_{{ passes }} as f
+inner join nodes as n using (record_key)
 inner join labels_{{ passes - 1 }} as prev using (record_key)
 left join conflict_groups as cg on cg.person_group_key = f.person_group_key

--- a/dbt/project/models/intermediate/civics/int__civics_person_nodes.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_person_nodes.sql
@@ -1,0 +1,55 @@
+-- Person record universe: one row per record_key participating in person
+-- identity. Must contain every key the edge model can emit — an edge endpoint
+-- missing from labels_0 silently drops its neighbors during propagation — so
+-- the cluster- and bridge-derived gp_api user ids are unioned in alongside
+-- the staging user table. See canonical-person-plan.md decision 1.
+with
+    campaigns as (
+        select cast(campaign_id as string) as campaign_id, user_id
+        from {{ ref("campaigns") }}
+        where is_latest_version and user_id is not null
+    ),
+
+    clustered as (
+        select source_id, source_name, split(source_id, '__')[0] as gp_api_campaign_id
+        from {{ ref("stg_er_source__clustered_candidacy_stages") }}
+    ),
+
+    record_keys as (
+        select 'ballotready|' || cast(br_candidate_id as string) as record_key
+        from {{ ref("stg_airbyte_source__ballotready_s3_candidacies_v3") }}
+        where br_candidate_id is not null
+        union
+        select 'ballotready|' || cast(br_candidate_id as string)
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+        where br_candidate_id is not null
+        union
+        select 'gp_api|' || cast(id as string)
+        from {{ ref("stg_airbyte_source__gp_api_db_user") }}
+        union
+        -- E5 endpoint mirror: gp_api cluster members resolve to user ids via
+        -- campaigns; a user missing from staging must still seed a label.
+        select 'gp_api|' || cast(camp.user_id as string)
+        from clustered as cc
+        inner join campaigns as camp on camp.campaign_id = cc.gp_api_campaign_id
+        where cc.source_name = 'gp_api'
+        union
+        -- E6 endpoint mirror, same rationale.
+        select 'gp_api|' || cast(gp_api_user_id as string)
+        from {{ ref("int__civics_elected_official_gp_api_bridge") }}
+        where gp_api_user_id is not null
+        union
+        select 'hubspot|' || cast(id as string)
+        from {{ ref("stg_airbyte_source__hubspot_api_contacts") }}
+        union
+        select 'techspeed_officeholder|' || cast(ts_officeholder_id as string)
+        from {{ ref("int__civics_elected_official_canonical_ids") }}
+        where not ts_officeholder_id_is_reused
+        union
+        select source_name || '|' || source_id
+        from clustered
+        where source_name in ('techspeed', 'ddhq')
+    )
+
+select record_key, substring_index(record_key, '|', 1) as source_name
+from record_keys

--- a/dbt/project/tests/assert_person_group_single_br_candidate.sql
+++ b/dbt/project/tests/assert_person_group_single_br_candidate.sql
@@ -2,8 +2,9 @@
 -- candidacy-stage clusters carry >1 distinct br_candidate_id (~108 of 70,960,
 -- 0.15% per plan finding 9); propagation resolves each such group to its min
 -- br_candidate_id and this test flags the residual. Warn on the known set,
--- error on a regression that would indicate an edge bug.
-{{ config(severity="warn", error_if="> 200") }}
+-- error on a regression that would indicate an edge bug. No severity
+-- override: severity warn would disable error_if entirely.
+{{ config(warn_if="!= 0", error_if="> 200") }}
 
 with
     br_records as (

--- a/dbt/project/tests/assert_person_group_single_br_candidate.sql
+++ b/dbt/project/tests/assert_person_group_single_br_candidate.sql
@@ -1,0 +1,18 @@
+-- At most one distinct br_candidate_id per person group. A handful of
+-- candidacy-stage clusters carry >1 distinct br_candidate_id (~108 of 70,960,
+-- 0.15% per plan finding 9); propagation resolves each such group to its min
+-- br_candidate_id and this test flags the residual. Warn on the known set,
+-- error on a regression that would indicate an edge bug.
+{{ config(severity="warn", error_if="> 200") }}
+
+with
+    br_records as (
+        select person_group_key, substring_index(record_key, '|', -1) as br_candidate_id
+        from {{ ref("int__civics_person_groups") }}
+        where source_name = 'ballotready'
+    )
+
+select person_group_key, count(distinct br_candidate_id) as distinct_br
+from br_records
+group by person_group_key
+having count(distinct br_candidate_id) > 1


### PR DESCRIPTION
Derives person clusters in dbt from signals that already exist, with no new matching (canonical-person plan decision 1). Three intermediate models plus tests.

## int__civics_person_nodes
The record universe: one row per record_key (`source_name || '|' || source_id`) participating in person identity. Also unions in the cluster- and bridge-derived gp_api user ids so every edge endpoint is guaranteed a label seed even if the user row is missing from staging.

## int__civics_person_edges
One row per typed, direction-agnostic edge between two record keys:

- **e1_hubspot_user** – HubSpot contact `goodparty_user_id` <-> gp_api user `hubspot_contact_id` (bidirectional native ids, one pair per link)
- **e3_hubspot_br_candidacy** – HubSpot `br_candidacy_id` -> BR candidacy -> `br_candidate_id`
- **e4_ts_officeholder** – `ts_officeholder_id` == `br_office_holder_id` -> `br_candidate_id` (reused ids suppressed)
- **e5_cluster** – candidacy-stage Splink cluster co-membership; members hubbed to the cluster's min record key (no pairwise cross join). BR members map via candidacy, gp_api via campaign -> user, TS/DDHQ are their own keys
- **e6_eo_bridge** – gp_api user <-> BR person via `int__civics_elected_official_gp_api_bridge`
- **e7_within_source** – TS records sharing a stage-stripped candidate_code (`strip_ts_stage_suffix` macro); DDHQ records sharing candidate_id. Pre-filtered: keys resolving to >1 distinct `br_candidate_id` — via direct BR cluster co-membership or via a gp_api co-member plus the elected-official bridge — are flagged `is_conflict` and excluded from propagation (DDHQ candidate_id reuse guard)

## int__civics_person_groups
One row per record_key with a stable `person_group_key` = min record_key reachable over non-conflicting edges, via min-label propagation across 15 unrolled passes (Spark SQL, no recursion; self-loop adjacency keeps each pass a single-reference linear chain). Exposes `pass_penultimate_key` so convergence is testable; `had_conflict` rolls up E7 conflict edges to the groups of both endpoints.

## Tests
- Convergence: `person_group_key = pass_penultimate_key` for every record (error) — passes
- `record_key` unique + not_null on nodes and groups; `person_group_key` not_null; `edge_type` / `source_name` accepted_values
- Relationships from `record_key_1` / `record_key_2` to `int__civics_person_nodes.record_key` (edge endpoints must exist as nodes; no test-time cycle since nodes is upstream of both)
- At most one distinct `br_candidate_id` per group (warn 1-200, error >200)
- Edge conflict count (warn >0, error >200; no severity override so error_if can fire)

## Dev sanity metrics

Records per source:

| source_name | records |
|---|---|
| ballotready | 460,669 |
| hubspot | 328,662 |
| gp_api | 69,500 |
| techspeed | 43,982 |
| techspeed_officeholder | 30,289 |
| ddhq | 18,162 |
| **total** | **951,264** |

| metric | value |
|---|---|
| total person groups | 826,817 |
| multi-source groups | 106,751 |
| biggest group | 11 records (top 5: 11, 10, 10, 10, 10; all legitimately multi-source) |
| total edges | 124,804 |
| E7 conflict edges | 23 |
| groups with >1 br_candidate_id | 23 |
| conflicted groups (had_conflict) | 43 |
| records in conflicted groups | 134 |
| non-converged records | 0 |

`dbt build` result: PASS=21, WARN=2 (the two intended conflict-count warns), ERROR=0.

## Notes / judgment calls
- **15 passes, not 5.** The plan specified 5 unrolled passes. Verified against the data: labels stop changing after pass 5 (pass 6 == pass 5, zero diffs), but the convergence test compares the last two passes, so 5 passes fails the test even though the labels are final. 15 passes gives headroom for growth at negligible cost; the test proves convergence on every run.
- **Linear-chain propagation.** The naive `least(self, min(neighbors))` per pass references the prior pass twice, so inlined dbt CTEs recompute exponentially and the build hung. Reformulated with a self-loop in the adjacency so each pass takes `min()` over neighbors only, referencing the prior pass once. Build is ~40s.
- **Record universe is its own model** (`int__civics_person_nodes`) so the endpoint-coverage contract is testable without a cycle and cluster/bridge-derived user ids can't fall out of the label seed.
- Runs against the current 2026 clustered candidacy-stage set, so the br-per-group conflict count is 23 here (the plan's 108 is the all-time expectation); the test errors only above 200.