### PR TITLE
calib(process): review batch 2 (dispatch template, agent generalization, ratified column, methodology split)

### DIFF
--- a/.claude/agents/product-data-scientist.md
+++ b/.claude/agents/product-data-scientist.md
@@ -2,7 +2,6 @@
 name: product-data-scientist
 description: Reviews data and ML approach feasibility and methodology, and interprets executed analyses from a product data scientist's perspective. Surfaces leakage, overfitting, survivorship, calibration, and generalization concerns during methodology review; reads results for signal, cohort divergence, and effect-size meaningfulness during interpretation. Use proactively at plan checkpoints, pre-PR, and after analysis execution. Read-only and advisory.
 tools: Bash, Read, Grep, Glob, WebFetch
-model: opus
 ---
 
 You are a senior product data scientist embedded with the GoodParty.org data team. Your job is to review proposed plans, models, features, and analyses from a methodological-rigor perspective. You do NOT implement code.
@@ -75,4 +74,4 @@ If you have no concerns at a level, say so explicitly rather than padding. If th
 
 ## Context supplied at invocation
 
-The invocation prompt will supply project-specific framing (product, cadence, population, intended action). Read the named plan / CLAUDE.md / model files before forming your assessment. For Win-product analyses, load the docs relevant to your review — the win-analytics-process skill's `methodology.md` (methodology and verification protocol) and the win-analytics-knowledge skill's `viability.md` and `gotchas.md` — rather than every doc. The pipeline topology (where your review sits and what it hands off) is in the process skill's `pipeline.md`.
+The invocation prompt will supply project-specific framing (product, cadence, population, intended action) and the product's reviewer doc pointers. Read the named plan / CLAUDE.md / model files before forming your assessment, and load the docs the dispatch names — the product knowledge skill's docs for your role plus the process skill's `methodology.md` (methodology and verification protocol) — rather than every doc. The pipeline topology (where your review sits and what it hands off) is in the process skill's `pipeline.md`.

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -2,7 +2,6 @@
 name: product-manager
 description: Reviews framing, usefulness, and actionability from a product manager's perspective. Asks whether we're answering the right questions, whether the artifact will be actionable for the team, and whether names/segmentations/thresholds match how consumers think. Use proactively at plan checkpoints and pre-PR for substantive analytics/product work. Read-only and advisory.
 tools: Bash, Read, Grep, Glob, WebFetch
-model: opus
 ---
 
 You are a product manager embedded with the GoodParty.org data team. Your job is to review proposed plans, analyses, and data artifacts from a usefulness and clarity perspective. You do NOT implement code.
@@ -50,4 +49,4 @@ If you have no concerns at a level, say so explicitly rather than padding. If th
 
 ## Context supplied at invocation
 
-The invocation prompt will supply project-specific framing (product, cadence, intended audience, where the output lands). Read the named plan / CLAUDE.md / model files before forming your assessment. For Win-product work, load the docs relevant to your review — the win-analytics-knowledge skill's `segmentation.md` and the win-analytics-process skill's `methodology.md` — rather than every doc. The pipeline topology (where your review sits) is in the process skill's `pipeline.md`.
+The invocation prompt will supply project-specific framing (product, cadence, intended audience, where the output lands) and the product's reviewer doc pointers. Read the named plan / CLAUDE.md / model files before forming your assessment, and load the docs the dispatch names — the product knowledge skill's docs for your role plus the process skill's `methodology.md` — rather than every doc. The pipeline topology (where your review sits) is in the process skill's `pipeline.md`.

--- a/.claude/skills/win-analytics-knowledge/SKILL.md
+++ b/.claude/skills/win-analytics-knowledge/SKILL.md
@@ -27,6 +27,7 @@ the analyst workflow and patterns, see the **win-analytics-process** skill.
 | Engagement / activation metrics, the Amplitude event landscape, onboarding flow versions, UTM | [`references/engagement.md`](references/engagement.md) | use `is_onboarded` / `has_completed_onboarding_flow` across the 2026-05-07 cutover |
 | Viability Score 2.0 — definition, bands, coverage, calibration | [`references/viability.md`](references/viability.md) | bucket into deciles (the score is bimodal) |
 | Slicing dimensions (office, level, state, party, Pro, ICP) | [`references/segmentation.md`](references/segmentation.md) | **filter** on `icp_office_win` (slice instead) |
+| Win's analysis defaults (resolved scoping, default cohorts, the working-set builder + its column caveats, reviewer doc pointers) | [`references/methodology_defaults.md`](references/methodology_defaults.md) | use the builder's `onboarded` column as the canonical Onboarded cohort |
 | A symptom you're seeing / a recurring trap | [`references/gotchas.md`](references/gotchas.md) | restate a fact the symptom table points elsewhere for |
 
 ## Governance

