### PR TITLE
[DATA-2015] Deliver Projected_Turnout via the sync_election_api swap DAG

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -765,17 +765,30 @@ def sync_election_api():
                     )
                     prior_exists = cur.fetchone()[0] is not None
                     if prior_exists:
-                        cur.execute(f'SELECT COUNT(*) FROM "{PT.target_schema}"."{PT.target_table}"')
-                        prior_count = cur.fetchone()[0]
+                        # Baseline on DISTINCT natural keys, not raw rows: a
+                        # live table last written by the legacy upsert path can
+                        # be bloated with superseded model_version duplicates,
+                        # while staging is deduped (gate above) — a raw-count
+                        # ratio could refuse a legitimate dedupe cutover.
+                        # Keys-vs-keys compares like with like.
+                        cur.execute(
+                            f"SELECT COUNT(*) FROM ("
+                            f"SELECT DISTINCT district_id, election_year, election_code "
+                            f'FROM "{PT.target_schema}"."{PT.target_table}"'
+                            f") AS prior_keys"
+                        )
+                        prior_key_count = cur.fetchone()[0]
                     else:
-                        prior_count = 0
+                        prior_key_count = 0
 
-                    if prior_count > 0:
-                        ratio = loaded_count / prior_count
+                    if prior_key_count > 0:
+                        ratio = loaded_count / prior_key_count
                         if ratio < 0.5:
                             raise ValueError(
                                 f"Loaded {loaded_count} rows, prior live had "
-                                f"{prior_count} (ratio {ratio:.2f}) — refusing to swap"
+                                f"{prior_key_count} distinct (district_id, "
+                                f"election_year, election_code) keys "
+                                f"(ratio {ratio:.2f}) — refusing to swap"
                             )
                     elif loaded_count < 100_000:
                         raise ValueError(
@@ -784,10 +797,10 @@ def sync_election_api():
                         )
 
                     t_log.info(
-                        "Quality checks passed: %d rows (prior %d), "
+                        "Quality checks passed: %d rows (prior %d distinct keys), "
                         "no duplicate (district, election) keys",
                         loaded_count,
-                        prior_count,
+                        prior_key_count,
                     )
                 finally:
                     cur.close()

--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -335,12 +335,17 @@ def _pt_constraint_ddl() -> list[str]:
     ]
 
 
-def _pt_quality_gate(loaded_count: int, dup_keys: int, prior_key_count: int) -> None:
+def _pt_quality_gate(loaded_count: int, dup_keys: int, prior_key_count: int, null_keys: int) -> None:
     """Decide whether staged Projected_Turnout data may swap into place.
 
     Pure decision logic (unit-tested); the quality_checks task gathers the
     inputs from Postgres. Raises ValueError (task fails, no swap) when:
 
+    - ``null_keys`` > 0 — staged rows with a NULL district_id, election_year,
+      or election_code. Belt-and-braces over the staging table's inherited
+      NOT NULLs (the LIKE-clone copies them, so such a row should already
+      have failed the load): the gate carries its own proof rather than
+      relying on an inherited constraint.
     - ``dup_keys`` > 0 — duplicate (district_id, election_year, election_code)
       keys in staging. Must be zero: the election-api consumer does not
       disambiguate model_version, so a duplicate key would make it serve an
@@ -354,6 +359,11 @@ def _pt_quality_gate(loaded_count: int, dup_keys: int, prior_key_count: int) -> 
       cutover pass while still refusing a coverage collapse.
     - cold start (no prior table) with an implausibly small load.
     """
+    if null_keys > 0:
+        raise ValueError(
+            f"{null_keys} staging rows have a NULL district_id, "
+            f"election_year, or election_code — refusing to swap"
+        )
     if dup_keys > 0:
         raise ValueError(
             f"{dup_keys} duplicate (district_id, election_year, "
@@ -785,6 +795,17 @@ def sync_election_api():
                     )
                     dup_keys = cur.fetchone()[0]
 
