### PR TITLE
Add 10DLC Segment staging models and amplitude_api_events passthrough (+ election-api race CI guards)

### DIFF
--- a/dbt/project/models/marts/analytics/amplitude_api_events.sql
+++ b/dbt/project/models/marts/analytics/amplitude_api_events.sql
@@ -1,0 +1,4 @@
+{{ config(materialized="view") }}
+
+select *
+from {{ ref("stg_airbyte_source__amplitude_api_events") }}

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1484,6 +1484,23 @@ models:
                 to: ref('stg_airbyte_source__hubspot_api_contacts')
                 field: id
 
+  - name: amplitude_api_events
+    description: >
+      Passthrough exposure of stg_airbyte_source__amplitude_api_events into
+      mart_analytics so consumers read the mart, not the staging layer. View
+      materialization, no transformations — the raw Amplitude event stream
+      without the taxonomy-derived family / is_win / is_recurrent columns
+      (those live on amplitude_events). Columns documented at the upstream
+      staging model.
+
+      Source: stg_airbyte_source__amplitude_api_events.
+    columns:
+      - name: uuid
+        description: Unique identifier for the event (primary key).
+        data_tests:
+          - not_null
+          - unique
+
   - name: amplitude_events
     description: >
       Exposure of stg_airbyte_source__amplitude_api_events into

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -113,7 +113,8 @@ select
     -- '-ccd' strip on the position part preserves the previous derivation,
     -- which stripped it from the whole concatenated slug.
     -- Fall back to position_names when normalized_position_name is absent so
