### PR TITLE
Use least() for gp_person_id instead of array_min(array_compact())

### DIFF
--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -342,9 +342,7 @@ select
     deduplicated.gp_candidacy_id,
     -- gp_person_id: min over the person reached by HubSpot contact, product
     -- campaign -> user, and the candidacy's stage rows.
-    array_min(
-        array_compact(array(hp.gp_person_id, gpp.gp_person_id, sp.gp_person_id))
-    ) as gp_person_id,
+    least(hp.gp_person_id, gpp.gp_person_id, sp.gp_person_id) as gp_person_id,
     deduplicated.gp_candidate_id,
     deduplicated.gp_election_id,
     deduplicated.product_campaign_id,

--- a/dbt/project/models/marts/civics/candidacy_stage.sql
+++ b/dbt/project/models/marts/civics/candidacy_stage.sql
@@ -358,15 +358,8 @@ with
         select
             m.*,
             coalesce(es.stage_type, m.native_stage) as election_stage,
-            array_min(
-                array_compact(
-                    array(
-                        bcp.gp_person_id,
-                        tcp.gp_person_id,
-                        gcp.gp_person_id,
-                        dp.gp_person_id
-                    )
-                )
+            least(
+                bcp.gp_person_id, tcp.gp_person_id, gcp.gp_person_id, dp.gp_person_id
             ) as gp_person_id
         from merged_foj as m
         left join

--- a/dbt/project/models/marts/civics/candidate.sql
+++ b/dbt/project/models/marts/civics/candidate.sql
@@ -176,9 +176,7 @@ select
     deduplicated.gp_candidate_id,
     -- gp_person_id: min over the person reached by HubSpot contact,
     -- prod_db user, and the candidate's candidacies.
-    array_min(
-        array_compact(array(hp.gp_person_id, gpp.gp_person_id, cp.gp_person_id))
-    ) as gp_person_id,
+    least(hp.gp_person_id, gpp.gp_person_id, cp.gp_person_id) as gp_person_id,
     hubspot_contact_id,
     prod_db_user_id,
     candidate_id_tier,

--- a/dbt/project/models/marts/civics/elected_official_terms.sql
+++ b/dbt/project/models/marts/civics/elected_official_terms.sql
@@ -47,7 +47,7 @@ select
 
     -- Canonical person. min over the person ids reached by br_candidate_id
     -- and the bridged gp_api_user_id (one person by construction).
-    array_min(array_compact(array(bp.gp_person_id, gpp.gp_person_id))) as gp_person_id,
+    least(bp.gp_person_id, gpp.gp_person_id) as gp_person_id,
 
     -- Source IDs
     br.br_office_holder_id,

--- a/dbt/project/models/marts/civics/elected_officials.sql
+++ b/dbt/project/models/marts/civics/elected_officials.sql
@@ -149,10 +149,7 @@ with
 -- gp_api_user_id, and hubspot_contact_id (one person by construction; min
 -- guards residual multi-source disagreement).
 select
-    merged.*,
-    array_min(
-        array_compact(array(bp.gp_person_id, gpp.gp_person_id, hp.gp_person_id))
-    ) as gp_person_id
+    merged.*, least(bp.gp_person_id, gpp.gp_person_id, hp.gp_person_id) as gp_person_id
 from merged
 left join
     person_ids as bp


### PR DESCRIPTION
Reverts candidacy.sql, candidacy_stage.sql, candidate.sql, elected_official_terms.sql, and elected_officials.sql to select gp_person_id with least() across sources instead of array_min(array_compact(array(...))).

Databricks least() already skips nulls and only returns null when every argument is null, so the array wrapping added no behavior. It was introduced only to satisfy an automated review bot's flag on the original least() usage; the underlying concern doesn't hold on Databricks. least() reads more directly for what the query is doing: pick the lowest person id among the sources that resolved one.

Verified with dbt build --select on all five models: 0 errors, 119 tests pass (9 pre-existing warn-severity tests unrelated to this change), including the gp_person_id relationship and uniqueness tests on candidacy and candidate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Expression-only refactor on person ID resolution; PR author reports full dbt build and gp_person_id tests passing with no intended semantic change.
> 
> **Overview**
> **`gp_person_id`** on five civics marts is computed again with **`least(...)`** over the per-source person IDs from joins, instead of **`array_min(array_compact(array(...)))`**.
> 
> Affected models: **`candidacy`**, **`candidacy_stage`**, **`candidate`**, **`elected_officials`**, and **`elected_official_terms`**. The intent is unchanged—take the minimum resolved person ID across HubSpot, gp_api, BallotReady/TechSpeed/DDHQ bridges, and rollups—while matching Databricks semantics where **`least`** ignores null arguments and only returns null when all inputs are null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db57862041a2bc0fd057f1dcd83ab731e3a37298. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->