### PR TITLE
[DATA-2147] Materialize heavy reverse-ETL and prospects marts as tables

### DIFF
--- a/dbt/project/dbt_project.yml
+++ b/dbt/project/dbt_project.yml
@@ -65,7 +65,10 @@ models:
         +tags: ["mart", "analytics"]
       sales_reverse_etl:
         +schema: mart_sales_reverse_etl
-        +materialized: view
+        # Table, not view: these are heavy multi-join feeds with several tests
+        # each. As views, every test (and the reverse-ETL read) re-executes the
+        # full query; materializing once per build makes tests hit stored data.
+        +materialized: table
         +tags: ["mart", "sales_reverse_etl"]
       mban2026:
         +schema: mart_mban2026

--- a/dbt/project/dbt_project.yml
+++ b/dbt/project/dbt_project.yml
@@ -69,6 +69,13 @@ models:
         # each. As views, every test (and the reverse-ETL read) re-executes the
         # full query; materializing once per build makes tests hit stored data.
         +materialized: table
+        # These feeds emit the HubSpot import contract, whose column names have
+        # spaces ("First Name"). Delta tables reject those unless column mapping
+        # is on; enabling it keeps the contract names while allowing a table.
+        # Mode alone lets Databricks auto-upgrade the table protocol (avoids
+        # pinning reader/writer versions that could clash with liquid clustering).
+        +tblproperties:
+          delta.columnMapping.mode: "name"
         +tags: ["mart", "sales_reverse_etl"]
       mban2026:
         +schema: mart_mban2026

--- a/dbt/project/models/marts/analytics/prospects.sql
+++ b/dbt/project/models/marts/analytics/prospects.sql
@@ -1,5 +1,3 @@
-{{ config(materialized="view") }}
-
 /*
     mart_analytics.prospects
 


### PR DESCRIPTION
## Why

Investigating the Databricks cost increase, node-level attribution of dbt queries showed the cost concentrates in **tests that act on `view`-materialized models**. A test on a view re-executes the model's entire query every run; a test on a table just scans stored rows.

Measured over the last month (tests bucketed by the materialization of the model they test):

| Model is a… | tests | runs | exec-hr | avg/run | % of test cost |
|---|---|---|---|---|---|
| **view** | 1,618 | 117K | **228** | **7.0 s** | **88%** |
| table | 1,056 | 234K | 19 | 0.3 s | 7% |
| incremental | 311 | 44K | 7 | 0.6 s | 3% |

**88% of all test execution time is on views**, and a view test is ~23× the cost of the same test on a table (7.0s vs 0.3s per run). Two `candidacy_hubspot` tests alone were ~158 exec-hr (~15 min each). The three models this PR converts hold ~90% of that view-test cost.

## What

Materialize the offending marts as tables so tests (and the reverse-ETL reads) hit stored data instead of re-running the query per test:

- **`sales_reverse_etl` → table** (`dbt_project.yml` directory config): `candidacy_hubspot`, `candidacy_techspeed`.
- **`prospects` → table** by removing its top-level `{{ config(materialized="view") }}` override so it inherits the `marts` table default (also aligns with the repo convention against top-level materialization overrides).
- **Delta column mapping** (`delta.columnMapping.mode: name`) on `sales_reverse_etl`: these feeds emit the HubSpot import contract with spaced column names (`First Name`), which a Delta table rejects unless column mapping is on. Keeps the contract names while allowing a table.

These three marts are leaf feeds with no dbt downstream consumers, so materializing them is safe. They already rebuild on the normal cadence, so a table adds no data loss (at most the usual build-cadence staleness for a batch reverse-ETL feed).

## Expected impact (and its limit)

Materialization moves the heavy query from "re-run once per test" to "run once per build to materialize the table." So this is a large cut, not elimination: expect roughly a **40–60% reduction on these marts** (the two candidacy_hubspot tests stop re-executing; the model materializes once instead). It does **not** change build frequency and does **not** touch the biggest single node overall, the `int__l2_nationwide_uniform` snapshot.

## Validation

CI (dbt Cloud) is green after the column-mapping fix — that is the first full-refresh build of these models as tables, so the change is exercised end-to-end.

## Out of scope (follow-ups)

- `snapshot__int__l2_nationwide_uniform` (~146 exec-hr, 61 TB over the window): `strategy: check` over ~50 columns. A `timestamp` strategy on `loaded_at` was considered but could bloat snapshot history since `loaded_at` advances for all rows each load — needs the L2 owner's review (`l2-uniform-drift-remediator` skill).
- Heavy incrementals (`m_people_api__districtstats`, `m_people_api__voter`): legitimate data volume; separate pruning review.

Ticket: DATA-2147