### PR TITLE
Add p25/p95 prediction-interval columns to turnout projections

### DIFF
--- a/dbt/project/models/intermediate/int__model_prediction.yaml
+++ b/dbt/project/models/intermediate/int__model_prediction.yaml
@@ -28,6 +28,24 @@ models:
                   "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
                   "DC", "US",
                 ]
+      - name: ballots_projected_lower
+        description: >
+          Lower prediction bound (p25) on projected ballots, passed through from the
+          LightGBM model. NULL for legacy static feeds, which carry no interval.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: ballots_projected_upper
+        description: >
+          Upper prediction bound (p95) on projected ballots, passed through from the
+          LightGBM model. NULL for legacy static feeds, which carry no interval.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
     tests:
     - dbt_utils.unique_combination_of_columns:
         arguments:

--- a/dbt/project/models/intermediate/int__model_prediction_voter_turnout.sql
+++ b/dbt/project/models/intermediate/int__model_prediction_voter_turnout.sql
@@ -147,7 +147,9 @@ with
             election_year,
             election_code,
             model_version,
-            inference_at
+            inference_at,
+            ballots_projected_lower,
+            ballots_projected_upper
         from {{ ref("int__voter_turnout_lgbm_inference") }}
         qualify
             row_number() over (
@@ -158,20 +160,30 @@ with
             = 1
     ),
     legacy_union as (
-        select *
-        from odd_year_projections
-        union all
-        select *
-        from even_year_projections_pre_2026
-        union all
-        select *
-        from projections_2026_v2
-        union all
-        select *
-        from projections_2027
-        union all
-        select *
-        from projections_2028
+        -- Legacy static feeds carry no prediction interval; emit NULL bounds so the
+        -- column set and ordering match the lgbm projections for the position-based
+        -- union all below (appended last on both sides to keep positions aligned).
+        select
+            legacy_projections.*,
+            cast(null as double) as ballots_projected_lower,
+            cast(null as double) as ballots_projected_upper
+        from
+            (
+                select *
+                from odd_year_projections
+                union all
+                select *
+                from even_year_projections_pre_2026
+                union all
+                select *
+                from projections_2026_v2
+                union all
+                select *
+                from projections_2027
+                union all
+                select *
+                from projections_2028
+            ) as legacy_projections
     )
 
 -- The lgbm model owns every natural key it emits; legacy fills the rest

--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -146,6 +146,30 @@ models:
               arguments:
                 min_value: 0
                 inclusive: true
+      - name: ballots_projected_lower
+        description: >
+          Lower prediction bound (p25) on projected ballots. Applies the per-model
+          variance-stabilised residual model to the district's implied predicted rate
+          (see the turnout_prediction_intervals notebook):
+          round(clip(pred_rate + bias + q25*sqrt(p*(1-p)), 0, 1) * district_voters).
+          Always populated for this model (params are required at load).
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: ballots_projected_upper
+        description: >
+          Upper prediction bound (p95) on projected ballots, the risk-relevant band for
+          win-number planning (turnout coming in above projection). Same formula as
+          ballots_projected_lower with q95. Always >= ballots_projected_lower.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
       - name: model_version
         description: "model_family value (load-bearing - part of the election-api projected_turnout id)."
         tests:

--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -447,21 +447,31 @@ def _build_district_projection_sql(interval_params):
     """Pure: final district-level projection SQL, including p25 (lower) / p95 (upper)
     prediction-interval bounds.
 
-    interval_params maps model_slug -> {q25, q95, ...}. Bounds are the
+    interval_params maps model_slug -> {q25, q95, scaler, ...}. Bounds are the
     variance-stabilised residual model fit per slug in the turnout_prediction_intervals
     notebook (raw-standardized residual quantiles, no constant bias term). For each
     district we take the model's implied predicted rate,
     pred_rate = ballots_projected / district_voters, and apply
 
-        bound_rate  = clip(pred_rate + q * sqrt(pred_rate*(1-pred_rate)), 0, 1)
+        bound_rate  = clip(pred_rate + q * w(pred_rate), 0, 1)
         bound_votes = round(bound_rate * district_voters)
 
-    with q = q25 for the lower bound and q = q95 for the upper. q25 < 0 < q95 for every
-    model, so the point (q=0) always lies within [lower, upper] and both bounds collapse
-    toward the point as pred_rate -> 0/1. The residual model was fit on eligible-weighted
-    rates; inference uses the registered-voter denominator (district_voters =
-    SUM(n_voters), no eligibility gate) on the deliberate assumption that today's L2 is
-    the eligible-if-held-today universe (research decision).
+    with q = q25 for the lower bound and q = q95 for the upper, and w() a per-model
+    residual-spread scaler:
+      - 'binom'    -> sqrt(p*(1-p)): tapers to 0 at both 0% and 100% turnout.
+      - 'headroom' -> sqrt(1-p): tapers only near 100%, staying wide at low turnout.
+    The low-turnout local models (off_year_local_lag2, even_year_local) use 'headroom':
+    the binom shape collapses the band to ~0 at low turnout while the model's real error
+    there stays large and positive (small low-turnout jurisdictions surprise upward), so
+    binom badly under-covered the p95 upper bound (see the training runbook). 'headroom'
+    keeps the low-turnout band wide enough to cover that upside; the other three models
+    stay on 'binom'.
+
+    q25 < 0 < q95 for every model, so the point (q=0) always lies within [lower, upper].
+    The residual model was fit on eligible-weighted rates; inference uses the
+    registered-voter denominator (district_voters = SUM(n_voters), no eligibility gate) on
+    the deliberate assumption that today's L2 is the eligible-if-held-today universe
+    (research decision).
 
     A LEFT JOIN to the params means a slug with no params yields NULL bounds rather than
     dropping the ballots_projected row. Model routing guarantees (election_year,
@@ -469,23 +479,24 @@ def _build_district_projection_sql(interval_params):
     change ballots_projected or the natural-key grain."""
     if interval_params:
         values = ",\n                ".join(
-            f"('{slug}', {p['q25']!r}, {p['q95']!r})" for slug, p in sorted(interval_params.items())
+            f"('{slug}', {p['q25']!r}, {p['q95']!r}, '{p['scaler']}')"
+            for slug, p in sorted(interval_params.items())
         )
         params_cte = f"""_interval_params AS (
             SELECT * FROM (VALUES
                 {values}
-            ) AS t(model_slug, q_lower, q_upper)
+            ) AS t(model_slug, q_lower, q_upper, scaler)
         ),
         """
         join_sql = "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug"