--- a/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
@@ -5,25 +5,27 @@ follow the "owns detail" link for the full definition's caveats, coverage, and q
 
 **Governance.** These definitions are human-owned. Claude may draft the surrounding prose,
 column descriptions, and gotchas in the linked docs, but must **not invent or silently change
-a definition in this table**. Rows below were lifted from the prior runbook and are **pending
-human ratification** — confirm with the metric owner before treating a definition as settled.
+a definition in this table**. The **Ratified** column records per-row sign-off: a date plus the
+owner's initials once the metric owner has confirmed the definition. Treat a `pending` row as
+lifted from the prior runbook and not yet settled — confirm with the metric owner before
+building a headline on it. Ratifying a row is a human edit, never Claude's.
 
 Keep this file thin: one row per genuinely-canonical concept, a one-line definition, the
 owning `table.column` (or event), and the doc that owns the detail. Caveats and usage notes
 live in the owning doc, not here, so this stays small enough to load on every resolution.
 
-| Concept | Governed definition (one line) | Source (`table.column` / event) | Owns detail |
-|---|---|---|---|
-| **Active Candidates (OKR)** | Viewed the candidate dashboard in the trailing 30 days | `users_win_base.is_active_candidate_30d` | [engagement.md](engagement.md) |
-| **Activated Candidates (OKR)** | Has sent ≥1 voter outreach campaign | `users_win_base.is_activated` | [engagement.md](engagement.md) |
-| **Onboarded (canonical cohort)** | Viewed `Dashboard - Candidate Dashboard Viewed` within 14 days of account creation; recomputed from the raw event (version-agnostic across the onboarding-flow cutover) | recomputed from `Dashboard - Candidate Dashboard Viewed` vs `users_win_candidacy.user_created_at` | [engagement.md](engagement.md) |
-| **Onboarding completed (pledge)** | Fired `Onboarding - Candidate Pledge Completed` within 14 days of account creation (strict funnel completion) | recomputed from `Onboarding - Candidate Pledge Completed` | [engagement.md](engagement.md) |
-| **Outreach intensity** | Count of `Voter Outreach - Campaign Completed` events | `users_win_base.total_campaigns_sent` | [engagement.md](engagement.md) |
-| **Amplitude coverage** | Has ≥1 milestone event (lower bound; materially undercounts true coverage) | `users_win_base.has_amplitude_data` | [engagement.md](engagement.md) |
-| **Win/loss outcome (preferred)** | Deepest stage reached + result there: `latest_stage_reached` + `latest_stage_result` | `mart_civics.candidacy.latest_stage_result` | [outcomes.md](outcomes.md) |
-| **Viability Score 2.0** | `round(5 × P(win))`, range 0.0–5.0, mapped to a 5-band label (`No Chance` … `Frontrunner`) | `int__techspeed_viability_scoring.viability_rating_2_0` / `score_viability_automated` | [viability.md](viability.md) |
-| **PMF (KR2)** | Share of ICP-activated users answering "very disappointed" (Option 1) on the Win PMF survey if they could no longer use Win; target 40% | `stg_airbyte_source__hubspot_api_feedback_submissions` (`survey_name LIKE 'Win PMF%'`, `pmf_response`) | [outcomes.md](outcomes.md) |
-| **Upcoming/live election base** | Distinct `is_latest_version AND NOT is_demo` users whose per-user `MAX(election_date)`, bounded to `[2020-01-01, 2050-01-01]`, is `>= the as-of date` (open-ended; includes future cycles) | `users_win_candidacy.election_date` | [segmentation.md](segmentation.md) |
+| Concept | Governed definition (one line) | Source (`table.column` / event) | Owns detail | Ratified |
+|---|---|---|---|---|
+| **Active Candidates (OKR)** | Viewed the candidate dashboard in the trailing 30 days | `users_win_base.is_active_candidate_30d` | [engagement.md](engagement.md) | pending |
+| **Activated Candidates (OKR)** | Has sent ≥1 voter outreach campaign | `users_win_base.is_activated` | [engagement.md](engagement.md) | pending |
+| **Onboarded (canonical cohort)** | Viewed `Dashboard - Candidate Dashboard Viewed` within 14 days of account creation; recomputed from the raw event (version-agnostic across the onboarding-flow cutover) | recomputed from `Dashboard - Candidate Dashboard Viewed` vs `users_win_candidacy.user_created_at` | [engagement.md](engagement.md) | pending |
+| **Onboarding completed (pledge)** | Fired `Onboarding - Candidate Pledge Completed` within 14 days of account creation (strict funnel completion) | recomputed from `Onboarding - Candidate Pledge Completed` | [engagement.md](engagement.md) | pending |
+| **Outreach intensity** | Count of `Voter Outreach - Campaign Completed` events | `users_win_base.total_campaigns_sent` | [engagement.md](engagement.md) | pending |
+| **Amplitude coverage** | Has ≥1 milestone event (lower bound; materially undercounts true coverage) | `users_win_base.has_amplitude_data` | [engagement.md](engagement.md) | pending |
+| **Win/loss outcome (preferred)** | Deepest stage reached + result there: `latest_stage_reached` + `latest_stage_result` | `mart_civics.candidacy.latest_stage_result` | [outcomes.md](outcomes.md) | pending |
+| **Viability Score 2.0** | `round(5 × P(win))`, range 0.0–5.0, mapped to a 5-band label (`No Chance` … `Frontrunner`) | `int__techspeed_viability_scoring.viability_rating_2_0` / `score_viability_automated` | [viability.md](viability.md) | pending |
+| **PMF (KR2)** | Share of ICP-activated users answering "very disappointed" (Option 1) on the Win PMF survey if they could no longer use Win; target 40% | `stg_airbyte_source__hubspot_api_feedback_submissions` (`survey_name LIKE 'Win PMF%'`, `pmf_response`) | [outcomes.md](outcomes.md) | pending |
+| **Upcoming/live election base** | Distinct `is_latest_version AND NOT is_demo` users whose per-user `MAX(election_date)`, bounded to `[2020-01-01, 2050-01-01]`, is `>= the as-of date` (open-ended; includes future cycles) | `users_win_candidacy.election_date` | [segmentation.md](segmentation.md) | pending |
 
 When a question names a concept not in this table, fall through to the per-domain routing
 table in the knowledge skill's `SKILL.md`. When you define a genuinely new canonical metric,

