### PR TITLE
[DATA-2015] Harden the election-api swap delivery and dbt writer

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -10,7 +10,9 @@ in Databricks. Each table is its own task group following the same lifecycle:
 3. **build_indexes_and_fk** — add PK, indexes, and FK constraints.
 4. **quality_checks** — gate the swap on row-count / coverage floors.
 5. **swap** — atomic rename swap (`_new` -> live, live -> `_old`) with all
-   indexes and constraints renamed to canonical Prisma names.
+   indexes and constraints renamed to canonical Prisma names. A leftover
+   `_old` from a run that crashed before drop_old is pre-dropped in the same
+   transaction, so a crashed run never wedges subsequent ones.
 6. **drop_old** — drop the renamed-aside `_old` table.
 
 The shared lifecycle lives in
@@ -42,6 +44,15 @@ table wholesale each run, so the API always matches the Databricks mart.
 The source schema is hardcoded to `dbt` (not `databricks_dbt_schema`, which
 points at `dbt_staging` for in-flight dbt build artifacts). The election-api
 sync reads the production-quality version of the marts in both dev and prod.
+
+### Failure alerting (Astro-side, one-time setup):
+Nothing in this repo sends failure notifications — there is no
+`on_failure_callback`/notifier wiring, no Slack provider, and no SMTP
+config. Alerting for this DAG is configured in the Astro UI (Workspace →
+Alerts): create a DAG Failure alert scoped to `sync_election_api` on the
+prod deployment and attach the team's Slack communication channel. Without
+it, the only failure signal is `max_consecutive_failed_dag_runs=5`
+eventually pausing the DAG, which freezes all synced tables silently.
 
 ### Deploy model:
 - `main` → `astro-prod`. `astro-dev`'s branch mapping is set manually in the

--- a/airflow/astro/include/custom_functions/election_api_utils.py
+++ b/airflow/astro/include/custom_functions/election_api_utils.py
@@ -12,7 +12,9 @@ Each pipeline:
 5. Atomic rename swap: `public."<Target>"` → `public."<Target>_old"`,
    `staging."<Target>_new"` → `public."<Target>"`. All indexes/constraints
    are renamed to/from canonical Prisma names so the post-swap shape matches
-   the migration exactly.
+   the migration exactly. Any `<Target>_old` leftover from a run that crashed
+   before step 6 is dropped first, inside the same transaction, so a crashed
+   run never wedges subsequent ones.
 6. Drops `public."<Target>_old"`.
 
 Index/constraint names follow Prisma's convention (`<Table>_<col>_idx`,
@@ -169,7 +171,9 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
     All indexes/constraints listed on `spec` are renamed to/from canonical
     Prisma names so the post-swap shape matches the migration exactly. Safe
     on first run when `public.<table>` doesn't yet exist (skip the rename-old
