### PR TITLE
[DATA-2113] Link checker for the win-analytics skill doc graph

### DIFF
--- a/analytics/tests/test_skill_doc_links.py
+++ b/analytics/tests/test_skill_doc_links.py
@@ -1,0 +1,54 @@
+"""Link checker for the win-analytics skill doc graph (DATA-2113).
+
+The process/knowledge skills follow a one-fact-one-home rule, so the docs lean on
+relative markdown links (including fragile cross-skill paths) instead of restating
+facts. A renamed or moved reference doc breaks those links silently. This test walks
+every markdown file in the win-analytics skills plus the reviewer agents and asserts
+each relative markdown link resolves to an existing file.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DOC_GLOBS = [
+    ".claude/skills/win-analytics-*/**/*.md",
+    ".claude/agents/product-*.md",
+]
+
+LINK_RE = re.compile(r"\]\(([^)]+)\)")
+
+
+def _doc_files() -> list[Path]:
+    files: list[Path] = []
+    for pattern in DOC_GLOBS:
+        files.extend(REPO_ROOT.glob(pattern))
+    return sorted(files)
+
+
+def _relative_md_targets(text: str):
+    """Yield relative .md link targets, skipping external URLs and pure fragments."""
+    for match in LINK_RE.finditer(text):
+        target = match.group(1).split("#", 1)[0].strip()
+        if not target or target.startswith(("http://", "https://", "mailto:", "/")):
+            continue
+        if target.endswith(".md"):
+            yield target
+
+
+def test_doc_files_found():
+    files = _doc_files()
+    assert files, "no skill docs matched - the glob or repo layout changed"
+    assert any("win-analytics-process" in str(f) for f in files)
+    assert any("win-analytics-knowledge" in str(f) for f in files)
+
+
+def test_relative_markdown_links_resolve():
+    broken = []
+    for doc in _doc_files():
+        for target in _relative_md_targets(doc.read_text()):
+            resolved = (doc.parent / target).resolve()
+            if not resolved.is_file():
+                broken.append(f"{doc.relative_to(REPO_ROOT)} -> {target}")
+    assert not broken, "broken relative links:\n" + "\n".join(broken)


### PR DESCRIPTION
## What

R8 from the framework architecture review (DATA-2113, subtask of DATA-2109). A small pytest in `analytics/tests/` that walks `.claude/skills/win-analytics-*/**/*.md` plus the two reviewer agent files and asserts every relative markdown link resolves to an existing file.

## Why

The skill docs follow the one-fact-one-home rule, so they depend on relative links - including fragile cross-skill paths like `../../win-analytics-knowledge/references/segmentation.md` - instead of restating facts. A renamed or moved doc breaks navigation silently today. This makes a rename break CI instead, which matters before the planned `analytics-process` skill rename (Serve extension).

## Notes

- Stdlib only, no new dependencies; runs in the existing analytics CI workflow and the pre-push hook automatically (it is just a test in the suite).
- Two tests: a canary that the globs still match files (so a repo-layout change cannot silently reduce coverage to zero), and the link check itself.
- Verified red/green: temporarily renaming a link target fails the test with the offending file and target listed; restoring passes. Full analytics suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation link validation only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **CI coverage** so broken relative markdown links in the win-analytics skill docs and `product-*` reviewer agents fail tests instead of breaking navigation silently.
> 
> `analytics/tests/test_skill_doc_links.py` globs `.claude/skills/win-analytics-*/**/*.md` and `.claude/agents/product-*.md`, parses `](...)` targets (skipping external URLs and non-`.md` paths), and resolves each link from the source file’s directory. A **canary** test asserts the globs still find process and knowledge skill files so layout changes cannot zero out coverage without failing.
> 
> Stdlib-only (`re`, `pathlib`); runs with the existing analytics test suite and pre-push hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 289491f53f7ffe5b4cc06a104076f135fc283f63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->