### PR TITLE
Cover all uv projects in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/dbt"
-    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -29,9 +28,8 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/airflow"
-    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -87,9 +85,8 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/analytics"
-    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -116,9 +113,8 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/matcha"
-    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -145,9 +141,8 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/people-api-loader"
-    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -174,9 +169,8 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/apps/genie-tools"
-    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -203,9 +197,8 @@ updates:
         update-types:
           - "major"
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/apps/genie-slack-bot"
-    versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
       day: "sunday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,36 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/dbt"
+    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "18:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependabot"
+      - "security"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 2
+      semver-patch-days: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  - package-ecosystem: "pip"
+    directory: "/airflow"
     versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"
@@ -59,7 +88,123 @@ updates:
           - "major"
 
   - package-ecosystem: "pip"
-    directory: "/dbt"
+    directory: "/analytics"
+    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "18:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependabot"
+      - "security"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 2
+      semver-patch-days: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  - package-ecosystem: "pip"
+    directory: "/matcha"
+    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "18:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependabot"
+      - "security"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 2
+      semver-patch-days: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  - package-ecosystem: "pip"
+    directory: "/people-api-loader"
+    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "18:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependabot"
+      - "security"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 2
+      semver-patch-days: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  - package-ecosystem: "pip"
+    directory: "/apps/genie-tools"
+    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "18:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependabot"
+      - "security"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 2
+      semver-patch-days: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  - package-ecosystem: "pip"
+    directory: "/apps/genie-slack-bot"
     versioning-strategy: increase-if-necessary
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## What

Dependabot version-updates were only configured for `/dbt` and `/airflow/astro`, plus a root `directory: "/"` entry. Since the uv migration there is no Python manifest at the repo root, and `directory` is not recursive, so that root entry scanned nothing.

This replaces the dead root entry and adds the remaining uv projects, so every directory that ships a Python manifest (`pyproject.toml`/`uv.lock`, or `requirements.txt` for the Astro image) is tracked.

Directories now covered:
- `/dbt` (existing)
- `/airflow` (new)
- `/airflow/astro` (existing)
- `/analytics` (new)
- `/matcha` (new)
- `/people-api-loader` (new)
- `/apps/genie-tools` (new)
- `/apps/genie-slack-bot` (new)

Each entry keeps the existing settings unchanged (weekly schedule, `increase-if-necessary`, cooldown, minor/patch and major groups, 2 open-PR limit per directory). Kept as explicit per-directory blocks rather than YAML anchors or a `directories` list, since Dependabot's parser rejects unknown top-level keys and a shared PR limit would starve most directories.

## Why

The other uv projects currently get no automated dependency-update PRs. This is also related to a batch of stale security alerts that were just dismissed: they pointed at `dbt/poetry.lock` and `airflow/poetry.lock`, which were removed in the uv migration, while the current `uv.lock` files already carry the patched versions.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly (8 update entries, all `pip`).
- pre-commit `check yaml` hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)