-    branch).
+    branch), and self-healing when a prior run crashed between this
+    transaction committing and `drop_old_table` completing: the leftover
+    `<table>_old` is dropped inside the same transaction before the renames.
     """
     cur = conn.cursor()
     try:
@@ -180,6 +184,14 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
         target_exists = cur.fetchone() is not None
 
         statements: list[str] = []
+        # A `<table>_old` left behind by a run that died in the swap->drop_old
+        # window would collide with every rename below (table name and the
+        # `_old`-suffixed index/constraint names), failing each subsequent run
+        # until someone dropped it by hand — and five consecutive failed runs
+        # auto-pause the DAG. Pre-drop it in this transaction: DDL is
+        # transactional, so a mid-swap failure rolls the drop back with the
+        # renames, and a clean run drops nothing that drop_old_table wouldn't.
+        statements.append(f'DROP TABLE IF EXISTS "{spec.target_schema}"."{spec.old_table}"')
         if target_exists:
             statements.append(
                 f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" ' f'RENAME TO "{spec.old_table}"'

--- a/airflow/astro/tests/test_election_api_swap.py
+++ b/airflow/astro/tests/test_election_api_swap.py
@@ -1,0 +1,499 @@
+"""Crash-recovery tests for the shared election-api build-and-swap lifecycle.
+
+``swap_staging_into_target`` renames the live table aside (``<Table>_old``)
+inside its transaction, and ``drop_old_table`` runs later as a separate
+task/transaction. The dangerous window: a crash after the swap commits but
+before drop_old completes leaves ``public."<Table>_old"`` behind. Without the
+in-transaction pre-drop, the next run's swap then fails on the rename
+collision — run after run, until a human drops the leftover — and five
+consecutive failed runs auto-pause the whole DAG, freezing every table group.
+These tests prove the lifecycle self-heals from a crash at every point in the
+sequence.
+
+FakePostgres models just enough real Postgres semantics for the proofs to be
+honest: transactional DDL (rollback restores everything, including a
+rolled-back pre-drop), duplicate-name errors on CREATE/RENAME targets,
+DROP TABLE cascading to the table's indexes and constraints, and SET SCHEMA
+moving a table's indexes along with it. It parses the exact closed set of
+statements the lifecycle emits and fails loudly on anything it does not
+recognize, so drift between the fake and the real SQL shows up as a test
+error rather than a silent pass.
+"""
+
+import re
+from copy import deepcopy
+
+import pytest
+from include.custom_functions.election_api_utils import (
+    TableSyncSpec,
+    apply_ddl,
+    create_staging_table,
+    drop_old_table,
+    swap_staging_into_target,
+)
+
+
+class FakePostgresError(Exception):
+    """Stand-in for psycopg2 errors (duplicate/missing relations)."""
+
+
+class FakePostgres:
+    """In-memory model of the Postgres objects the swap lifecycle touches.
+
+    State:
+      - ``tables``: (schema, table) -> set of constraint names on the table.
+      - ``indexes``: (schema, index_name) -> (schema, table) owning it.
+        Index names are schema-scoped (as in Postgres); constraint names are
+        table-scoped.
+
+    ``arm_crash(after=k)`` makes the k-th subsequent statement raise before
+    executing, simulating a worker crash at that exact point; the lifecycle's
+    error handling then rolls the transaction back.
+    """
+
+    def __init__(self):
+        self.tables: dict[tuple[str, str], set[str]] = {}
+        self.indexes: dict[tuple[str, str], tuple[str, str]] = {}
+        self._durable = self._copy_state()
+        self._crash_countdown: int | None = None
+        self.crash_fired = False
+
+    # -- setup / inspection -------------------------------------------------
+
+    def seed_table(self, schema, table, constraints=(), indexes=()):
+        """Create a table durably, outside any transaction (test setup)."""
+        self.tables[(schema, table)] = set(constraints)
+        for idx in indexes:
+            self.indexes[(schema, idx)] = (schema, table)
+        self._durable = self._copy_state()
+
+    def connect(self):
+        return _FakeConnection(self)
+
+    def has_table(self, schema, table):
+        return (schema, table) in self.tables
+
+    def constraints(self, schema, table):
+        return set(self.tables[(schema, table)])
+
+    def index_names(self, schema):
+        return {idx for (s, idx) in self.indexes if s == schema}
+
+    def state(self):
+        return self._copy_state()
+
+    def _copy_state(self):
+        return (deepcopy(self.tables), deepcopy(self.indexes))
+
+    # -- crash injection ----------------------------------------------------
+
+    def arm_crash(self, after: int):
+        """Raise on the ``after``-th subsequent statement, before executing it."""
+        self._crash_countdown = after
+        self.crash_fired = False
+
+    # -- transaction control ------------------------------------------------
+
+    def _commit(self):
+        self._durable = self._copy_state()
+
+    def _rollback(self):
+        self.tables, self.indexes = deepcopy(self._durable)
+
+    # -- statement execution --------------------------------------------------
+
+    def _execute(self, sql, params=None):
+        if self._crash_countdown is not None:
+            self._crash_countdown -= 1
+            if self._crash_countdown <= 0:
+                self._crash_countdown = None
+                self.crash_fired = True
+                raise RuntimeError("simulated crash")
+
+        stmt = " ".join(sql.split())
+
+        if stmt == "SELECT 1 FROM pg_tables WHERE schemaname = %s AND tablename = %s":
+            schema, table = params
+            return [(1,)] if self.has_table(schema, table) else []
+
+        m = re.fullmatch(r'DROP TABLE IF EXISTS "([^"]+)"\."([^"]+)"', stmt)
+        if m:
+            self._drop_table(m.group(1), m.group(2), missing_ok=True)
+            return []
+
+        m = re.fullmatch(
+            r'CREATE TABLE "([^"]+)"\."([^"]+)" \(LIKE "([^"]+)"\."([^"]+)" INCLUDING DEFAULTS\)',
+            stmt,
+        )
+        if m:
+            schema, table, like_schema, like_table = m.groups()
+            self._require_table(like_schema, like_table)
+            self._require_no_table(schema, table)
+            # LIKE without INCLUDING INDEXES copies no indexes/constraints.
+            self.tables[(schema, table)] = set()
+            return []
+
+        m = re.fullmatch(r'ALTER TABLE "([^"]+)"\."([^"]+)" RENAME TO "([^"]+)"', stmt)
+        if m:
+            schema, table, new_name = m.groups()
+            self._require_table(schema, table)
+            self._require_no_table(schema, new_name)
+            self.tables[(schema, new_name)] = self.tables.pop((schema, table))
+            self._reown_indexes((schema, table), (schema, new_name))
+            return []
+
+        m = re.fullmatch(r'ALTER TABLE "([^"]+)"\."([^"]+)" SET SCHEMA "([^"]+)"', stmt)
+        if m:
+            schema, table, new_schema = m.groups()
+            self._require_table(schema, table)
+            self._require_no_table(new_schema, table)
+            self.tables[(new_schema, table)] = self.tables.pop((schema, table))
+            # A table's indexes move to the new schema with it.
+            for (idx_schema, idx), owner in list(self.indexes.items()):
+                if owner == (schema, table):
+                    if (new_schema, idx) in self.indexes:
+                        raise FakePostgresError(f'index "{idx}" already exists in schema "{new_schema}"')
+                    del self.indexes[(idx_schema, idx)]
+                    self.indexes[(new_schema, idx)] = (new_schema, table)
+            return []
+
+        m = re.fullmatch(r'ALTER INDEX "([^"]+)"\."([^"]+)" RENAME TO "([^"]+)"', stmt)
+        if m:
+            schema, idx, new_idx = m.groups()
+            if (schema, idx) not in self.indexes:
+                raise FakePostgresError(f'index "{schema}"."{idx}" does not exist')
+            if (schema, new_idx) in self.indexes:
+                raise FakePostgresError(f'index "{new_idx}" already exists')
+            owner = self.indexes.pop((schema, idx))
+            self.indexes[(schema, new_idx)] = owner
+            # Renaming an index that backs a constraint (e.g. a PK) renames
+            # the constraint with it — Postgres keeps the two names equal.
+            owner_cons = self.tables[owner]
+            if idx in owner_cons:
+                owner_cons.remove(idx)
+                owner_cons.add(new_idx)
+            return []
+
+        m = re.fullmatch(
+            r'ALTER TABLE "([^"]+)"\."([^"]+)" RENAME CONSTRAINT "([^"]+)" TO "([^"]+)"',
+            stmt,
+        )
+        if m:
+            schema, table, con, new_con = m.groups()
+            self._require_table(schema, table)
+            table_cons = self.tables[(schema, table)]
+            if con not in table_cons:
+                raise FakePostgresError(f'constraint "{con}" of "{schema}"."{table}" does not exist')
+            if new_con in table_cons:
+                raise FakePostgresError(f'constraint "{new_con}" already exists')
+            table_cons.remove(con)
+            table_cons.add(new_con)
+            return []
+
+        m = re.fullmatch(
+            r'ALTER TABLE "([^"]+)"\."([^"]+)" ADD CONSTRAINT "([^"]+)" PRIMARY KEY \(.+\)',
+            stmt,
+        )
+        if m:
+            schema, table, con = m.groups()
+            self._require_table(schema, table)
+            self._add_constraint(schema, table, con)
+            # A PK constraint creates a same-named backing index.
+            if (schema, con) in self.indexes:
+                raise FakePostgresError(f'index "{con}" already exists')
+            self.indexes[(schema, con)] = (schema, table)
+            return []
+
+        m = re.fullmatch(
+            r'ALTER TABLE "([^"]+)"\."([^"]+)" ADD CONSTRAINT "([^"]+)" FOREIGN KEY .+',
+            stmt,
+        )
+        if m:
+            schema, table, con = m.groups()
+            self._require_table(schema, table)
+            self._add_constraint(schema, table, con)
+            return []
+
+        m = re.fullmatch(r'CREATE (?:UNIQUE )?INDEX "([^"]+)" ON "([^"]+)"\."([^"]+)" ?\(?.*', stmt)
+        if m:
+            idx, schema, table = m.groups()
+            self._require_table(schema, table)
+            if (schema, idx) in self.indexes:
+                raise FakePostgresError(f'index "{idx}" already exists')
+            self.indexes[(schema, idx)] = (schema, table)
+            return []
+
+        raise AssertionError(f"FakePostgres: unhandled SQL: {stmt}")
+
+    # -- internals ------------------------------------------------------------
+
+    def _require_table(self, schema, table):
+        if (schema, table) not in self.tables:
+            raise FakePostgresError(f'relation "{schema}"."{table}" does not exist')
+
+    def _require_no_table(self, schema, table):
+        if (schema, table) in self.tables:
+            raise FakePostgresError(f'relation "{table}" already exists')
+
+    def _add_constraint(self, schema, table, con):
+        if con in self.tables[(schema, table)]:
+            raise FakePostgresError(f'constraint "{con}" already exists')
+        self.tables[(schema, table)].add(con)
+
+    def _drop_table(self, schema, table, missing_ok=False):
+        if (schema, table) not in self.tables:
+            if missing_ok:
+                return
+            raise FakePostgresError(f'relation "{schema}"."{table}" does not exist')
+        del self.tables[(schema, table)]
+        # DROP TABLE takes the table's indexes (and constraints) with it.
+        self.indexes = {k: v for k, v in self.indexes.items() if v != (schema, table)}
+
+    def _reown_indexes(self, old_owner, new_owner):
+        for key, owner in self.indexes.items():
+            if owner == old_owner:
+                self.indexes[key] = new_owner
+
+
+class _FakeConnection:
+    def __init__(self, pg):
+        self._pg = pg
+
+    def cursor(self):
+        return _FakeCursor(self._pg)
+
+    def commit(self):
+        self._pg._commit()
+
+    def rollback(self):
+        self._pg._rollback()
+
+
+class _FakeCursor:
+    def __init__(self, pg):
+        self._pg = pg
+        self._rows = []
+
+    def execute(self, sql, params=None):
+        self._rows = self._pg._execute(sql, params)
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle helpers mirroring the sync_election_api task groups
+# ---------------------------------------------------------------------------
+
+SPEC = TableSyncSpec(
+    target_table="Projected_Turnout",
+    indexes=("Projected_Turnout_district_id_election_year_idx",),
+    fkeys=("Projected_Turnout_district_id_fkey",),
+)
+
+
+def _stage_ddl(spec):
+    """Staging constraint DDL exactly as the DAG's per-table builders emit it."""
+    sn, nt = spec.staging_schema, spec.new_table
+    return [
+        f'ALTER TABLE "{sn}"."{nt}" ADD CONSTRAINT "{spec.stage_name(spec.pk_name)}" PRIMARY KEY (id)',
+        (
+            f'CREATE INDEX "{spec.stage_name(spec.indexes[0])}" '
+            f'ON "{sn}"."{nt}" (district_id, election_year)'
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{spec.stage_name(spec.fkeys[0])}" '
+            f'FOREIGN KEY (district_id) REFERENCES "public"."District"(id)'
+        ),
+    ]
+
+
+def _seed_live(pg, spec):
+    """The live table as the election-api Prisma migration creates it."""
+    pg.seed_table(
+        spec.target_schema,
+        spec.target_table,
+        constraints={spec.pk_name, *spec.fkeys},
+        indexes={spec.pk_name, *spec.indexes},
+    )
+
+
+def _seed_leftover_old(pg, spec):
+    """Exactly what a swap that committed without drop_old leaves behind."""
+    pg.seed_table(
+        spec.target_schema,
+        spec.old_table,
+        constraints={spec.archive_name(spec.pk_name)} | {spec.archive_name(fk) for fk in spec.fkeys},
+        indexes={spec.archive_name(spec.pk_name)} | {spec.archive_name(idx) for idx in spec.indexes},
+    )
+
+
+def _run_cycle(pg, spec, skip_drop_old=False):
+    """One DAG-run's build -> stage-DDL -> swap [-> drop_old] sequence."""
+    conn = pg.connect()
+    create_staging_table(conn, spec)
+    apply_ddl(conn, _stage_ddl(spec))
+    swap_staging_into_target(conn, spec)
+    if not skip_drop_old:
+        drop_old_table(conn, spec)
+
+
+def _assert_canonical_shape(pg, spec):
+    """Post-cycle invariant: live table under canonical Prisma names, no debris."""
+    assert pg.has_table(spec.target_schema, spec.target_table)
+    assert not pg.has_table(spec.target_schema, spec.old_table)
+    assert not pg.has_table(spec.staging_schema, spec.new_table)
+    assert pg.constraints(spec.target_schema, spec.target_table) == {spec.pk_name, *spec.fkeys}
+    assert pg.index_names(spec.target_schema) == {spec.pk_name, *spec.indexes}
+    assert pg.index_names(spec.staging_schema) == set()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_cycle_leaves_canonical_shape():
+    pg = FakePostgres()
+    _seed_live(pg, SPEC)
+
+    _run_cycle(pg, SPEC)
+
+    _assert_canonical_shape(pg, SPEC)
+
+
+def test_next_run_recovers_after_crash_between_swap_and_drop_old():
+    """THE wedge: swap commits, worker dies before drop_old, `_old` lingers.
+
+    The next scheduled run must clear the leftover inside its own swap
+    transaction and complete normally, instead of failing the rename
+    collision forever until a human drops the leftover.
+    """
+    pg = FakePostgres()
+    _seed_live(pg, SPEC)
+
+    _run_cycle(pg, SPEC, skip_drop_old=True)  # crash window: drop_old never ran
+    assert pg.has_table(SPEC.target_schema, SPEC.old_table)
+
+    _run_cycle(pg, SPEC)  # next daily run must self-heal
+
+    _assert_canonical_shape(pg, SPEC)
+
+
+def test_recovers_after_repeated_crashes_between_swap_and_drop_old():
+    """Back-to-back crashed runs each replace the leftover; any full run heals."""
+    pg = FakePostgres()
+    _seed_live(pg, SPEC)
+
+    _run_cycle(pg, SPEC, skip_drop_old=True)
+    _run_cycle(pg, SPEC, skip_drop_old=True)
+    _run_cycle(pg, SPEC)
+
+    _assert_canonical_shape(pg, SPEC)
+
+
+def test_swap_rolls_back_cleanly_at_every_crash_point():
+    """Crash before each statement of the swap, in the worst-case state
+    (leftover `_old` present): the transaction must roll back to exactly the
+    pre-swap state — including resurrecting the pre-dropped leftover — and an
+    immediate retry plus drop_old must complete the cycle."""
+    crash_points_covered = 0
+    k = 1
+    while True:
+        pg = FakePostgres()
+        _seed_live(pg, SPEC)
+        _seed_leftover_old(pg, SPEC)
+        conn = pg.connect()
+        create_staging_table(conn, SPEC)
+        apply_ddl(conn, _stage_ddl(SPEC))
+        state_before_swap = pg.state()
+
+        pg.arm_crash(after=k)
+        try:
+            swap_staging_into_target(conn, SPEC)
+        except RuntimeError:
+            assert pg.crash_fired
+            # Transactional DDL: everything (incl. the pre-drop) rolled back.
+            assert pg.state() == state_before_swap
+            # A task retry right after the crash must succeed.
+            swap_staging_into_target(conn, SPEC)
+        else:
+            # k exceeded the swap's statement count: sequence fully covered.
+            assert not pg.crash_fired
+            break
+
+        drop_old_table(conn, SPEC)
+        _assert_canonical_shape(pg, SPEC)
+        crash_points_covered += 1
+        k += 1
+
+    # SELECT + pre-drop + 4 archive renames + 5 stage renames = 11 statements
+    # for a spec with one index and one fkey; more statements only add points.
+    assert crash_points_covered >= 11
+
+
+def test_swap_retry_after_committed_swap_fails_closed_then_next_run_heals():
+    """Worker dies after the swap COMMITs but before the task is marked done,
+    so Airflow retries the swap task. The retry must fail closed (roll back,
+    leaving the freshly swapped table live and untouched) rather than rename
+    the fresh table aside with nothing to put in its place; the next full
+    run then heals the leftover `_old`."""
+    pg = FakePostgres()
+    _seed_live(pg, SPEC)
+
+    _run_cycle(pg, SPEC, skip_drop_old=True)
+    state_after_commit = pg.state()
+
+    # The retry: staging `_new` no longer exists, so the transaction must fail
+    # partway and roll back without touching the durable state.
+    with pytest.raises(FakePostgresError):
+        swap_staging_into_target(pg.connect(), SPEC)
+    assert pg.state() == state_after_commit
+
+    _run_cycle(pg, SPEC)  # next daily run heals the leftover
+
+    _assert_canonical_shape(pg, SPEC)
+
+
+def test_next_run_recovers_after_crash_before_swap():
+    """A run that dies after building staging (before the swap) leaves a
+    committed staging table; the next run's create_staging_table must
+    replace it and the cycle completes."""
+    pg = FakePostgres()
+    _seed_live(pg, SPEC)
+
+    conn = pg.connect()
+    create_staging_table(conn, SPEC)
+    apply_ddl(conn, _stage_ddl(SPEC))  # crash after this point: no swap
+
+    _run_cycle(pg, SPEC)
+
+    _assert_canonical_shape(pg, SPEC)
+
+
+def test_first_swap_without_live_target():
+    """Cold start: no live table yet — the swap takes the rename-old-skipping
+    branch, and the pre-drop of a nonexistent `_old` is a no-op."""
+    pg = FakePostgres()
+    pg.seed_table(SPEC.staging_schema, SPEC.new_table)
+    conn = pg.connect()
+    apply_ddl(conn, _stage_ddl(SPEC))
+
+    swap_staging_into_target(conn, SPEC)
+    drop_old_table(conn, SPEC)
+
+    _assert_canonical_shape(pg, SPEC)
+
+
+def test_drop_old_is_idempotent():
+    pg = FakePostgres()
+    _seed_live(pg, SPEC)
+    _run_cycle(pg, SPEC)
+
+    drop_old_table(pg.connect(), SPEC)  # second drop: IF EXISTS no-op
+
+    _assert_canonical_shape(pg, SPEC)

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -572,7 +572,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
                 stance_df,
                 district_df,
             ],
