### PR TITLE
[DATA-2118] Person + OfficeHolder marts and grouped-swap election-api sync

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -2,7 +2,8 @@
 ## Sync election-api marts from Databricks to PostgreSQL
 
 Builds and atomically swaps election-api Postgres tables from their dbt marts
-in Databricks. Each table is its own task group following the same lifecycle:
+in Databricks. Every table is declared as a `SyncTableConfig`; the shared
+lifecycle is:
 
 1. **build_staging** — drop & recreate `staging."<Table>_new"` LIKE the live
    target (no indexes — fast bulk-insert).
@@ -15,18 +16,29 @@ in Databricks. Each table is its own task group following the same lifecycle:
    transaction, so a crashed run never wedges subsequent ones.
 6. **drop_old** — drop the renamed-aside `_old` table.
 
-The shared lifecycle lives in
-`include/custom_functions/election_api_utils.py`. Each task group below is
-a thin per-table wrapper that supplies the source query, transform, and
-constraint DDL.
+Independent tables get steps 5-6 from the `_sync_table_group` factory. Person
+and OfficeHolder cannot swap independently: FK constraints bind to the
+referenced table's OID, so an FK pointing at a swapped table would follow the
+renamed-aside `_old` copy. The `person_spine` group instead stages both
+tables and builds their FKs staged-to-staged, in dependency order:
+`OfficeHolder_new.person_id` references `staging."Person_new"` directly (so
+its constraint travels with the pair through the rename swap and validates
+the staged data exactly), and both tables swap in ONE transaction. Only
+`Candidacy.person_id -> Person` — owned by a table outside the group — still
+needs rewiring: the swap transaction drops it first, renames both tables,
+nulls Candidacy rows whose person left the new set (its ON DELETE SET NULL
+semantics), and re-creates it against the fresh Person.
 
-This is the prototype for migrating the legacy
+The shared lifecycle lives in
+`include/custom_functions/election_api_utils.py`.
+
+This DAG is the migration target for the legacy
 `dbt/project/models/write/write__election_api_db.py` (which writes the other
-election tables to Postgres via JDBC from a Databricks cluster) onto Airflow.
-Projected_Turnout is the first table cut over from that writer: upsert-by-id
-delivery can never delete, so model-version supersessions and L2 coverage
-drift stranded stale rows in the API (DATA-2015). The swap replaces the
-table wholesale each run, so the API always matches the Databricks mart.
+election tables to Postgres via JDBC from a Databricks cluster).
+Projected_Turnout was the first table cut over: upsert-by-id delivery can
+never delete, so model-version supersessions and L2 coverage drift stranded
+stale rows in the API (DATA-2015). Person and OfficeHolder (DATA-2118) are
+delivered here from the start.
 
 ### Connections (set in Astro Environment Manager):
 - `databricks` / `databricks_dev` (Generic) — Databricks OAuth M2M.
@@ -60,14 +72,19 @@ eventually pausing the DAG, which freezes all synced tables silently.
   to the mapped branch, so a branch-mapping change alone does not redeploy —
   a subsequent push to the new branch (or a manual redeploy via the Astro UI)
   is what triggers the sync.
