### PR TITLE
[DATA-2119] Classify 2026 Serve events + Onboarding V2, add is_serve flag

### DIFF
--- a/dbt/project/macros/amplitude_event_taxonomy.sql
+++ b/dbt/project/macros/amplitude_event_taxonomy.sql
@@ -10,7 +10,8 @@
         and the win-analytics-knowledge skill's references/engagement.md.
 
         Win families are prefixed `win_`; the is_win flag downstream is derived
-        as `family like 'win_%'`. Anything unmatched falls through to 'other'
+        as `family like 'win_%'`. Serve is a single flat family, so is_serve is
+        derived as `family = 'serve'`. Anything unmatched falls through to 'other'
         so unclassified events surface for triage rather than silently dropping.
 
         Args:
@@ -24,6 +25,10 @@
         when
             {{ event_type_col }} like 'Onboarding -%'
             or {{ event_type_col }} like 'Onboarding:%'
+            -- 'Onboarding V2 -%' is the 2026-06 onboarding redesign (candidate
+            -- steps: ballot status, office, votes-needed, voter insights); the
+            -- 'V2' means it misses the 'Onboarding -%' pattern above.
+            or {{ event_type_col }} like 'Onboarding V2 -%'
             or {{ event_type_col }}
             in ('onboarding_complete', 'Invalid Party', 'Sign Up Clicked')
         then 'win_onboarding'
@@ -84,6 +89,15 @@
             or {{ event_type_col }} like 'Polls -%'
             or {{ event_type_col }} like 'Polls:%'
             or {{ event_type_col }} like 'Payment -%'
+            -- 2026-05/06 Serve generation. Briefing Assistant and Org Switcher
+            -- are live; Community Issues has no events in the stream yet, so its
+            -- pattern is speculative and classifies nothing until it ships.
+            -- Briefing Assistant includes server-emitted events (Agenda Created,
+            -- session_id = -1): family = serve is correct, but engagement
+            -- filtering of those stays with the consumer, not the family bucket.
+            or {{ event_type_col }} like 'Briefing Assistant -%'
+            or {{ event_type_col }} like 'Community Issues -%'
+            or {{ event_type_col }} like 'Org Switcher -%'
         then 'serve'
         when
             {{ event_type_col }} like 'Sign In:%'

--- a/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
@@ -531,6 +531,15 @@ models:
         data_tests:
           - not_null
 
+      - name: is_serve
+        description: >
+          True for Serve-product events (family = 'serve'). Serve is a single
+          flat family, hence the equality check rather than a prefix like is_win.
+          Superset of Serve user actions: some Serve events are server-emitted
+          (session_id = -1), so engagement filtering stays with the consumer.
+        data_tests:
+          - not_null
+
       - name: is_recurrent
         description: >
           True for recurrent-activity events (vs one-off lifecycle milestones).
@@ -604,3 +613,6 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "is_win or not is_recurrent"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "not (is_win and is_serve)"

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_event_catalog.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_event_catalog.sql
@@ -49,6 +49,7 @@ select
     s.event_type,
     {{ amplitude_event_family("s.event_type") }} as family,
     family like 'win_%' as is_win,
+    family = 'serve' as is_serve,
     {{ amplitude_event_is_recurrent("s.event_type") }} as is_recurrent,
     s.first_seen_date,
     s.last_seen_date,

--- a/dbt/project/models/marts/analytics/amplitude_events.sql
+++ b/dbt/project/models/marts/analytics/amplitude_events.sql
@@ -14,6 +14,7 @@ select
     *,
     {{ amplitude_event_family("event_type") }} as family,
     family like 'win_%' as is_win,
+    family = 'serve' as is_serve,
     -- null-safe: IN-list yields null (not false) on a null event_type
     coalesce({{ amplitude_event_is_recurrent("event_type") }}, false) as is_recurrent
 from {{ ref("stg_airbyte_source__amplitude_api_events") }}

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1575,6 +1575,13 @@ models:
           pattern. False, never null, when event_type is null.
         data_tests:
           - not_null
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "not (is_win and is_serve)"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_win or not is_recurrent"
 
   - name: amplitude_event_catalog
     description: >

--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1521,8 +1521,8 @@ models:
     description: >
       Exposure of stg_airbyte_source__amplitude_api_events into
       mart_analytics (Sigma reads marts only), enriched with the governed
-      event taxonomy: family, is_win, and is_recurrent derive from the
-      amplitude_event_taxonomy macros so BI consumers never re-derive
+      event taxonomy: family, is_win, is_serve, and is_recurrent derive from
+      the amplitude_event_taxonomy macros so BI consumers never re-derive
       serve/win classification from event_type strings. Passthrough columns
       are documented at the upstream staging model; the event_type-grain
       catalog (volume, recency, Govern metadata) is
