### PR TITLE
[DATA-2015] Floor projected turnout at 3 ballots per district

### DIFF
--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -683,7 +683,7 @@ def model(dbt, session):
             p.State                          AS state,
             m.district_type,
             m.district_name,
-            ROUND(SUM(p.p_hat * p.n_voters)) AS ballots_projected,
+            GREATEST(ROUND(SUM(p.p_hat * p.n_voters)), 3) AS ballots_projected,
             p.model_family                   AS model_version,
             current_timestamp()              AS inference_at
         FROM _precinct_preds p


### PR DESCRIPTION
## What

Floors district-level `ballots_projected` at 3 in `int__voter_turnout_lgbm_inference`.

```diff
- ROUND(SUM(p.p_hat * p.n_voters)) AS ballots_projected,
+ GREATEST(ROUND(SUM(p.p_hat * p.n_voters)), 3) AS ballots_projected,
```

## Why

Any district whose rounded projected turnout would fall below 3 (i.e. 0, 1, or 2) is now reported as 3.

## Notes

- `GREATEST` skips nulls in Spark SQL, so a district with a null `SUM` also floors to 3 rather than staying null.
- Applied at the district output grain only; does not change the model grain, so the unique-combination data test on this model is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eaee2262108ff664d27c3e1c1416cbba52c32a6f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->