+                    # NULL keys: belt-and-braces over the staging table's
+                    # inherited NOT NULLs — the gate proves it directly.
+                    cur.execute(
+                        f"SELECT COUNT(*) "
+                        f'FROM "{PT.staging_schema}"."{PT.new_table}" '
+                        f"WHERE district_id IS NULL "
+                        f"OR election_year IS NULL "
+                        f"OR election_code IS NULL"
+                    )
+                    null_keys = cur.fetchone()[0]
+
                     # Prior live state (absent on a true cold start). Both
                     # identifiers must be double-quoted in the regclass argument
                     # so Postgres does not fold the mixed-case name to lowercase.
@@ -806,11 +827,11 @@ def sync_election_api():
                 finally:
                     cur.close()
 
-            _pt_quality_gate(loaded_count, dup_keys, prior_key_count)
+            _pt_quality_gate(loaded_count, dup_keys, prior_key_count, null_keys)
 
             t_log.info(
                 "Quality checks passed: %d rows (prior %d distinct keys), "
-                "no duplicate (district, election) keys",
+                "no duplicate and no NULL (district, election) keys",
                 loaded_count,
                 prior_key_count,
             )

--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -335,6 +335,43 @@ def _pt_constraint_ddl() -> list[str]:
     ]
 
 
+def _pt_quality_gate(loaded_count: int, dup_keys: int, prior_key_count: int) -> None:
+    """Decide whether staged Projected_Turnout data may swap into place.
+
+    Pure decision logic (unit-tested); the quality_checks task gathers the
+    inputs from Postgres. Raises ValueError (task fails, no swap) when:
+
+    - ``dup_keys`` > 0 — duplicate (district_id, election_year, election_code)
+      keys in staging. Must be zero: the election-api consumer does not
+      disambiguate model_version, so a duplicate key would make it serve an
+      arbitrary row. This is the invariant the swap delivery exists to
+      guarantee (the legacy upsert writer could not).
+    - loaded rows fall below half of ``prior_key_count``, the prior live
+      table's DISTINCT natural-key count (0 on a true cold start). The
+      baseline is keys, not raw rows: a live table last written by the legacy
+      upsert path can be bloated with superseded model_version duplicates,
+      while staging is deduped, so keys-vs-keys lets a legitimate dedupe
+      cutover pass while still refusing a coverage collapse.
+    - cold start (no prior table) with an implausibly small load.
+    """
+    if dup_keys > 0:
+        raise ValueError(
+            f"{dup_keys} duplicate (district_id, election_year, "
+            f"election_code) keys in staging — refusing to swap"
+        )
+    if prior_key_count > 0:
+        ratio = loaded_count / prior_key_count
+        if ratio < 0.5:
+            raise ValueError(
+                f"Loaded {loaded_count} rows, prior live had "
+                f"{prior_key_count} distinct (district_id, "
+                f"election_year, election_code) keys "
+                f"(ratio {ratio:.2f}) — refusing to swap"
+            )
+    elif loaded_count < 100_000:
+        raise ValueError(f"Cold-start load of {loaded_count} rows is implausibly small — refusing to swap")
+
+
 @dag(
     start_date=pendulum_datetime(2026, 5, 5, tz="UTC"),
     schedule="@daily",
@@ -732,12 +769,9 @@ def sync_election_api():
 
         @task
         def quality_checks(loaded_count: int) -> None:
-            # The swap exists to guarantee the invariant the upsert writer
-            # could not: exactly one row per (district_id, election_year,
-            # election_code). The election-api consumer does not disambiguate
-            # model_version, so a duplicate key would make it serve an
-            # arbitrary row — gate the swap on it directly, plus the
-            # shape-aware row-count ratio used by the other groups.
+            # Gate decisions (and their rationale) live in _pt_quality_gate,
+            # which is pure and unit-tested; this task only gathers the
+            # inputs from Postgres.
             with _open_pg() as conn:
                 cur = conn.cursor()
                 try:
@@ -750,11 +784,6 @@ def sync_election_api():
                         f") AS dupe_keys"
                     )
                     dup_keys = cur.fetchone()[0]
-                    if dup_keys > 0:
-                        raise ValueError(
-                            f"{dup_keys} duplicate (district_id, election_year, "
-                            f"election_code) keys in staging — refusing to swap"
-                        )
 
                     # Prior live state (absent on a true cold start). Both
                     # identifiers must be double-quoted in the regclass argument