-        lower_expr = (
-            "ROUND(LEAST(GREATEST(a.pred_rate + ip.q_lower * "
-            "SQRT(a.pred_rate * (1 - a.pred_rate)), 0), 1) * a.district_voters)"
+        # Per-model residual-spread scaler w(pred_rate): 'headroom' = sqrt(1-p) for the
+        # low-turnout local models, 'binom' = sqrt(p*(1-p)) otherwise.
+        w_expr = (
+            "(CASE WHEN ip.scaler = 'headroom' THEN SQRT(1 - a.pred_rate) "
+            "ELSE SQRT(a.pred_rate * (1 - a.pred_rate)) END)"
         )
-        upper_expr = (
-            "ROUND(LEAST(GREATEST(a.pred_rate + ip.q_upper * "
-            "SQRT(a.pred_rate * (1 - a.pred_rate)), 0), 1) * a.district_voters)"
-        )
+        lower_expr = f"ROUND(LEAST(GREATEST(a.pred_rate + ip.q_lower * {w_expr}, 0), 1) * a.district_voters)"
+        upper_expr = f"ROUND(LEAST(GREATEST(a.pred_rate + ip.q_upper * {w_expr}, 0), 1) * a.district_voters)"
     else:
         params_cte = ""
         join_sql = ""
@@ -671,6 +682,15 @@ def _read_interval_params_tag(model_version_tags, registered_model_name):
         raise ValueError(
             f"prediction_interval_params on {registered_model_name} is missing keys "
             f"{sorted(missing)}: {params}"
+        )
+    # Residual-spread scaler travels with the params so the shape stays locked to the fit.
+    # Default 'binom' (sqrt(p*(1-p))) when absent; the low-turnout local models set
+    # 'headroom' (sqrt(1-p)). Reject unknown values rather than silently mis-shape the band.
+    scaler = params.setdefault("scaler", "binom")
+    if scaler not in ("binom", "headroom"):
+        raise ValueError(
+            f"prediction_interval_params on {registered_model_name} has unknown scaler "
+            f"{scaler!r} (expected 'binom' or 'headroom')."
         )
     return params
 

--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -454,7 +454,7 @@ def _build_district_projection_sql(interval_params):
     pred_rate = ballots_projected / district_voters, and apply
 
         bound_rate  = clip(pred_rate + q * w(pred_rate), 0, 1)
-        bound_votes = round(bound_rate * district_voters)
+        bound_votes = greatest(round(bound_rate * district_voters), 3)
 
     with q = q25 for the lower bound and q = q95 for the upper, and w() a per-model
     residual-spread scaler:
@@ -495,8 +495,12 @@ def _build_district_projection_sql(interval_params):
             "(CASE WHEN ip.scaler = 'taper_top' THEN SQRT(1 - a.pred_rate) "
             "ELSE SQRT(a.pred_rate * (1 - a.pred_rate)) END)"
         )
-        lower_expr = f"ROUND(LEAST(GREATEST(a.pred_rate + ip.q_lower * {w_expr}, 0), 1) * a.district_voters)"
-        upper_expr = f"ROUND(LEAST(GREATEST(a.pred_rate + ip.q_upper * {w_expr}, 0), 1) * a.district_voters)"
+        # Floor each bound at 3 ballots, matching the point-estimate floor (DATA-2015 /
+        # PR #598: GREATEST(ROUND(...), 3)). All three of point/lower/upper are floored the
+        # same way so the lower <= point <= upper ordering is preserved (GREATEST is
+        # monotonic); flooring only the point could leave upper < point for a tiny district.
+        lower_expr = f"GREATEST(ROUND(LEAST(GREATEST(a.pred_rate + ip.q_lower * {w_expr}, 0), 1) * a.district_voters), 3)"
+        upper_expr = f"GREATEST(ROUND(LEAST(GREATEST(a.pred_rate + ip.q_upper * {w_expr}, 0), 1) * a.district_voters), 3)"
     else:
         params_cte = ""
         join_sql = ""
@@ -536,7 +540,7 @@ def _build_district_projection_sql(interval_params):
             a.state,
             a.district_type,
             a.district_name,
-            ROUND(a.projected_raw)  AS ballots_projected,
+            GREATEST(ROUND(a.projected_raw), 3)  AS ballots_projected,
             {lower_expr}  AS ballots_projected_lower,
             {upper_expr}  AS ballots_projected_upper,
             a.model_version,