@@ -1553,6 +1553,17 @@ models:
           'win_%'); false for serve / cross-product / noise. Event-level
           filter only — user-level "Win active" questions belong on
           users_win_activity / users_win_base, not on raw event counts.
+        data_tests:
+          - not_null
+
+      - name: is_serve
+        description: >
+          True for Serve-product events (family = 'serve'). Serve is a single
+          flat family, hence the equality check rather than a prefix like
+          is_win. Superset of Serve user actions: some Serve events are
+          server-emitted (session_id = -1), so engagement filtering stays with
+          the consumer. Event-level filter only — user-level "Serve active"
+          questions belong on users_serve_base, not on raw event counts.
         data_tests:
           - not_null
 


### PR DESCRIPTION
## What

Extends the `amplitude_event_family` macro to classify three event generations that were falling through to `family = 'other'`, and adds an `is_serve` flag to the event catalog and mart mirroring `is_win`.

Follow-up from DATA-2116 (Serve analytics skeleton, #608). Ticket: https://app.clickup.com/t/86ajj226a

## Changes

- **`Onboarding V2 -%` -> `win_onboarding`.** Verifying event names against the prod catalog before writing patterns showed the "new Serve Onboarding steps" named in the ticket are actually the 2026-06 **Win** onboarding redesign (steps: Ballot Status, Office, Party Designation, Pledge, Votes Needed Calculator, Voter Insights, Strategic Landscape, Campaign Manager). 35 event types, ~5.5k events/30d. The `V2` in the name means they missed the existing `Onboarding -%` pattern and sat in `other`. Classifying them `serve` would have corrupted the Win onboarding funnel.
- **`Briefing Assistant -%`, `Org Switcher -%` -> `serve`.** The live 2026-05/06 Serve generation (14 event types, ~1.3k/30d).
- **`Community Issues -%` -> `serve` (speculative).** Named in the ticket but not flowing to the warehouse yet; the pattern classifies nothing today and takes effect automatically once events land.
- **`is_serve` added** to `int__amplitude_event_catalog` and the `amplitude_events` mart, derived as `family = 'serve'`. Serve is a single flat family (unlike the `win_%` prefix), so it is an equality check. `is_serve` is a superset of Serve user actions: some `Briefing Assistant -%` events are server-emitted (`session_id = -1`, e.g. `Agenda Created`), so engagement filtering stays with the consumer, not the family bucket.
- **Tests:** `not_null` on `is_serve`, and a `not (is_win and is_serve)` mutual-exclusion invariant.

## Validation

Built and tested in dev (`private_tristan`): `dbt build` 28/28 pass, plus the macro-level guards `assert_milestone_events_classified` and `assert_recurrent_events_are_win`. Reclassification confirmed against the current event stream (35 -> win_onboarding, 14 -> serve, Community Issues 0).

## Downstream impact

- Win activity rollups and `int__amplitude_user_milestones` filter on `is_win` / `win_%`, so they are unaffected.
- This **does** shift family-level aggregates in Sigma (events leaving `other`) and changes `win_onboarding` funnel counts. The latter is the intended fix.

## Follow-up (separate PR, after this merges and prod refreshes)

Simplify `analytics/lib/serve_analysis.py` to source Serve membership from `is_serve` (demote the hardcoded prefix list, keep the server-emitted exclusion and the `Viewed` + path-prefix logic), and correct the `serve-analytics-knowledge/references/sources.md` two-generations note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reclassifies live event volume (Win onboarding funnel and `other` vs `serve` aggregates); logic is centralized in one macro with dbt tests, but dashboards comparing before/after will shift.
> 
> **Overview**
> Updates **`amplitude_event_family`** so events that were landing in **`other`** get the right product buckets: **`Onboarding V2 -%`** → **`win_onboarding`** (Win’s 2026 redesign, not Serve), and **`Briefing Assistant -%`**, **`Org Switcher -%`**, plus speculative **`Community Issues -%`** → **`serve`**. Macro comments document Serve server-emitted Briefing Assistant events and that engagement filtering stays downstream.
> 
> Adds **`is_serve`** (`family = 'serve'`) on **`int__amplitude_event_catalog`** and the **`amplitude_events`** mart, parallel to **`is_win`**, with **`not_null`** on **`is_serve`** and **`not (is_win and is_serve)`** in YAML.
> 
> **Downstream:** Win rollups that filter on **`is_win`** are unchanged; family-level reporting (e.g. Sigma) will show volume moving out of **`other`** and higher **`win_onboarding`** counts where V2 events were mis-bucketed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a71d2a576c2268a77e5d176026955b393ad6978. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->