-- The election-api Postgres schema is owned by the election-api repo. Prisma
-  migrations apply when election-api is deployed to the corresponding env,
-  not on PR merge alone. Check status via the `_prisma_migrations` table on
-  the target Postgres before kicking a sync that depends on new columns.
+- The election-api Postgres schema is owned by the election-api package in
+  the omni repo. Prisma migrations apply when election-api is deployed to the
+  corresponding env, not on PR merge alone. Check status via the
+  `_prisma_migrations` table on the target Postgres before kicking a sync
+  that depends on new columns/tables (Person and OfficeHolder need
+  `20260708163759_add_person_officeholder`).
 """
 
+import json
 import logging
 import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from airflow.sdk import Variable, dag, task, task_group
@@ -77,6 +94,7 @@ from include.custom_functions.election_api_utils import (
     bulk_insert_from_databricks,
     create_staging_table,
     drop_old_table,
+    swap_group_staging_into_target,
     swap_staging_into_target,
 )
 from include.custom_functions.postgres_utils import get_postgres_via_ssh
@@ -108,6 +126,112 @@ def _open_pg():
         bastion_conn_id=bastion or None,
         pg_conn_id=PG_CONN_ID,
     )
+
+
+def _prior_live_rowcount(conn, spec: TableSyncSpec) -> int | None:
+    """Row count of the live target table, or None on a true cold start.
+
+    Both identifiers must be double-quoted in the regclass argument — Postgres
+    folds unquoted mixed-case to lowercase, so `public.DistrictTopIssue` would
+    resolve to `public.districttopissue` and always return NULL.
+    """
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT to_regclass(%s)",
+            (f'"{spec.target_schema}"."{spec.target_table}"',),
+        )
+        if cur.fetchone()[0] is None:
+            return None
+        cur.execute(f'SELECT COUNT(*) FROM "{spec.target_schema}"."{spec.target_table}"')
+        return cur.fetchone()[0]
+    finally:
+        cur.close()
+
+
+# ---------------------------------------------------------------------------
+# Table-group factory
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SyncTableConfig:
+    """One synced table: where it comes from, how it loads, how it's gated."""
+
+    group_id: str
+    spec: TableSyncSpec
+    source_table: str
+    # Databricks SELECT order; positional with target_columns/transform_row.
+    source_columns: tuple[str, ...]
+    # Staging-named constraint/index DDL applied after the load.
+    constraint_ddl: Callable[[], list[str]]
+    # Opens its own Postgres connection; raises to block the swap.
+    quality_checks: Callable[[int], None]
+    target_columns: tuple[str, ...] | None = None  # defaults to source_columns
+    transform_row: Callable[[tuple], tuple] | None = None
+    partition_column: str | None = None
+
+
+def _staged_load(cfg: SyncTableConfig) -> dict:
+    """Steps 1-4 (build/load/index/quality); returns the task nodes by name
+    so callers can chain the whole pipeline (via `quality_checks`) or add
+    cross-table dependencies (e.g. an FK build that needs another staged
+    table's PK in place first, via `build_indexes_and_fk`)."""
+
+    @task
+    def build_staging() -> None:
+        with _open_pg() as conn:
+            create_staging_table(conn, cfg.spec)
+
+    @task
+    def load_staging() -> int:
+        catalog = Variable.get("databricks_catalog")
+        col_list = ", ".join(cfg.source_columns)
+        query = f"SELECT {col_list} " f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`.`{cfg.source_table}`"
+        with _open_pg() as conn:
+            return bulk_insert_from_databricks(
+                conn,
+                cfg.spec,
+                source_query=query,
+                target_columns=list(cfg.target_columns or cfg.source_columns),
+                transform_row=cfg.transform_row,
+                partition_column=cfg.partition_column,
+            )
+
+    @task
+    def build_indexes_and_fk() -> None:
+        with _open_pg() as conn:
+            apply_ddl(conn, cfg.constraint_ddl())
+
+    @task
+    def quality_checks(loaded_count: int) -> None:
+        cfg.quality_checks(loaded_count)
+
+    loaded = load_staging()
+    indexes = build_indexes_and_fk()
+    qc = quality_checks(loaded)
+    build_staging() >> loaded >> indexes >> qc
+    return {"build_indexes_and_fk": indexes, "quality_checks": qc}
+
+
+def _sync_table_group(cfg: SyncTableConfig):
+    """Full lifecycle for a table with no FK ties to other swapped tables."""
+
+    @task_group(group_id=cfg.group_id)
+    def group():
+        @task
+        def swap() -> None:
+            with _open_pg() as conn:
+                swap_staging_into_target(conn, cfg.spec)
+
+        @task
+        def drop_old() -> None:
+            with _open_pg() as conn:
+                drop_old_table(conn, cfg.spec)
+
+        _staged_load(cfg)["quality_checks"] >> swap() >> drop_old()
+
+    return group()
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +309,79 @@ def _ztp_transform_row(row: tuple) -> tuple:
     )
 
 
+def _ztp_constraint_ddl() -> list[str]:
+    sn, nt = ZTP.staging_schema, ZTP.new_table
+    target_schema = ZTP.target_schema
+    return [
+        (f'ALTER TABLE "{sn}"."{nt}" ' f'ADD CONSTRAINT "{ZTP.stage_name(ZTP.pk_name)}" PRIMARY KEY (id)'),
+        (f'CREATE INDEX "{ZTP.stage_name("ZipToPosition_zip_code_idx")}" ' f'ON "{sn}"."{nt}" (zip_code)'),
+        (
+            f'CREATE INDEX "{ZTP.stage_name("ZipToPosition_position_id_idx")}" '
+            f'ON "{sn}"."{nt}" (position_id)'
+        ),
+        (
+            f"CREATE INDEX "
+            f'"{ZTP.stage_name("ZipToPosition_zip_code_pct_districtzip_to_zip_idx")}" '
+            f'ON "{sn}"."{nt}" (zip_code, pct_districtzip_to_zip)'
+        ),
+        (
+            f"CREATE UNIQUE INDEX "
+            f'"{ZTP.stage_name("ZipToPosition_zip_code_position_id_election_date_key")}" '
+            f'ON "{sn}"."{nt}" '
+            f"(zip_code, position_id, election_date) NULLS NOT DISTINCT"
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{ZTP.stage_name("ZipToPosition_position_id_fkey")}" '
+            f"FOREIGN KEY (position_id) "
+            f'REFERENCES "{target_schema}"."Position"(id) '
+            f"ON UPDATE CASCADE ON DELETE RESTRICT"
+        ),
+    ]
+
+
+def _ztp_quality_checks(loaded_count: int) -> None:
+    if loaded_count < 1_000:
+        raise ValueError(f"Only {loaded_count} rows loaded (<1000) — refusing to swap")
+    with _open_pg() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(f"SELECT COUNT(DISTINCT state) " f'FROM "{ZTP.staging_schema}"."{ZTP.new_table}"')
+            distinct_states = cur.fetchone()[0]
+            if distinct_states < 30:
+                raise ValueError(f"Only {distinct_states} distinct states " f"— refusing to swap")
+            cur.execute(
+                f"SELECT MIN(election_date), MAX(election_date) "
+                f'FROM "{ZTP.staging_schema}"."{ZTP.new_table}"'
+            )
+            min_date, max_date = cur.fetchone()
+            t_log.info(
+                "Quality checks passed: %d rows, %d states, %s..%s",
+                loaded_count,
+                distinct_states,
+                min_date,
+                max_date,
+            )
+        finally:
+            cur.close()
+
+
+ZTP_CONFIG = SyncTableConfig(
+    group_id="zip_to_position",
+    spec=ZTP,
+    source_table="m_election_api__zip_to_position",
+    source_columns=tuple(ZTP_SOURCE_COLUMNS),
+    target_columns=tuple(ZTP_TARGET_COLUMNS),
+    transform_row=_ztp_transform_row,
+    # Statewide coverage (DATA-1986) added ~260k rows; read one state at a
+    # time so the worker's peak memory stays bounded as the mart grows,
+    # instead of buffering the full result.
+    partition_column="state",
+    constraint_ddl=_ztp_constraint_ddl,
+    quality_checks=_ztp_quality_checks,
+)
+
+
 # ---------------------------------------------------------------------------
 # DistrictTopIssue
 # ---------------------------------------------------------------------------
@@ -232,35 +429,112 @@ def _dti_constraint_ddl() -> list[str]:
     ]
 
 
-def _ztp_constraint_ddl() -> list[str]:
-    sn, nt = ZTP.staging_schema, ZTP.new_table
-    target_schema = ZTP.target_schema
-    return [
-        (f'ALTER TABLE "{sn}"."{nt}" ' f'ADD CONSTRAINT "{ZTP.stage_name(ZTP.pk_name)}" PRIMARY KEY (id)'),
-        (f'CREATE INDEX "{ZTP.stage_name("ZipToPosition_zip_code_idx")}" ' f'ON "{sn}"."{nt}" (zip_code)'),
-        (
-            f'CREATE INDEX "{ZTP.stage_name("ZipToPosition_position_id_idx")}" '
-            f'ON "{sn}"."{nt}" (position_id)'
-        ),
-        (
-            f"CREATE INDEX "
-            f'"{ZTP.stage_name("ZipToPosition_zip_code_pct_districtzip_to_zip_idx")}" '
-            f'ON "{sn}"."{nt}" (zip_code, pct_districtzip_to_zip)'
-        ),
-        (
-            f"CREATE UNIQUE INDEX "
-            f'"{ZTP.stage_name("ZipToPosition_zip_code_position_id_election_date_key")}" '
-            f'ON "{sn}"."{nt}" '
-            f"(zip_code, position_id, election_date) NULLS NOT DISTINCT"
-        ),
-        (
-            f'ALTER TABLE "{sn}"."{nt}" '
-            f'ADD CONSTRAINT "{ZTP.stage_name("ZipToPosition_position_id_fkey")}" '
-            f"FOREIGN KEY (position_id) "
-            f'REFERENCES "{target_schema}"."Position"(id) '
-            f"ON UPDATE CASCADE ON DELETE RESTRICT"
-        ),
-    ]
+def _dti_quality_checks(loaded_count: int) -> None:
+    # Shape-aware: compare staging to the prior live table so the
+    # thresholds auto-track the table's natural size as it grows.
+    # Catches catastrophic regressions (e.g., a partial Databricks
+    # load that drops most rows) without hardcoding numbers that
+    # will drift as the seed grows or shrinks.
+    with _open_pg() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f"SELECT "
+                f"COUNT(DISTINCT issue), "
+                f"MIN(issue_rank), MAX(issue_rank), "
+                f"COUNT(*) FILTER ("
+                f"  WHERE is_local IS NULL OR is_regional IS NULL"
+                f"  OR is_state IS NULL OR is_federal IS NULL) "
+                f'FROM "{DTI.staging_schema}"."{DTI.new_table}"'
+            )
+            distinct_issues, min_rank, max_rank, null_flag_rows = cur.fetchone()
+
+            prior_count = _prior_live_rowcount(conn, DTI)
+            if prior_count is not None:
+                cur.execute(
+                    f"SELECT COUNT(DISTINCT issue) " f'FROM "{DTI.target_schema}"."{DTI.target_table}"'
+                )
+                prior_issues = cur.fetchone()[0]
+            else:
+                prior_count, prior_issues = 0, 0
+
+            # Row count: refuse on a >50% drop vs prior live;
+            # absolute floor only used on cold start. High-ratio
+            # syncs (>3x prior) log a warning but do not refuse —
+            # the DATA-1903 phase-c cutover is intentionally ~6.8x
+            # (970K legacy top-10 rows -> 6.6M full-mart rows), so
+            # blocking on growth would self-DOS the cutover. After
+            # cutover the ratio stabilizes near 1.0; future >3x
+            # excursions are worth on-call attention.
+            if prior_count > 0:
+                ratio = loaded_count / prior_count
+                if ratio < 0.5:
+                    raise ValueError(
+                        f"Loaded {loaded_count} rows, prior live had "
+                        f"{prior_count} (ratio {ratio:.2f}) "
+                        f"— refusing to swap"
+                    )
+                if ratio > 3:
+                    t_log.warning(
+                        "High-ratio sync: loaded %d rows, prior live "
+                        "had %d (ratio %.2f). Sometimes intentional "
+                        "(e.g., DATA-1903 phase-c cutover) — sometimes "
+                        "a JOIN fan-out or duplication bug. Verify "
+                        "the source mart's grain before trusting.",
+                        loaded_count,
+                        prior_count,
+                        ratio,
+                    )
+            elif loaded_count < 100_000:
+                raise ValueError(
+                    f"Cold-start load of {loaded_count} rows is " f"implausibly small — refusing to swap"
+                )
+
+            # Distinct issues: stay at-or-above prior. Allows growth
+            # (e.g., seed adds new issues) and catches regression.
+            if distinct_issues < prior_issues:
+                raise ValueError(
+                    f"Staging has {distinct_issues} distinct issues, "
+                    f"prior live had {prior_issues} — refusing to swap"
+                )
+
+            # Flag integrity: every row should have all four flags
+            # populated. The mart's LEFT JOIN to haystaq_issue_tags
+            # only emits NULLs on drift, which the dbt-side tests
+            # catch — this check is a belt-and-suspenders gate.
+            if null_flag_rows > 0:
+                raise ValueError(
+                    f"{null_flag_rows} staging rows have a NULL " f"jurisdictional flag — refusing to swap"
+                )
+
+            t_log.info(
+                "Quality checks passed: %d rows (prior %d), "
+                "%d distinct issues (prior %d), "
+                "issue_rank %s..%s, all flags populated",
+                loaded_count,
+                prior_count,
+                distinct_issues,
+                prior_issues,
+                min_rank,
+                max_rank,
+            )
+        finally:
+            cur.close()
+
+
+DTI_CONFIG = SyncTableConfig(
+    group_id="district_top_issues",
+    spec=DTI,
+    source_table="m_election_api__district_top_issues",
+    source_columns=tuple(DTI_COLUMNS),
+    # ~5.1M rows; this load runs concurrently with zip_to_position on the same
+    # worker, so read one issue at a time (~68 partitions, <=~96k rows each)
+    # to keep the combined peak memory bounded and avoid OOM (the zip-only
+    # partition in #493 left this load unbounded).
+    partition_column="issue",
+    constraint_ddl=_dti_constraint_ddl,
+    quality_checks=_dti_quality_checks,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +565,62 @@ def _eos_constraint_ddl() -> list[str]:
             f'ADD CONSTRAINT "{EOS.stage_name(EOS.pk_name)}" PRIMARY KEY (elected_office_id)'
         ),
     ]
+
+
+def _eos_quality_checks(loaded_count: int) -> None:
+    # Coverage is intentionally low: the support score needs an election
+    # vote tally, which exists for only a small share of offices (see the
+    # model docs / DATA-2000 PR). A flat floor can't catch a regression
+    # that halves a ~1.1k-row table (a ~550-row load would clear 500), so
+    # gate on the ratio to the prior live table (same pattern as the
+    # DistrictTopIssue block); the absolute floor is the cold-start
+    # fallback only.
+    with _open_pg() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f"SELECT COUNT(*), COUNT(DISTINCT elected_office_id), "
+                f"COUNT(*) FILTER (WHERE elected_office_id IS NULL) "
+                f'FROM "{EOS.staging_schema}"."{EOS.new_table}"'
+            )
+            n, distinct_pos, null_pos = cur.fetchone()
+
+            prior_count = _prior_live_rowcount(conn, EOS) or 0
+
+            if prior_count > 0:
+                ratio = loaded_count / prior_count
+                if ratio < 0.5:
+                    raise ValueError(
+                        f"Loaded {loaded_count} rows, prior live had "
+                        f"{prior_count} (ratio {ratio:.2f}) — refusing to swap"
+                    )
+            elif loaded_count < 500:
+                raise ValueError(f"Cold-start load of {loaded_count} rows (<500) — refusing to swap")
+
+            if null_pos > 0:
+                raise ValueError(f"{null_pos} staging rows have a NULL elected_office_id — refusing to swap")
+            if distinct_pos != n:
+                raise ValueError(
+                    f"elected_office_id not unique ({distinct_pos} distinct of {n}) — refusing to swap"
+                )
+            t_log.info(
+                "Quality checks passed: %d rows (prior %d), elected_office_id unique and non-null",
+                n,
+                prior_count,
+            )
+        finally:
+            cur.close()
+
+
+EOS_CONFIG = SyncTableConfig(
+    group_id="elected_official_support",
+    spec=EOS,
+    source_table="m_election_api__elected_official_support",
+    source_columns=tuple(EOS_COLUMNS),
+    # ~1.1k rows; no partitioning needed (one small result fits easily).
+    constraint_ddl=_eos_constraint_ddl,
+    quality_checks=_eos_quality_checks,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -393,6 +723,389 @@ def _pt_quality_gate(loaded_count: int, dup_keys: int, prior_key_count: int, nul
         raise ValueError(f"Cold-start load of {loaded_count} rows is implausibly small — refusing to swap")
 
 
+def _pt_quality_checks(loaded_count: int) -> None:
+    # Gate decisions (and their rationale) live in _pt_quality_gate,
+    # which is pure and unit-tested; this task only gathers the
+    # inputs from Postgres.
+    with _open_pg() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f"SELECT COUNT(*) FROM ("
+                f"SELECT district_id, election_year, election_code "
+                f'FROM "{PT.staging_schema}"."{PT.new_table}" '
+                f"GROUP BY district_id, election_year, election_code "
+                f"HAVING COUNT(*) > 1"
+                f") AS dupe_keys"
+            )
+            dup_keys = cur.fetchone()[0]
+
+            # NULL keys: belt-and-braces over the staging table's
+            # inherited NOT NULLs — the gate proves it directly.
+            cur.execute(
+                f"SELECT COUNT(*) "
+                f'FROM "{PT.staging_schema}"."{PT.new_table}" '
+                f"WHERE district_id IS NULL "
+                f"OR election_year IS NULL "
+                f"OR election_code IS NULL"
+            )
+            null_keys = cur.fetchone()[0]
+
+            # Prior live state (absent on a true cold start). Keys, not raw
+            # rows — see _pt_quality_gate.
+            cur.execute(
+                "SELECT to_regclass(%s)",
+                (f'"{PT.target_schema}"."{PT.target_table}"',),
+            )
+            prior_exists = cur.fetchone()[0] is not None
+            if prior_exists:
+                cur.execute(
+                    f"SELECT COUNT(*) FROM ("
+                    f"SELECT DISTINCT district_id, election_year, election_code "
+                    f'FROM "{PT.target_schema}"."{PT.target_table}"'
+                    f") AS prior_keys"
+                )
+                prior_key_count = cur.fetchone()[0]
+            else:
+                prior_key_count = 0
+        finally:
+            cur.close()
+
+    _pt_quality_gate(loaded_count, dup_keys, prior_key_count, null_keys)
+
+    t_log.info(
+        "Quality checks passed: %d rows (prior %d distinct keys), "
+        "no duplicate and no NULL (district, election) keys",
+        loaded_count,
+        prior_key_count,
+    )
+
+
+PT_CONFIG = SyncTableConfig(
+    group_id="projected_turnout",
+    spec=PT,
+    source_table="m_election_api__projected_turnout",
+    source_columns=tuple(PT_COLUMNS),
+    # ~800k rows; this load runs concurrently with the other groups on the
+    # same worker, so read one election year at a time (a handful of
+    # partitions) to keep the combined peak memory bounded.
+    partition_column="election_year",
+    constraint_ddl=_pt_constraint_ddl,
+    quality_checks=_pt_quality_checks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Person + OfficeHolder (grouped swap — other tables hold FKs to Person)
+# ---------------------------------------------------------------------------
+
+PERSON = TableSyncSpec(
+    target_table="Person",
+    indexes=("Person_slug_idx",),
+)
+
+PERSON_SOURCE_COLUMNS = [
+    "id",
+    "br_person_id",
+    "slug",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "nickname",
+    "suffix",
+    "full_name",
+    "bio_text",
+    "headshot_url",
+    "website_url",
+    "linkedin_url",
+    "facebook_url",
+    "twitter_url",
+    "instagram_url",
+    "email",
+    "phone",
+    "degrees",
+    "experiences",
+    "state",
+]
+# created_at is filled by the staging table's inherited column default;
+# updated_at has no default (Prisma @updatedAt), so the transform stamps it.
+PERSON_TARGET_COLUMNS = [*PERSON_SOURCE_COLUMNS, "updated_at"]
+
+
+def _person_transform_row(row: tuple) -> tuple:
+    # degrees/experiences arrive as JSON strings and land in JSONB as-is.
+    return (*row, datetime.now(UTC))
+
+
+def _person_constraint_ddl() -> list[str]:
+    sn, nt = PERSON.staging_schema, PERSON.new_table
+    return [
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{PERSON.stage_name(PERSON.pk_name)}" PRIMARY KEY (id)'
+        ),
+        (f'CREATE INDEX "{PERSON.stage_name("Person_slug_idx")}" ' f'ON "{sn}"."{nt}" (slug)'),
+    ]
+
+
+def _person_quality_gate(loaded_count: int, null_slugs: int, prior_count: int) -> None:
+    """Decide whether staged Person data may swap into place.
+
+    Pure decision logic (unit-tested); the quality_checks task gathers the
+    inputs from Postgres. Duplicate/NULL ids already failed the staged PK
+    build, so the gate checks the remaining invariants: `slug` present (NOT
+    NULL in the API) and no coverage collapse vs the prior live table.
+    """
+    if null_slugs > 0:
+        raise ValueError(f"{null_slugs} staging rows have a NULL slug — refusing to swap")
+    if prior_count > 0:
+        ratio = loaded_count / prior_count
+        if ratio < 0.5:
+            raise ValueError(
+                f"Loaded {loaded_count} rows, prior live had "
+                f"{prior_count} (ratio {ratio:.2f}) — refusing to swap"
+            )
+    elif loaded_count < 100_000:
+        raise ValueError(f"Cold-start load of {loaded_count} rows is implausibly small — refusing to swap")
+
+
+def _person_quality_checks(loaded_count: int) -> None:
+    with _open_pg() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f"SELECT COUNT(*) FILTER (WHERE slug IS NULL) "
+                f'FROM "{PERSON.staging_schema}"."{PERSON.new_table}"'
+            )
+            null_slugs = cur.fetchone()[0]
+            prior_count = _prior_live_rowcount(conn, PERSON) or 0
+        finally:
+            cur.close()
+
+    _person_quality_gate(loaded_count, null_slugs, prior_count)
+    t_log.info("Quality checks passed: %d rows (prior %d), slugs present", loaded_count, prior_count)
+
+
+PERSON_CONFIG = SyncTableConfig(
+    group_id="person",
+    spec=PERSON,
+    source_table="m_election_api__person",
+    source_columns=tuple(PERSON_SOURCE_COLUMNS),
+    target_columns=tuple(PERSON_TARGET_COLUMNS),
+    transform_row=_person_transform_row,
+    # ~500k rows; read one state at a time to bound peak memory.
+    partition_column="state",
+    constraint_ddl=_person_constraint_ddl,
+    quality_checks=_person_quality_checks,
+)
+
+
+OFFICE_HOLDER = TableSyncSpec(
+    target_table="OfficeHolder",
+    indexes=(
+        "OfficeHolder_person_id_idx",
+        "OfficeHolder_position_id_idx",
+    ),
+    # person_id references staging."Person_new" when built; the constraint is
+    # OID-bound, so it follows the pair through the rename swap and comes out
+    # pointing at the fresh live Person.
+    fkeys=(
+        "OfficeHolder_person_id_fkey",
+        "OfficeHolder_position_id_fkey",
+    ),
+)
+
+OFFICE_HOLDER_SOURCE_COLUMNS = [
+    "id",
+    "br_office_holder_id",
+    "position_name",
+    "normalized_position_name",
+    "office_title",
+    "party_names",
+    "start_at",
+    "end_at",
+    "term_date_specificity",
+    "is_current",
+    "is_appointed",
+    "is_vacant",
+    "number_of_seats",
+    "next_election_date",
+    "mailing_address_line_1",
+    "mailing_address_line_2",
+    "mailing_city",
+    "mailing_state",
+    "mailing_zip",
+    "office_phone",
+    "office_email",
+    "website_url",
+    "linkedin_url",
+    "facebook_url",
+    "twitter_url",
+    "instagram_url",
+    "sub_area_name",
+    "sub_area_value",
+    "state",
+    "geo_id",
+    "mtfcc",
+    "person_id",
+    "position_id",
+]
+OFFICE_HOLDER_TARGET_COLUMNS = [*OFFICE_HOLDER_SOURCE_COLUMNS, "updated_at"]
+
+_PARTY_NAMES_IDX = OFFICE_HOLDER_SOURCE_COLUMNS.index("party_names")
+
+
+def _office_holder_transform_row(row: tuple) -> tuple:
+    # party_names arrives as a JSON string (the mart emits to_json because the
+    # Databricks reader doesn't round-trip complex types); decode to a Python
+    # list so psycopg2 adapts it to the text[] column.
+    values = list(row)
+    if values[_PARTY_NAMES_IDX] is not None:
+        values[_PARTY_NAMES_IDX] = json.loads(values[_PARTY_NAMES_IDX])
+    return (*values, datetime.now(UTC))
+
+
+def _office_holder_constraint_ddl() -> list[str]:
+    # Runs after person's build_indexes_and_fk (needs the staged Person PK):
+    # the person_id FK references the STAGED Person table, validating the two
+    # loads against each other exactly — any office holder without a staged
+    # person fails here, loudly, before the swap. The position FK references
+    # the live Position (delivered by the legacy dbt writer on its own
+    # cadence), so positions the API doesn't know yet are nulled first —
+    # matching the constraint's ON DELETE SET NULL semantics.
+    sn, nt = OFFICE_HOLDER.staging_schema, OFFICE_HOLDER.new_table
+    return [
+        (
+            f'UPDATE "{sn}"."{nt}" AS oh SET position_id = NULL '
+            f"WHERE oh.position_id IS NOT NULL "
+            f"AND NOT EXISTS ("
+            f'SELECT 1 FROM "{OFFICE_HOLDER.target_schema}"."Position" AS p '
+            f"WHERE p.id = oh.position_id)"
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{OFFICE_HOLDER.stage_name(OFFICE_HOLDER.pk_name)}" PRIMARY KEY (id)'
+        ),
+        (
+            f'CREATE INDEX "{OFFICE_HOLDER.stage_name("OfficeHolder_person_id_idx")}" '
+            f'ON "{sn}"."{nt}" (person_id)'
+        ),
+        (
+            f'CREATE INDEX "{OFFICE_HOLDER.stage_name("OfficeHolder_position_id_idx")}" '
+            f'ON "{sn}"."{nt}" (position_id)'
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{OFFICE_HOLDER.stage_name("OfficeHolder_person_id_fkey")}" '
+            f"FOREIGN KEY (person_id) "
+            f'REFERENCES "{PERSON.staging_schema}"."{PERSON.new_table}"(id) '
+            f"ON DELETE CASCADE ON UPDATE CASCADE"
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{OFFICE_HOLDER.stage_name("OfficeHolder_position_id_fkey")}" '
+            f"FOREIGN KEY (position_id) "
+            f'REFERENCES "{OFFICE_HOLDER.target_schema}"."Position"(id) '
+            f"ON DELETE SET NULL ON UPDATE CASCADE"
+        ),
+    ]
+
+
+def _office_holder_quality_gate(loaded_count: int, null_person_ids: int, prior_count: int) -> None:
+    """Decide whether staged OfficeHolder data may swap into place.
+
+    Pure decision logic (unit-tested). `person_id` NULLs must be zero: the
+    column is NOT NULL in the API and the mart inner-joins the person mart,
+    so any NULL means the mart contract broke.
+    """
+    if null_person_ids > 0:
+        raise ValueError(f"{null_person_ids} staging rows have a NULL person_id — refusing to swap")
+    if prior_count > 0:
+        ratio = loaded_count / prior_count
+        if ratio < 0.5:
+            raise ValueError(
+                f"Loaded {loaded_count} rows, prior live had "
+                f"{prior_count} (ratio {ratio:.2f}) — refusing to swap"
+            )
+    elif loaded_count < 100_000:
+        raise ValueError(f"Cold-start load of {loaded_count} rows is implausibly small — refusing to swap")
+
+
+def _office_holder_quality_checks(loaded_count: int) -> None:
+    with _open_pg() as conn:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f"SELECT COUNT(*) FILTER (WHERE person_id IS NULL) "
+                f'FROM "{OFFICE_HOLDER.staging_schema}"."{OFFICE_HOLDER.new_table}"'
+            )
+            null_person_ids = cur.fetchone()[0]
+            prior_count = _prior_live_rowcount(conn, OFFICE_HOLDER) or 0
+        finally:
+            cur.close()
+
+    _office_holder_quality_gate(loaded_count, null_person_ids, prior_count)
+    t_log.info(
+        "Quality checks passed: %d rows (prior %d), person_id present",
+        loaded_count,
+        prior_count,
+    )
+
+
+OFFICE_HOLDER_CONFIG = SyncTableConfig(
+    group_id="office_holder",
+    spec=OFFICE_HOLDER,
+    source_table="m_election_api__office_holder",
+    source_columns=tuple(OFFICE_HOLDER_SOURCE_COLUMNS),
+    target_columns=tuple(OFFICE_HOLDER_TARGET_COLUMNS),
+    transform_row=_office_holder_transform_row,
+    # ~520k rows; read one state at a time to bound peak memory.
+    partition_column="state",
+    constraint_ddl=_office_holder_constraint_ddl,
+    quality_checks=_office_holder_quality_checks,
+)
+
+
+def _person_spine_pre_swap_ddl() -> list[str]:
+    """Run inside the group-swap transaction, before any rename.
+
+    Candidacy is outside the swap group but holds an FK to Person; the
+    constraint binds to the live table's OID and would follow it to
+    `Person_old`, wedging drop_old. Drop it here (IF EXISTS covers cold start
+    and crash recovery) and re-create it in the post-swap DDL. The staged
+    OfficeHolder FKs need no such handling — they reference the staged Person
+    (swapped in the same transaction) and the stable live Position.
+    """
+    return [
+        'ALTER TABLE "public"."Candidacy" ' 'DROP CONSTRAINT IF EXISTS "Candidacy_person_id_fkey"',
+    ]
+
+
+def _person_spine_post_swap_ddl() -> list[str]:
+    """Run inside the group-swap transaction, after both tables are renamed.
+
+    Candidacy rows whose person is absent from the new Person set are nulled
+    (the constraint's ON DELETE SET NULL semantics; the legacy dbt writer
+    back-fills person_id once persons arrive), then the FK is re-created
+    against the fresh Person — validating as it goes, so a violation rolls
+    the whole swap back.
+    """
+    return [
+        (
+            'UPDATE "public"."Candidacy" AS c SET person_id = NULL '
+            "WHERE c.person_id IS NOT NULL "
+            "AND NOT EXISTS ("
+            'SELECT 1 FROM "public"."Person" AS p WHERE p.id = c.person_id)'
+        ),
+        (
+            'ALTER TABLE "public"."Candidacy" '
+            'ADD CONSTRAINT "Candidacy_person_id_fkey" '
+            'FOREIGN KEY (person_id) REFERENCES "public"."Person"(id) '
+            "ON DELETE SET NULL ON UPDATE CASCADE"
+        ),
+    ]
+
+
 @dag(
     start_date=pendulum_datetime(2026, 5, 5, tz="UTC"),
     schedule="@daily",
@@ -409,469 +1122,49 @@ def _pt_quality_gate(loaded_count: int, dup_keys: int, prior_key_count: int, nul
     is_paused_upon_creation=True,
 )
 def sync_election_api():
-    @task_group(group_id="zip_to_position")
-    def zip_to_position():
-        @task
-        def build_staging() -> None:
-            with _open_pg() as conn:
-                create_staging_table(conn, ZTP)
-
-        @task
-        def load_staging() -> int:
-            catalog = Variable.get("databricks_catalog")
-            col_list = ", ".join(ZTP_SOURCE_COLUMNS)
-            query = (
-                f"SELECT {col_list} "
-                f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
-                f"`m_election_api__zip_to_position`"
-            )
-            with _open_pg() as conn:
-                return bulk_insert_from_databricks(
-                    conn,
-                    ZTP,
-                    source_query=query,
-                    target_columns=ZTP_TARGET_COLUMNS,
-                    transform_row=_ztp_transform_row,
-                    # Statewide coverage (DATA-1986) added ~260k rows; read one
-                    # state at a time so the worker's peak memory stays bounded
-                    # as the mart grows, instead of buffering the full result.
-                    partition_column="state",
-                )
-
-        @task
-        def build_indexes_and_fk() -> None:
-            with _open_pg() as conn:
-                apply_ddl(conn, _ztp_constraint_ddl())
-
-        @task
-        def quality_checks(loaded_count: int) -> None:
-            if loaded_count < 1_000:
-                raise ValueError(f"Only {loaded_count} rows loaded (<1000) — refusing to swap")
-            with _open_pg() as conn:
-                cur = conn.cursor()
-                try:
-                    cur.execute(
-                        f"SELECT COUNT(DISTINCT state) " f'FROM "{ZTP.staging_schema}"."{ZTP.new_table}"'
-                    )
-                    distinct_states = cur.fetchone()[0]
-                    if distinct_states < 30:
-                        raise ValueError(f"Only {distinct_states} distinct states " f"— refusing to swap")
-                    cur.execute(
-                        f"SELECT MIN(election_date), MAX(election_date) "
-                        f'FROM "{ZTP.staging_schema}"."{ZTP.new_table}"'
-                    )
-                    min_date, max_date = cur.fetchone()
-                    t_log.info(
-                        "Quality checks passed: %d rows, %d states, %s..%s",
-                        loaded_count,
-                        distinct_states,
-                        min_date,
-                        max_date,
-                    )
-                finally:
-                    cur.close()
-
-        @task
-        def swap() -> None:
-            with _open_pg() as conn:
-                swap_staging_into_target(conn, ZTP)
-
-        @task
-        def drop_old() -> None:
-            with _open_pg() as conn:
-                drop_old_table(conn, ZTP)
-
-        s = build_staging()
-        loaded = load_staging()
-        idx = build_indexes_and_fk()
-        qc = quality_checks(loaded)
-        sw = swap()
-        do = drop_old()
-        s >> loaded >> idx >> qc >> sw >> do
-
-    @task_group(group_id="district_top_issues")
-    def district_top_issues():
-        @task
-        def build_staging() -> None:
-            with _open_pg() as conn:
-                create_staging_table(conn, DTI)
-
-        @task
-        def load_staging() -> int:
-            catalog = Variable.get("databricks_catalog")
-            col_list = ", ".join(DTI_COLUMNS)
-            query = (
-                f"SELECT {col_list} "
-                f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
-                f"`m_election_api__district_top_issues`"
-            )
-            with _open_pg() as conn:
-                return bulk_insert_from_databricks(
-                    conn,
-                    DTI,
-                    source_query=query,
-                    target_columns=DTI_COLUMNS,
-                    # ~5.1M rows; this load runs concurrently with
-                    # zip_to_position on the same worker, so read one issue at a
-                    # time (~68 partitions, <=~96k rows each) to keep the
-                    # combined peak memory bounded and avoid OOM (the zip-only
-                    # partition in #493 left this load unbounded).
-                    partition_column="issue",
-                )
-
-        @task
-        def build_indexes_and_fk() -> None:
-            with _open_pg() as conn:
-                apply_ddl(conn, _dti_constraint_ddl())
-
-        @task
-        def quality_checks(loaded_count: int) -> None:
-            # Shape-aware: compare staging to the prior live table so the
-            # thresholds auto-track the table's natural size as it grows.
-            # Catches catastrophic regressions (e.g., a partial Databricks
-            # load that drops most rows) without hardcoding numbers that
-            # will drift as the seed grows or shrinks.
-            with _open_pg() as conn:
-                cur = conn.cursor()
-                try:
-                    cur.execute(
-                        f"SELECT "
-                        f"COUNT(DISTINCT issue), "
-                        f"MIN(issue_rank), MAX(issue_rank), "
-                        f"COUNT(*) FILTER ("
-                        f"  WHERE is_local IS NULL OR is_regional IS NULL"
-                        f"  OR is_state IS NULL OR is_federal IS NULL) "
-                        f'FROM "{DTI.staging_schema}"."{DTI.new_table}"'
-                    )
-                    distinct_issues, min_rank, max_rank, null_flag_rows = cur.fetchone()
-
-                    # Prior live state (may be absent on a true cold start).
-                    # Both identifiers must be double-quoted in the regclass
-                    # argument — Postgres folds unquoted mixed-case to lowercase,
-                    # so `public.DistrictTopIssue` would resolve to
-                    # `public.districttopissue` and always return NULL.
-                    cur.execute(
-                        "SELECT to_regclass(%s)",
-                        (f'"{DTI.target_schema}"."{DTI.target_table}"',),
-                    )
-                    prior_exists = cur.fetchone()[0] is not None
-                    if prior_exists:
-                        cur.execute(
-                            f"SELECT COUNT(*), COUNT(DISTINCT issue) "
-                            f'FROM "{DTI.target_schema}"."{DTI.target_table}"'
-                        )
-                        prior_count, prior_issues = cur.fetchone()
-                    else:
-                        prior_count, prior_issues = 0, 0
-
-                    # Row count: refuse on a >50% drop vs prior live;
-                    # absolute floor only used on cold start. High-ratio
-                    # syncs (>3x prior) log a warning but do not refuse —
-                    # the DATA-1903 phase-c cutover is intentionally ~6.8x
-                    # (970K legacy top-10 rows -> 6.6M full-mart rows), so
-                    # blocking on growth would self-DOS the cutover. After
-                    # cutover the ratio stabilizes near 1.0; future >3x
-                    # excursions are worth on-call attention.
-                    if prior_count > 0:
-                        ratio = loaded_count / prior_count
-                        if ratio < 0.5:
-                            raise ValueError(
-                                f"Loaded {loaded_count} rows, prior live had "
-                                f"{prior_count} (ratio {ratio:.2f}) "
-                                f"— refusing to swap"
-                            )
-                        if ratio > 3:
-                            t_log.warning(
-                                "High-ratio sync: loaded %d rows, prior live "
-                                "had %d (ratio %.2f). Sometimes intentional "
-                                "(e.g., DATA-1903 phase-c cutover) — sometimes "
-                                "a JOIN fan-out or duplication bug. Verify "
-                                "the source mart's grain before trusting.",
-                                loaded_count,
-                                prior_count,
-                                ratio,
-                            )
-                    elif loaded_count < 100_000:
-                        raise ValueError(
-                            f"Cold-start load of {loaded_count} rows is "
-                            f"implausibly small — refusing to swap"
-                        )
-
-                    # Distinct issues: stay at-or-above prior. Allows growth
-                    # (e.g., seed adds new issues) and catches regression.
-                    if distinct_issues < prior_issues:
-                        raise ValueError(
-                            f"Staging has {distinct_issues} distinct issues, "
-                            f"prior live had {prior_issues} — refusing to swap"
-                        )
-
-                    # Flag integrity: every row should have all four flags
-                    # populated. The mart's LEFT JOIN to haystaq_issue_tags
-                    # only emits NULLs on drift, which the dbt-side tests
-                    # catch — this check is a belt-and-suspenders gate.
-                    if null_flag_rows > 0:
-                        raise ValueError(
-                            f"{null_flag_rows} staging rows have a NULL "
-                            f"jurisdictional flag — refusing to swap"
-                        )
-
-                    t_log.info(
-                        "Quality checks passed: %d rows (prior %d), "
-                        "%d distinct issues (prior %d), "
-                        "issue_rank %s..%s, all flags populated",
-                        loaded_count,
-                        prior_count,
-                        distinct_issues,
-                        prior_issues,
-                        min_rank,
-                        max_rank,
-                    )
-                finally:
-                    cur.close()
-
-        @task
-        def swap() -> None:
-            with _open_pg() as conn:
-                swap_staging_into_target(conn, DTI)
-
-        @task
-        def drop_old() -> None:
-            with _open_pg() as conn:
-                drop_old_table(conn, DTI)
-
-        s = build_staging()
-        loaded = load_staging()
-        idx = build_indexes_and_fk()
-        qc = quality_checks(loaded)
-        sw = swap()
-        do = drop_old()
-        s >> loaded >> idx >> qc >> sw >> do
-
-    @task_group(group_id="elected_official_support")
-    def elected_official_support():
-        @task
-        def build_staging() -> None:
-            with _open_pg() as conn:
-                create_staging_table(conn, EOS)
-
-        @task
-        def load_staging() -> int:
-            catalog = Variable.get("databricks_catalog")
-            col_list = ", ".join(EOS_COLUMNS)
-            query = (
-                f"SELECT {col_list} "
-                f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
-                f"`m_election_api__elected_official_support`"
-            )
-            # ~1.1k rows; no partitioning needed (one small result fits easily).
-            with _open_pg() as conn:
-                return bulk_insert_from_databricks(
-                    conn,
-                    EOS,
-                    source_query=query,
-                    target_columns=EOS_COLUMNS,
-                )
-
-        @task
-        def build_indexes_and_fk() -> None:
-            with _open_pg() as conn:
-                apply_ddl(conn, _eos_constraint_ddl())
-
-        @task
-        def quality_checks(loaded_count: int) -> None:
-            # Coverage is intentionally low: the support score needs an election
-            # vote tally, which exists for only a small share of offices (see the
-            # model docs / DATA-2000 PR). A flat floor can't catch a regression
-            # that halves a ~1.1k-row table (a ~550-row load would clear 500), so
-            # gate on the ratio to the prior live table (same pattern as the
-            # DistrictTopIssue block); the absolute floor is the cold-start
-            # fallback only.
-            with _open_pg() as conn:
-                cur = conn.cursor()
-                try:
-                    cur.execute(
-                        f"SELECT COUNT(*), COUNT(DISTINCT elected_office_id), "
-                        f"COUNT(*) FILTER (WHERE elected_office_id IS NULL) "
-                        f'FROM "{EOS.staging_schema}"."{EOS.new_table}"'
-                    )
-                    n, distinct_pos, null_pos = cur.fetchone()
-
-                    # Prior live state (absent on a true cold start). Both
-                    # identifiers must be double-quoted in the regclass argument
-                    # so Postgres does not fold the mixed-case name to lowercase.
-                    cur.execute(
-                        "SELECT to_regclass(%s)",
-                        (f'"{EOS.target_schema}"."{EOS.target_table}"',),
-                    )
-                    prior_exists = cur.fetchone()[0] is not None
-                    if prior_exists:
-                        cur.execute(f'SELECT COUNT(*) FROM "{EOS.target_schema}"."{EOS.target_table}"')
-                        prior_count = cur.fetchone()[0]
-                    else:
-                        prior_count = 0
-
-                    if prior_count > 0:
-                        ratio = loaded_count / prior_count
-                        if ratio < 0.5:
-                            raise ValueError(
-                                f"Loaded {loaded_count} rows, prior live had "
-                                f"{prior_count} (ratio {ratio:.2f}) — refusing to swap"
-                            )
-                    elif loaded_count < 500:
-                        raise ValueError(f"Cold-start load of {loaded_count} rows (<500) — refusing to swap")
-
-                    if null_pos > 0:
-                        raise ValueError(
-                            f"{null_pos} staging rows have a NULL elected_office_id — refusing to swap"
-                        )
-                    if distinct_pos != n:
-                        raise ValueError(
-                            f"elected_office_id not unique ({distinct_pos} distinct of {n}) — refusing to swap"
-                        )
-                    t_log.info(
-                        "Quality checks passed: %d rows (prior %d), elected_office_id unique and non-null",
-                        n,
-                        prior_count,
-                    )
-                finally:
-                    cur.close()
-
-        @task
-        def swap() -> None:
-            with _open_pg() as conn:
-                swap_staging_into_target(conn, EOS)
-
-        @task
-        def drop_old() -> None:
-            with _open_pg() as conn:
-                drop_old_table(conn, EOS)
-
-        s = build_staging()
-        loaded = load_staging()
-        idx = build_indexes_and_fk()
-        qc = quality_checks(loaded)
-        sw = swap()
-        do = drop_old()
-        s >> loaded >> idx >> qc >> sw >> do
-
-    @task_group(group_id="projected_turnout")
-    def projected_turnout():
-        @task
-        def build_staging() -> None:
-            with _open_pg() as conn:
-                create_staging_table(conn, PT)
-
-        @task
-        def load_staging() -> int:
-            catalog = Variable.get("databricks_catalog")
-            col_list = ", ".join(PT_COLUMNS)
-            query = (
-                f"SELECT {col_list} "
-                f"FROM `{catalog}`.`{DATABRICKS_SCHEMA}`."
-                f"`m_election_api__projected_turnout`"
-            )
-            with _open_pg() as conn:
-                return bulk_insert_from_databricks(
-                    conn,
-                    PT,
-                    source_query=query,
-                    target_columns=PT_COLUMNS,
-                    # ~800k rows; this load runs concurrently with the other
-                    # groups on the same worker, so read one election year at a
-                    # time (a handful of partitions) to keep the combined peak
-                    # memory bounded.
-                    partition_column="election_year",
-                )
-
-        @task
-        def build_indexes_and_fk() -> None:
-            with _open_pg() as conn:
-                apply_ddl(conn, _pt_constraint_ddl())
-
-        @task
-        def quality_checks(loaded_count: int) -> None:
-            # Gate decisions (and their rationale) live in _pt_quality_gate,
-            # which is pure and unit-tested; this task only gathers the
-            # inputs from Postgres.
-            with _open_pg() as conn:
-                cur = conn.cursor()
-                try:
-                    cur.execute(
-                        f"SELECT COUNT(*) FROM ("
-                        f"SELECT district_id, election_year, election_code "
-                        f'FROM "{PT.staging_schema}"."{PT.new_table}" '
-                        f"GROUP BY district_id, election_year, election_code "
-                        f"HAVING COUNT(*) > 1"
-                        f") AS dupe_keys"
-                    )
-                    dup_keys = cur.fetchone()[0]
-
-                    # NULL keys: belt-and-braces over the staging table's
-                    # inherited NOT NULLs — the gate proves it directly.
-                    cur.execute(
-                        f"SELECT COUNT(*) "
-                        f'FROM "{PT.staging_schema}"."{PT.new_table}" '
-                        f"WHERE district_id IS NULL "
-                        f"OR election_year IS NULL "
-                        f"OR election_code IS NULL"
-                    )
-                    null_keys = cur.fetchone()[0]
-
-                    # Prior live state (absent on a true cold start). Both
-                    # identifiers must be double-quoted in the regclass argument
-                    # so Postgres does not fold the mixed-case name to lowercase.
-                    cur.execute(
-                        "SELECT to_regclass(%s)",
-                        (f'"{PT.target_schema}"."{PT.target_table}"',),
-                    )
-                    prior_exists = cur.fetchone()[0] is not None
-                    if prior_exists:
-                        cur.execute(
-                            f"SELECT COUNT(*) FROM ("
-                            f"SELECT DISTINCT district_id, election_year, election_code "
-                            f'FROM "{PT.target_schema}"."{PT.target_table}"'
-                            f") AS prior_keys"
-                        )
-                        prior_key_count = cur.fetchone()[0]
-                    else:
-                        prior_key_count = 0
-                finally:
-                    cur.close()
-
-            _pt_quality_gate(loaded_count, dup_keys, prior_key_count, null_keys)
-
-            t_log.info(
-                "Quality checks passed: %d rows (prior %d distinct keys), "
-                "no duplicate and no NULL (district, election) keys",
-                loaded_count,
-                prior_key_count,
-            )
-
-        @task
-        def swap() -> None:
-            with _open_pg() as conn:
-                swap_staging_into_target(conn, PT)
-
-        @task
-        def drop_old() -> None:
-            with _open_pg() as conn:
-                drop_old_table(conn, PT)
-
-        s = build_staging()
-        loaded = load_staging()
-        idx = build_indexes_and_fk()
-        qc = quality_checks(loaded)
-        sw = swap()
-        do = drop_old()
-        s >> loaded >> idx >> qc >> sw >> do
-
-    # The pipelines run in parallel; under the Kubernetes executor each task
-    # is its own pod, and each load_staging reads one partition at a time, so
+    # The pipelines run in parallel; under the Astro executor each task is its
+    # own subprocess, and each load_staging reads one partition at a time, so
     # they don't contend for memory.
-    zip_to_position()
-    district_top_issues()
-    elected_official_support()
-    projected_turnout()
+    for config in (ZTP_CONFIG, DTI_CONFIG, EOS_CONFIG, PT_CONFIG):
+        _sync_table_group(config)
+
+    @task_group(group_id="person_spine")
+    def person_spine():
+        @task_group(group_id=PERSON_CONFIG.group_id)
+        def person_stage():
+            return _staged_load(PERSON_CONFIG)
+
+        @task_group(group_id=OFFICE_HOLDER_CONFIG.group_id)
+        def office_holder_stage():
+            return _staged_load(OFFICE_HOLDER_CONFIG)
+
+        @task
+        def swap() -> None:
+            with _open_pg() as conn:
+                swap_group_staging_into_target(
+                    conn,
+                    [PERSON, OFFICE_HOLDER],  # parent-first
+                    pre_swap_ddl=_person_spine_pre_swap_ddl(),
+                    post_swap_ddl=_person_spine_post_swap_ddl(),
+                )
+
+        @task
+        def drop_old() -> None:
+            with _open_pg() as conn:
+                # Child first: OfficeHolder_old's FK references Person_old.
+                drop_old_table(conn, OFFICE_HOLDER)
+                drop_old_table(conn, PERSON)
+
+        person_nodes = person_stage()
+        office_holder_nodes = office_holder_stage()
+        # The staged OfficeHolder person_id FK references staging."Person_new",
+        # so it can only build (and validate) after person's staged PK exists.
+        person_nodes["build_indexes_and_fk"] >> office_holder_nodes["build_indexes_and_fk"]
+
+        sw = swap()
+        [person_nodes["quality_checks"], office_holder_nodes["quality_checks"]] >> sw >> drop_old()
+
+    person_spine()
 
 
 sync_election_api()

--- a/airflow/astro/include/custom_functions/election_api_utils.py
+++ b/airflow/astro/include/custom_functions/election_api_utils.py
@@ -17,6 +17,19 @@ Each pipeline:
    run never wedges subsequent ones.
 6. Drops `public."<Target>_old"`.
 
+Tables tied together by FKs (Person ← OfficeHolder) cannot swap
+independently: an FK constraint binds to the referenced table's OID, so an FK
+pointing at a swapped table would follow the renamed-aside `_old` copy. Those
+tables stage their FKs staged-to-staged (`OfficeHolder_new.person_id` →
+`staging."Person_new"`, populated in dependency order) and swap together via
+`swap_group_staging_into_target` — the constraints ride the renames and come
+out pointing at the fresh tables. Its single transaction also runs
+caller-supplied DDL before the renames (drop inbound FKs held by tables
+outside the group, e.g. Candidacy → Person) and after them (null orphans and
+re-create those FKs against the fresh tables). Group `specs` are ordered
+parent-first; leftover `_old` pre-drops run child-first so a dependent FK
+never blocks its parent.
+
 Index/constraint names follow Prisma's convention (`<Table>_<col>_idx`,
 `<Table>_pkey`, `<Table>_<col>_fkey`). Staging and archive variants insert
 `_new` / `_old` after the table prefix so the same canonical name maps
@@ -47,7 +60,9 @@ class TableSyncSpec:
     # Canonical (post-swap) index names — used to rename during the swap.
     # Do NOT include the PK constraint here; it's tracked separately.
     indexes: tuple[str, ...] = field(default_factory=tuple)
-    # Canonical (post-swap) foreign-key constraint names.
+    # Canonical (post-swap) foreign-key constraint names. Only FKs that ride
+    # the rename swap belong here (outbound FKs staged with `_new` names);
+    # FKs re-created from scratch after a group swap do not.
     fkeys: tuple[str, ...] = field(default_factory=tuple)
 
     @property
@@ -165,23 +180,80 @@ def apply_ddl(conn, statements: Sequence[str]) -> None:
         cur.close()
 
 
-def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
-    """Atomic rename-swap: stage `_new` -> `public.<table>`, old -> `_old`.
+def _archive_statements(spec: TableSyncSpec) -> list[str]:
+    """Rename the live table (and its indexes/constraints) aside to `_old`."""
+    statements = [
+        f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" ' f'RENAME TO "{spec.old_table}"',
+        f'ALTER INDEX "{spec.target_schema}"."{spec.pk_name}" '
+        f'RENAME TO "{spec.archive_name(spec.pk_name)}"',
+    ]
+    for idx in spec.indexes:
+        statements.append(
+            f'ALTER INDEX "{spec.target_schema}"."{idx}" ' f'RENAME TO "{spec.archive_name(idx)}"'
+        )
+    for fk in spec.fkeys:
+        statements.append(
+            f'ALTER TABLE "{spec.target_schema}"."{spec.old_table}" '
+            f'RENAME CONSTRAINT "{fk}" '
+            f'TO "{spec.archive_name(fk)}"'
+        )
+    return statements
 
-    All indexes/constraints listed on `spec` are renamed to/from canonical
-    Prisma names so the post-swap shape matches the migration exactly. Safe
-    on first run when `public.<table>` doesn't yet exist (skip the rename-old
-    branch), and self-healing when a prior run crashed between this
+
+def _promote_statements(spec: TableSyncSpec) -> list[str]:
+    """Move `staging.<table>_new` into place under canonical names."""
+    statements = [
+        f'ALTER TABLE "{spec.staging_schema}"."{spec.new_table}" ' f'SET SCHEMA "{spec.target_schema}"',
+        f'ALTER TABLE "{spec.target_schema}"."{spec.new_table}" ' f'RENAME TO "{spec.target_table}"',
+        f'ALTER INDEX "{spec.target_schema}"."{spec.stage_name(spec.pk_name)}" '
+        f'RENAME TO "{spec.pk_name}"',
+    ]
+    for idx in spec.indexes:
+        statements.append(
+            f'ALTER INDEX "{spec.target_schema}"."{spec.stage_name(idx)}" ' f'RENAME TO "{idx}"'
+        )
+    for fk in spec.fkeys:
+        statements.append(
+            f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" '
+            f'RENAME CONSTRAINT "{spec.stage_name(fk)}" '
+            f'TO "{fk}"'
+        )
+    return statements
+
+
+def swap_group_staging_into_target(
+    conn,
+    specs: Sequence[TableSyncSpec],
+    pre_swap_ddl: Sequence[str] = (),
+    post_swap_ddl: Sequence[str] = (),
+) -> None:
+    """Atomic rename-swap of one or more staged tables in a single transaction.
+
+    `specs` must be ordered parent-first when the tables reference each other:
+    leftover `_old` pre-drops run in reverse (child-first) so a dependent FK on
+    a leftover child never blocks dropping its parent.
+
+    `pre_swap_ddl` runs after the pre-drops and before any rename — the place
+    to drop inbound FK constraints held by tables outside the group (they bind
+    to the live table's OID and would otherwise follow it to `_old`).
+    `post_swap_ddl` runs after every rename — the place to clean up orphans
+    and re-create those FKs against the fresh tables. Both ride the same
+    transaction, so any failure rolls the whole swap back.
+
+    Safe on first run when a live table doesn't yet exist (its rename-old
+    branch is skipped), and self-healing when a prior run crashed between this
     transaction committing and `drop_old_table` completing: the leftover
-    `<table>_old` is dropped inside the same transaction before the renames.
+    `_old` tables are dropped inside the same transaction before the renames.
     """
     cur = conn.cursor()
     try:
-        cur.execute(
-            "SELECT 1 FROM pg_tables WHERE schemaname = %s AND tablename = %s",
-            (spec.target_schema, spec.target_table),
-        )
-        target_exists = cur.fetchone() is not None
+        target_exists: dict[str, bool] = {}
+        for spec in specs:
+            cur.execute(
+                "SELECT 1 FROM pg_tables WHERE schemaname = %s AND tablename = %s",
+                (spec.target_schema, spec.target_table),
+            )
+            target_exists[spec.target_table] = cur.fetchone() is not None
 
         statements: list[str] = []
         # A `<table>_old` left behind by a run that died in the swap->drop_old
@@ -191,53 +263,22 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
         # auto-pause the DAG. Pre-drop it in this transaction: DDL is
         # transactional, so a mid-swap failure rolls the drop back with the
         # renames, and a clean run drops nothing that drop_old_table wouldn't.
-        statements.append(f'DROP TABLE IF EXISTS "{spec.target_schema}"."{spec.old_table}"')
-        if target_exists:
-            statements.append(
-                f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" ' f'RENAME TO "{spec.old_table}"'
-            )
-            statements.append(
-                f'ALTER INDEX "{spec.target_schema}"."{spec.pk_name}" '
-                f'RENAME TO "{spec.archive_name(spec.pk_name)}"'
-            )
-            for idx in spec.indexes:
-                statements.append(
-                    f'ALTER INDEX "{spec.target_schema}"."{idx}" ' f'RENAME TO "{spec.archive_name(idx)}"'
-                )
-            for fk in spec.fkeys:
-                statements.append(
-                    f'ALTER TABLE "{spec.target_schema}"."{spec.old_table}" '
-                    f'RENAME CONSTRAINT "{fk}" '
-                    f'TO "{spec.archive_name(fk)}"'
-                )
-
-        statements.append(
-            f'ALTER TABLE "{spec.staging_schema}"."{spec.new_table}" ' f'SET SCHEMA "{spec.target_schema}"'
-        )
-        statements.append(
-            f'ALTER TABLE "{spec.target_schema}"."{spec.new_table}" ' f'RENAME TO "{spec.target_table}"'
-        )
-        statements.append(
-            f'ALTER INDEX "{spec.target_schema}"."{spec.stage_name(spec.pk_name)}" '
-            f'RENAME TO "{spec.pk_name}"'
-        )
-        for idx in spec.indexes:
-            statements.append(
-                f'ALTER INDEX "{spec.target_schema}"."{spec.stage_name(idx)}" ' f'RENAME TO "{idx}"'
-            )
-        for fk in spec.fkeys:
-            statements.append(
-                f'ALTER TABLE "{spec.target_schema}"."{spec.target_table}" '
-                f'RENAME CONSTRAINT "{spec.stage_name(fk)}" '
-                f'TO "{fk}"'
-            )
+        for spec in reversed(specs):
+            statements.append(f'DROP TABLE IF EXISTS "{spec.target_schema}"."{spec.old_table}"')
+        statements.extend(pre_swap_ddl)
+        for spec in specs:
+            if target_exists[spec.target_table]:
+                statements.extend(_archive_statements(spec))
+        for spec in specs:
+            statements.extend(_promote_statements(spec))
+        statements.extend(post_swap_ddl)
 
         for stmt in statements:
             cur.execute(stmt)
         conn.commit()
         logger.info(
             "Swap complete for %s (target_existed=%s)",
-            spec.target_table,
+            ", ".join(spec.target_table for spec in specs),
             target_exists,
         )
     except Exception:
@@ -247,8 +288,20 @@ def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
         cur.close()
 
 
+def swap_staging_into_target(conn, spec: TableSyncSpec) -> None:
+    """Atomic rename-swap: stage `_new` -> `public.<table>`, old -> `_old`.
+
+    Single-table form of `swap_group_staging_into_target`.
+    """
+    swap_group_staging_into_target(conn, [spec])
+
+
 def drop_old_table(conn, spec: TableSyncSpec) -> None:
-    """DROP TABLE IF EXISTS `public.<table>_old`. Run after swap commits."""
+    """DROP TABLE IF EXISTS `public.<table>_old`. Run after swap commits.
+
+    For a group swap, call once per spec in child-first order so a dependent
+    FK on a leftover child never blocks dropping its parent.
+    """
     cur = conn.cursor()
     try:
         cur.execute(f'DROP TABLE IF EXISTS "{spec.target_schema}"."{spec.old_table}"')

--- a/airflow/astro/tests/test_election_api_swap.py
+++ b/airflow/astro/tests/test_election_api_swap.py
@@ -29,6 +29,7 @@ from include.custom_functions.election_api_utils import (
     apply_ddl,
     create_staging_table,
     drop_old_table,
+    swap_group_staging_into_target,
     swap_staging_into_target,
 )
 
@@ -54,17 +55,30 @@ class FakePostgres:
     def __init__(self):
         self.tables: dict[tuple[str, str], set[str]] = {}
         self.indexes: dict[tuple[str, str], tuple[str, str]] = {}
+        # FK dependency graph: (owner_schema, owner_table, constraint) ->
+        # (ref_schema, ref_table). Tracked only when the referenced table is
+        # itself modeled in the fake (constraints referencing tables outside
+        # the model, e.g. District in the single-table tests, stay untracked).
+        # References follow renames/schema moves — FKs bind to the table OID,
+        # not its name — and a tracked reference blocks DROP TABLE, as in
+        # real Postgres.
+        self.fk_refs: dict[tuple[str, str, str], tuple[str, str]] = {}
         self._durable = self._copy_state()
         self._crash_countdown: int | None = None
         self.crash_fired = False
 
     # -- setup / inspection -------------------------------------------------
 
-    def seed_table(self, schema, table, constraints=(), indexes=()):
-        """Create a table durably, outside any transaction (test setup)."""
+    def seed_table(self, schema, table, constraints=(), indexes=(), fk_refs=None):
+        """Create a table durably, outside any transaction (test setup).
+
+        `fk_refs` maps a constraint name to the (schema, table) it references.
+        """
         self.tables[(schema, table)] = set(constraints)
         for idx in indexes:
             self.indexes[(schema, idx)] = (schema, table)
+        for con, ref in (fk_refs or {}).items():
+            self.fk_refs[(schema, table, con)] = ref
         self._durable = self._copy_state()
 
     def connect(self):
@@ -79,11 +93,14 @@ class FakePostgres:
     def index_names(self, schema):
         return {idx for (s, idx) in self.indexes if s == schema}
 
+    def fk_target(self, schema, table, con):
+        return self.fk_refs.get((schema, table, con))
+
     def state(self):
         return self._copy_state()
 
     def _copy_state(self):
-        return (deepcopy(self.tables), deepcopy(self.indexes))
+        return (deepcopy(self.tables), deepcopy(self.indexes), deepcopy(self.fk_refs))
 
     # -- crash injection ----------------------------------------------------
 
@@ -98,7 +115,7 @@ class FakePostgres:
         self._durable = self._copy_state()
 
     def _rollback(self):
-        self.tables, self.indexes = deepcopy(self._durable)
+        self.tables, self.indexes, self.fk_refs = deepcopy(self._durable)
 
     # -- statement execution --------------------------------------------------
 
@@ -140,6 +157,7 @@ class FakePostgres:
             self._require_no_table(schema, new_name)
             self.tables[(schema, new_name)] = self.tables.pop((schema, table))
             self._reown_indexes((schema, table), (schema, new_name))
+            self._retarget_fk_refs((schema, table), (schema, new_name))
             return []
 
         m = re.fullmatch(r'ALTER TABLE "([^"]+)"\."([^"]+)" SET SCHEMA "([^"]+)"', stmt)
@@ -155,6 +173,7 @@ class FakePostgres:
                         raise FakePostgresError(f'index "{idx}" already exists in schema "{new_schema}"')
                     del self.indexes[(idx_schema, idx)]
                     self.indexes[(new_schema, idx)] = (new_schema, table)
+            self._retarget_fk_refs((schema, table), (new_schema, table))
             return []
 
         m = re.fullmatch(r'ALTER INDEX "([^"]+)"\."([^"]+)" RENAME TO "([^"]+)"', stmt)
@@ -188,6 +207,27 @@ class FakePostgres:
                 raise FakePostgresError(f'constraint "{new_con}" already exists')
             table_cons.remove(con)
             table_cons.add(new_con)
+            if (schema, table, con) in self.fk_refs:
+                self.fk_refs[(schema, table, new_con)] = self.fk_refs.pop((schema, table, con))
+            return []
+
+        m = re.fullmatch(
+            r'ALTER TABLE "([^"]+)"\."([^"]+)" DROP CONSTRAINT IF EXISTS "([^"]+)"',
+            stmt,
+        )
+        if m:
+            schema, table, con = m.groups()
+            self._require_table(schema, table)
+            self.tables[(schema, table)].discard(con)
+            self.fk_refs.pop((schema, table, con), None)
+            return []
+
+        # Row-level statements (orphan cleanup in the swap transaction). The
+        # fake models schema objects only, so these just check the tables
+        # they touch exist.
+        m = re.fullmatch(r'UPDATE "([^"]+)"\."([^"]+)" AS \w+ SET .+', stmt)
+        if m:
+            self._require_table(m.group(1), m.group(2))
             return []
 
         m = re.fullmatch(
@@ -205,13 +245,18 @@ class FakePostgres:
             return []
 
         m = re.fullmatch(
-            r'ALTER TABLE "([^"]+)"\."([^"]+)" ADD CONSTRAINT "([^"]+)" FOREIGN KEY .+',
+            r'ALTER TABLE "([^"]+)"\."([^"]+)" ADD CONSTRAINT "([^"]+)" '
+            r'FOREIGN KEY \([^)]+\) REFERENCES "([^"]+)"\."([^"]+)"\(.+',
             stmt,
         )
         if m:
-            schema, table, con = m.groups()
+            schema, table, con, ref_schema, ref_table = m.groups()
             self._require_table(schema, table)
             self._add_constraint(schema, table, con)
+            # Track the dependency only when the referenced table is modeled
+            # (see fk_refs docs) — it then follows renames and blocks drops.
+            if (ref_schema, ref_table) in self.tables:
+                self.fk_refs[(schema, table, con)] = (ref_schema, ref_table)
             return []
 
         m = re.fullmatch(r'CREATE (?:UNIQUE )?INDEX "([^"]+)" ON "([^"]+)"\."([^"]+)" ?\(?.*', stmt)
@@ -245,14 +290,36 @@ class FakePostgres:
             if missing_ok:
                 return
             raise FakePostgresError(f'relation "{schema}"."{table}" does not exist')
+        # A tracked FK from another (still-existing) table blocks the drop,
+        # as in real Postgres — proving drop ordering is child-first.
+        for (own_schema, own_table, con), ref in self.fk_refs.items():
+            if ref == (schema, table) and (own_schema, own_table) != (schema, table):
+                raise FakePostgresError(
+                    f'cannot drop table "{schema}"."{table}" because constraint '
+                    f'"{con}" on "{own_schema}"."{own_table}" depends on it'
+                )
         del self.tables[(schema, table)]
         # DROP TABLE takes the table's indexes (and constraints) with it.
         self.indexes = {k: v for k, v in self.indexes.items() if v != (schema, table)}
+        self.fk_refs = {k: v for k, v in self.fk_refs.items() if (k[0], k[1]) != (schema, table)}
 
     def _reown_indexes(self, old_owner, new_owner):
         for key, owner in self.indexes.items():
             if owner == old_owner:
                 self.indexes[key] = new_owner
+
+    def _retarget_fk_refs(self, old_table, new_table):
+        """A rename/schema move keeps the OID: FKs owned by and FKs pointing
+        at the moved table both follow it."""
+        updated = {}
+        for (own_schema, own_table, con), ref in self.fk_refs.items():
+            owner = (own_schema, own_table)
+            if owner == old_table:
+                owner = new_table
+            if ref == old_table:
+                ref = new_table
+            updated[(*owner, con)] = ref
+        self.fk_refs = updated
 
 
 class _FakeConnection:
@@ -497,3 +564,317 @@ def test_drop_old_is_idempotent():
     drop_old_table(pg.connect(), SPEC)  # second drop: IF EXISTS no-op
 
     _assert_canonical_shape(pg, SPEC)
+
+
+# ---------------------------------------------------------------------------
+# Person + OfficeHolder grouped swap (mirrors the DAG's person_spine group)
+# ---------------------------------------------------------------------------
+
+PERSON_SPEC = TableSyncSpec(target_table="Person", indexes=("Person_slug_idx",))
+OFFICE_HOLDER_SPEC = TableSyncSpec(
+    target_table="OfficeHolder",
+    indexes=("OfficeHolder_person_id_idx", "OfficeHolder_position_id_idx"),
+    fkeys=("OfficeHolder_person_id_fkey", "OfficeHolder_position_id_fkey"),
+)
+SPINE_SPECS = [PERSON_SPEC, OFFICE_HOLDER_SPEC]  # parent-first
+
+
+def _person_stage_ddl():
+    """Staging DDL exactly as the DAG's _person_constraint_ddl emits it."""
+    sn, nt = PERSON_SPEC.staging_schema, PERSON_SPEC.new_table
+    return [
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{PERSON_SPEC.stage_name(PERSON_SPEC.pk_name)}" PRIMARY KEY (id)'
+        ),
+        f'CREATE INDEX "{PERSON_SPEC.stage_name("Person_slug_idx")}" ON "{sn}"."{nt}" (slug)',
+    ]
+
+
+def _office_holder_stage_ddl():
+    """Staging DDL exactly as the DAG's _office_holder_constraint_ddl emits
+    it: null positions the API doesn't know, PK + indexes, then FKs — the
+    person FK referencing the STAGED Person table so it rides the swap."""
+    sn, nt = OFFICE_HOLDER_SPEC.staging_schema, OFFICE_HOLDER_SPEC.new_table
+    return [
+        (
+            f'UPDATE "{sn}"."{nt}" AS oh SET position_id = NULL '
+            f"WHERE oh.position_id IS NOT NULL "
+            f'AND NOT EXISTS (SELECT 1 FROM "public"."Position" AS p WHERE p.id = oh.position_id)'
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{OFFICE_HOLDER_SPEC.stage_name(OFFICE_HOLDER_SPEC.pk_name)}" '
+            f"PRIMARY KEY (id)"
+        ),
+        (
+            f'CREATE INDEX "{OFFICE_HOLDER_SPEC.stage_name("OfficeHolder_person_id_idx")}" '
+            f'ON "{sn}"."{nt}" (person_id)'
+        ),
+        (
+            f'CREATE INDEX "{OFFICE_HOLDER_SPEC.stage_name("OfficeHolder_position_id_idx")}" '
+            f'ON "{sn}"."{nt}" (position_id)'
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{OFFICE_HOLDER_SPEC.stage_name("OfficeHolder_person_id_fkey")}" '
+            f"FOREIGN KEY (person_id) "
+            f'REFERENCES "{PERSON_SPEC.staging_schema}"."{PERSON_SPEC.new_table}"(id) '
+            f"ON DELETE CASCADE ON UPDATE CASCADE"
+        ),
+        (
+            f'ALTER TABLE "{sn}"."{nt}" '
+            f'ADD CONSTRAINT "{OFFICE_HOLDER_SPEC.stage_name("OfficeHolder_position_id_fkey")}" '
+            f"FOREIGN KEY (position_id) "
+            f'REFERENCES "public"."Position"(id) '
+            f"ON DELETE SET NULL ON UPDATE CASCADE"
+        ),
+    ]
+
+
+def _spine_pre_swap_ddl():
+    return ['ALTER TABLE "public"."Candidacy" ' 'DROP CONSTRAINT IF EXISTS "Candidacy_person_id_fkey"']
+
+
+def _spine_post_swap_ddl():
+    return [
+        (
+            'UPDATE "public"."Candidacy" AS c SET person_id = NULL '
+            "WHERE c.person_id IS NOT NULL "
+            'AND NOT EXISTS (SELECT 1 FROM "public"."Person" AS p WHERE p.id = c.person_id)'
+        ),
+        (
+            'ALTER TABLE "public"."Candidacy" '
+            'ADD CONSTRAINT "Candidacy_person_id_fkey" '
+            'FOREIGN KEY (person_id) REFERENCES "public"."Person"(id) '
+            "ON DELETE SET NULL ON UPDATE CASCADE"
+        ),
+    ]
+
+
+def _seed_spine_live(pg):
+    """Live tables as the election-api Prisma migrations create them, plus
+    the out-of-group tables the spine's FKs touch (Position, Candidacy)."""
+    pg.seed_table("public", "Position", constraints={"Position_pkey"}, indexes={"Position_pkey"})
+    pg.seed_table(
+        "public",
+        "Person",
+        constraints={"Person_pkey"},
+        indexes={"Person_pkey", "Person_slug_idx"},
+    )
+    pg.seed_table(
+        "public",
+        "OfficeHolder",
+        constraints={
+            "OfficeHolder_pkey",
+            "OfficeHolder_person_id_fkey",
+            "OfficeHolder_position_id_fkey",
+        },
+        indexes={
+            "OfficeHolder_pkey",
+            "OfficeHolder_person_id_idx",
+            "OfficeHolder_position_id_idx",
+        },
+        fk_refs={
+            "OfficeHolder_person_id_fkey": ("public", "Person"),
+            "OfficeHolder_position_id_fkey": ("public", "Position"),
+        },
+    )
+    pg.seed_table(
+        "public",
+        "Candidacy",
+        constraints={"Candidacy_pkey", "Candidacy_person_id_fkey"},
+        indexes={"Candidacy_pkey"},
+        fk_refs={"Candidacy_person_id_fkey": ("public", "Person")},
+    )
+
+
+def _run_spine_cycle(pg, skip_drop_old=False):
+    """One DAG-run's person_spine sequence: build both stagings, person DDL
+    before office-holder DDL (the staged FK needs the staged Person PK),
+    grouped swap, then child-first drop_old."""
+    conn = pg.connect()
+    create_staging_table(conn, PERSON_SPEC)
+    create_staging_table(conn, OFFICE_HOLDER_SPEC)
+    apply_ddl(conn, _person_stage_ddl())
+    apply_ddl(conn, _office_holder_stage_ddl())
+    swap_group_staging_into_target(
+        conn,
+        SPINE_SPECS,
+        pre_swap_ddl=_spine_pre_swap_ddl(),
+        post_swap_ddl=_spine_post_swap_ddl(),
+    )
+    if not skip_drop_old:
+        drop_old_table(conn, OFFICE_HOLDER_SPEC)
+        drop_old_table(conn, PERSON_SPEC)
+
+
+def _assert_spine_canonical(pg):
+    """Post-cycle invariant: both tables live under canonical Prisma names,
+    every FK pointing at the FRESH tables, no debris."""
+    for spec in SPINE_SPECS:
+        assert pg.has_table("public", spec.target_table)
+        assert not pg.has_table("public", spec.old_table)
+        assert not pg.has_table(spec.staging_schema, spec.new_table)
+    assert pg.constraints("public", "Person") == {"Person_pkey"}
+    assert pg.constraints("public", "OfficeHolder") == {
+        "OfficeHolder_pkey",
+        "OfficeHolder_person_id_fkey",
+        "OfficeHolder_position_id_fkey",
+    }
+    assert "Candidacy_person_id_fkey" in pg.constraints("public", "Candidacy")
+    assert pg.fk_target("public", "OfficeHolder", "OfficeHolder_person_id_fkey") == ("public", "Person")
+    assert pg.fk_target("public", "OfficeHolder", "OfficeHolder_position_id_fkey") == ("public", "Position")
+    assert pg.fk_target("public", "Candidacy", "Candidacy_person_id_fkey") == ("public", "Person")
+    assert pg.index_names("staging") == set()
+    assert pg.index_names("public") == {
+        "Position_pkey",
+        "Candidacy_pkey",
+        "Person_pkey",
+        "Person_slug_idx",
+        "OfficeHolder_pkey",
+        "OfficeHolder_person_id_idx",
+        "OfficeHolder_position_id_idx",
+    }
+
+
+def test_person_spine_happy_path():
+    pg = FakePostgres()
+    _seed_spine_live(pg)
+
+    _run_spine_cycle(pg)
+
+    _assert_spine_canonical(pg)
+
+
+def test_person_spine_staged_fk_follows_the_swap():
+    """The staged person_id FK is created against staging."Person_new"; after
+    the swap it must point at the live public."Person" — the OID-following
+    property the whole design rests on."""
+    pg = FakePostgres()
+    _seed_spine_live(pg)
+    conn = pg.connect()
+    create_staging_table(conn, PERSON_SPEC)
+    create_staging_table(conn, OFFICE_HOLDER_SPEC)
+    apply_ddl(conn, _person_stage_ddl())
+    apply_ddl(conn, _office_holder_stage_ddl())
+    assert pg.fk_target("staging", "OfficeHolder_new", "OfficeHolder_new_person_id_fkey") == (
+        "staging",
+        "Person_new",
+    )
+
+    swap_group_staging_into_target(
+        conn,
+        SPINE_SPECS,
+        pre_swap_ddl=_spine_pre_swap_ddl(),
+        post_swap_ddl=_spine_post_swap_ddl(),
+    )
+
+    assert pg.fk_target("public", "OfficeHolder", "OfficeHolder_person_id_fkey") == ("public", "Person")
+
+
+def test_person_spine_recovers_after_crash_between_swap_and_drop_old():
+    """Leftover Person_old + OfficeHolder_old (with the FK between them) from
+    a crashed run: the next run's pre-drops run child-first inside the swap
+    transaction, so the dependent FK never wedges the cycle."""
+    pg = FakePostgres()
+    _seed_spine_live(pg)
+
+    _run_spine_cycle(pg, skip_drop_old=True)
+    assert pg.has_table("public", "Person_old")
+    assert pg.has_table("public", "OfficeHolder_old")
+
+    _run_spine_cycle(pg)
+
+    _assert_spine_canonical(pg)
+
+
+def test_person_spine_drop_old_must_be_child_first():
+    """OfficeHolder_old's FK follows Person_old through the swap, so dropping
+    Person_old first is a real-Postgres error; the DAG's drop_old drops the
+    child first."""
+    pg = FakePostgres()
+    _seed_spine_live(pg)
+    _run_spine_cycle(pg, skip_drop_old=True)
+
+    conn = pg.connect()
+    with pytest.raises(FakePostgresError, match="depends on it"):
+        drop_old_table(conn, PERSON_SPEC)
+
+    drop_old_table(conn, OFFICE_HOLDER_SPEC)
+    drop_old_table(conn, PERSON_SPEC)
+    _assert_spine_canonical(pg)
+
+
+def test_person_spine_swap_rolls_back_cleanly_at_every_crash_point():
+    """Crash before each statement of the grouped swap in the worst-case
+    state (leftover `_old` pair present): the transaction must roll back to
+    exactly the pre-swap state — Candidacy's dropped FK included — and an
+    immediate retry plus drop_old must complete the cycle."""
+    crash_points_covered = 0
+    k = 1
+    while True:
+        pg = FakePostgres()
+        _seed_spine_live(pg)
+        pg.seed_table(
+            "public",
+            "Person_old",
+            constraints={"Person_old_pkey"},
+            indexes={"Person_old_pkey", "Person_old_slug_idx"},
+        )
+        pg.seed_table(
+            "public",
+            "OfficeHolder_old",
+            constraints={
+                "OfficeHolder_old_pkey",
+                "OfficeHolder_old_person_id_fkey",
+                "OfficeHolder_old_position_id_fkey",
+            },
+            indexes={
+                "OfficeHolder_old_pkey",
+                "OfficeHolder_old_person_id_idx",
+                "OfficeHolder_old_position_id_idx",
+            },
+            fk_refs={
+                "OfficeHolder_old_person_id_fkey": ("public", "Person_old"),
+                "OfficeHolder_old_position_id_fkey": ("public", "Position"),
+            },
+        )
+        conn = pg.connect()
+        create_staging_table(conn, PERSON_SPEC)
+        create_staging_table(conn, OFFICE_HOLDER_SPEC)
+        apply_ddl(conn, _person_stage_ddl())
+        apply_ddl(conn, _office_holder_stage_ddl())
+        state_before_swap = pg.state()
+
+        pg.arm_crash(after=k)
+        try:
+            swap_group_staging_into_target(
+                conn,
+                SPINE_SPECS,
+                pre_swap_ddl=_spine_pre_swap_ddl(),
+                post_swap_ddl=_spine_post_swap_ddl(),
+            )
+        except RuntimeError:
+            assert pg.crash_fired
+            assert pg.state() == state_before_swap
+            swap_group_staging_into_target(
+                conn,
+                SPINE_SPECS,
+                pre_swap_ddl=_spine_pre_swap_ddl(),
+                post_swap_ddl=_spine_post_swap_ddl(),
+            )
+        else:
+            assert not pg.crash_fired
+            break
+
+        drop_old_table(conn, OFFICE_HOLDER_SPEC)
+        drop_old_table(conn, PERSON_SPEC)
+        _assert_spine_canonical(pg)
+        crash_points_covered += 1
+        k += 1
+
+    # 2 pg_tables probes + 2 pre-drops + 1 pre-swap DDL + 3 person archive
+    # renames + 6 office-holder archive renames + 4 person promotes +
+    # 7 office-holder promotes + 2 post-swap DDL = 27 statements.
+    assert crash_points_covered >= 27

--- a/airflow/astro/tests/test_sync_election_api.py
+++ b/airflow/astro/tests/test_sync_election_api.py
@@ -34,9 +34,20 @@ for _mod in _STUBS:
 from dags.sync_election_api import (  # noqa: E402
     DTI_COLUMNS,
     EOS_COLUMNS,
+    OFFICE_HOLDER_SOURCE_COLUMNS,
+    OFFICE_HOLDER_TARGET_COLUMNS,
+    PERSON_SOURCE_COLUMNS,
+    PERSON_TARGET_COLUMNS,
     PT_COLUMNS,
     ZTP_SOURCE_COLUMNS,
     ZTP_TARGET_COLUMNS,
+    _office_holder_constraint_ddl,
+    _office_holder_quality_gate,
+    _office_holder_transform_row,
+    _person_quality_gate,
+    _person_spine_post_swap_ddl,
+    _person_spine_pre_swap_ddl,
+    _person_transform_row,
     _pt_quality_gate,
     _ztp_transform_row,
 )
@@ -215,3 +226,174 @@ def test_pt_quality_gate_refuses_null_keys():
     """
     with pytest.raises(ValueError, match="NULL"):
         _pt_quality_gate(loaded_count=800_000, dup_keys=0, prior_key_count=800_000, null_keys=1)
+
+
+def test_person_columns_pinned():
+    """Pin PERSON_SOURCE_COLUMNS to catch silent column reorderings.
+
+    The Person bulk-insert is positional and most columns are same-typed text,
+    so a reorder would land values in the wrong columns without an insert-time
+    error. The mart's SELECT order must match this list.
+    """
+    assert PERSON_SOURCE_COLUMNS == [
+        "id",
+        "br_person_id",
+        "slug",
+        "first_name",
+        "middle_name",
+        "last_name",
+        "nickname",
+        "suffix",
+        "full_name",
+        "bio_text",
+        "headshot_url",
+        "website_url",
+        "linkedin_url",
+        "facebook_url",
+        "twitter_url",
+        "instagram_url",
+        "email",
+        "phone",
+        "degrees",
+        "experiences",
+        "state",
+    ]
+    assert [*PERSON_SOURCE_COLUMNS, "updated_at"] == PERSON_TARGET_COLUMNS
+
+
+def test_person_transform_row_appends_timestamp_only():
+    """Pass-through except a single appended updated_at."""
+    row = tuple(range(len(PERSON_SOURCE_COLUMNS)))
+    out = _person_transform_row(row)
+    assert len(out) == len(PERSON_TARGET_COLUMNS)
+    assert out[: len(row)] == row
+    assert isinstance(out[-1], datetime)
+
+
+def test_office_holder_columns_pinned():
+    """Pin OFFICE_HOLDER_SOURCE_COLUMNS to catch silent column reorderings."""
+    assert OFFICE_HOLDER_SOURCE_COLUMNS == [
+        "id",
+        "br_office_holder_id",
+        "position_name",
+        "normalized_position_name",
+        "office_title",
+        "party_names",
+        "start_at",
+        "end_at",
+        "term_date_specificity",
+        "is_current",
+        "is_appointed",
+        "is_vacant",
+        "number_of_seats",
+        "next_election_date",
+        "mailing_address_line_1",
+        "mailing_address_line_2",
+        "mailing_city",
+        "mailing_state",
+        "mailing_zip",
+        "office_phone",
+        "office_email",
+        "website_url",
+        "linkedin_url",
+        "facebook_url",
+        "twitter_url",
+        "instagram_url",
+        "sub_area_name",
+        "sub_area_value",
+        "state",
+        "geo_id",
+        "mtfcc",
+        "person_id",
+        "position_id",
+    ]
+    assert [*OFFICE_HOLDER_SOURCE_COLUMNS, "updated_at"] == OFFICE_HOLDER_TARGET_COLUMNS
+
+
+def test_office_holder_transform_decodes_party_names():
+    """party_names arrives as a JSON string (the mart emits to_json because
+    the Databricks reader doesn't round-trip complex types) and must land as a
+    Python list for psycopg2 to adapt to text[]; everything else passes
+    through, plus an appended updated_at."""
+    idx = OFFICE_HOLDER_SOURCE_COLUMNS.index("party_names")
+    row = list(range(len(OFFICE_HOLDER_SOURCE_COLUMNS)))
+    row[idx] = '["Republican", "Conservative"]'
+
+    out = _office_holder_transform_row(tuple(row))
+
+    assert len(out) == len(OFFICE_HOLDER_TARGET_COLUMNS)
+    assert out[idx] == ["Republican", "Conservative"]
+    assert isinstance(out[-1], datetime)
+    passthrough = [v for i, v in enumerate(out[:-1]) if i != idx]
+    assert passthrough == [v for i, v in enumerate(row) if i != idx]
+
+
+def test_office_holder_transform_keeps_null_party_names():
+    row = [None] * len(OFFICE_HOLDER_SOURCE_COLUMNS)
+    out = _office_holder_transform_row(tuple(row))
+    assert out[OFFICE_HOLDER_SOURCE_COLUMNS.index("party_names")] is None
+
+
+def test_person_quality_gate():
+    """NULL slugs and coverage collapses refuse; plausible loads pass."""
+    with pytest.raises(ValueError, match="NULL slug"):
+        _person_quality_gate(loaded_count=500_000, null_slugs=1, prior_count=500_000)
+    with pytest.raises(ValueError, match="refusing to swap"):
+        _person_quality_gate(loaded_count=200_000, null_slugs=0, prior_count=500_000)
+    with pytest.raises(ValueError, match="Cold-start"):
+        _person_quality_gate(loaded_count=99_999, null_slugs=0, prior_count=0)
+    _person_quality_gate(loaded_count=500_000, null_slugs=0, prior_count=500_000)
+    _person_quality_gate(loaded_count=100_000, null_slugs=0, prior_count=0)
+
+
+def test_office_holder_quality_gate():
+    """NULL person_ids and coverage collapses refuse; plausible loads pass."""
+    with pytest.raises(ValueError, match="NULL person_id"):
+        _office_holder_quality_gate(loaded_count=500_000, null_person_ids=1, prior_count=500_000)
+    with pytest.raises(ValueError, match="refusing to swap"):
+        _office_holder_quality_gate(loaded_count=200_000, null_person_ids=0, prior_count=500_000)
+    with pytest.raises(ValueError, match="Cold-start"):
+        _office_holder_quality_gate(loaded_count=99_999, null_person_ids=0, prior_count=0)
+    _office_holder_quality_gate(loaded_count=520_000, null_person_ids=0, prior_count=500_000)
+
+
+def test_office_holder_constraint_ddl_matches_prisma_migration():
+    """Pin the staged FK DDL to the constraint semantics the election-api
+    Prisma migrations created (20260708163759_add_person_officeholder +
+    20260710150000_officeholder_person_fk_cascade). The person FK must
+    reference the STAGED Person table (so it rides the rename swap and
+    validates the two staged loads against each other), and the position
+    orphan-nulling must precede the position FK so validation cannot fail on
+    rows its SET NULL semantics would have cleared."""
+    statements = _office_holder_constraint_ddl()
+    ddl = "\n".join(statements)
+
+    person_fk = next(s for s in statements if "OfficeHolder_new_person_id_fkey" in s)
+    assert 'REFERENCES "staging"."Person_new"(id)' in person_fk
+    assert "ON DELETE CASCADE" in person_fk  # dependent child of Person
+
+    position_fk = next(s for s in statements if "OfficeHolder_new_position_id_fkey" in s)
+    assert 'REFERENCES "public"."Position"(id)' in position_fk
+    assert "ON DELETE SET NULL" in position_fk
+
+    null_orphans = next(i for i, s in enumerate(statements) if s.startswith("UPDATE"))
+    assert "SET position_id = NULL" in statements[null_orphans]
+    assert null_orphans < statements.index(position_fk)
+
+    assert '"OfficeHolder_new_pkey"' in ddl
+
+
+def test_person_spine_candidacy_fk_rewiring():
+    """Candidacy sits outside the swap group, so its FK to Person is dropped
+    before the renames and re-created after them — with orphan person_ids
+    nulled first (its ON DELETE SET NULL semantics) so validation cannot
+    fail the swap."""
+    pre = "\n".join(_person_spine_pre_swap_ddl())
+    assert 'DROP CONSTRAINT IF EXISTS "Candidacy_person_id_fkey"' in pre
+
+    statements = _person_spine_post_swap_ddl()
+    candidacy_fk = next(s for s in statements if "ADD CONSTRAINT" in s)
+    assert '"Candidacy_person_id_fkey"' in candidacy_fk
+    assert "ON DELETE SET NULL" in candidacy_fk
+    null_orphans = next(i for i, s in enumerate(statements) if "SET person_id = NULL" in s)
+    assert null_orphans < statements.index(candidacy_fk)

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -772,9 +772,14 @@ models:
       gp_candidate_id, so the API can join a Person to its Candidacies and
       OfficeHolders. Scoped to people with a candidacy or an office term and
       at least one name part (the API slug column is NOT NULL).
-      BallotReady-rich profile fields (bio, nickname, links, degrees,
-      experiences) attach via the person group's unambiguous br_person_id and
-      stay null for GP-native people.
+      BallotReady-rich profile fields attach via the person group's
+      unambiguous br_person_id: first from int__ballotready_person (which is
+      fetched candidacy-first, so it misses officials with no BR candidacy —
+      ~44% of this mart), then falling back to the office_holders_v3 feed for
+      name parts and links. bio_text, headshot_url, degrees, and experiences
+      exist only on the API person object and stay null for office-only
+      people until int__ballotready_person also fetches office-holder ids.
+      All BR fields stay null for GP-native people.
     columns:
       - name: id
         description: "Canonical person UUID (gp_person_id / gp_candidate_id)"

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -46,6 +46,18 @@ models:
               config:
                 warn_if: ">10"
                 error_if: ">1000"
+          # The election-api Candidacy.person_id FK is populated from this
+          # column via a guarded join against the Person table, so misses only
+          # cost link coverage. A few no-name people are excluded from the
+          # person mart by design (20 known).
+          - relationships:
+              arguments:
+                to: ref('m_election_api__person')
+                field: id
+              config:
+                severity: warn
+                warn_if: ">0"
+                error_if: ">1000"
       - name: email
         description: >
           Candidate email, sourced from int__civics_candidate_ballotready
@@ -269,6 +281,12 @@ models:
           - accepted_values:
               arguments:
                 values: [true, false]
+      - name: salary
+        description: >
+          Office compensation from the BallotReady API position feed. Free
+          text (values include ranges and notes), mirroring Candidacy.salary.
+          Powers the profile About Office salary row for sitting officials
+          with no active candidacy.
 
   - name: m_election_api__projected_turnout
     description: Turnout projections data load from model predictions
@@ -745,3 +763,107 @@ models:
           name: eos_support_never_exceeds_total_constituents
           config:
             severity: warn
+
+  - name: m_election_api__person
+    description: >
+      Person spine for the election-api Person table, backing the public
+      /people/<slug>-<id> profile pages. One row per canonical person; id is
+      gp_person_id, the same id space m_election_api__candidacy publishes as
+      gp_candidate_id, so the API can join a Person to its Candidacies and
+      OfficeHolders. Scoped to people with a candidacy or an office term and
+      at least one name part (the API slug column is NOT NULL).
+      BallotReady-rich profile fields (bio, nickname, links, degrees,
+      experiences) attach via the person group's unambiguous br_person_id and
+      stay null for GP-native people.
+    columns:
+      - name: id
+        description: "Canonical person UUID (gp_person_id / gp_candidate_id)"
+        tests:
+          - not_null
+          - unique
+          - is_uuid
+      - name: br_person_id
+        description: >
+          BallotReady Person databaseId (br_candidate_id), populated only when
+          the person group carries exactly one BallotReady id. Null for
+          GP-native people and ambiguous groups.
+        tests:
+          - unique
+      - name: slug
+        description: >
+          slugify(first_name-last_name). Cosmetic URL prefix; NOT unique —
+          the API disambiguates on the trailing person UUID.
+        tests:
+          - not_null
+      - name: degrees
+        description: >
+          BallotReady degrees as a JSON string
+          ([{degree, major, school, gradYear}]); the Airflow loader ships it
+          into a JSONB column. Null when BallotReady has none.
+      - name: experiences
+        description: >
+          BallotReady experiences as a JSON string
+          ([{title, organization, start, end, type}]). Null when BallotReady
+          has none.
+
+  - name: m_election_api__office_holder
+    description: >
+      Office terms for the election-api OfficeHolder table (the elected
+      official spine behind public profiles). One row per BallotReady
+      office-holder term; id is gp_elected_official_term_id. person_id is NOT
+      NULL in the API, so the mart inner-joins m_election_api__person —
+      vacancies and no-name people drop here rather than failing the FK at
+      load. position_id resolves the BR position to the election-api Position
+      UUID where the position mart covers it.
+    columns:
+      - name: id
+        description: "Term UUID (gp_elected_official_term_id)"
+        tests:
+          - not_null
+          - unique
+          - is_uuid
+      - name: br_office_holder_id
+        description: "BallotReady office_holder databaseId"
+        tests:
+          - not_null
+          - unique
+      - name: person_id
+        description: "Canonical person UUID; FK to m_election_api__person.id"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('m_election_api__person')
+                field: id
+      - name: position_id
+        description: >
+          election-api Position UUID via the BR position databaseId. Null when
+          the position mart doesn't cover the office (~0.2%).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('m_election_api__position')
+                field: id
+      - name: party_names
+        description: >
+          BallotReady party names as a JSON string (["Republican"]); the
+          Airflow loader ships it into a text[] column. Null when the feed
+          carries none.
+      - name: is_current
+        description: >
+          Whether the term window contains today (null-tolerant on open
+          ends). Null when both term dates are unknown.
+        tests:
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: next_election_date
+        description: >
+          Earliest upcoming election_stage election_date on the same BR
+          position. Powers "Next election" in the profile About Office
+          section.
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "end_at >= start_at"
+          name: office_holder_term_dates_ordered

--- a/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
@@ -1,0 +1,92 @@
+-- Office terms for public /people profiles (election-api "OfficeHolder" table).
+-- Grain: one row per BallotReady office-holder term (id =
+-- gp_elected_official_term_id). person_id is NOT NULL in the API, so the mart
+-- inner-joins m_election_api__person: vacancies and no-name people drop here
+-- rather than failing the FK at load time.
+with
+    terms as (
+        select * from {{ ref("elected_official_terms") }} where gp_person_id is not null
+    ),
+
+    persons as (select id from {{ ref("m_election_api__person") }}),
+
+    positions as (select id, br_database_id from {{ ref("m_election_api__position") }}),
+
+    -- Term fields the civics mart doesn't carry; staging is unique per
+    -- br_office_holder_id.
+    office_holder_source as (
+        select
+            br_office_holder_id,
+            -- the S3 feed uses '' (not null) for absent values on these
+            nullif(office_title, '') as office_title,
+            nullif(term_date_specificity, '') as term_date_specificity,
+            number_of_seats,
+            nullif(sub_area_name, '') as sub_area_name,
+            nullif(sub_area_value, '') as sub_area_value,
+            nullif(mtfcc, '') as mtfcc,
+            -- JSON string (not a native array): the Airflow loader reads over
+            -- databricks-sql-connector, which does not round-trip complex types.
+            case when size(party_names) > 0 then to_json(party_names) end as party_names
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+    ),
+
+    -- Earliest upcoming election on the same BR position: "next election" for
+    -- the seat in the profile's About Office section.
+    next_elections as (
+        select br_position_id, min(election_date) as next_election_date
+        from {{ ref("election_stage") }}
+        where election_date >= current_date()
+        group by br_position_id
+    )
+
+select
+    terms.gp_elected_official_term_id as id,
+    terms.br_office_holder_id,
+    terms.position_name,
+    terms.normalized_position_name,
+    office_holder_source.office_title,
+    office_holder_source.party_names,
+    terms.term_start_date as start_at,
+    terms.term_end_date as end_at,
+    office_holder_source.term_date_specificity,
+    case
+        when terms.term_end_date < current_date()
+        then false
+        when terms.term_start_date > current_date()
+        then false
+        when terms.term_start_date is null and terms.term_end_date is null
+        then cast(null as boolean)
+        else true
+    end as is_current,
+    terms.is_appointed,
+    terms.is_vacant,
+    office_holder_source.number_of_seats,
+    next_elections.next_election_date,
+    terms.mailing_address_line_1,
+    terms.mailing_address_line_2,
+    terms.mailing_city,
+    terms.mailing_state,
+    terms.mailing_zip,
+    terms.office_phone,
+    terms.email as office_email,
+    terms.website_url,
+    terms.linkedin_url,
+    terms.facebook_url,
+    terms.twitter_url,
+    get(
+        filter(terms.urls, x -> x.type = 'instagram' and x.url is not null), 0
+    ).url as instagram_url,
+    office_holder_source.sub_area_name,
+    office_holder_source.sub_area_value,
+    terms.state,
+    terms.br_geo_id as geo_id,
+    office_holder_source.mtfcc,
+    terms.gp_person_id as person_id,
+    positions.id as position_id
+from terms
+inner join persons on terms.gp_person_id = persons.id
+left join
+    office_holder_source
+    on terms.br_office_holder_id = office_holder_source.br_office_holder_id
+left join positions on terms.br_position_id = positions.br_database_id
+left join next_elections on terms.br_position_id = next_elections.br_position_id

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -1,0 +1,103 @@
+-- Person spine for public /people profiles (election-api "Person" table).
+-- Grain: one row per canonical person (id = gp_person_id, the id space
+-- Candidacy.gp_candidate_id already publishes). Scoped to people with a
+-- candidacy or office term and at least one name part (slug is NOT NULL in
+-- the API). BallotReady-rich fields come from int__ballotready_person via the
+-- unambiguous br_person_id; GP-native people keep them null.
+with
+    public_people as (
+        select *
+        from {{ ref("people") }}
+        where
+            (is_candidate or is_elected_official)
+            and (first_name is not null or last_name is not null)
+    ),
+
+    br_person as (
+        select
+            database_id,
+            bio_text,
+            middle_name,
+            nickname,
+            suffix,
+            full_name,
+            get(
+                filter(images, x -> x.type = 'default' and x.url is not null), 0
+            ).url as headshot_url,
+            get(
+                filter(urls, x -> x.type = 'website' and x.url is not null), 0
+            ).url as website_url,
+            get(
+                filter(urls, x -> x.type = 'linkedin' and x.url is not null), 0
+            ).url as linkedin_url,
+            get(
+                filter(urls, x -> x.type = 'facebook' and x.url is not null), 0
+            ).url as facebook_url,
+            get(
+                filter(urls, x -> x.type = 'twitter' and x.url is not null), 0
+            ).url as twitter_url,
+            get(
+                filter(urls, x -> x.type = 'instagram' and x.url is not null), 0
+            ).url as instagram_url,
+            -- JSON strings (not native arrays): the Airflow loader reads over
+            -- databricks-sql-connector, which does not round-trip complex types.
+            case
+                when size(degrees) > 0
+                then
+                    to_json(
+                        transform(
+                            degrees,
+                            d -> struct(
+                                d.degree as degree,
+                                d.major as major,
+                                d.school as school,
+                                d.gradyear as `gradYear`
+                            )
+                        )
+                    )
+            end as degrees,
+            case
+                when size(experiences) > 0
+                then
+                    to_json(
+                        transform(
+                            experiences,
+                            e -> struct(
+                                e.title as title,
+                                e.organization as organization,
+                                e.start as start,
+                                e.end as end,
+                                e.type as type
+                            )
+                        )
+                    )
+            end as experiences
+        from {{ ref("int__ballotready_person") }}
+    )
+
+select
+    people.gp_person_id as id,
+    cast(people.br_person_id as int) as br_person_id,
+    {{ slugify("concat_ws('-', people.first_name, people.last_name)") }} as slug,
+    people.first_name,
+    br_person.middle_name,
+    people.last_name,
+    br_person.nickname,
+    br_person.suffix,
+    coalesce(
+        br_person.full_name, trim(concat_ws(' ', people.first_name, people.last_name))
+    ) as full_name,
+    br_person.bio_text,
+    br_person.headshot_url,
+    br_person.website_url,
+    br_person.linkedin_url,
+    br_person.facebook_url,
+    br_person.twitter_url,
+    br_person.instagram_url,
+    people.email,
+    people.phone,
+    br_person.degrees,
+    br_person.experiences,
+    people.state
+from public_people as people
+left join br_person on cast(people.br_person_id as int) = br_person.database_id

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -3,7 +3,13 @@
 -- Candidacy.gp_candidate_id already publishes). Scoped to people with a
 -- candidacy or office term and at least one name part (slug is NOT NULL in
 -- the API). BallotReady-rich fields come from int__ballotready_person via the
--- unambiguous br_person_id; GP-native people keep them null.
+-- unambiguous br_person_id, falling back to the office_holders_v3 feed:
+-- int__ballotready_person is fetched candidacy-first, so elected officials
+-- with no BR candidacy (~220k people, 44% of this mart) are absent from it,
+-- while the office feed carries their name parts and links. bio/headshot/
+-- degrees/experiences exist only on the API person object and stay null for
+-- them until that model also fetches office-holder ids. GP-native people
+-- keep all BR fields null.
 with
     public_people as (
         select *
@@ -73,6 +79,30 @@ with
                     )
             end as experiences
         from {{ ref("int__ballotready_person") }}
+    ),
+
+    -- Fallback person fields from the office feed, one row per BR person
+    -- (latest term wins). The feed uses '' (not null) for absent name parts.
+    office_holder_person as (
+        select
+            br_candidate_id,
+            nullif(middle_name, '') as middle_name,
+            nullif(nickname, '') as nickname,
+            nullif(suffix, '') as suffix,
+            website_url,
+            linkedin_url,
+            facebook_url,
+            twitter_url,
+            get(
+                filter(urls, x -> x.type = 'instagram' and x.url is not null), 0
+            ).url as instagram_url
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+        where br_candidate_id is not null
+        qualify
+            row_number() over (
+                partition by br_candidate_id order by office_holder_updated_at desc
+            )
+            = 1
     )
 
 select
@@ -80,20 +110,20 @@ select
     cast(people.br_person_id as int) as br_person_id,
     {{ slugify("concat_ws('-', people.first_name, people.last_name)") }} as slug,
     people.first_name,
-    br_person.middle_name,
+    coalesce(br_person.middle_name, office_holder.middle_name) as middle_name,
     people.last_name,
-    br_person.nickname,
-    br_person.suffix,
+    coalesce(br_person.nickname, office_holder.nickname) as nickname,
+    coalesce(br_person.suffix, office_holder.suffix) as suffix,
     coalesce(
         br_person.full_name, trim(concat_ws(' ', people.first_name, people.last_name))
     ) as full_name,
     br_person.bio_text,
     br_person.headshot_url,
-    br_person.website_url,
-    br_person.linkedin_url,
-    br_person.facebook_url,
-    br_person.twitter_url,
-    br_person.instagram_url,
+    coalesce(br_person.website_url, office_holder.website_url) as website_url,
+    coalesce(br_person.linkedin_url, office_holder.linkedin_url) as linkedin_url,
+    coalesce(br_person.facebook_url, office_holder.facebook_url) as facebook_url,
+    coalesce(br_person.twitter_url, office_holder.twitter_url) as twitter_url,
+    coalesce(br_person.instagram_url, office_holder.instagram_url) as instagram_url,
     people.email,
     people.phone,
     br_person.degrees,
@@ -101,3 +131,6 @@ select
     people.state
 from public_people as people
 left join br_person on cast(people.br_person_id as int) = br_person.database_id
+left join
+    office_holder_person as office_holder
+    on cast(people.br_person_id as int) = office_holder.br_candidate_id

--- a/dbt/project/models/marts/election_api/m_election_api__position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__position.sql
@@ -171,8 +171,15 @@ select
     all_positions.created_at,
     all_positions.updated_at,
     icp.icp_office_win as is_win_icp,
-    icp.icp_office_serve as is_serve_icp
+    icp.icp_office_serve as is_serve_icp,
+    -- Office compensation (free text: BR values include ranges/notes). Powers
+    -- the profile About Office salary row for sitting officials with no
+    -- active candidacy.
+    api_position.salary
 from all_positions
 left join
     {{ ref("int__icp_offices") }} as icp
     on all_positions.br_database_id = icp.br_database_position_id
+left join
+    {{ ref("stg_airbyte_source__ballotready_api_position") }} as api_position
+    on all_positions.br_database_id = api_position.database_id

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -37,33 +37,37 @@ CANDIDACY_UPSERT_QUERY = """
         email,
         website_url,
         is_incumbent,
-        race_id
+        race_id,
+        person_id
     )
     SELECT
-        id::uuid,
-        created_at,
-        updated_at,
-        br_database_id,
-        slug,
-        first_name,
-        last_name,
-        party,
-        place_name,
-        state,
-        image,
-        about,
-        urls,
-        election_frequency,
-        salary,
-        normalized_position_name,
-        position_name,
-        position_description,
-        gp_candidate_id::uuid,
-        email,
-        website_url,
-        is_incumbent,
-        race_id::uuid
-    FROM {staging_schema}."Candidacy"
+        stg.id::uuid,
+        stg.created_at,
+        stg.updated_at,
+        stg.br_database_id,
+        stg.slug,
+        stg.first_name,
+        stg.last_name,
+        stg.party,
+        stg.place_name,
+        stg.state,
+        stg.image,
+        stg.about,
+        stg.urls,
+        stg.election_frequency,
+        stg.salary,
+        stg.normalized_position_name,
+        stg.position_name,
+        stg.position_description,
+        stg.gp_candidate_id::uuid,
+        stg.email,
+        stg.website_url,
+        stg.is_incumbent,
+        stg.race_id::uuid,
+        person.id
+    FROM {staging_schema}."Candidacy" AS stg
+    LEFT JOIN {db_schema}."Person" AS person
+        ON person.id = stg.gp_candidate_id::uuid
     ON CONFLICT (id) DO UPDATE SET
         created_at = EXCLUDED.created_at,
         updated_at = EXCLUDED.updated_at,
@@ -86,7 +90,8 @@ CANDIDACY_UPSERT_QUERY = """
         email = EXCLUDED.email,
         website_url = EXCLUDED.website_url,
         is_incumbent = EXCLUDED.is_incumbent,
-        race_id = EXCLUDED.race_id
+        race_id = EXCLUDED.race_id,
+        person_id = EXCLUDED.person_id
 """
 
 DISTRICT_UPSERT_QUERY = """
@@ -133,7 +138,8 @@ POSITION_UPSERT_QUERY = """
         level,
         district_id,
         is_win_icp,
-        is_serve_icp
+        is_serve_icp,
+        salary
     )
     SELECT
         id::uuid,
@@ -144,7 +150,8 @@ POSITION_UPSERT_QUERY = """
         level::\"PositionLevel\",
         district_id::uuid,
         is_win_icp,
-        is_serve_icp
+        is_serve_icp,
+        salary
     FROM {staging_schema}."Position"
     ON CONFLICT (id) DO UPDATE SET
         br_database_id = EXCLUDED.br_database_id,
@@ -154,7 +161,8 @@ POSITION_UPSERT_QUERY = """
         level = EXCLUDED.level,
         district_id = EXCLUDED.district_id,
         is_win_icp = EXCLUDED.is_win_icp,
-        is_serve_icp = EXCLUDED.is_serve_icp
+        is_serve_icp = EXCLUDED.is_serve_icp,
+        salary = EXCLUDED.salary
 """
 ISSUE_UPSERT_QUERY = """
     INSERT INTO {db_schema}."Issue" (
@@ -665,6 +673,26 @@ def model(dbt, session: SparkSession) -> DataFrame:
     # now drop the candidacy's that have no race or it's now null
     _execute_sql_query(
         f'DELETE FROM {db_schema}."Candidacy" WHERE race_id not in (select id from {db_schema}."Race") or race_id is null',
+        db_host,
+        db_port,
+        db_user,
+        db_pw,
+        db_name,
+    )
+
+    # Heal person links: the upsert only touches rows the incremental filter
+    # selects, and its guarded join can only link people already synced to
+    # "Person" (delivered separately by the sync_election_api Airflow DAG).
+    # Backfill any candidacy whose person has since arrived.
+    _execute_sql_query(
+        f"""
+        UPDATE {db_schema}."Candidacy" AS c
+        SET person_id = c.gp_candidate_id::uuid
+        FROM {db_schema}."Person" AS p
+        WHERE c.person_id IS NULL
+          AND c.gp_candidate_id IS NOT NULL
+          AND p.id = c.gp_candidate_id::uuid
+        """,
         db_host,
         db_port,
         db_user,


### PR DESCRIPTION
## Summary

Populates the election-api Person spine added by omni PR thegoodparty/omni#696 (`Person`, `OfficeHolder`, `Candidacy.person_id`, `Position.salary`) from the civics mart, and syncs the new tables through the `sync_election_api` Airflow DAG.

## dbt

- **m_election_api__person** (new): one row per canonical person (`id` = `gp_person_id`, the id space `m_election_api__candidacy.gp_candidate_id` already publishes). Spine = civics `people` scoped to candidates/officials with at least one name part (the API `slug` column is NOT NULL). BallotReady-rich fields (bio, nickname, suffix, headshot, typed links, degrees, experiences) attach via the group's unambiguous `br_person_id`, falling back to the office_holders_v3 feed for name parts and links: `int__ballotready_person` is fetched candidacy-first, so ~220k officials with no BR candidacy (44% of the mart) are absent from it. The fallback lifts website coverage 33.5k -> 253.5k, linkedin 47k -> 78k, facebook 49k -> 65k. bio/headshot/degrees/experiences exist only on the BR API person object and stay null for office-only people; extending `int__ballotready_person` to also fetch office-holder ids (~2.2k one-time batched API calls) is a follow-up. GP-native people keep all BR fields null. `degrees`/`experiences` are emitted as JSON strings because the Airflow loader reads over databricks-sql-connector, which does not round-trip complex types. 507k rows in dev; covers 41,158/41,178 candidacy persons (the 20 known misses are pinned by a warn-severity relationships test).
- **m_election_api__office_holder** (new): one row per BR office-holder term (`id` = `gp_elected_official_term_id`) from `elected_official_terms`, plus term fields the civics mart doesn't carry (specificity, seats, sub-area, mtfcc, party_names, office_title) from the office_holders_v3 staging model. Inner-joins the person mart so the required `person_id` FK always validates; `position_id` resolves through `m_election_api__position` (99.8% coverage); derives `is_current` and `next_election_date` (earliest upcoming election_stage on the position). 524k rows in dev.
- **m_election_api__position**: adds `salary` from the BR API position feed (~64k positions). The mart is incremental with default `on_schema_change`, so the prod job needs a one-time `--full-refresh` of this model to add the column.
- **write__election_api_db**: the Candidacy upsert populates `person_id` via a guarded LEFT JOIN on the live `Person` table (a missing person can never fail the load), and a post-load heal backfills `person_id` on rows the incremental filter skips once their person arrives. The Position upsert carries `salary`.

## Airflow

- `sync_election_api` is refactored onto a declarative `SyncTableConfig` + task-group factory; the four existing tables become config declarations and keep their exact task ids, gates, and partitioning.
- Person and OfficeHolder cannot rename-swap independently: FK constraints bind to the referenced table's OID, so an FK pointing at a swapped table would follow the renamed-aside `_old` copy. The new `person_spine` group stages both tables and builds the staged `OfficeHolder_new.person_id` FK against `staging."Person_new"` (after the staged Person PK exists — cross-group dependency), loading in FK order. The constraint rides the atomic swap of both tables in one transaction and comes out pointing at the fresh `Person`, having validated the two staged loads against each other exactly. Positions the API doesn't know yet are nulled before the position FK builds, matching its ON DELETE SET NULL semantics.
- Only `Candidacy_person_id_fkey` (owned by a table outside the swap group) is rewired: dropped before the renames, orphan `person_id`s nulled (its SET NULL semantics), re-created after — all inside the same transaction. Leftover `_old` pre-drops and `drop_old` run child-first so the FK between old copies never wedges a run.
- `FakePostgres` now models an FK dependency graph (references follow renames/schema moves as OIDs do; a tracked reference blocks DROP TABLE) and the grouped swap is covered by happy-path, FK-follows-the-swap, leftover-`_old` recovery, child-first drop ordering, and all-27-crash-point rollback tests.

## Verification

- `dbt build` of the three marts in dev: 33 tests pass, 1 expected warn (the 20 documented candidacy-person misses).
- dbt-side writer contract tests: 54 pass.
- Airflow suite: 96 pass; DAG parses under the real Airflow SDK with the intended task graph.
- Dev RDS checked via psql: both Person migrations applied 2026-07-10; live DDL matches the specs/DDL here.

## Deploy notes

- Prod dbt job needs a one-time `dbt run --select m_election_api__position --full-refresh` for the salary column.
- The `person_spine` group needs the `20260708163759_add_person_officeholder` migration on the target Postgres (already applied to dev).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large change to production Postgres sync (atomic multi-table swap, Candidacy FK rewiring) and election-api core identity tables (~500k+ rows); incorrect ordering or DDL could wedge swaps or break referential integrity until rollback/heal.
> 
> **Overview**
> Adds **Person** and **OfficeHolder** election-api delivery end-to-end: new dbt marts, Airflow sync (including a FK-safe grouped swap), and legacy writer updates so **Candidacy** links to **Person**.
> 
> **dbt:** New `m_election_api__person` and `m_election_api__office_holder` marts back public profile spines (`gp_person_id` / term ids, BallotReady enrichments, JSON for complex fields the Databricks reader can’t round-trip). `m_election_api__position` gains **`salary`** from the BR API feed. Schema/tests document candidacy→person coverage and office-holder grain.
> 
> **Airflow:** `sync_election_api` is refactored to declarative **`SyncTableConfig`** + `_staged_load` / `_sync_table_group` factories (existing four tables unchanged in behavior). **`swap_group_staging_into_target`** swaps multiple tables in one transaction with optional pre/post DDL. The **`person_spine`** group loads Person then OfficeHolder (staged `person_id` FK → `Person_new`), swaps both atomically, drops **`Candidacy_person_id_fkey`** before renames, nulls orphan candidacies, and re-adds the FK; **`drop_old`** is child-first.
> 
> **Legacy writer:** Candidacy upsert sets **`person_id`** via guarded join to live Person plus a post-load heal; Position upsert carries **`salary`**.
> 
> **Tests:** Extended `FakePostgres` FK graph and person-spine swap crash/recovery coverage; unit tests for transforms, quality gates, and DDL pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977a18c852454a69720edabec2e6087d9c5f5301. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