-    -- the race still gets a routable slug rather than a null.
+    -- the race still gets a routable slug rather than a null. position_names is
+    -- an array; element_at(.., 1) is its first entry (Databricks is 1-indexed).
     concat(
         tbl_place.slug,
         '/',

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -112,12 +112,14 @@ select
     -- always extends the place slug election-api actually serves. The
     -- '-ccd' strip on the position part preserves the previous derivation,
     -- which stripped it from the whole concatenated slug.
-    -- Fall back to position_names when normalized_position_name is absent so
-    -- the race still gets a routable slug rather than a null. position_names is
-    -- an array; element_at(.., 1) is its first entry (Databricks is 1-indexed).
-    concat(
-        tbl_place.slug,
+    -- Fall back to position_names when normalized_position_name is absent, and
+    -- use concat_ws so a fully missing position (both null) degrades to just the
+    -- place slug instead of nulling the whole value (concat returns null on any
+    -- null arg). position_names is an array; element_at(.., 1) is its first
+    -- entry (Databricks is 1-indexed).
+    concat_ws(
         '/',
+        tbl_place.slug,
         replace(
             {{
                 slugify(

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -45,13 +45,15 @@ with
     -- past elections fall well outside this mart's date window (a 2-month
     -- grace period at the oldest), so win_number is null for every row this
     -- mart emits, and consumers fall back
-    -- to a computed estimate. Aggregate with any non-null value; downstream Race
+    -- to a computed estimate. Aggregate with any valid value; downstream Race
     -- rows that share a gp_election_id (i.e. multiple BR race stages for the
-    -- same election cycle) will all carry the same values.
+    -- same election cycle) will all carry the same values. Drop non-positive
+    -- win_number sentinels (e.g. -1) an archive candidacy can attach to an
+    -- in-window race after id re-keying; a sub-1 "votes to win" is never real.
     civics_race_attrs as (
         select
             gp_election_id,
-            max(win_number) as win_number,
+            max(case when win_number >= 1 then win_number end) as win_number,
             bool_or(is_partisan) as is_partisan,
             max(office_type) as office_type,
             max(official_office_name) as official_office_name,
@@ -110,10 +112,20 @@ select
     -- always extends the place slug election-api actually serves. The
     -- '-ccd' strip on the position part preserves the previous derivation,
     -- which stripped it from the whole concatenated slug.
+    -- Fall back to position_names when normalized_position_name is absent so
+    -- the race still gets a routable slug rather than a null.
     concat(
         tbl_place.slug,
         '/',
-        replace({{ slugify("tbl_race.normalized_position_name") }}, '-ccd', '')
+        replace(
+            {{
+                slugify(
+                    "coalesce(tbl_race.normalized_position_name, element_at(tbl_race.position_names, 1))"
+                )
+            }},
+            '-ccd',
+            ''
+        )
     ) as slug,
     tbl_race.position_names,
     tbl_position.id as position_id,

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -1255,6 +1255,8 @@ sources:
         description: Segment user profiles with traits and properties
       - name: voter_outreach_10dlc_compliance_completed
         description: Segment event fired when 10DLC compliance is completed
+      - name: voter_outreach_10dlc_compliance_pin_submitted
+        description: Segment event fired when a user submits their 10DLC compliance PIN
 
   - name: segment_storage_source_web_app
     database: segment_storage
@@ -1262,6 +1264,8 @@ sources:
     description: Event data from Segment's web app source synced to dedicated catalog
 
     tables:
+      - name: _10_dlc_compliance_pin_verification_completed
+        description: Segment web app event - 10 dlc compliance pin verification completed
       - name: _10_dlc_compliance_registration_submitted
         description: Segment web app event -  10 dlc compliance registration submitted
       - name: account_password_reset_completed

--- a/dbt/project/models/staging/segment_storage_source/gp_api/stg_segment_storage_source__gp_api.yaml
+++ b/dbt/project/models/staging/segment_storage_source/gp_api/stg_segment_storage_source__gp_api.yaml
@@ -89,3 +89,31 @@ models:
         description: Timestamp when Segment received the event
         data_tests:
           - not_null
+
+  - name: stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_pin_submitted
+    description: Segment event fired when a user submits their 10DLC compliance PIN
+    columns:
+      - name: id
+        description: Unique identifier for the event
+        data_tests:
+          - not_null
+          - unique
+      - name: event
+        description: Name of the tracked event, always voter_outreach_10dlc_compliance_pin_submitted
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["voter_outreach_10dlc_compliance_pin_submitted"]
+      - name: user_id
+        description: Segment user ID associated with the event
+        data_tests:
+          - not_null
+      - name: timestamp
+        description: Timestamp when the event occurred
+        data_tests:
+          - not_null
+      - name: received_at
+        description: Timestamp when Segment received the event
+        data_tests:
+          - not_null

--- a/dbt/project/models/staging/segment_storage_source/gp_api/stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_pin_submitted.sql
+++ b/dbt/project/models/staging/segment_storage_source/gp_api/stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_pin_submitted.sql
@@ -1,0 +1,8 @@
+select *
+from
+    {{
+        source(
+            "segment_storage_source",
+            "voter_outreach_10dlc_compliance_pin_submitted",
+        )
+    }}

--- a/dbt/project/models/staging/segment_storage_source/web_app/stg_segment_storage_source__web_app.yaml
+++ b/dbt/project/models/staging/segment_storage_source/web_app/stg_segment_storage_source__web_app.yaml
@@ -86,3 +86,31 @@ models:
         description: Timestamp when Segment received the event
         data_tests:
           - not_null
+
+  - name: stg_segment_storage_source__web_app__10_dlc_compliance_pin_verification_completed
+    description: Segment web app event fired when 10DLC compliance PIN verification completes
+    columns:
+      - name: id
+        description: Unique identifier for the event
+        data_tests:
+          - not_null
+          - unique
+      - name: event
+        description: Name of the tracked event, always 10_dlc_compliance_pin_verification_completed
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["10_dlc_compliance_pin_verification_completed"]
+      - name: user_id
+        description: Segment user ID associated with the event
+        data_tests:
+          - not_null
+      - name: timestamp
+        description: Timestamp when the event occurred
+        data_tests:
+          - not_null
+      - name: received_at
+        description: Timestamp when Segment received the event
+        data_tests:
+          - not_null

--- a/dbt/project/models/staging/segment_storage_source/web_app/stg_segment_storage_source__web_app__10_dlc_compliance_pin_verification_completed.sql
+++ b/dbt/project/models/staging/segment_storage_source/web_app/stg_segment_storage_source__web_app__10_dlc_compliance_pin_verification_completed.sql
@@ -1,0 +1,8 @@
+select *
+from
+    {{
+        source(
+            "segment_storage_source_web_app",
+            "_10_dlc_compliance_pin_verification_completed",
+        )
+    }}


### PR DESCRIPTION
## Summary

Three additions to the dbt project, plus the CI guards needed to land them on current `main`.

### 1. Segment staging models (10DLC compliance)

Passthrough staging models for two Segment collections from the 10DLC compliance flow, with `__sources.yaml` entries:

| Model | Source collection | Schema | Rows |
|---|---|---|---|
| `stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_pin_submitted` | `voter_outreach_10dlc_compliance_pin_submitted` | `gp_api` | 162 |
| `stg_segment_storage_source__web_app__10_dlc_compliance_pin_verification_completed` | `_10_dlc_compliance_pin_verification_completed` | `web_app` | 51 |

Both are documented and tested in the per-source schema yamls (mirroring `peerly_identity_id_created`): `id` not_null + unique, `event` not_null + accepted_values, and `user_id` / `timestamp` / `received_at` not_null.

### 2. amplitude_api_events mart passthrough

`models/marts/analytics/amplitude_api_events.sql` — a thin view over `stg_airbyte_source__amplitude_api_events`, exposing the raw event stream through `mart_analytics` without the taxonomy-derived columns that `amplitude_events` adds. Documented + tested (`uuid` not_null + unique) in `m_analytics.yaml`, following the pattern from #609.

### 3. election-api race CI guards

Merging `main` (which brought in #539's candidacy re-key) caused the PR's fresh rebuild of `m_election_api__race` to trip two live-data checks unrelated to the work above. Both fixed in `m_election_api__race.sql`:

- **`win_number` accepted_range (`>= 1`)**: a `-1` sentinel from an archive candidacy now attaches to an in-window race after id re-keying. Aggregate only valid (`>= 1`) values so it drops to null — the model's documented in-window behavior, where consumers compute a fallback estimate.
- **`slug` not_null**: a race drifted in with a null `normalized_position_name`. Fall back to `position_names`, and build the slug with `concat_ws` so a fully-missing position degrades to a non-null place-only slug rather than nulling the whole value (`concat` returns null on any null arg). Race slug is not_null but not unique, and the place-slug prefix assertion still holds.

## Verification

`dbt build` on all touched models passes:
- Segment models: 16 nodes (2 views + 14 tests).
- `amplitude_api_events`: 3 nodes (1 view + 2 tests).
- `m_election_api__race`: 16 nodes, including the two previously-failing tests.

`inspect_data` confirms core columns are 100% populated and `id`/`uuid` grains are fully distinct.

## Not included

Two requested Segment events do not yet exist as tables in `segment_storage` (Segment materializes a collection only after it receives events and syncs), so no models were created for them:

- `voter_outreach_10dlc_compliance_candidate_profile_submitted` (Pro Upgrade - Candidate Profile Submitted)
- `voter_outreach_10dlc_compliance_filing_details_submitted` (Pro Upgrade - Filing Details Submitted)

`voter_outreach_10dlc_compliance_completed` was already modeled in `gp_api`, so it needed no change.

## Follow-up (not blocking)

The `m_election_api__race` data-quality tests are fragile to BallotReady source drift and will keep tripping fresh PR builds as new bad rows appear. Worth hardening upstream (`int__enhanced_race` position-name population and the candidacy `win_number` sentinel) rather than guarding at the mart each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