--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -443,6 +443,96 @@ def _build_district_membership_sql(l2_col_set, district_types):
     """
 
 
+def _build_district_projection_sql(interval_params):
+    """Pure: final district-level projection SQL, including p25 (lower) / p95 (upper)
+    prediction-interval bounds.
+
+    interval_params maps model_slug -> {bias, q25, q95, ...}. Bounds are the
+    variance-stabilised residual model fit per slug in the turnout_prediction_intervals
+    notebook. For each district we take the model's implied predicted rate,
+    pred_rate = ballots_projected / district_voters, and apply
+
+        bound_rate  = clip(pred_rate + bias + q * sqrt(pred_rate*(1-pred_rate)), 0, 1)
+        bound_votes = round(bound_rate * district_voters)
+
+    with q = q25 for the lower bound and q = q95 for the upper. The residual model was
+    fit on eligible-weighted rates; inference uses the registered-voter denominator
+    (district_voters = SUM(n_voters), no eligibility gate) on the deliberate assumption
+    that today's L2 is the eligible-if-held-today universe (research decision).
+
+    A LEFT JOIN to the params means a slug with no params yields NULL bounds rather than
+    dropping the ballots_projected row. Model routing guarantees (election_year,
+    election_code) -> a single slug, so carrying model_slug into the GROUP BY does not
+    change ballots_projected or the natural-key grain."""
+    if interval_params:
+        values = ",\n                ".join(
+            f"('{slug}', {p['bias']!r}, {p['q25']!r}, {p['q95']!r})"
+            for slug, p in sorted(interval_params.items())
+        )
+        params_cte = f"""_interval_params AS (
+            SELECT * FROM (VALUES
+                {values}
+            ) AS t(model_slug, bias, q_lower, q_upper)
+        ),
+        """
+        join_sql = "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug"
+        lower_expr = (
+            "ROUND(LEAST(GREATEST(a.pred_rate + ip.bias + ip.q_lower * "
+            "SQRT(a.pred_rate * (1 - a.pred_rate)), 0), 1) * a.district_voters)"
+        )
+        upper_expr = (
+            "ROUND(LEAST(GREATEST(a.pred_rate + ip.bias + ip.q_upper * "
+            "SQRT(a.pred_rate * (1 - a.pred_rate)), 0), 1) * a.district_voters)"
+        )
+    else:
+        params_cte = ""
+        join_sql = ""
+        lower_expr = "CAST(NULL AS DOUBLE)"
+        upper_expr = "CAST(NULL AS DOUBLE)"
+
+    return f"""
+        WITH {params_cte}_district_agg AS (
+            SELECT
+                CAST(p.inference_year AS INT)    AS election_year,
+                p.election_code,
+                p.State                          AS state,
+                m.district_type,
+                m.district_name,
+                p.model_slug,
+                p.model_family                   AS model_version,
+                SUM(p.p_hat * p.n_voters)        AS projected_raw,
+                SUM(p.n_voters)                  AS district_voters
+            FROM _precinct_preds p
+            JOIN _membership m
+              ON  p.State    = m.State
+              AND p.County   = m.County
+              AND p.Precinct = m.Precinct
+            GROUP BY
+                p.inference_year, p.election_code, p.State,
+                m.district_type, m.district_name, p.model_slug, p.model_family
+        ),
+        _with_rate AS (
+            SELECT
+                *,
+                CASE WHEN district_voters > 0 THEN projected_raw / district_voters END AS pred_rate
+            FROM _district_agg
+        )
+        SELECT
+            a.election_year,
+            a.election_code,
+            a.state,
+            a.district_type,
+            a.district_name,
+            ROUND(a.projected_raw)  AS ballots_projected,
+            {lower_expr}  AS ballots_projected_lower,
+            {upper_expr}  AS ballots_projected_upper,
+            a.model_version,
+            current_timestamp()     AS inference_at
+        FROM _with_rate a
+        {join_sql}
+    """
+
+
 def _parse_state_allowlist(raw):
     """DEV-ONLY iteration knob. NEVER set when building the wired int model."""
     if raw is None:
@@ -553,6 +643,36 @@ def _read_model_family_tag(registered_model_tags, registered_model_name):
     return family
 
 
+def _read_interval_params_tag(model_version_tags, registered_model_name):
+    """Read the per-slug prediction-interval params (bias + empirical residual quantiles)
+    from the @production model-VERSION tag set at promotion.
+
+    Stored as a JSON version tag (not a registered-model tag) so the params stay locked to
+    the exact booster they were fit against — a retrain must re-fit and re-tag. A missing
+    or malformed tag fails loudly rather than silently dropping the interval columns.
+    """
+    raw = (model_version_tags or {}).get("prediction_interval_params")
+    if not raw:
+        raise ValueError(
+            f"Registered model {registered_model_name} @production is missing the required "
+            f"'prediction_interval_params' version tag. Fit it in the turnout "
+            f"prediction-intervals notebook and set it at promotion."
+        )
+    try:
+        params = json.loads(raw)
+    except (ValueError, TypeError) as e:
+        raise ValueError(
+            f"prediction_interval_params on {registered_model_name} is not valid JSON: {raw!r}"
+        ) from e
+    missing = {"bias", "q25", "q95"} - set(params)
+    if missing:
+        raise ValueError(
+            f"prediction_interval_params on {registered_model_name} is missing keys "
+            f"{sorted(missing)}: {params}"
+        )
+    return params
+
+
 def model(dbt, session):
     import mlflow
     import mlflow.lightgbm
@@ -582,7 +702,7 @@ def model(dbt, session):
     client = mlflow.MlflowClient()
 
     needed_slugs = sorted({slug for y in inference_years for slug in _year_to_model_slugs(y)})
-    models, cat_maps, model_families = {}, {}, {}
+    models, cat_maps, model_families, interval_params = {}, {}, {}, {}
     for slug in needed_slugs:
         full_name = f"{catalog}.{models_schema}.voter_turnout_model_{slug}"
         _check_lgbm_version(full_name, client)
@@ -593,6 +713,12 @@ def model(dbt, session):
         # inconsistent promotion is caught below, not silently stamped from one slug.
         registered = client.get_registered_model(full_name)
         model_families[slug] = _read_model_family_tag(registered.tags, full_name)
+        # Prediction-interval params (bias + empirical residual quantiles) are a model-VERSION
+        # tag on the @production version, so they stay locked to the exact booster they were
+        # fit against (a retrain must re-fit + re-tag). Read them off the resolved production
+        # version, not the registered-model tag set.
+        prod_version = client.get_model_version_by_alias(full_name, "production")
+        interval_params[slug] = _read_interval_params_tag(prod_version.tags, full_name)
         # Download the @production model once, then load it and resolve its categorical feature
         # map. The map is logged under model/ (so it travels with copy_model_version) but with
         # a tmp-prefixed filename, so glob for it rather than assume a fixed artifact path.
@@ -675,24 +801,4 @@ def model(dbt, session):
     # see the LAST iteration's view — collapsing all years/slugs to the final one and
     # duplicating it. The unique-combination test on this model guards that regression.
     reduce(lambda a, b: a.unionByName(b), pred_dfs).createOrReplaceTempView("_precinct_preds")
-    return session.sql(
-        """
-        SELECT
-            CAST(p.inference_year AS INT)    AS election_year,
-            p.election_code,
-            p.State                          AS state,
-            m.district_type,
-            m.district_name,
-            ROUND(SUM(p.p_hat * p.n_voters)) AS ballots_projected,
-            p.model_family                   AS model_version,
-            current_timestamp()              AS inference_at
-        FROM _precinct_preds p
-        JOIN _membership m
-          ON  p.State    = m.State
-          AND p.County   = m.County
-          AND p.Precinct = m.Precinct
-        GROUP BY
-            p.inference_year, p.election_code, p.State,
-            m.district_type, m.district_name, p.model_family
-        """
-    )
+    return session.sql(_build_district_projection_sql(interval_params))

--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -458,9 +458,9 @@ def _build_district_projection_sql(interval_params):
 
     with q = q25 for the lower bound and q = q95 for the upper, and w() a per-model
     residual-spread scaler:
-      - 'binom'    -> sqrt(p*(1-p)): tapers to 0 at both 0% and 100% turnout.
-      - 'headroom' -> sqrt(1-p): tapers only near 100%, staying wide at low turnout.
-    The low-turnout local models (off_year_local_lag2, even_year_local) use 'headroom':
+      - 'binom'     -> sqrt(p*(1-p)): tapers to 0 at both 0% and 100% turnout.
+      - 'taper_top' -> sqrt(1-p): tapers only near 100%, staying wide at low turnout.
+    The low-turnout local models (off_year_local_lag2, even_year_local) use 'taper_top':
     the binom shape collapses the band to ~0 at low turnout while the model's real error
     there stays large and positive (small low-turnout jurisdictions surprise upward), so
     binom badly under-covered the p95 upper bound (see the training runbook). 'headroom'
@@ -489,10 +489,10 @@ def _build_district_projection_sql(interval_params):
         ),
         """
         join_sql = "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug"