-            strict=False,
+            strict=True,
         )
         for table, df in to_load:
             query = f'SELECT MAX(updated_at) AS max_updated_at FROM {db_schema}."{table}"'
@@ -605,10 +605,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
     #   Stance -> Issue, Candidacy
     # so referenced parents must load before their children.
     # Projected_Turnout is NOT written here: this writer upserts and never
-    # deletes, so superseded rows would linger. Delivery moves to the
-    # sync_election_api Airflow DAG's atomic table swap (added in PR #585);
-    # until that lands, the API serves its current rows, aging but clean
-    # (accepted interim, DATA-2015).
+    # deletes, so superseded rows would linger. It is delivered by the
+    # sync_election_api Airflow DAG's atomic table swap instead (PR #585,
+    # DATA-2015); tests/test_write__election_api_db.py pins its absence.
     table_load_counts: dict[str, int] = {}
     for table_name, df, upsert_query in zip(
         [
@@ -638,7 +637,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
             ISSUE_UPSERT_QUERY,
             STANCE_UPSERT_QUERY,
         ],
-        strict=False,
+        strict=True,
     ):
         table_load_counts[table_name] = _load_data_to_postgres(
             df=df,

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -1,0 +1,118 @@
+"""Source-contract tests for the election-api dbt writer.
+
+The writer drives its Postgres loads off parallel literal lists zipped
+together inside model(); an edit that removes an entry from one list but not
+its siblings would truncate (strict=False) or misalign the loads without any
+error near the mistake. These tests pin the table set and the zip discipline
+at the source level: the module only runs on a Databricks cluster (dbutils,
+JDBC), and the lists live inside model(), so the contract is asserted by
+parsing the source rather than importing and executing it.
+"""
+
+import ast
+from pathlib import Path
+
+WRITER_PATH = Path(__file__).parent.parent / "project" / "models" / "write" / "write__election_api_db.py"
+
+# The writer's full table set, in FK-dependency order (parents before
+# children); Projected_Turnout is intentionally absent — it is delivered by
+# the sync_election_api Airflow DAG's atomic table swap (DATA-2015).
+EXPECTED_LOAD_TABLES = ["Place", "District", "Position", "Race", "Candidacy", "Issue", "Stance"]
+
+# The incremental max-updated_at filter covers every load table except
+# Position, whose Postgres table has no updated_at column.
+EXPECTED_INCREMENTAL_TABLES = ["Candidacy", "Issue", "Place", "Race", "Stance", "District"]
+
+
+def _writer_tree() -> ast.Module:
+    return ast.parse(WRITER_PATH.read_text())
+
+
+def _zip_calls(tree: ast.Module) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "zip"
+    ]
+
+
+def _literal_string_list(node: ast.expr) -> list[str] | None:
+    """The list of string constants in a list literal, or None if not one."""
+    if not isinstance(node, ast.List):
+        return None
+    values = [elt.value for elt in node.elts if isinstance(elt, ast.Constant) and isinstance(elt.value, str)]
+    return values if len(values) == len(node.elts) else None
+
+
+def _name_list(node: ast.expr) -> list[str] | None:
+    """The identifier names in a list literal, or None if not one."""
+    if not isinstance(node, ast.List):
+        return None
+    names = [elt.id for elt in node.elts if isinstance(elt, ast.Name)]
+    return names if len(names) == len(node.elts) else None
+
+
+def _zip_by_first_list(tree: ast.Module, table_names: list[str]) -> ast.Call:
+    for call in _zip_calls(tree):
+        if call.args and _literal_string_list(call.args[0]) == table_names:
+            return call
+    raise AssertionError(
+        f"No zip() whose first argument is the literal table list {table_names}; "
+        "if the writer was restructured, update these pins deliberately."
+    )
+
+
+def test_every_zip_is_strict():
+    """A silently truncating zip over the parallel load lists must be
+    impossible: every zip in the writer carries strict=True."""
+    zips = _zip_calls(_writer_tree())
+    assert len(zips) >= 2, "expected the incremental-filter zip and the load-loop zip"
+    for call in zips:
+        strict = [kw for kw in call.keywords if kw.arg == "strict"]
+        assert strict, f"zip() at line {call.lineno} has no strict= keyword"
+        assert (
+            isinstance(strict[0].value, ast.Constant) and strict[0].value.value is True
+        ), f"zip() at line {call.lineno} must use strict=True"
+
+
+def test_load_loop_table_set_is_pinned():
+    """The load loop writes exactly the seven tables, in FK-dependency
+    order, with each table's DataFrame and upsert query aligned by name."""
+    call = _zip_by_first_list(_writer_tree(), EXPECTED_LOAD_TABLES)
+    assert len(call.args) == 3, "load loop zips (tables, dataframes, upsert queries)"
+
+    dfs = _name_list(call.args[1])
+    queries = _name_list(call.args[2])
+    assert dfs is not None and queries is not None
+    # Same length as the table list (strict=True would also catch this at
+    # runtime, but only on a Databricks cluster; assert it here first).
+    assert len(dfs) == len(EXPECTED_LOAD_TABLES)
+    assert len(queries) == len(EXPECTED_LOAD_TABLES)
+    # Positional alignment by naming convention: <table>_df / <TABLE>_UPSERT_QUERY.
+    assert dfs == [f"{t.lower()}_df" for t in EXPECTED_LOAD_TABLES]
+    assert queries == [f"{t.upper()}_UPSERT_QUERY" for t in EXPECTED_LOAD_TABLES]
+
+
+def test_incremental_filter_table_set_is_pinned():
+    """The incremental max-updated_at zip stays in lockstep with the load
+    set (minus Position, which has no updated_at column)."""
+    call = _zip_by_first_list(_writer_tree(), EXPECTED_INCREMENTAL_TABLES)
+    assert len(call.args) == 2, "incremental filter zips (tables, dataframes)"
+
+    dfs = _name_list(call.args[1])
+    assert dfs is not None
+    assert dfs == [f"{t.lower()}_df" for t in EXPECTED_INCREMENTAL_TABLES]
+    assert set(EXPECTED_INCREMENTAL_TABLES) == set(EXPECTED_LOAD_TABLES) - {"Position"}
+
+
+def test_projected_turnout_is_absent():
+    """Projected_Turnout must never reappear in this writer: the upsert path
+    cannot delete superseded rows, which is why its delivery moved to the
+    sync_election_api swap DAG (DATA-2015). Checks every string literal, so
+    a reintroduced table-list entry or upsert query both fail."""
+    for node in ast.walk(_writer_tree()):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            assert "Projected_Turnout" not in node.value, (
+                f"'Projected_Turnout' found in a string literal at line {node.lineno}; "
+                "it is delivered by the sync_election_api swap DAG, not this writer."
+            )