@@ -765,12 +794,6 @@ def sync_election_api():
                     )
                     prior_exists = cur.fetchone()[0] is not None
                     if prior_exists:
-                        # Baseline on DISTINCT natural keys, not raw rows: a
-                        # live table last written by the legacy upsert path can
-                        # be bloated with superseded model_version duplicates,
-                        # while staging is deduped (gate above) — a raw-count
-                        # ratio could refuse a legitimate dedupe cutover.
-                        # Keys-vs-keys compares like with like.
                         cur.execute(
                             f"SELECT COUNT(*) FROM ("
                             f"SELECT DISTINCT district_id, election_year, election_code "
@@ -780,30 +803,17 @@ def sync_election_api():
                         prior_key_count = cur.fetchone()[0]
                     else:
                         prior_key_count = 0
-
-                    if prior_key_count > 0:
-                        ratio = loaded_count / prior_key_count
-                        if ratio < 0.5:
-                            raise ValueError(
-                                f"Loaded {loaded_count} rows, prior live had "
-                                f"{prior_key_count} distinct (district_id, "
-                                f"election_year, election_code) keys "
-                                f"(ratio {ratio:.2f}) — refusing to swap"
-                            )
-                    elif loaded_count < 100_000:
-                        raise ValueError(
-                            f"Cold-start load of {loaded_count} rows is "
-                            f"implausibly small — refusing to swap"
-                        )
-
-                    t_log.info(
-                        "Quality checks passed: %d rows (prior %d distinct keys), "
-                        "no duplicate (district, election) keys",
-                        loaded_count,
-                        prior_key_count,
-                    )
                 finally:
                     cur.close()
+
+            _pt_quality_gate(loaded_count, dup_keys, prior_key_count)
+
+            t_log.info(
+                "Quality checks passed: %d rows (prior %d distinct keys), "
+                "no duplicate (district, election) keys",
+                loaded_count,
+                prior_key_count,
+            )
 
         @task
         def swap() -> None:

--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -19,8 +19,12 @@ a thin per-table wrapper that supplies the source query, transform, and
 constraint DDL.
 
 This is the prototype for migrating the legacy
-`dbt/project/models/write/write__election_api_db.py` (which writes 8 election
-tables to Postgres via JDBC from a Databricks cluster) onto Airflow.
+`dbt/project/models/write/write__election_api_db.py` (which writes the other
+election tables to Postgres via JDBC from a Databricks cluster) onto Airflow.
+Projected_Turnout is the first table cut over from that writer: upsert-by-id
+delivery can never delete, so model-version supersessions and L2 coverage
+drift stranded stale rows in the API (DATA-2015). The swap replaces the
+table wholesale each run, so the API always matches the Databricks mart.
 
 ### Connections (set in Astro Environment Manager):
 - `databricks` / `databricks_dev` (Generic) — Databricks OAuth M2M.
@@ -274,6 +278,59 @@ def _eos_constraint_ddl() -> list[str]:
         (
             f'ALTER TABLE "{sn}"."{nt}" '
             f'ADD CONSTRAINT "{EOS.stage_name(EOS.pk_name)}" PRIMARY KEY (elected_office_id)'
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Projected_Turnout
+# ---------------------------------------------------------------------------
+
+# First table cut over from the legacy dbt writer (DATA-2015): the writer
+# upserts by id and never deletes, so model-version supersessions and L2
+# coverage drift stranded stale rows. Swapping the whole table each run keeps
+# the API equal to the mart with no supersession bookkeeping.
+PT = TableSyncSpec(
+    target_table="Projected_Turnout",
+    indexes=("Projected_Turnout_district_id_election_year_idx",),
+    fkeys=("Projected_Turnout_district_id_fkey",),
+)
+
+# The mart emits these columns directly, so rows pass through with no transform
+# (source order must match this list; it mirrors the legacy dbt writer's column
+# mapping for this table). election_code arrives as the enum label text
+# (General | LocalOrMunicipal | ConsolidatedGeneral | Primary); the staging
+# table is a LIKE-clone of the live table, so the column keeps the
+# "ElectionCode" enum type and Postgres rejects any unknown label at insert.
+PT_COLUMNS = [
+    "id",
+    "created_at",
+    "updated_at",
+    "election_year",
+    "election_code",
+    "projected_turnout",
+    "inference_at",
+    "model_version",
+    "district_id",
+]
+
+
+def _pt_constraint_ddl() -> list[str]:
+    sn, nt = PT.staging_schema, PT.new_table
+    target_schema = PT.target_schema
+    return [
+        (f'ALTER TABLE "{sn}"."{nt}" ' f'ADD CONSTRAINT "{PT.stage_name(PT.pk_name)}" PRIMARY KEY (id)'),
+        (
+            f"CREATE INDEX "
+            f'"{PT.stage_name("Projected_Turnout_district_id_election_year_idx")}" '
+            f'ON "{sn}"."{nt}" (district_id, election_year)'
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{PT.stage_name("Projected_Turnout_district_id_fkey")}" '
+            f"FOREIGN KEY (district_id) "
+            f'REFERENCES "{target_schema}"."District"(id) '
+            f"ON UPDATE CASCADE ON DELETE RESTRICT"
         ),
     ]
 
@@ -639,12 +696,127 @@ def sync_election_api():
         do = drop_old()
         s >> loaded >> idx >> qc >> sw >> do
 
+    @task_group(group_id="projected_turnout")
+    def projected_turnout():
+        @task
+        def build_staging() -> None:
+            with _open_pg() as conn:
+                create_staging_table(conn, PT)
+
+        @task
+        def load_staging() -> int:
+            catalog = Variable.get("databricks_catalog")
+            col_list = ", ".join(PT_COLUMNS)
+            query = (
+                f"SELECT {col_list} "
+                f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
+                f"`m_election_api__projected_turnout`"
+            )
+            with _open_pg() as conn:
+                return bulk_insert_from_databricks(
+                    conn,
+                    PT,
+                    source_query=query,
+                    target_columns=PT_COLUMNS,
+                    # ~800k rows; this load runs concurrently with the other
+                    # groups on the same worker, so read one election year at a
+                    # time (a handful of partitions) to keep the combined peak
+                    # memory bounded.
+                    partition_column="election_year",
+                )
+
+        @task
+        def build_indexes_and_fk() -> None:
+            with _open_pg() as conn:
+                apply_ddl(conn, _pt_constraint_ddl())
+
+        @task
+        def quality_checks(loaded_count: int) -> None:
+            # The swap exists to guarantee the invariant the upsert writer
+            # could not: exactly one row per (district_id, election_year,
+            # election_code). The election-api consumer does not disambiguate
+            # model_version, so a duplicate key would make it serve an
+            # arbitrary row — gate the swap on it directly, plus the
+            # shape-aware row-count ratio used by the other groups.
+            with _open_pg() as conn:
+                cur = conn.cursor()
+                try:
+                    cur.execute(
+                        f"SELECT COUNT(*) FROM ("
+                        f"SELECT district_id, election_year, election_code "
+                        f'FROM "{PT.staging_schema}"."{PT.new_table}" '
+                        f"GROUP BY district_id, election_year, election_code "
+                        f"HAVING COUNT(*) > 1"
+                        f") AS dupe_keys"
+                    )
+                    dup_keys = cur.fetchone()[0]
+                    if dup_keys > 0:
+                        raise ValueError(
+                            f"{dup_keys} duplicate (district_id, election_year, "
+                            f"election_code) keys in staging — refusing to swap"
+                        )
+
+                    # Prior live state (absent on a true cold start). Both
+                    # identifiers must be double-quoted in the regclass argument
+                    # so Postgres does not fold the mixed-case name to lowercase.
+                    cur.execute(
+                        "SELECT to_regclass(%s)",
+                        (f'"{PT.target_schema}"."{PT.target_table}"',),
+                    )
+                    prior_exists = cur.fetchone()[0] is not None
+                    if prior_exists:
+                        cur.execute(f'SELECT COUNT(*) FROM "{PT.target_schema}"."{PT.target_table}"')
+                        prior_count = cur.fetchone()[0]
+                    else:
+                        prior_count = 0
+
+                    if prior_count > 0:
+                        ratio = loaded_count / prior_count
+                        if ratio < 0.5:
+                            raise ValueError(
+                                f"Loaded {loaded_count} rows, prior live had "
+                                f"{prior_count} (ratio {ratio:.2f}) — refusing to swap"
+                            )
+                    elif loaded_count < 100_000:
+                        raise ValueError(
+                            f"Cold-start load of {loaded_count} rows is "
+                            f"implausibly small — refusing to swap"
+                        )
+
+                    t_log.info(
+                        "Quality checks passed: %d rows (prior %d), "
+                        "no duplicate (district, election) keys",
+                        loaded_count,
+                        prior_count,
+                    )
+                finally:
+                    cur.close()
+
+        @task
+        def swap() -> None:
+            with _open_pg() as conn:
+                swap_staging_into_target(conn, PT)
+
+        @task
+        def drop_old() -> None:
+            with _open_pg() as conn:
+                drop_old_table(conn, PT)
+
+        s = build_staging()
+        loaded = load_staging()
+        idx = build_indexes_and_fk()
+        qc = quality_checks(loaded)
+        sw = swap()
+        do = drop_old()
+        s >> loaded >> idx >> qc >> sw >> do
+
     # The pipelines run in parallel; under the Kubernetes executor each task
     # is its own pod, and each load_staging reads one partition at a time, so
     # they don't contend for memory.
     zip_to_position()
     district_top_issues()
     elected_official_support()
+    projected_turnout()
 
 
 sync_election_api()

--- a/airflow/astro/tests/test_sync_election_api.py
+++ b/airflow/astro/tests/test_sync_election_api.py
@@ -10,6 +10,8 @@ import sys
 from datetime import datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 # Stub external modules so the DAG file can be imported in any environment.
 _STUBS = (
     "airflow",
@@ -35,6 +37,7 @@ from dags.sync_election_api import (  # noqa: E402
     PT_COLUMNS,
     ZTP_SOURCE_COLUMNS,
     ZTP_TARGET_COLUMNS,
+    _pt_quality_gate,
     _ztp_transform_row,
 )
 
@@ -169,3 +172,35 @@ def test_pt_columns_pinned():
         "model_version",
         "district_id",
     ]
+
+
+def test_pt_quality_gate_refuses_duplicate_keys():
+    """Any duplicate (district_id, election_year, election_code) key refuses
+    the swap — the invariant the swap delivery exists to guarantee."""
+    with pytest.raises(ValueError, match="duplicate"):
+        _pt_quality_gate(loaded_count=800_000, dup_keys=1, prior_key_count=800_000)
+
+
+def test_pt_quality_gate_refuses_coverage_collapse():
+    """Staging under half the prior distinct-key count refuses the swap."""
+    with pytest.raises(ValueError, match="refusing to swap"):
+        _pt_quality_gate(loaded_count=300_000, dup_keys=0, prior_key_count=800_000)
+
+
+def test_pt_quality_gate_allows_dedupe_cutover():
+    """Keys-vs-keys baseline: a deduped load matching the prior key count
+    passes even when the prior table's RAW row count was much larger (bloat
+    from the legacy upsert path must not refuse a legitimate cutover)."""
+    _pt_quality_gate(loaded_count=800_000, dup_keys=0, prior_key_count=800_000)
+
+
+def test_pt_quality_gate_boundary_ratio_passes():
+    """Exactly 0.5 passes — same boundary semantics as the other groups."""
+    _pt_quality_gate(loaded_count=400_000, dup_keys=0, prior_key_count=800_000)
+
+
+def test_pt_quality_gate_cold_start_floor():
+    """No prior table: implausibly small loads refuse, plausible loads pass."""
+    with pytest.raises(ValueError, match="Cold-start"):
+        _pt_quality_gate(loaded_count=99_999, dup_keys=0, prior_key_count=0)
+    _pt_quality_gate(loaded_count=100_000, dup_keys=0, prior_key_count=0)

--- a/airflow/astro/tests/test_sync_election_api.py
+++ b/airflow/astro/tests/test_sync_election_api.py
@@ -32,6 +32,7 @@ for _mod in _STUBS:
 from dags.sync_election_api import (  # noqa: E402
     DTI_COLUMNS,
     EOS_COLUMNS,
+    PT_COLUMNS,
     ZTP_SOURCE_COLUMNS,
     ZTP_TARGET_COLUMNS,
     _ztp_transform_row,
@@ -144,4 +145,27 @@ def test_eos_columns_pinned():
         "total_constituents",
         "created_at",
         "updated_at",
+    ]
+
+
+def test_pt_columns_pinned():
+    """Pin PT_COLUMNS to catch silent column reorderings.
+
+    Projected_Turnout loads with no row transform: PT_COLUMNS drives both the
+    Databricks SELECT order and the positional Postgres insert. id/district_id
+    are both uuids and created_at/updated_at/inference_at are all timestamps,
+    so a swap within either group would corrupt data without any insert-time
+    error. The order mirrors the legacy dbt writer's column mapping for this
+    table.
+    """
+    assert PT_COLUMNS == [
+        "id",
+        "created_at",
+        "updated_at",
+        "election_year",
+        "election_code",
+        "projected_turnout",
+        "inference_at",
+        "model_version",
+        "district_id",
     ]

--- a/airflow/astro/tests/test_sync_election_api.py
+++ b/airflow/astro/tests/test_sync_election_api.py
@@ -178,29 +178,40 @@ def test_pt_quality_gate_refuses_duplicate_keys():
     """Any duplicate (district_id, election_year, election_code) key refuses
     the swap — the invariant the swap delivery exists to guarantee."""
     with pytest.raises(ValueError, match="duplicate"):
-        _pt_quality_gate(loaded_count=800_000, dup_keys=1, prior_key_count=800_000)
+        _pt_quality_gate(loaded_count=800_000, dup_keys=1, prior_key_count=800_000, null_keys=0)
 
 
 def test_pt_quality_gate_refuses_coverage_collapse():
     """Staging under half the prior distinct-key count refuses the swap."""
     with pytest.raises(ValueError, match="refusing to swap"):
-        _pt_quality_gate(loaded_count=300_000, dup_keys=0, prior_key_count=800_000)
+        _pt_quality_gate(loaded_count=300_000, dup_keys=0, prior_key_count=800_000, null_keys=0)
 
 
 def test_pt_quality_gate_allows_dedupe_cutover():
     """Keys-vs-keys baseline: a deduped load matching the prior key count
     passes even when the prior table's RAW row count was much larger (bloat
     from the legacy upsert path must not refuse a legitimate cutover)."""
-    _pt_quality_gate(loaded_count=800_000, dup_keys=0, prior_key_count=800_000)
+    _pt_quality_gate(loaded_count=800_000, dup_keys=0, prior_key_count=800_000, null_keys=0)
 
 
 def test_pt_quality_gate_boundary_ratio_passes():
     """Exactly 0.5 passes — same boundary semantics as the other groups."""
-    _pt_quality_gate(loaded_count=400_000, dup_keys=0, prior_key_count=800_000)
+    _pt_quality_gate(loaded_count=400_000, dup_keys=0, prior_key_count=800_000, null_keys=0)
 
 
 def test_pt_quality_gate_cold_start_floor():
     """No prior table: implausibly small loads refuse, plausible loads pass."""
     with pytest.raises(ValueError, match="Cold-start"):
-        _pt_quality_gate(loaded_count=99_999, dup_keys=0, prior_key_count=0)
-    _pt_quality_gate(loaded_count=100_000, dup_keys=0, prior_key_count=0)
+        _pt_quality_gate(loaded_count=99_999, dup_keys=0, prior_key_count=0, null_keys=0)
+    _pt_quality_gate(loaded_count=100_000, dup_keys=0, prior_key_count=0, null_keys=0)
+
+
+def test_pt_quality_gate_refuses_null_keys():
+    """Any staged row with a NULL key column refuses the swap.
+
+    Belt-and-braces: the staging LIKE-clone inherits NOT NULL from the live
+    table so such a row should fail at load time, but the gate proves the
+    property directly instead of relying on the inherited constraint.
+    """
+    with pytest.raises(ValueError, match="NULL"):
+        _pt_quality_gate(loaded_count=800_000, dup_keys=0, prior_key_count=800_000, null_keys=1)


### PR DESCRIPTION
## Why

The legacy dbt writer (`write__election_api_db.py`) upserts Projected_Turnout by id and never deletes, so model-version supersessions and L2 voter-file coverage drift strand stale rows in the election API and break its one-row-per-(district_id, election_year, election_code) invariant. Per the supersession design call, delivery moves to the existing atomic table-swap pattern in `sync_election_api`: the API table is replaced wholesale each run, so it always equals the Databricks mart and self-heals any lingering duplicate (including the current WY remnant) on first run.

Companion PR #584 flips the mart to a full-refresh table and drops Projected_Turnout from the dbt writer. That PR should merge first; until this DAG change deploys, the API serves its current clean rows, slightly aging (accepted interim).

## What changed

`airflow/astro/dags/sync_election_api.py` gains a `projected_turnout` task group with the same six-step lifecycle as the existing three tables (build staging LIKE-clone, bulk load from Databricks, add constraints, quality gate, atomic rename swap, drop old):

- **Source:** `<catalog>.dbt.m_election_api__projected_turnout`, columns passed through with no transform. `PT_COLUMNS` mirrors the legacy dbt writer's column mapping: `id` (uuid), `created_at`, `updated_at`, `election_year` (int), `election_code` (label text for the Postgres "ElectionCode" enum: General | LocalOrMunicipal | ConsolidatedGeneral | Primary), `projected_turnout`, `inference_at`, `model_version`, `district_id` (uuid). The staging table is a LIKE-clone of the live one, so the enum column type is preserved and any unknown label fails at insert.
- **Load:** partitioned by `election_year` (a handful of partitions) so peak worker memory stays bounded while the group runs alongside the other three.
- **Quality gate:** refuses to swap on any duplicate (district_id, election_year, election_code) key — the exact invariant this migration exists to protect (the API consumer does not disambiguate model_version) — and on a >50% row-count drop vs the prior live table (cold-start floor otherwise), same shape-aware pattern as the DistrictTopIssue and Elected_Office_Support groups.
- **Constraint/swap names** match the election-api Prisma migrations exactly: `Projected_Turnout_pkey` (PK on id), `Projected_Turnout_district_id_election_year_idx`, and `Projected_Turnout_district_id_fkey` → District(id) ON UPDATE CASCADE ON DELETE RESTRICT. The old inbound Race → Projected_Turnout FK was dropped in the 2025-07-03 pivot migration, so the rename swap is safe.
- Connections, secrets, schedule (@daily), and swap mechanics are all reused unchanged from the existing DAG.

`airflow/astro/tests/test_sync_election_api.py`: pins `PT_COLUMNS` like the other no-transform tables (id/district_id are both uuids and three columns are timestamps, so a silent reorder would corrupt data without an insert-time error).

## Verification

- `cd airflow && uv run pytest`: 66 passed, 2 skipped.
- `uv run mypy astro/dags astro/tests astro/include/custom_functions`: clean.
- Explicit DagBag parse: no import errors; `projected_turnout` group registers all six tasks with the correct chain.
- No run against the real election DB was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces production election-api turnout data via daily atomic table swap (~800k rows); misconfigured mart or failed QC could block swaps or briefly serve wrong data if gates were bypassed.
> 
> **Overview**
> Adds **Projected_Turnout** as a fourth parallel task group on `sync_election_api`, cutting delivery over from the legacy dbt JDBC upsert writer to the same staging → load → constraints → QC → atomic swap pipeline used for the other election-api tables.
> 
> Loads `m_election_api__projected_turnout` from Databricks with **no row transform** (`PT_COLUMNS` drives SELECT and insert order), partitions reads by `election_year`, and applies Prisma-aligned PK/index/FK DDL before swap. **Quality checks** block the swap if any duplicate `(district_id, election_year, election_code)` exists in staging (the API invariant the upsert path could not enforce) and if row count drops more than 50% vs prior live (100k floor on cold start).
> 
> DAG docstring is updated to frame this as the first table migrated from `write__election_api_db.py` for DATA-2015. Tests pin `PT_COLUMNS` like the other pass-through tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81cb78b5f332955103eefc57ce60c6ced6e2da42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->