### PR TITLE
[DATA-2069] Expose amplitude catalog + taxonomy through mart_analytics

### DIFF
--- a/dbt/project/models/marts/analytics/amplitude_event_catalog.sql
+++ b/dbt/project/models/marts/analytics/amplitude_event_catalog.sql
@@ -1,7 +1,4 @@
 {{ config(materialized="view") }}
 
--- Exposure of int__amplitude_event_catalog into mart_analytics so governance
--- consumers read the mart (grants live at the mart schema, not per relation).
--- Thin view over an already-materialized table; no storage duplication.
 select *
 from {{ ref("int__amplitude_event_catalog") }}

--- a/dbt/project/models/marts/analytics/amplitude_event_catalog.sql
+++ b/dbt/project/models/marts/analytics/amplitude_event_catalog.sql
@@ -1,0 +1,7 @@
+{{ config(materialized="view") }}
+
+-- Exposure of int__amplitude_event_catalog into mart_analytics so governance
+-- consumers read the mart (grants live at the mart schema, not per relation).
+-- Thin view over an already-materialized table; no storage duplication.
+select *
+from {{ ref("int__amplitude_event_catalog") }}

--- a/dbt/project/models/marts/analytics/amplitude_taxonomy_event_type.sql
+++ b/dbt/project/models/marts/analytics/amplitude_taxonomy_event_type.sql
@@ -1,7 +1,4 @@
 {{ config(materialized="view") }}
 
--- Exposure of stg_airbyte_source__amplitude_taxonomy_event_type (the Amplitude
--- Govern declared event universe, ~434 events) into mart_analytics so governance
--- consumers read the mart. Thin 1:1 view; no storage duplication.
 select *
 from {{ ref("stg_airbyte_source__amplitude_taxonomy_event_type") }}

--- a/dbt/project/models/marts/analytics/amplitude_taxonomy_event_type.sql
+++ b/dbt/project/models/marts/analytics/amplitude_taxonomy_event_type.sql
@@ -1,0 +1,7 @@
+{{ config(materialized="view") }}
+
+-- Exposure of stg_airbyte_source__amplitude_taxonomy_event_type (the Amplitude
+-- Govern declared event universe, ~434 events) into mart_analytics so governance
+-- consumers read the mart. Thin 1:1 view; no storage duplication.
+select *
+from {{ ref("stg_airbyte_source__amplitude_taxonomy_event_type") }}

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1532,6 +1532,38 @@ models:
         data_tests:
           - not_null
 
+  - name: amplitude_event_catalog
+    description: >
+      Passthrough exposure of int__amplitude_event_catalog into mart_analytics
+      so governance consumers read the mart, not the intermediate layer. View
+      materialization, no transformations. The event_type-grain catalog: firing
+      volume, recency, and Govern metadata, with family / is_win from the
+      amplitude_event_taxonomy macros. Columns documented at the upstream int
+      model.
+
+      Source: int__amplitude_event_catalog.
+    columns:
+      - name: event_type
+        description: Amplitude event name (grain of this model).
+        data_tests:
+          - not_null
+          - unique
+
+  - name: amplitude_taxonomy_event_type
+    description: >
+      Passthrough exposure of stg_airbyte_source__amplitude_taxonomy_event_type
+      into mart_analytics so governance consumers read the mart, not the staging
+      layer. View materialization, no transformations. The Amplitude Govern
+      declared event universe (~434 events, all active), synced from Amplitude
+      via Airbyte. Columns documented at the upstream staging model.
+
+      Source: stg_airbyte_source__amplitude_taxonomy_event_type.
+    columns:
+      - name: event_type
+        description: Amplitude event name from the Govern taxonomy.
+        data_tests:
+          - not_null
+
   - name: hubspot_contacts
     description: >
       Passthrough exposure of stg_airbyte_source__hubspot_api_contacts


### PR DESCRIPTION
## What

Exposes the two remaining Amplitude relations the governance loop reads through `mart_analytics`, so every reader hits the mart and access can be granted at the mart schema instead of on individual dbt relations.

- `amplitude_event_catalog` — view over `int__amplitude_event_catalog`
- `amplitude_taxonomy_event_type` — view over `stg_airbyte_source__amplitude_taxonomy_event_type`

The event stream is already exposed via the existing `amplitude_events` view, so no third model is needed.

## Why

The analytics governance loop (the event-health monitor and the event-provenance backfill) reads three relations: the event catalog, the event stream, and the Govern taxonomy. Its service principal had been granted `SELECT` on each individual relation. Per-relation grants break when a model is rebuilt or reconfigured, and they blur the line between what Terraform owns (access) and what dbt owns (models).

Routing the reads through the mart lets the service principal join the existing `mart_analytics` reader group and inherit `SELECT` on the whole schema, so nothing is granted per relation and rebuilds cannot break access. Both models are thin views (no storage duplication), matching the existing `amplitude_events` and `hubspot_contacts` mart exposures.

## Validation

`dbt build --select "amplitude_event_catalog amplitude_taxonomy_event_type"`: both views created, 3 tests passed (not_null on `event_type` for both; unique on the catalog). The taxonomy model omits a `unique` test because the upstream staging table is an Airbyte passthrough whose event_type-grain uniqueness is not guaranteed, and the backfill already selects distinct.

## Pairs with

- omni: repoints the monitor and backfill at `mart_analytics.*`.
- gp-terraform-dataplatform: adds the service principal to the `mart_analytics` reader group and drops the per-relation grants.