### PR DESCRIPTION
Post-DATA-2015 hardening fast-follows for the Projected_Turnout swap delivery (#584/#585), accepted as fast-follows in the pre-merge reviews of #585. One PR, three items.

## 1. Swap self-heals from a leftover `_old` table (airflow)

`swap_staging_into_target` renames the live table aside to `<Table>_old` inside its transaction, but `drop_old_table` runs later as a separate task/transaction. A crash in that window leaves `public."<Table>_old"` behind, and every later run's swap then fails on the rename collision (table name plus the `_old`-suffixed index/constraint names) until someone drops the leftover by hand. With `max_consecutive_failed_dag_runs=5`, five silent daily failures auto-pause the DAG and freeze all four synced tables.

Fix: `DROP TABLE IF EXISTS "<schema>"."<Table>_old"` at the top of the swap transaction. DDL is transactional in Postgres, so a mid-swap failure rolls the pre-drop back along with the renames, and a clean run drops nothing that `drop_old_table` would not have dropped anyway. The fix lives in the shared util, so all four table groups get it.

Tests (`airflow/astro/tests/test_election_api_swap.py`): a transactional in-memory fake of the exact DDL statement set the lifecycle emits, modeling the Postgres semantics the swap relies on (duplicate-name errors, DROP cascading to the table's indexes/constraints, SET SCHEMA moving indexes with the table, constraint-backed index renames renaming the constraint). It proves:

- the wedge scenario recovers on the next run (this test fails against the previous util with `relation "Projected_Turnout_old" already exists`),
- the swap transaction rolls back to the exact pre-swap state when crashed before every one of its statements, and an immediate retry then succeeds,
- a retry after a committed-but-unrecorded swap fails closed (the freshly swapped table stays live and untouched) and the next run heals the leftover,
- cold start, crash-before-swap, and repeated drop_old all behave.

## 2. DAG failure alerting: findings (no code change)

Investigated the repo for an existing alerting pattern to wire `sync_election_api` into: there is none. No `on_failure_callback` or notifier usage in any DAG or include, no Slack provider in `requirements.txt`/`packages.txt`, no SMTP config, and no alerting-related terraform in this repo. Wiring code-level alerting would mean inventing a new path (provider + connection + secret), which this fast-follow deliberately avoids, so alerting is documented as Astro-platform configuration instead.

**One-time human action (Astro UI, not done by this PR):** in the Astro Workspace, create an Alert of type "DAG failure" scoped to `sync_election_api` on the prod deployment, and attach the team's Slack communication channel (add the Slack channel under the workspace's alert/notification settings first if none exists). Until that alert exists, the only failure signal is the DAG silently pausing after 5 consecutive failed runs. This is now documented in the DAG docstring alongside the other Astro-side operational config, and in the local recovery runbook.

## 3. Writer hardening (dbt)

`write__election_api_db.py` drives its Postgres loads off parallel literal lists zipped together; removing an entry from one list but not its siblings would silently truncate the load under `strict=False`. Both zip calls in the file (the incremental max-`updated_at` filter and the load loop) flip to `strict=True`, and a new unit test (`dbt/tests/test_write__election_api_db.py`) pins the source contract: every zip strict, exactly the current seven tables in FK-dependency order, dataframe/query lists name-aligned per position, and `Projected_Turnout` absent from every string literal in the module (its delivery moved to the swap DAG and must not silently return).

Note: touching the writer puts it in dbt CI scope, so the CI run executes it against the CI target and writes the seven tables there. Expected; budget ~40-60 min for the check.

## Verification

- `cd airflow && uv run pytest`: 80 passed, 2 skipped (skips pre-existing).
- `cd dbt && uv run pytest`: 54 passed.
- Remote parse via the dbt Cloud CLI (from `dbt/project/`): clean, no lock-file churn.
- Ruff pinned at the pre-commit rev (0.7.4), check + format: clean; pre-commit hooks passed on both commits.
- Mutation checks: reverting `strict=True` makes `test_every_zip_is_strict` fail; the wedge test fails against the pre-fix util.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swap logic touches live Postgres election-api tables for all synced marts; the pre-drop is transactional and tested, but failed swaps still gate API data freshness. Writer strictness only changes failure mode on list drift (fail fast vs silent truncate).
> 
> **Overview**
> Hardens election-api delivery after the Projected_Turnout swap cutover (DATA-2015).
> 
> **Airflow swap recovery:** `swap_staging_into_target` now runs `DROP TABLE IF EXISTS … "<Table>_old"` at the start of the swap transaction so a leftover `_old` from a crash between swap and `drop_old` cannot block every later rename. The change is in the shared util, so all `sync_election_api` table groups get it. New `test_election_api_swap.py` uses a transactional in-memory Postgres fake to cover wedge recovery, rollback at each swap statement, and related edge cases. DAG/docs describe the same behavior and add **Astro UI** DAG-failure alerting setup (no in-repo notifier wiring).
> 
> **dbt writer:** Both `zip()` calls in `write__election_api_db.py` use `strict=True` so parallel table/dataframe/query lists cannot silently misalign. New AST-based tests pin the seven-table load set, incremental table set, strict zips, and that `Projected_Turnout` stays out of this writer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7954c3c030bc27e609b1fb3633cf3d9e2b8d34e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->