-        # Per-model residual-spread scaler w(pred_rate): 'headroom' = sqrt(1-p) for the
+        # Per-model residual-spread scaler w(pred_rate): 'taper_top' = sqrt(1-p) for the
         # low-turnout local models, 'binom' = sqrt(p*(1-p)) otherwise.
         w_expr = (
-            "(CASE WHEN ip.scaler = 'headroom' THEN SQRT(1 - a.pred_rate) "
+            "(CASE WHEN ip.scaler = 'taper_top' THEN SQRT(1 - a.pred_rate) "
             "ELSE SQRT(a.pred_rate * (1 - a.pred_rate)) END)"
         )
         lower_expr = f"ROUND(LEAST(GREATEST(a.pred_rate + ip.q_lower * {w_expr}, 0), 1) * a.district_voters)"
@@ -685,12 +685,12 @@ def _read_interval_params_tag(model_version_tags, registered_model_name):
         )
     # Residual-spread scaler travels with the params so the shape stays locked to the fit.
     # Default 'binom' (sqrt(p*(1-p))) when absent; the low-turnout local models set
-    # 'headroom' (sqrt(1-p)). Reject unknown values rather than silently mis-shape the band.
+    # 'taper_top' (sqrt(1-p)). Reject unknown values rather than silently mis-shape the band.
     scaler = params.setdefault("scaler", "binom")
-    if scaler not in ("binom", "headroom"):
+    if scaler not in ("binom", "taper_top"):
         raise ValueError(
             f"prediction_interval_params on {registered_model_name} has unknown scaler "
-            f"{scaler!r} (expected 'binom' or 'headroom')."
+            f"{scaler!r} (expected 'binom' or 'taper_top')."
         )
     return params
 

--- a/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
+++ b/dbt/project/models/intermediate/l2/int__voter_turnout_lgbm_inference.py
@@ -447,18 +447,21 @@ def _build_district_projection_sql(interval_params):
     """Pure: final district-level projection SQL, including p25 (lower) / p95 (upper)
     prediction-interval bounds.
 
-    interval_params maps model_slug -> {bias, q25, q95, ...}. Bounds are the
+    interval_params maps model_slug -> {q25, q95, ...}. Bounds are the
     variance-stabilised residual model fit per slug in the turnout_prediction_intervals
-    notebook. For each district we take the model's implied predicted rate,
+    notebook (raw-standardized residual quantiles, no constant bias term). For each
+    district we take the model's implied predicted rate,
     pred_rate = ballots_projected / district_voters, and apply
 
-        bound_rate  = clip(pred_rate + bias + q * sqrt(pred_rate*(1-pred_rate)), 0, 1)
+        bound_rate  = clip(pred_rate + q * sqrt(pred_rate*(1-pred_rate)), 0, 1)
         bound_votes = round(bound_rate * district_voters)
 
-    with q = q25 for the lower bound and q = q95 for the upper. The residual model was
-    fit on eligible-weighted rates; inference uses the registered-voter denominator
-    (district_voters = SUM(n_voters), no eligibility gate) on the deliberate assumption
-    that today's L2 is the eligible-if-held-today universe (research decision).
+    with q = q25 for the lower bound and q = q95 for the upper. q25 < 0 < q95 for every
+    model, so the point (q=0) always lies within [lower, upper] and both bounds collapse
+    toward the point as pred_rate -> 0/1. The residual model was fit on eligible-weighted
+    rates; inference uses the registered-voter denominator (district_voters =
+    SUM(n_voters), no eligibility gate) on the deliberate assumption that today's L2 is
+    the eligible-if-held-today universe (research decision).
 
     A LEFT JOIN to the params means a slug with no params yields NULL bounds rather than
     dropping the ballots_projected row. Model routing guarantees (election_year,
@@ -466,22 +469,21 @@ def _build_district_projection_sql(interval_params):
     change ballots_projected or the natural-key grain."""
     if interval_params:
         values = ",\n                ".join(
-            f"('{slug}', {p['bias']!r}, {p['q25']!r}, {p['q95']!r})"
-            for slug, p in sorted(interval_params.items())
+            f"('{slug}', {p['q25']!r}, {p['q95']!r})" for slug, p in sorted(interval_params.items())
         )
         params_cte = f"""_interval_params AS (
             SELECT * FROM (VALUES
                 {values}
-            ) AS t(model_slug, bias, q_lower, q_upper)
+            ) AS t(model_slug, q_lower, q_upper)
         ),
         """
         join_sql = "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug"
         lower_expr = (
-            "ROUND(LEAST(GREATEST(a.pred_rate + ip.bias + ip.q_lower * "
+            "ROUND(LEAST(GREATEST(a.pred_rate + ip.q_lower * "
             "SQRT(a.pred_rate * (1 - a.pred_rate)), 0), 1) * a.district_voters)"
         )
         upper_expr = (
-            "ROUND(LEAST(GREATEST(a.pred_rate + ip.bias + ip.q_upper * "
+            "ROUND(LEAST(GREATEST(a.pred_rate + ip.q_upper * "
             "SQRT(a.pred_rate * (1 - a.pred_rate)), 0), 1) * a.district_voters)"
         )
     else:
@@ -644,8 +646,8 @@ def _read_model_family_tag(registered_model_tags, registered_model_name):
 
 
 def _read_interval_params_tag(model_version_tags, registered_model_name):
-    """Read the per-slug prediction-interval params (bias + empirical residual quantiles)
-    from the @production model-VERSION tag set at promotion.
+    """Read the per-slug prediction-interval params (empirical residual quantiles) from
+    the @production model-VERSION tag set at promotion.
 
     Stored as a JSON version tag (not a registered-model tag) so the params stay locked to
     the exact booster they were fit against — a retrain must re-fit and re-tag. A missing
@@ -664,7 +666,7 @@ def _read_interval_params_tag(model_version_tags, registered_model_name):
         raise ValueError(
             f"prediction_interval_params on {registered_model_name} is not valid JSON: {raw!r}"
         ) from e
-    missing = {"bias", "q25", "q95"} - set(params)
+    missing = {"q25", "q95"} - set(params)
     if missing:
         raise ValueError(
             f"prediction_interval_params on {registered_model_name} is missing keys "

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -302,6 +302,24 @@ models:
         description: The projected turnout
         tests:
           - not_null
+      - name: projected_turnout_lower
+        description: >
+          Lower prediction bound (p25) on projected turnout. NULL for legacy static
+          feeds, which carry no interval (left NULL rather than coalesced to 0).
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: projected_turnout_upper
+        description: >
+          Upper prediction bound (p95) on projected turnout, the risk-relevant band
+          for win-number planning. NULL for legacy static feeds.
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:

--- a/dbt/project/models/marts/election_api/m_election_api__projected_turnout.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__projected_turnout.sql
@@ -27,6 +27,11 @@ with
                 else election_code
             end as election_code,
             coalesce(ballots_projected, 0) as projected_turnout,
+            -- p25 / p95 prediction-interval bounds. NULL for legacy feeds (no
+            -- interval); left NULL not coalesced to 0 so a missing bound reads
+            -- as "unknown", not "zero turnout".
+            ballots_projected_lower as projected_turnout_lower,
+            ballots_projected_upper as projected_turnout_upper,
             inference_at,
             model_version
         from {{ ref("int__model_prediction_voter_turnout") }}
@@ -52,5 +57,7 @@ select
     projected_turnout.election_code,
     projected_turnout.model_version,
     projected_turnout.projected_turnout,
+    projected_turnout.projected_turnout_lower,
+    projected_turnout.projected_turnout_upper,
     projected_turnout.inference_at
 from projected_turnout

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -14,12 +14,14 @@ from dbt.project.models.intermediate.l2.int__voter_turnout_lgbm_inference import
     _SLUG_ELECTION_CODE,
     _assert_consistent_model_family,
     _build_district_membership_sql,
+    _build_district_projection_sql,
     _build_precinct_features_sql,
     _detect_election_cols,
     _op_years,
     _opp_view_sql,
     _parse_state_allowlist,
     _predict_precinct,
+    _read_interval_params_tag,
     _read_model_family_tag,
     _select_cat_map_path,
     _year_to_model_slugs,
@@ -258,3 +260,81 @@ def test_read_model_family_tag_returns_value():
 def test_read_model_family_tag_raises_when_missing_or_empty(tags):
     with pytest.raises(ValueError):
         _read_model_family_tag(tags, "some.model.name")
+
+
+# ── Prediction intervals: params tag reader + projection SQL builder ──────────
+def test_read_interval_params_tag_returns_parsed_dict():
+    tags = {
+        "prediction_interval_params": '{"bias":-0.0007,"q25":-0.013,"q75":0.012,"q841":0.025,"q95":0.071}'
+    }
+    params = _read_interval_params_tag(tags, "some.model.name")
+    assert params["bias"] == -0.0007
+    assert params["q25"] == -0.013
+    assert params["q95"] == 0.071
+
+
+@pytest.mark.parametrize(
+    "tags",
+    [
+        None,
+        {},
+        {"model_family": "x"},  # unrelated tag only
+        {"prediction_interval_params": ""},  # empty
+        {"prediction_interval_params": "not json"},  # malformed
+        {"prediction_interval_params": '{"bias":0.0,"q25":-0.01}'},  # missing q95
+        {"prediction_interval_params": '{"bias":0.0,"q95":0.05}'},  # missing q25
+    ],
+)
+def test_read_interval_params_tag_raises_when_missing_malformed_or_incomplete(tags):
+    with pytest.raises(ValueError):
+        _read_interval_params_tag(tags, "some.model.name")
+
+
+_INTERVAL_PARAMS = {
+    "midterm": {"bias": -0.00066, "q25": -0.01307, "q75": 0.01246, "q841": 0.02501, "q95": 0.07087},
+    "even_year_primary": {"bias": 0.00845, "q25": -0.03699, "q75": 0.00737, "q841": 0.03438, "q95": 0.12761},
+}
+
+
+def test_projection_sql_carries_model_slug_and_district_voters():
+    sql = _build_district_projection_sql(_INTERVAL_PARAMS)
+    # model_slug must reach the GROUP BY so params can be joined per slug; district_voters
+    # is the denominator the bound rate is multiplied back by.
+    assert "SUM(p.n_voters)" in sql
+    assert "AS district_voters" in sql
+    assert "m.district_type, m.district_name, p.model_slug, p.model_family" in sql
+    # ballots_projected value is unchanged (round of the p_hat-weighted sum).
+    assert "ROUND(a.projected_raw)" in sql
+    assert "AS ballots_projected" in sql
+
+
+def test_projection_sql_emits_lower_and_upper_bound_columns():
+    sql = _build_district_projection_sql(_INTERVAL_PARAMS)
+    assert "AS ballots_projected_lower" in sql
+    assert "AS ballots_projected_upper" in sql
+    # bound formula: pred_rate + bias + q * sqrt(p*(1-p)), clipped to [0,1], * district_voters
+    assert "ip.q_lower * SQRT(a.pred_rate * (1 - a.pred_rate))" in sql
+    assert "ip.q_upper * SQRT(a.pred_rate * (1 - a.pred_rate))" in sql
+    assert "* a.district_voters" in sql
+    assert "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug" in sql
+
+
+def test_projection_sql_embeds_lower_upper_params_per_slug():
+    sql = _build_district_projection_sql(_INTERVAL_PARAMS)
+    # VALUES rows carry (slug, bias, q25 as lower, q95 as upper) — NOT q75/q841.
+    assert "'midterm', -0.00066, -0.01307, 0.07087" in sql
+    assert "'even_year_primary', 0.00845, -0.03699, 0.12761" in sql
+    assert "AS t(model_slug, bias, q_lower, q_upper)" in sql
+    # q75 / q841 are stored in the tag but must not leak into the two-bound SQL.
+    assert "0.01246" not in sql
+    assert "0.03438" not in sql
+
+
+def test_projection_sql_without_params_emits_null_bounds():
+    sql = _build_district_projection_sql({})
+    # No params -> NULL bound columns and no join, but ballots_projected still produced.
+    assert "CAST(NULL AS DOUBLE)" in sql
+    assert "AS ballots_projected_lower" in sql
+    assert "AS ballots_projected_upper" in sql
+    assert "_interval_params" not in sql
+    assert "ROUND(a.projected_raw)" in sql

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -268,6 +268,16 @@ def test_read_interval_params_tag_returns_parsed_dict():
     params = _read_interval_params_tag(tags, "some.model.name")
     assert params["q25"] == -0.0144
     assert params["q95"] == 0.0695
+    assert params["scaler"] == "binom"  # default when the tag omits it
+
+
+def test_read_interval_params_tag_scaler_default_and_validation():
+    base = '{"q25":-0.04,"q75":0.03,"q841":0.06,"q95":0.14%s}'
+    assert _read_interval_params_tag({"prediction_interval_params": base % ""}, "m")["scaler"] == "binom"
+    got = _read_interval_params_tag({"prediction_interval_params": base % ',"scaler":"headroom"'}, "m")
+    assert got["scaler"] == "headroom"
+    with pytest.raises(ValueError):  # unknown scaler is rejected, not silently used
+        _read_interval_params_tag({"prediction_interval_params": base % ',"scaler":"bogus"'}, "m")
 
 
 @pytest.mark.parametrize(
@@ -288,8 +298,14 @@ def test_read_interval_params_tag_raises_when_missing_malformed_or_incomplete(ta
 
 
 _INTERVAL_PARAMS = {
-    "midterm": {"q25": -0.01444, "q75": 0.01107, "q841": 0.02357, "q95": 0.06949},
-    "even_year_primary": {"q25": -0.0138, "q75": 0.02892, "q841": 0.05517, "q95": 0.15031},
+    "midterm": {"q25": -0.01444, "q75": 0.01107, "q841": 0.02357, "q95": 0.06949, "scaler": "binom"},
+    "off_year_local_lag2": {
+        "q25": -0.04362,
+        "q75": 0.03098,
+        "q841": 0.05765,
+        "q95": 0.14162,
+        "scaler": "headroom",
+    },
 }
 
 
@@ -309,10 +325,12 @@ def test_projection_sql_emits_lower_and_upper_bound_columns():
     sql = _build_district_projection_sql(_INTERVAL_PARAMS)
     assert "AS ballots_projected_lower" in sql
     assert "AS ballots_projected_upper" in sql
-    # bound formula: pred_rate + q * sqrt(p*(1-p)), clipped to [0,1], * district_voters.
-    # No constant bias term (raw-standardized residual quantiles).
-    assert "ip.q_lower * SQRT(a.pred_rate * (1 - a.pred_rate))" in sql
-    assert "ip.q_upper * SQRT(a.pred_rate * (1 - a.pred_rate))" in sql
+    # bound formula: pred_rate + q * w(p), clipped to [0,1], * district_voters, no bias.
+    # w(p) is a per-model CASE: 'headroom' = sqrt(1-p), else binom sqrt(p*(1-p)).
+    assert "CASE WHEN ip.scaler = 'headroom' THEN SQRT(1 - a.pred_rate)" in sql
+    assert "ELSE SQRT(a.pred_rate * (1 - a.pred_rate)) END" in sql
+    assert "ip.q_lower *" in sql
+    assert "ip.q_upper *" in sql
     assert "* a.district_voters" in sql
     assert "ip.bias" not in sql
     assert "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug" in sql
@@ -320,13 +338,13 @@ def test_projection_sql_emits_lower_and_upper_bound_columns():
 
 def test_projection_sql_embeds_lower_upper_params_per_slug():
     sql = _build_district_projection_sql(_INTERVAL_PARAMS)
-    # VALUES rows carry (slug, q25 as lower, q95 as upper) — NOT q75/q841, and no bias.
-    assert "'midterm', -0.01444, 0.06949" in sql
-    assert "'even_year_primary', -0.0138, 0.15031" in sql
-    assert "AS t(model_slug, q_lower, q_upper)" in sql
+    # VALUES rows carry (slug, q25 as lower, q95 as upper, scaler) — NOT q75/q841, no bias.
+    assert "'midterm', -0.01444, 0.06949, 'binom'" in sql
+    assert "'off_year_local_lag2', -0.04362, 0.14162, 'headroom'" in sql
+    assert "AS t(model_slug, q_lower, q_upper, scaler)" in sql
     # q75 / q841 are stored in the tag but must not leak into the two-bound SQL.
     assert "0.01107" not in sql
-    assert "0.05517" not in sql
+    assert "0.05765" not in sql
 
 
 def test_projection_sql_without_params_emits_null_bounds():

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -264,13 +264,10 @@ def test_read_model_family_tag_raises_when_missing_or_empty(tags):
 
 # ── Prediction intervals: params tag reader + projection SQL builder ──────────
 def test_read_interval_params_tag_returns_parsed_dict():
-    tags = {
-        "prediction_interval_params": '{"bias":-0.0007,"q25":-0.013,"q75":0.012,"q841":0.025,"q95":0.071}'
-    }
+    tags = {"prediction_interval_params": '{"q25":-0.0144,"q75":0.0111,"q841":0.0236,"q95":0.0695}'}
     params = _read_interval_params_tag(tags, "some.model.name")
-    assert params["bias"] == -0.0007
-    assert params["q25"] == -0.013
-    assert params["q95"] == 0.071
+    assert params["q25"] == -0.0144
+    assert params["q95"] == 0.0695
 
 
 @pytest.mark.parametrize(
@@ -281,8 +278,8 @@ def test_read_interval_params_tag_returns_parsed_dict():
         {"model_family": "x"},  # unrelated tag only
         {"prediction_interval_params": ""},  # empty
         {"prediction_interval_params": "not json"},  # malformed
-        {"prediction_interval_params": '{"bias":0.0,"q25":-0.01}'},  # missing q95
-        {"prediction_interval_params": '{"bias":0.0,"q95":0.05}'},  # missing q25
+        {"prediction_interval_params": '{"q25":-0.01}'},  # missing q95
+        {"prediction_interval_params": '{"q95":0.05}'},  # missing q25
     ],
 )
 def test_read_interval_params_tag_raises_when_missing_malformed_or_incomplete(tags):
@@ -291,8 +288,8 @@ def test_read_interval_params_tag_raises_when_missing_malformed_or_incomplete(ta
 
 
 _INTERVAL_PARAMS = {
-    "midterm": {"bias": -0.00066, "q25": -0.01307, "q75": 0.01246, "q841": 0.02501, "q95": 0.07087},
-    "even_year_primary": {"bias": 0.00845, "q25": -0.03699, "q75": 0.00737, "q841": 0.03438, "q95": 0.12761},
+    "midterm": {"q25": -0.01444, "q75": 0.01107, "q841": 0.02357, "q95": 0.06949},
+    "even_year_primary": {"q25": -0.0138, "q75": 0.02892, "q841": 0.05517, "q95": 0.15031},
 }
 
 
@@ -312,22 +309,24 @@ def test_projection_sql_emits_lower_and_upper_bound_columns():
     sql = _build_district_projection_sql(_INTERVAL_PARAMS)
     assert "AS ballots_projected_lower" in sql
     assert "AS ballots_projected_upper" in sql
-    # bound formula: pred_rate + bias + q * sqrt(p*(1-p)), clipped to [0,1], * district_voters
+    # bound formula: pred_rate + q * sqrt(p*(1-p)), clipped to [0,1], * district_voters.
+    # No constant bias term (raw-standardized residual quantiles).
     assert "ip.q_lower * SQRT(a.pred_rate * (1 - a.pred_rate))" in sql
     assert "ip.q_upper * SQRT(a.pred_rate * (1 - a.pred_rate))" in sql
     assert "* a.district_voters" in sql
+    assert "ip.bias" not in sql
     assert "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug" in sql
 
 
 def test_projection_sql_embeds_lower_upper_params_per_slug():
     sql = _build_district_projection_sql(_INTERVAL_PARAMS)
-    # VALUES rows carry (slug, bias, q25 as lower, q95 as upper) — NOT q75/q841.
-    assert "'midterm', -0.00066, -0.01307, 0.07087" in sql
-    assert "'even_year_primary', 0.00845, -0.03699, 0.12761" in sql
-    assert "AS t(model_slug, bias, q_lower, q_upper)" in sql
+    # VALUES rows carry (slug, q25 as lower, q95 as upper) — NOT q75/q841, and no bias.
+    assert "'midterm', -0.01444, 0.06949" in sql
+    assert "'even_year_primary', -0.0138, 0.15031" in sql
+    assert "AS t(model_slug, q_lower, q_upper)" in sql
     # q75 / q841 are stored in the tag but must not leak into the two-bound SQL.
-    assert "0.01246" not in sql
-    assert "0.03438" not in sql
+    assert "0.01107" not in sql
+    assert "0.05517" not in sql
 
 
 def test_projection_sql_without_params_emits_null_bounds():

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -316,8 +316,8 @@ def test_projection_sql_carries_model_slug_and_district_voters():
     assert "SUM(p.n_voters)" in sql
     assert "AS district_voters" in sql
     assert "m.district_type, m.district_name, p.model_slug, p.model_family" in sql
-    # ballots_projected value is unchanged (round of the p_hat-weighted sum).
-    assert "ROUND(a.projected_raw)" in sql
+    # ballots_projected = round of the p_hat-weighted sum, floored at 3 (DATA-2015 / #598).
+    assert "GREATEST(ROUND(a.projected_raw), 3)" in sql
     assert "AS ballots_projected" in sql
 
 
@@ -334,6 +334,21 @@ def test_projection_sql_emits_lower_and_upper_bound_columns():
     assert "* a.district_voters" in sql
     assert "ip.bias" not in sql
     assert "LEFT JOIN _interval_params ip ON a.model_slug = ip.model_slug" in sql
+    # both bounds are floored at 3 (matching the point-estimate floor), preserving
+    # lower <= point <= upper. Two bound columns each end with "* a.district_voters), 3)".
+    assert sql.count("* a.district_voters), 3)") == 2
+
+
+def test_projection_sql_floors_point_and_both_bounds_at_3():
+    sql = _build_district_projection_sql(_INTERVAL_PARAMS)
+    # point + lower + upper all wrapped in GREATEST(..., 3) so tiny districts never report
+    # below 3 and the ordering invariant survives the floor.
+    assert "GREATEST(ROUND(a.projected_raw), 3)" in sql
+    assert sql.count("), 3)") >= 3  # point + lower + upper
+    # the no-params branch must NOT floor NULL bounds into 3.
+    null_sql = _build_district_projection_sql({})
+    assert "GREATEST(CAST(NULL" not in null_sql
+    assert "GREATEST(ROUND(a.projected_raw), 3)" in null_sql  # point still floored
 
 
 def test_projection_sql_embeds_lower_upper_params_per_slug():

--- a/dbt/tests/test_voter_turnout_lgbm_inference.py
+++ b/dbt/tests/test_voter_turnout_lgbm_inference.py
@@ -274,8 +274,8 @@ def test_read_interval_params_tag_returns_parsed_dict():
 def test_read_interval_params_tag_scaler_default_and_validation():
     base = '{"q25":-0.04,"q75":0.03,"q841":0.06,"q95":0.14%s}'
     assert _read_interval_params_tag({"prediction_interval_params": base % ""}, "m")["scaler"] == "binom"
-    got = _read_interval_params_tag({"prediction_interval_params": base % ',"scaler":"headroom"'}, "m")
-    assert got["scaler"] == "headroom"
+    got = _read_interval_params_tag({"prediction_interval_params": base % ',"scaler":"taper_top"'}, "m")
+    assert got["scaler"] == "taper_top"
     with pytest.raises(ValueError):  # unknown scaler is rejected, not silently used
         _read_interval_params_tag({"prediction_interval_params": base % ',"scaler":"bogus"'}, "m")
 
@@ -304,7 +304,7 @@ _INTERVAL_PARAMS = {
         "q75": 0.03098,
         "q841": 0.05765,
         "q95": 0.14162,
-        "scaler": "headroom",
+        "scaler": "taper_top",
     },
 }
 
@@ -326,8 +326,8 @@ def test_projection_sql_emits_lower_and_upper_bound_columns():
     assert "AS ballots_projected_lower" in sql
     assert "AS ballots_projected_upper" in sql
     # bound formula: pred_rate + q * w(p), clipped to [0,1], * district_voters, no bias.
-    # w(p) is a per-model CASE: 'headroom' = sqrt(1-p), else binom sqrt(p*(1-p)).
-    assert "CASE WHEN ip.scaler = 'headroom' THEN SQRT(1 - a.pred_rate)" in sql
+    # w(p) is a per-model CASE: 'taper_top' = sqrt(1-p), else binom sqrt(p*(1-p)).
+    assert "CASE WHEN ip.scaler = 'taper_top' THEN SQRT(1 - a.pred_rate)" in sql
     assert "ELSE SQRT(a.pred_rate * (1 - a.pred_rate)) END" in sql
     assert "ip.q_lower *" in sql
     assert "ip.q_upper *" in sql
@@ -340,7 +340,7 @@ def test_projection_sql_embeds_lower_upper_params_per_slug():
     sql = _build_district_projection_sql(_INTERVAL_PARAMS)
     # VALUES rows carry (slug, q25 as lower, q95 as upper, scaler) — NOT q75/q841, no bias.
     assert "'midterm', -0.01444, 0.06949, 'binom'" in sql
-    assert "'off_year_local_lag2', -0.04362, 0.14162, 'headroom'" in sql
+    assert "'off_year_local_lag2', -0.04362, 0.14162, 'taper_top'" in sql
     assert "AS t(model_slug, q_lower, q_upper, scaler)" in sql
     # q75 / q841 are stored in the tag but must not leak into the two-bound SQL.
     assert "0.01107" not in sql


### PR DESCRIPTION
## What

Adds two prediction-interval columns to the district-level turnout projection table and plumbs them through to the election-api mart:

- `ballots_projected_lower` — p25 lower bound
- `ballots_projected_upper` — p95 upper bound (the risk-relevant band for win-number planning)

Implements Section 3.2 of the turnout serving TDD (DATA-2117), using the variance-stabilised residual model fit in the `turnout_prediction_intervals` notebook.

## How

**Params storage — a version tag on each `@production` model.** Per-model params `{scaler, q25, q75, q841, q95}` (empirical quantiles of the standardised residual) are stored as a `prediction_interval_params` JSON tag on each `@production` model **version**, read in the same MLflow load loop that already reads `model_family` / `cat_map`; fail-loud if missing/malformed.

**Bounds at inference.** The final aggregation carries `model_slug` and `district_voters = SUM(n_voters)`, computes `pred_rate = ballots_projected / district_voters`, and applies per slug:

```
bound_rate  = clip(pred_rate + q * w(pred_rate), 0, 1)
bound_votes = round(bound_rate * district_voters)
```

with `q = q25` (lower) / `q95` (upper). Extracted into a pure, unit-tested `_build_district_projection_sql`.

**Per-model spread scaler `w(p)`.** `binom = sqrt(p*(1-p))` (tapers both ends) for presidential/midterm/primary; `taper_top = sqrt(1-p)` (tapers only near 100%, stays wide at low turnout) for the two low-turnout local models (`off_year_local_lag2`, `even_year_local`). The `taper_top` exception exists because `binom` collapsed the band at low turnout where those models genuinely under-project — `off_year_local_lag2` at `p<5%` covered only ~54% vs the 95% target (pushed by small-N districts, where most of our candidates run). `taper_top` lifts that to ~73% (2–5%) / ~87% (5–10%) with mid/high bins unchanged. The scaler travels in the tag so inference applies the right `w`.

**No constant bias term.** `q25 < 0 < q95` for every model, so the point always sits inside `[lower, upper]`.

**Denominator (by design):** params fit on eligible-weighted rates; inference uses the registered-voter denominator (`SUM(n_voters)`, no eligibility gate) on the assumption that today's L2 is the eligible-if-held-today universe.

**Downstream.** `int__model_prediction_voter_turnout` and `m_election_api__projected_turnout` pass the columns through; legacy static feeds carry `NULL` bounds. Scope is int model + mart; the Postgres `Projected_Turnout` / election-api read path is a separate follow-up.

## Tests

- `_read_interval_params_tag`: valid / missing / malformed / incomplete / scaler default+validation
- `_build_district_projection_sql`: carries model_slug + district_voters, per-model `w(p)` CASE, embeds q25/q95+scaler per slug, NULL bounds when params absent
- `accepted_range >= 0` on all four new columns; `not_null` on the lgbm model output
- 45 unit tests pass; ruff + sqlfmt clean

## Deploy dependency

Requires the `prediction_interval_params` version tag on each `@production` turnout model before this runs, or the model fails loud. The `write_turnout_interval_tags` notebook sets them (needs `APPLY TAG` on `model_predictions` — promotion principal).

Note: treat this PR as a draft demonstration of how the columns can be added, not the final implementation (e.g. it keeps the table name `dbt.int__voter_turnout_lgbm_inference`, which the TDD says to rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)