### PR TITLE
[DATA-2094] Allow TechSpeed-anchored <=2025 rows in candidacy_stage archive contract

### DIFF
--- a/dbt/project/tests/assert_candidacy_stage_archive_era_source_systems.sql
+++ b/dbt/project/tests/assert_candidacy_stage_archive_era_source_systems.sql
@@ -1,14 +1,16 @@
--- <=2025 rows must either be archive-rooted (hubspot in source_systems) or
--- TechSpeed-only. A BR, DDHQ, or gp_api row without hubspot means a vendor
--- row reached the mart without merging into the archive: their candidacy /
--- election-stage intermediates stay 2026-gated, so a pre-2026 row keyed to
--- one of them should only ever survive by enriching an archive row or
--- riding a TS-keyed merged row.
+-- <=2025 rows without a hubspot root must be TechSpeed-anchored: the BR/DDHQ
+-- candidacy and election-stage intermediates stay 2026-gated, so only a TS trio
+-- carries FK-valid pre-2026 ids. A BR/DDHQ/gp_api row that is neither
+-- hubspot-rooted nor part of a TS-keyed cluster reached the mart without either
+-- enriching an archive row or riding a TS-keyed merged row. Looser election-date
+-- matching now clusters BR/DDHQ into TS-anchored clusters, so source_systems
+-- credits them alongside techspeed -- expected, not a leak.
 select gp_candidacy_stage_id, election_stage_date, source_systems
 from {{ ref("candidacy_stage") }}
 where
     election_stage_date <= '2025-12-31'
     and not array_contains(source_systems, 'hubspot')
+    and not array_contains(source_systems, 'techspeed')
     and (
         array_contains(source_systems, 'ballotready')
         or array_contains(source_systems, 'ddhq')


### PR DESCRIPTION
## Why

Main's scheduled `dbt build on merge` / `dbt build frequent` jobs have been failing repeatedly, leaving prod half-deployed. The persistent blocker across every merge build is the data test `assert_candidacy_stage_archive_era_source_systems`, which returned **16,884** rows (fails if != 0). The scheduled build runs `--full-refresh`, so it fails on every merge even though a normal incremental prod read looks clean.

## Root cause

The 10-day `election_date` match window (#582) now clusters BR/DDHQ records into TS-anchored clusters that exact-date matching previously kept separate. Every one of the 16,884 offending rows in `mart_civics.candidacy_stage` is **TechSpeed-anchored**:

| source_systems | rows |
|---|---|
| ballotready, ddhq, techspeed | 9,086 |
| ddhq, techspeed | 5,701 |
| ballotready, techspeed | 2,097 |

Zero offenders lack a `techspeed` key (`ts_source_candidate_id` is populated on all of them). These rows still ride a valid TS key, which the model header explicitly treats as legitimate ("rides a TS-keyed merged row"). Their `source_systems` now credits the co-clustered BR/DDHQ contributors, which is correct. The test's "TechSpeed-**only**" assumption predates the looser matching and is stale.

## Change

Add `and not array_contains(source_systems, 'techspeed')` so the contract flags only genuinely archive-orphaned pre-2026 vendor rows (non-hubspot, non-TechSpeed), and refresh the header comment. This mirrors the recalibration in #583 for the all-time ER expansion.

## Verification

Against current prod (`mart_civics.candidacy_stage`):
- Old contract: 16,884 failing rows
- Refined contract: **0**
- `dbt test --select assert_candidacy_stage_archive_era_source_systems`: **PASS**
- Pre-commit (sqlfmt included): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)