--- a/.claude/skills/win-analytics-knowledge/references/engagement.md
+++ b/.claude/skills/win-analytics-knowledge/references/engagement.md
@@ -111,7 +111,7 @@ UTM lives only in the `user_properties` JSON on `stg_airbyte_source__amplitude_a
 
 The pattern: read raw events from `stg_airbyte_source__amplitude_api_events`, filter to the relevant family + window, aggregate to `user_id × time bucket` or `user_id × funnel step`. Mirror the structure of `int__amplitude_user_milestones` (user-grain milestones) or `int__amplitude_win_activity` (per-month aggregates).
 
-Reusable Python pull-script template at `analytics/projects/win_outcomes_scout/notebooks/_pull_amplitude_universe.py`. Connect via the profile-auth helper `analytics/lib/databricks_conn.py` (`run_query`, authenticates via the `~/.databrickscfg` profile). The reusable build-once-slice-many helper is `analytics/lib/win_analysis.py` (see the process skill's `methodology.md`).
+Reusable Python pull-script template at `analytics/projects/win_outcomes_scout/notebooks/_pull_amplitude_universe.py`. Connect via the profile-auth helper `analytics/lib/databricks_conn.py` (`run_query`, authenticates via the `~/.databrickscfg` profile). The reusable build-once-slice-many helper is `analytics/lib/win_analysis.py` (see [methodology_defaults.md](methodology_defaults.md)).
 
 ## Cross-references
 

--- a/.claude/skills/win-analytics-knowledge/references/methodology_defaults.md
+++ b/.claude/skills/win-analytics-knowledge/references/methodology_defaults.md
@@ -1,0 +1,57 @@
+# Win methodology defaults
+
+Part of the **win-analytics-knowledge** skill. The Win-product defaults consumed by the
+process skill's [methodology.md](../../win-analytics-process/references/methodology.md):
+that doc owns the product-agnostic discipline (scoping checklist, folder patterns, binning,
+verification protocol); this one owns what is true *for Win* — the resolved scoping
+decisions, the default cohorts, and the working-set builder.
+
+## Resolved scoping decisions (DATA-1935, 2026-05-27)
+
+These apply by default to Win-product analyses. Document deviations in your project's `SESSION_NOTES.md`.
+
+| Decision | Default |
+|---|---|
+| Unit of analysis | Candidacy (`gp_candidacy_id`) |
+| Outcome variable | `latest_stage_reached + latest_stage_result` from `mart_civics.candidacy` (NOT `general_election_result`) |
+| Cycle window | `general_election_date BETWEEN '2025-05-01' AND '2026-12-31'` (adjust per project) |
+| Engagement window | Same as candidacy window unless analysis specifically wants trailing features |
+| Baseline | All registered Win users; engagement-zero is a valid predictor value (not an exclusion) |
+| ICP gating | `icp_office_win` is a slicing dimension, not a filter |
+
+## Default cohorts by analysis type
+
+Different analyses call for different cohorts. The full Win-product registered population includes registered-but-never-active candidates, pre-instrumentation registrants, CRM-sync candidates who never logged in, and other heterogeneous funnel stages. Pooling them produces misleading correlations — for example, raw engagement-vs-win-rate looks *inverse* (more engagement → lower win rate) because the 0-engagement bin is dominated by candidates who never used the product at all, not by candidates who tried-and-failed to engage.
+
+| Analysis type | Default cohort | Source flag |
+|---|---|---|
+| Engagement vs outcome | Onboarded cohort | **onboarding dashboard viewed** = dashboard view within 14d of `user_created_at`, recomputed from the raw event (NOT the new-flow-blind `has_completed_onboarding_flow` / `is_onboarded` flags — see [engagement.md](engagement.md) and [gotchas.md](gotchas.md)) |
+| Outreach intensity vs outcome | Activated cohort (sent ≥1 outreach) | `is_activated = TRUE` |
+| Funnel / dropoff analyses | Full registered population | `users_win_candidacy` filtered to `is_latest_version AND NOT is_demo` |
+| Active candidates OKR reporting | Active candidates (trailing 30d) | `is_active_candidate_30d = TRUE` (or recompute anchored to a target date) |
+
+Always name the cohort in the analysis title and headline so consumers know which population is being characterized. "Among onboarded Win candidates..." not "Among Win candidates..."
+
+## The working-set builder
+
+The committed package `analytics/lib/win_analysis.py` holds the canonical Win event-family allowlist (`win_event_predicate`), a `build_win_working_set(run_query, cohorts, ...)` that returns one consolidated per-user `cohort × engagement` DataFrame carrying the standard slicing dimensions from [segmentation.md](segmentation.md), and `wilson`. Build that one working set first, then slice every cut from it in pandas (the build-once-slice-many rule in the process skill's methodology.md). Carrying the slice dimensions up front makes re-cuts (e.g. ICP vs not) free — see the amend path in the process skill's brief-schema.md. The event classification is sourced from `int__amplitude_event_catalog` (see [engagement.md](engagement.md) — no separate hand-maintained allowlist to keep in sync).
+
+> **Column caveat — don't use the helper's `onboarded` column as the Onboarded cohort.** `build_win_working_set`'s `onboarded` column keys on `onboarding_complete`, which is the **new-flow-blind** flag (FALSE for every post-2026-05-07 user). It is **not** the canonical **Onboarded** cohort from the default-cohorts table above (dashboard view within 14 days of account creation). For that cohort, recompute the 14-day dashboard-view logic — the helper's `dash_viewed` is dashboard-view-*ever* within the pre-anchor window, not the 14-day-of-creation window — and for cross-cutover onboarding *completion* use `Onboarding - Candidate Pledge Completed`. Same new-flow-blindness documented in [engagement.md](engagement.md) and [gotchas.md](gotchas.md), and in the lib's own README.
+
+## Reviewer doc pointers (used by the dispatch template)
+
+When the reviewer dispatch template in the process skill's pipeline.md asks for the product's reviewer doc pointers, Win's are:
+
+- `product-data-scientist`: this skill's [viability.md](viability.md) and [gotchas.md](gotchas.md), plus the process skill's methodology.md.
+- `product-manager`: this skill's [segmentation.md](segmentation.md), plus the process skill's methodology.md.
+
+## Source pointers
+
+**Project scouts that contributed insights:**
+- **`analytics/projects/win_outcomes_scout/INVENTORY.md`** (DATA-1935) — Win product × electoral outcomes data scout. Seeded most of this skill's content, especially `outcomes.md` through `viability.md`. Source 7 in the inventory carries the full HubSpot survey detail (per-survey submission counts, response distribution by ICP/Win bucket, the verified Option 1/2 mapping evidence).
+- **`analytics/projects/win_churn/`** (DATA-1924) — Win churn modeling. Engagement-as-outcome counterpart. Source for some of the multi-cycle and pre-2023-12-10 gotchas.
+
+**Authoritative dbt model docs:**
+- `dbt/project/models/marts/civics/m_civics.yaml` — column descriptions for candidacy / candidate / candidacy_stage / election / election_stage.
+- `dbt/project/models/marts/analytics/m_analytics.yaml` — for the analytics mart.
+- `dbt/project/models/intermediate/amplitude/int__amplitude.yaml` — Amplitude intermediate columns + tests.

--- a/.claude/skills/win-analytics-process/SKILL.md
+++ b/.claude/skills/win-analytics-process/SKILL.md
@@ -19,7 +19,7 @@ the single description of the pipeline flow.
 1. **Clarify and scope (framing).** Run the framing routine ([`references/framing.md`](references/framing.md)) in your own context — it converses with the user. No execution code until the human approves the framing.
 2. **Find sources.** Resolve every concept through the knowledge skill, and verify named tables/columns/events against the live catalog — docs drift.
 3. **Produce the brief.** The framing output is a structured brief per [`references/brief-schema.md`](references/brief-schema.md), the framing→execution contract.
-4. **Execute.** Build the working set once, then slice every cut from it in pandas — defaults, cohort tables, and the working-set column caveats are in [`references/methodology.md`](references/methodology.md).
+4. **Execute.** Build the working set once, then slice every cut from it in pandas — the discipline is in [`references/methodology.md`](references/methodology.md); the product's defaults, cohort tables, and working-set column caveats are in the product knowledge skill's `methodology_defaults.md`.
 5. **Review.** After the results checkpoint, route the executed analysis through the two adversarial reviewer agents; the gate and dispatch rules are in `pipeline.md`.
 6. **Close the loop.** Run the calibration pass ([`references/calibration.md`](references/calibration.md)), ending with the candidates-ledger read-back it requires. Pruning happens via **consolidation mode**, detailed in the same doc.
 
@@ -27,9 +27,9 @@ the single description of the pipeline flow.
 
 Common work that should not be reinvented each run:
 
-- **Build-once-slice-many.** One consolidated per-user `cohort × engagement` working set via `analytics/lib/win_analysis.py`, carrying the standard slice dimensions so re-cuts are free pandas `groupby`s. See `methodology.md`.
+- **Build-once-slice-many.** One consolidated per-user `cohort × engagement` working set via the product's committed builder, carrying the standard slice dimensions so re-cuts are free pandas `groupby`s. Builder and column caveats: the product knowledge skill's `methodology_defaults.md`.
 - **Funnel analysis.** Aggregate the raw event stream to `user_id × funnel step`; report "engaged beyond account creation" (≥2 distinct events) alongside raw any-evidence. Event families come from the knowledge skill's `engagement.md`.
-- **Rate decomposition.** Don't pool heterogeneous funnel stages — name the cohort (onboarded / activated / full registered) so a rate isn't dominated by never-active registrants. See the default-cohorts table in `methodology.md`.
+- **Rate decomposition.** Don't pool heterogeneous funnel stages — name the cohort (onboarded / activated / full registered) so a rate isn't dominated by never-active registrants. See the default-cohorts table in the product knowledge skill's `methodology_defaults.md`.
 - **Retention / reverse-retention curves.** Pair any closed-cohort curve with an open fixed-denominator view, then split open into new vs returning. The closed curve decays by construction; the open/returning view answers whether the base is more engaged. Full mechanism in the knowledge skill's `gotchas.md`.
 - **Wilson intervals + binning.** Report Wilson 95% CIs alongside point estimates; flag N<30 bins; pre-register bins in the brief. See `methodology.md`.
 
@@ -37,6 +37,6 @@ Common work that should not be reinvented each run:
 
 - [`references/framing.md`](references/framing.md) — the framing routine (persona, question set, pre-brief verification) the orchestrator runs in step 1.
 - [`references/pipeline.md`](references/pipeline.md) — stages, agents, handoff contracts (descriptive, not active).
-- [`references/methodology.md`](references/methodology.md) — scoping, default cohorts, query patterns, verification protocol, source pointers.
+- [`references/methodology.md`](references/methodology.md) — product-agnostic discipline: scoping checklist, folder patterns, query patterns, binning, verification protocol. Product defaults (scoping decisions, cohorts, working-set builder) live in the product knowledge skill's `methodology_defaults.md`.
 - [`references/brief-schema.md`](references/brief-schema.md) — the analysis-brief YAML contract + amend-vs-reframe rule.
 - [`references/calibration.md`](references/calibration.md) — the calibration-log convention, the candidates ledger, the ledger read-back, consolidation mode, and the over-calibration / bloat cautions.

--- a/.claude/skills/win-analytics-process/references/brief-schema.md
+++ b/.claude/skills/win-analytics-process/references/brief-schema.md
@@ -129,4 +129,4 @@ Decision rule: if population/eligibility/target/comparison are unchanged and you
 ## Cross-references
 
 - [pipeline.md](pipeline.md) — the stages this brief flows through.
-- [methodology.md](methodology.md) — scoping, default cohorts, and the build-once-slice-many pattern.
+- [methodology.md](methodology.md) — scoping and the build-once-slice-many pattern; the product's default cohorts are in the product knowledge skill's `methodology_defaults.md`.

--- a/.claude/skills/win-analytics-process/references/framing.md
+++ b/.claude/skills/win-analytics-process/references/framing.md
@@ -99,4 +99,4 @@ For the final brief: follow the structured format documented in [brief-schema.md
 
 - [brief-schema.md](brief-schema.md) — the brief format this routine produces.
 - [pipeline.md](pipeline.md) — where framing sits in the flow.
-- [methodology.md](methodology.md) — scoping checklist, default cohorts, verification protocol.
+- [methodology.md](methodology.md) — scoping checklist, verification protocol; the product's default cohorts and scoping decisions are in the product knowledge skill's `methodology_defaults.md`.

--- a/.claude/skills/win-analytics-process/references/methodology.md
+++ b/.claude/skills/win-analytics-process/references/methodology.md
@@ -1,32 +1,19 @@
 # Methodology
 
-Part of the **win-analytics-process** skill. Scoping + verifying an analysis.
+Part of the **win-analytics-process** skill. Scoping + verifying an analysis. This doc owns
+the product-agnostic discipline; the *product's* defaults — resolved scoping decisions,
+default cohorts, and the working-set builder — live in the product knowledge skill's
+`methodology_defaults.md` (Win: [methodology_defaults.md](../../win-analytics-knowledge/references/methodology_defaults.md)).
+Load both: the checklist below tells you *what to settle*; the defaults doc tells you the
+product's settled answers.
 
-## Resolved scoping decisions (DATA-1935, 2026-05-27)
+## Product defaults (pointer)
 
-These apply by default to Win-product analyses. Document deviations in your project's `SESSION_NOTES.md`.
+Before scoping, open the product's `methodology_defaults.md` for:
 
-| Decision | Default |
-|---|---|
-| Unit of analysis | Candidacy (`gp_candidacy_id`) |
-| Outcome variable | `latest_stage_reached + latest_stage_result` from `mart_civics.candidacy` (NOT `general_election_result`) |
-| Cycle window | `general_election_date BETWEEN '2025-05-01' AND '2026-12-31'` (adjust per project) |
-| Engagement window | Same as candidacy window unless analysis specifically wants trailing features |
-| Baseline | All registered Win users; engagement-zero is a valid predictor value (not an exclusion) |
-| ICP gating | `icp_office_win` is a slicing dimension, not a filter |
-
-## Default cohorts by analysis type
-
-Different analyses call for different cohorts. The full Win-product registered population includes registered-but-never-active candidates, pre-instrumentation registrants, CRM-sync candidates who never logged in, and other heterogeneous funnel stages. Pooling them produces misleading correlations — for example, raw engagement-vs-win-rate looks *inverse* (more engagement → lower win rate) because the 0-engagement bin is dominated by candidates who never used the product at all, not by candidates who tried-and-failed to engage.
-
-| Analysis type | Default cohort | Source flag |
-|---|---|---|
-| Engagement vs outcome | Onboarded cohort | **onboarding dashboard viewed** = dashboard view within 14d of `user_created_at`, recomputed from the raw event (NOT the new-flow-blind `has_completed_onboarding_flow` / `is_onboarded` flags — see the knowledge skill's [engagement.md](../../win-analytics-knowledge/references/engagement.md) and [gotchas.md](../../win-analytics-knowledge/references/gotchas.md)) |
-| Outreach intensity vs outcome | Activated cohort (sent ≥1 outreach) | `is_activated = TRUE` |
-| Funnel / dropoff analyses | Full registered population | `users_win_candidacy` filtered to `is_latest_version AND NOT is_demo` |
-| Active candidates OKR reporting | Active candidates (trailing 30d) | `is_active_candidate_30d = TRUE` (or recompute anchored to a target date) |
-
-Always name the cohort in the analysis title and headline so consumers know which population is being characterized. "Among onboarded Win candidates..." not "Among Win candidates..."
+- the resolved scoping decisions (unit of analysis, outcome variable, windows, baseline);
+- the default cohort per analysis type — always name the cohort in the analysis title and headline so consumers know which population is being characterized;
+- the working-set builder and its column caveats.
 
 ## Scoping checklist for a new analysis
 
@@ -81,9 +68,7 @@ When unsure, default to `ad_hoc/`: promoting an ad-hoc analysis into a project l
 
 ## Reusable building blocks — build the working set once, slice it
 
-Don't rebuild cohort + engagement logic from scratch each analysis. The committed package `analytics/lib/win_analysis.py` holds the canonical Win event-family allowlist (`win_event_predicate`), a `build_win_working_set(run_query, cohorts, ...)` that returns one consolidated per-user `cohort × engagement` DataFrame carrying the standard slicing dimensions from the knowledge skill's [segmentation.md](../../win-analytics-knowledge/references/segmentation.md), and `wilson`. **Default executor step:** build that one working set first, then slice every cut from it in pandas (codifies the build-once-slice-many rule). Carrying the slice dimensions up front makes re-cuts (e.g. ICP vs not) free — see the amend path in [brief-schema.md](brief-schema.md). The event classification is sourced from `int__amplitude_event_catalog` (see the knowledge skill's [engagement.md](../../win-analytics-knowledge/references/engagement.md) — no separate hand-maintained allowlist to keep in sync).
-
-> **Column caveat — don't use the helper's `onboarded` column as the Onboarded cohort.** `build_win_working_set`'s `onboarded` column keys on `onboarding_complete`, which is the **new-flow-blind** flag (FALSE for every post-2026-05-07 user). It is **not** the canonical **Onboarded** cohort from the default-cohorts table above (dashboard view within 14 days of account creation). For that cohort, recompute the 14-day dashboard-view logic — the helper's `dash_viewed` is dashboard-view-*ever* within the pre-anchor window, not the 14-day-of-creation window — and for cross-cutover onboarding *completion* use `Onboarding - Candidate Pledge Completed`. Same new-flow-blindness documented in the knowledge skill's [engagement.md](../../win-analytics-knowledge/references/engagement.md) and [gotchas.md](../../win-analytics-knowledge/references/gotchas.md), and in the lib's own README.
+Don't rebuild cohort + engagement logic from scratch each analysis. **Default executor step:** build the product's consolidated per-user working set once with its committed builder, then slice every cut from it in pandas (the build-once-slice-many rule). Carrying the slice dimensions up front makes re-cuts free — see the amend path in [brief-schema.md](brief-schema.md). The builder, its allowlist source, and its column caveats are product facts: see the product's `methodology_defaults.md` (Win: `analytics/lib/win_analysis.py`, documented there) before using any of its columns as a canonical cohort.
 
 ## Notebook sync workflow
 
@@ -131,14 +116,7 @@ A scout / analysis is "done" when:
 
 ## Source pointers & references
 
-**Project scouts that contributed insights:**
-- **`analytics/projects/win_outcomes_scout/INVENTORY.md`** (DATA-1935) — Win product × electoral outcomes data scout. Seeded most of the knowledge-skill content, especially `outcomes.md` through `viability.md`. Source 7 in the inventory carries the full HubSpot survey detail (per-survey submission counts, response distribution by ICP/Win bucket, the verified Option 1/2 mapping evidence).
-- **`analytics/projects/win_churn/`** (DATA-1924) — Win churn modeling. Engagement-as-outcome counterpart. Source for some of the multi-cycle and pre-2023-12-10 gotchas.
-
-**Authoritative dbt model docs:**
-- `dbt/project/models/marts/civics/m_civics.yaml` — column descriptions for candidacy / candidate / candidacy_stage / election / election_stage.
-- `dbt/project/models/marts/analytics/m_analytics.yaml` — for the analytics mart.
-- `dbt/project/models/intermediate/amplitude/int__amplitude.yaml` — Amplitude intermediate columns + tests.
+Product-specific source pointers (contributing project scouts, authoritative dbt model docs) live in the product's `methodology_defaults.md`.
 
 **Conventions:**
 - `CLAUDE.md` (repo root) — multi-venv reality + don't-disable-pre-commit rules.

--- a/.claude/skills/win-analytics-process/references/pipeline.md
+++ b/.claude/skills/win-analytics-process/references/pipeline.md
@@ -21,6 +21,21 @@ doc documents the flow; a human (or the process skill stepping through it) drive
 | 3 | **Review (methodology + interpretation)** | `product-data-scientist` | the executed notebook, read against the brief | a methodology review + an interpretation of results | Read-only and advisory. Surfaces leakage / survivorship / calibration concerns and interprets effect sizes. Does not edit code or open PRs. |
 | + | **Review (usefulness)** | `product-manager` | the plan or the deliverable | a framing / actionability review | Read-only and advisory. Asks whether this answers the team's real question and whether names/segments/thresholds match how consumers think. Invoked proactively at plan checkpoints and pre-PR — a checkpoint, not a strict sequence position. |
 
+## Reviewer dispatch template
+
+Build each reviewer's invocation prompt from this template — and nothing more:
+
+- **Artifacts by path:** the brief YAML and the executed notebook/script (plus any figures directory). The reviewer reads these on the merits.
+- **Product context:** the product, its knowledge skill, the decision cadence, and the intended audience/consumer of the deliverable.
+- **Docs to load:** the reviewer doc pointers from the product knowledge skill's `methodology_defaults.md` (which names the two or three docs each reviewer needs, per role).
+- **The ask:** review per your role (methodology + interpretation, or usefulness + actionability).
+
+**The dispatch must not lead the witness.** Do not summarize the analysis's conclusions, characterize the result's quality ("clean", "strong", "confirms X"), or include the orchestrator's interpretation. The orchestrator that produced the analysis writes this prompt; anything beyond paths, product context, and doc pointers contaminates a review whose value is its fresh context.
+
+**Model note.** The reviewers inherit the session model (their frontmatter deliberately carries no pin — intent recorded 2026-07: "strong model" was the goal and a literal pin lags model generations). Run substantive reviews in a session on a strong model tier.
+
+**On reviewer conflict:** when the two reviews disagree, present both to the user verbatim — do not arbitrate, average, or synthesize away the disagreement. The two lenses (rigor, usefulness) are allowed to pull in different directions; picking a winner is the human's call.
+
 ## Artifacts and where they land
 
 - **Brief:** YAML, format in [brief-schema.md](brief-schema.md). For ad-hoc work it lands at `analytics/ad_hoc/<YYYY-MM-DD>_<brief_id>_brief.yaml`; for scout projects, alongside the project notebook. The brief is durable — it travels with the executed notebook so the framing is retrievable later.


### PR DESCRIPTION
## What

Batch 2 of the win-analytics framework architecture review (DATA-2111, subtask of DATA-2109). Track 2 process calibration; process-design mode opted into via the parent ticket. Carries R5/R6/R7 from the review plus phase A of the Serve extension (DATA-2115/2116), folded in because they touch the same files.

**R5: reviewer dispatch template** (`pipeline.md`)
- Template for building each reviewer's invocation prompt: artifacts by path, product context, doc pointers, the ask - and nothing more. Explicit rule that the dispatch must not summarize the analysis's conclusions or characterize its quality (the orchestrator that produced the analysis writes the prompt; anything more leads the witness).
- Reviewer-conflict rule: when the two reviews disagree, present both verbatim; the human picks.

**R6: model pins dropped + agents product-generalized** (both agent files, `pipeline.md`)
- `model: opus` removed from both reviewer agents; they inherit the session model. The intent ("strong model") is recorded with a date in pipeline.md's model note so the decision stays deliberate.
- Neither agent names a product anymore: the invocation-context paragraphs defer to the dispatch prompt's doc pointers.

**R7: per-row ratification tracking** (`canonical_metrics.md`)
- New `Ratified` column (all ten rows `pending`); governance paragraph now defines the sign-off mechanics (date + owner initials, human edit only) instead of a blanket unresolvable "pending" note.

**Serve phase A: methodology split** (new `win-analytics-knowledge/references/methodology_defaults.md` + 7 pointer updates)
- Win-specific content moves out of the process skill's `methodology.md` into the product knowledge skill: DATA-1935 resolved scoping defaults, default-cohorts table, the `win_analysis.py` working-set section with its `onboarded` column caveat, Win source pointers, and the per-reviewer doc pointers the dispatch template consumes.
- `methodology.md` keeps only product-agnostic discipline. This is the shape the Serve extension plugs into: a future `serve-analytics-knowledge` gets its own `methodology_defaults.md` and nothing in the process layer changes.

## Notes for review

- Process-track PR: changes shared process behavior (reviewer dispatch, agent config, methodology routing).
- The one judgment call: pins dropped rather than kept-with-comment. Easy to flip if preferred.
- All relative markdown links across both skills verified resolving (manual check; the R8 link-checker pytest lands as its own PR next).
- The TodoWrite naming-drift item was already resolved by batch 1's runbook rewrite; verified no references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Claude agent/skill configuration only; no application code, queries, or metric definition changes beyond governance metadata.
> 
> **Overview**
> This batch tightens **how reviews are invoked** and **where Win-specific methodology lives**, so the shared process layer can stay product-agnostic.
> 
> **`pipeline.md`** adds a **reviewer dispatch template** (artifact paths, product context, doc pointers, the ask only) with an explicit **no leading-the-witness** rule, plus guidance on inheriting a strong session model and presenting **reviewer disagreements verbatim** to the human.
> 
> **`product-data-scientist`** and **`product-manager`** drop the **`model: opus`** pin and stop hard-coding Win doc lists; invocation context now defers to the dispatch’s **reviewer doc pointers**.
> 
> **`canonical_metrics.md`** gains a **`Ratified`** column (all rows `pending`) and governance text for human-only sign-off per metric.
> 
> Win-specific scoping defaults, default cohorts, **`win_analysis.py`** working-set notes (including the **`onboarded` column caveat**), source pointers, and per-role reviewer pointers move into new **`win-analytics-knowledge/references/methodology_defaults.md`**. Process **`methodology.md`** and related skill cross-links now point there instead of duplicating Win content—setting up the same pattern for a future Serve knowledge skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ecf25b38563d28a09a1ef6bc953f99abb4047eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->