### PR TITLE
[DATA-2095] Fix clustered_elected_officials source_name accepted_values

### DIFF
--- a/dbt/project/models/staging/er_source/__er_source.yaml
+++ b/dbt/project/models/staging/er_source/__er_source.yaml
@@ -42,7 +42,7 @@ models:
           - not_null
           - accepted_values:
               arguments:
-                values: ["ballotready", "techspeed", "ddhq", "gp_api"]
+                values: ["ballotready_techspeed", "gp_api", "ddhq"]
       - name: first_name
         description: Candidate first name (lowercased, trimmed in prematch).
       - name: last_name


### PR DESCRIPTION
## Why

The `accepted_values` test on `stg_er_source__clustered_elected_officials.source_name` is wrong on main. It lists `["ballotready", "techspeed", "ddhq", "gp_api"]`, but the elected-officials ER pipeline emits a **combined** source. Prod `source_name` values:

| source_name | rows |
|---|---|
| ballotready_techspeed | 524,168 |
| ddhq | 28,520 |
| gp_api | 1,538 |

None are `ballotready`/`techspeed` alone, so the test fails against ~524k prod rows. It hasn't tripped recent main builds only because the model wasn't in their `state:modified+` selection.

## Root cause

`ballotready_techspeed` is intentional — `int__er_prematch_elected_officials.sql` emits `'ballotready_techspeed' as source_name`, and three sibling `accepted_values` tests in this same `__er_source.yaml` already use `["ballotready_techspeed", "gp_api", "ddhq"]`. Only the `clustered_elected_officials.source_name` test had the wrong split list.

## Change

Set the accepted values to `["ballotready_techspeed", "gp_api", "ddhq"]`, matching the pipeline and its siblings.

## Verification

`dbt test --select stg_er_source__clustered_elected_officials` → all 6 tests PASS against prod. Pre-commit passes.

## Note

Surfaced from CI run `70471887646242`. The other three failures there (`experiment_run.status`, `is_state_abbreviation` on candidate/election state) are stale-branch artifacts already fixed on main (#561, #580); those branches just need main merged in. This PR is only the genuine main bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)