### PR TITLE
Recalibrate person conflict canary thresholds for all-time ER

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3251,16 +3251,18 @@ models:
           arguments:
             combination_of_columns: [record_key_1, record_key_2, edge_type]
       # Conflict edges are E7 vendor keys spanning >1 distinct br_candidate_id
-      # (DDHQ candidate_id reuse). Excluded from propagation and flagged. Warn
-      # on any; error on a large jump that would signal an E7-keying regression.
-      # No severity override: severity warn would disable error_if entirely.
+      # (mostly DDHQ candidate_id reuse across cycles). Excluded from
+      # propagation and flagged. Warn on any; error on a large jump that would
+      # signal an E7-keying regression. Baseline is ~1188 over the all-time
+      # historical ER universe (was ~23 before pre-2026 candidacies were
+      # included). No severity override: severity warn would disable error_if.
       - dbt_utils.expression_is_true:
           name: person_edges_conflict_count_warn
           arguments:
             expression: "not is_conflict"
           config:
             warn_if: ">0"
-            error_if: ">200"
+            error_if: ">2000"
     columns:
       - name: record_key_1
         description: Lower of the two endpoint record keys (source_name || '|' || source_id).
@@ -3314,7 +3316,7 @@ models:
           name: person_groups_converged
           arguments:
             expression: "person_group_key = pass_penultimate_key"
-      # At most one distinct br_candidate_id per group. ~108 known cluster
+      # At most one distinct br_candidate_id per group. ~223 known cluster
       # conflicts resolve to the min br_candidate_id (plan decision 1); warn
       # on the known set, error on a regression. See the singular test
       # assert_person_group_single_br_candidate.

--- a/dbt/project/tests/assert_person_group_single_br_candidate.sql
+++ b/dbt/project/tests/assert_person_group_single_br_candidate.sql
@@ -1,10 +1,11 @@
 -- At most one distinct br_candidate_id per person group. A handful of
--- candidacy-stage clusters carry >1 distinct br_candidate_id (~108 of 70,960,
--- 0.15% per plan finding 9); propagation resolves each such group to its min
--- br_candidate_id and this test flags the residual. Warn on the known set,
--- error on a regression that would indicate an edge bug. No severity
--- override: severity warn would disable error_if entirely.
-{{ config(warn_if="!= 0", error_if="> 200") }}
+-- candidacy-stage clusters carry >1 distinct br_candidate_id (~223 of 460,443
+-- BR-containing groups, 0.05% over the all-time historical ER universe; was
+-- ~108 before pre-2026 candidacies were included); propagation resolves each
+-- such group to its min br_candidate_id and this test flags the residual. Warn
+-- on the known set, error on a regression that would indicate an edge bug. No
+-- severity override: severity warn would disable error_if entirely.
+{{ config(warn_if="!= 0", error_if="> 400") }}
 
 with
     br_records as (


### PR DESCRIPTION
## Problem

The dbt Cloud production test `person_edges_conflict_count_warn` failed:

```
Got 1188 results, configured to fail if >200
```

The sibling singular test `assert_person_group_single_br_candidate` also fails (223 > 200) once `int__civics_person_groups` rebuilds on the same data.

## Root cause

Not a code regression. The first all-time ER run to include pre-2026 historical candidacies raises the legitimate vendor-key conflict baseline. The `int__civics_person_edges` model is unchanged since it shipped; the live `er_source.clustered_candidacy_stages` source (overwritten in place, no date suffix) now covers 2022 onward.

E7 conflict edges are within-source vendor keys that resolve to more than one distinct `br_candidate_id` — almost entirely DDHQ `candidate_id` reuse across cycles. They are correctly flagged (`is_conflict`) and excluded from propagation. Historical scope expands this legitimate set:

- E7 conflict edges: ~23 -> 1188 (728 DDHQ keys + 1 TechSpeed key; max distinct_br 6, avg 2.19 — no pathological over-merging)
- Person groups spanning >1 `br_candidate_id`: ~108 -> 223 (of 460,443 BR-containing groups, 0.05%)

Both tests are canaries: warn on any conflict, error only on a large jump signaling a keying regression. The `>200` error thresholds were set for the recent-only universe.

## Fix

Raise the error thresholds to sit above the new all-time baseline while still catching a genuine regression:

- `person_edges_conflict_count_warn`: `error_if >200` -> `>2000`
- `assert_person_group_single_br_candidate`: `error_if > 200` -> `> 400`

`warn_if` is unchanged, so both still warn on the known baseline. Comments updated to record the new figures and their cause.

## Verification

Rebuilt `int__civics_person_nodes`, `int__civics_person_edges`, and `int__civics_person_groups` against the current all-time source and ran their tests:

- `person_edges_conflict_count_warn`: WARN 1188, no error
- `assert_person_group_single_br_candidate`: WARN 223, no error
- `person_groups_converged`: PASS (propagation still converges)
- edge->node relationships tests: PASS (referential integrity holds once nodes rebuilds)
- all other node/edge/group tests: PASS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ecda31efc795fc77c53959e5468912dc4267577d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->