### PR TITLE
[DATA-2147] Add dbt/Databricks cost-audit skill with interactive dashboard

### DIFF
--- a/.claude/skills/dbt-databricks-cost-audit/SKILL.md
+++ b/.claude/skills/dbt-databricks-cost-audit/SKILL.md
@@ -59,7 +59,10 @@ figures are an allocation, not a metered per-query charge. State that.
 - **View-test antipattern (usual top driver):** a test on a `view`-materialized
   model re-executes the whole view query. Rank top nodes; if expensive nodes are
   `test` rows whose model is a view, materialize that model as a **table**
-  (in `dbt_project.yml` directory config, per `dbt/project/CLAUDE.md`).
+  (in `dbt_project.yml` directory config, per `dbt/project/CLAUDE.md`). If the
+  mart emits pretty/spaced column names (e.g. a reverse-ETL contract like
+  `First Name`), a Delta table rejects them (`DELTA_INVALID_CHARACTERS`) — add
+  `+tblproperties: {delta.columnMapping.mode: "name"}` to keep the names.
 - **Frequency is a multiplier:** the dbt Cloud models-built meter = models/run ×
   runs. A job of N models run 6×/day bills 6N. Incremental materialization cuts
   Databricks compute but **not** the models-built count.

--- a/.claude/skills/dbt-databricks-cost-audit/SKILL.md
+++ b/.claude/skills/dbt-databricks-cost-audit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: dbt-databricks-cost-audit
+description: Use when investigating a Databricks or dbt Cloud cost/usage increase, attributing spend across warehouses, clusters, jobs, models, and tests, or answering "what is driving our compute cost". Produces an interactive HTML cost dashboard from system tables.
+---
+
+# dbt / Databricks cost audit
+
+## Overview
+
+Attribute Databricks (and dbt Cloud) spend to its real drivers and produce an
+interactive HTML dashboard that slices cost monthly and weekly by product,
+by consumer, and by dbt node type (model vs **test** vs snapshot). Built to
+answer questions like "how much of our cost is testing?" and "is it enough to
+just slow down the high-frequency dbt job?".
+
+Core idea: **dbt is usually the dominant Databricks consumer, and within dbt,
+tests on view-materialized models plus high build frequency dominate.** The
+Databricks bill meters *compute time*; the dbt Cloud bill meters *successful
+models built* (count). They move for different reasons — separate them.
+
+## Prerequisites
+
+- Databricks CLI configured with a workspace profile that can read
+  `system.billing.*` and `system.query.history` (verify: `databricks current-user me -p <profile>`).
+- A SQL warehouse id to run queries against (`databricks warehouses list -p <profile>`).
+- Optional (dbt Cloud side): a service token + account id for the Admin API
+  (`https://<host>/api/v2/accounts/<id>/jobs/`), to read job selectors/schedules.
+
+## Quick start
+
+```bash
+python scripts/cost_audit.py --profile <profile> --warehouse <warehouse_id> \
+    --since 2026-01-01 --out cost_dashboard.html
+# iterate on the visualization without re-billing queries:
+python scripts/cost_audit.py --warehouse <id> --from-json cost_dashboard.json --out cost_dashboard.html
+```
+
+Outputs `cost_dashboard.html` (self-contained, opens in any browser; theme-aware)
+and `cost_dashboard.json` (raw pulled data). **The output contains internal cost
+figures — treat as internal, do not publish externally without sign-off.** Do not
+commit generated `cost_dashboard.*`; commit only the tool.
+
+## What it pulls
+
+| Query | Source | Answers |
+|---|---|---|
+| cost by product / month + week | `system.billing.usage` × `list_prices` | overall trend, SQL vs ALL_PURPOSE vs APPS… |
+| dbt exec-hr by node type | `system.query.history` (`statement_text` node_id) | **testing vs model vs snapshot cost** |
+| warehouse exec-hr by consumer | `system.query.history` `client_application` | dbt vs airbyte vs BI vs dev |
+| top dbt nodes | `system.query.history` | the specific expensive models/tests |
+| high-freq-job estimate | exec-hr in the 4-hourly-only UTC windows ×6/4 | is killing it sufficient? |
+
+$ for the dbt/consumer views is the **SQL-warehouse bill prorated by query
+execution time** (serverless bills warehouse uptime, not per query), so those
+figures are an allocation, not a metered per-query charge. State that.
+
+## Interpreting results
+
+- **View-test antipattern (usual top driver):** a test on a `view`-materialized
+  model re-executes the whole view query. Rank top nodes; if expensive nodes are
+  `test` rows whose model is a view, materialize that model as a **table**
+  (in `dbt_project.yml` directory config, per `dbt/project/CLAUDE.md`).
+- **Frequency is a multiplier:** the dbt Cloud models-built meter = models/run ×
+  runs. A job of N models run 6×/day bills 6N. Incremental materialization cuts
+  Databricks compute but **not** the models-built count.
+- **Is slowing the high-freq job enough?** Compare its estimate against total
+  testing cost. If tests (which also run in the twice-daily main job) exceed the
+  high-freq job, no — you must also decouple the full test suite from every build.
+
+## Gotchas (learned the hard way)
+
+- A dbt Cloud run writes **one** `run_results.json`, overwritten by its last step.
+  Jobs ending in `dbt docs generate` leave it reflecting the whole-project
+  *compile* (ignores `--exclude`), not the build. To measure what a job actually
+  built, parse the `dbt build` step's own debug log (`OK created … model`), not
+  `run_results.json`.
+- dbt Cloud job selectors/schedules live only in dbt Cloud — pull them via the
+  Admin API `jobs/` endpoint (`execute_steps`, `schedule.cron`, `triggers`).
+- `system.query.history` column is `statement_text` (not `query_text`); dbt stamps
+  each query with `"node_id": "..."` in a leading comment — regexp-extract it to
+  attribute cost to a model/test.

--- a/.claude/skills/dbt-databricks-cost-audit/scripts/cost_audit.py
+++ b/.claude/skills/dbt-databricks-cost-audit/scripts/cost_audit.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Pull dbt/Databricks cost + usage from system tables and emit an interactive HTML dashboard.
+
+Requires: databricks CLI configured with a workspace profile that can read the
+`system.billing` and `system.query` schemas, and a SQL warehouse to run against.
+
+Usage:
+  python cost_audit.py --profile databricks-gp --warehouse 18583d8b081c6486 \
+      --dbt-app "Databricks Dbt" --since 2026-01-01 --out cost_dashboard.html
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from collections import defaultdict
+
+
+def run_sql(profile, warehouse, stmt):
+    payload = {
+        "warehouse_id": warehouse,
+        "wait_timeout": "50s",
+        "format": "JSON_ARRAY",
+        "disposition": "INLINE",
+        "statement": stmt,
+    }
+    p = subprocess.run(
+        [
+            "databricks",
+            "api",
+            "post",
+            "/api/2.0/sql/statements",
+            "--json",
+            json.dumps(payload),
+            "-p",
+            profile,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    d = json.loads(p.stdout or "{}")
+    sid = d.get("statement_id")
+    while d.get("status", {}).get("state") in ("PENDING", "RUNNING"):
+        time.sleep(2)
+        g = subprocess.run(
+            ["databricks", "api", "get", f"/api/2.0/sql/statements/{sid}", "-p", profile],
+            capture_output=True,
+            text=True,
+        )
+        d = json.loads(g.stdout or "{}")
+    if d.get("status", {}).get("state") != "SUCCEEDED":
+        raise RuntimeError(json.dumps(d.get("status", {}))[:500])
+    return d.get("result", {}).get("data_array") or []
+
+
+# --- period expressions ---------------------------------------------------
+M = "date_format(date_trunc('MONTH', {c}), 'yyyy-MM')"
+W = "date_format(date_trunc('WEEK', {c}), 'yyyy-MM-dd')"
+
+PRICE_JOIN = (
+    "left join system.billing.list_prices p on u.sku_name=p.sku_name "
+    "and u.usage_start_time>=p.price_start_time "
+    "and (p.price_end_time is null or u.usage_end_time<=p.price_end_time)"
+)
+
+
+def q_product(grain_expr, since):
+    return (
+        f"select {grain_expr.format(c='u.usage_date')} period, u.billing_origin_product prod, "
+        f"round(sum(u.usage_quantity*p.pricing.default),2) usd "
+        f"from system.billing.usage u {PRICE_JOIN} "
+        f"where u.usage_date>='{since}' group by 1,2 having usd>0 order by 1,2"
+    )
+
+
+def q_wh_usd(grain_expr, since, wh):
+    # dollars for the dbt warehouse itself, for prorating query-time -> $
+    return (
+        f"select {grain_expr.format(c='u.usage_date')} period, "
+        f"round(sum(u.usage_quantity*p.pricing.default),2) usd "
+        f"from system.billing.usage u {PRICE_JOIN} "
+        f"where u.usage_date>='{since}' and u.billing_origin_product='SQL' "
+        f"and u.usage_metadata.warehouse_id='{wh}' group by 1"
+    )
+
+
+def q_nodetype(grain_expr, since, wh, dbt_app):
+    # dbt exec-hours split by node resource type (model/test/snapshot/seed/overhead)
+    node = 'regexp_extract(statement_text, \'"node_id": ?"([^"]+)"\', 1)'
+    typ = f"case when {node}='' then 'overhead' " f"else element_at(split({node},'[.]'),1) end"
+    return (
+        f"select {grain_expr.format(c='start_time')} period, {typ} node_type, "
+        f"round(sum(execution_duration_ms)/3600000,2) exec_hr, count(*) q "
+        f"from system.query.history where compute.warehouse_id='{wh}' "
+        f"and client_application='{dbt_app}' and start_time>='{since}' group by 1,2"
+    )
+
+
+def q_consumer(grain_expr, since, wh):
+    return (
+        f"select {grain_expr.format(c='start_time')} period, "
+        f"coalesce(nullif(client_application,''),'(service principal)') consumer, "
+        f"round(sum(execution_duration_ms)/3600000,2) exec_hr "
+        f"from system.query.history where compute.warehouse_id='{wh}' "
+        f"and start_time>='{since}' group by 1,2"
+    )
+
+
+def q_topnodes(since, wh, dbt_app):
+    node = 'regexp_extract(statement_text, \'"node_id": ?"([^"]+)"\', 1)'
+    return (
+        f"select {node} node, element_at(split({node},'[.]'),1) t, "
+        f"round(sum(execution_duration_ms)/3600000,1) exec_hr, count(*) q, "
+        f"round(sum(read_bytes)/1e12,2) tb "
+        f"from system.query.history where compute.warehouse_id='{wh}' "
+        f"and client_application='{dbt_app}' and start_time>='{since}' "
+        f"and {node}!='' group by 1,2 order by exec_hr desc limit 25"
+    )
+
+
+def q_freq_windows(since, wh, dbt_app):
+    # dbt exec-hr in the 4 daily hours that ONLY the every-4h job runs (UTC 4,8,16,20),
+    # scaled x6/4 to estimate the full high-frequency-job footprint.
+    return (
+        f"select {M.format(c='start_time')} period, "
+        f"round(sum(case when hour(start_time) in (4,8,16,20) then execution_duration_ms else 0 end)"
+        f"/3600000 *6.0/4.0,2) freq_hr "
+        f"from system.query.history where compute.warehouse_id='{wh}' "
+        f"and client_application='{dbt_app}' and start_time>='{since}' group by 1"
+    )
+
+
+def collect(profile, warehouse, since, dbt_app):
+    data = {"grains": {}}
+    for gname, gexpr in (("month", M), ("week", W)):
+        prod = run_sql(profile, warehouse, q_product(gexpr, since))
+        whusd = dict(
+            (r[0], float(r[1])) for r in run_sql(profile, warehouse, q_wh_usd(gexpr, since, warehouse))
+        )
+        ntype = run_sql(profile, warehouse, q_nodetype(gexpr, since, warehouse, dbt_app))
+        cons = run_sql(profile, warehouse, q_consumer(gexpr, since, warehouse))
+        # total WH exec-hr per period (all consumers) for prorating
+        tot_hr = defaultdict(float)
+        for period, consumer, hr in cons:
+            tot_hr[period] += float(hr or 0)
+
+        def prorate(period, hr):
+            t = tot_hr.get(period, 0)
+            return round(whusd.get(period, 0) * (float(hr or 0) / t), 2) if t else 0.0
+
+        data["grains"][gname] = {
+            "product": [{"period": r[0], "k": r[1], "usd": float(r[2])} for r in prod],
+            "nodetype": [
+                {
+                    "period": r[0],
+                    "k": r[1],
+                    "hr": float(r[2] or 0),
+                    "usd": prorate(r[0], r[2]),
+                    "q": int(r[3]),
+                }
+                for r in ntype
+            ],
+            "consumer": [
+                {"period": r[0], "k": r[1], "hr": float(r[2] or 0), "usd": prorate(r[0], r[2])} for r in cons
+            ],
+        }
+    data["topnodes"] = [
+        {
+            "node": r[0].split(".")[-1],
+            "type": r[1],
+            "hr": float(r[2] or 0),
+            "q": int(r[3]),
+            "tb": float(r[4] or 0),
+        }
+        for r in run_sql(profile, warehouse, q_topnodes(since, warehouse, dbt_app))
+    ]
+    data["freq"] = [
+        {"period": r[0], "hr": float(r[1] or 0)}
+        for r in run_sql(profile, warehouse, q_freq_windows(since, warehouse, dbt_app))
+    ]
+    data["meta"] = {"since": since, "warehouse": warehouse, "dbt_app": dbt_app}
+    return data
+
+
+def render_html(data, out):
+    tpl = open(__file__.replace("cost_audit.py", "dashboard_template.html")).read()
+    html = tpl.replace("/*__DATA__*/{}", json.dumps(data))
+    open(out, "w").write(html)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", default="databricks-gp")
+    ap.add_argument("--warehouse", required=True)
+    ap.add_argument("--dbt-app", default="Databricks Dbt")
+    ap.add_argument("--since", default="2026-01-01")
+    ap.add_argument("--out", default="cost_dashboard.html")
+    ap.add_argument("--data-only", action="store_true")
+    ap.add_argument("--from-json", help="skip queries, render HTML from an existing json file")
+    a = ap.parse_args()
+    if a.from_json:
+        data = json.load(open(a.from_json))
+        render_html(data, a.out)
+        print(f"rendered {a.out} from {a.from_json}")
+        sys.exit(0)
+    data = collect(a.profile, a.warehouse, a.since, a.dbt_app)
+    json.dump(data, open(a.out.replace(".html", ".json"), "w"), indent=2)
+    # quick validation summary
+    g = data["grains"]["month"]
+    months = sorted({r["period"] for r in g["product"]})
+    last = months[-1]
+    prod_total = sum(r["usd"] for r in g["product"] if r["period"] == last)
+    test_usd = sum(r["usd"] for r in g["nodetype"] if r["period"] == last and r["k"] == "test")
+    dbt_usd = sum(r["usd"] for r in g["nodetype"] if r["period"] == last)
+    freq = dict((r["period"], r["hr"]) for r in data["freq"])
+    print(f"months: {months}")
+    print(
+        f"latest {last}: total=${prod_total:.0f}  dbt(alloc)=${dbt_usd:.0f}  TEST=${test_usd:.0f} ({100*test_usd/prod_total:.0f}% of total)"
+    )
+    print(f"freq-job est exec-hr {last}: {freq.get(last,0):.0f}")
+    if a.data_only:
+        sys.exit(0)
+    render_html(data, a.out)
+    print(f"wrote {a.out}")

--- a/.claude/skills/dbt-databricks-cost-audit/scripts/cost_audit.py
+++ b/.claude/skills/dbt-databricks-cost-audit/scripts/cost_audit.py
@@ -107,6 +107,41 @@ def q_consumer(grain_expr, since, wh):
     )
 
 
+def q_principal(grain_expr, since, wh):
+    # who ran it: user email or service-principal application id (mapped to name below)
+    return (
+        f"select {grain_expr.format(c='start_time')} period, "
+        f"coalesce(executed_by,'(unknown)') principal, "
+        f"round(sum(execution_duration_ms)/3600000,2) exec_hr "
+        f"from system.query.history where compute.warehouse_id='{wh}' "
+        f"and start_time>='{since}' group by 1,2"
+    )
+
+
+def sp_names(profile):
+    """Map service-principal applicationId -> displayName (best effort)."""
+    try:
+        p = subprocess.run(
+            ["databricks", "service-principals", "list", "-o", "json", "-p", profile],
+            capture_output=True,
+            text=True,
+        )
+        arr = json.loads(p.stdout)
+        return {sp.get("applicationId"): sp.get("displayName") for sp in arr if sp.get("applicationId")}
+    except Exception:
+        return {}
+
+
+def label_principal(principal, spmap):
+    if principal in spmap:
+        return f"SP: {spmap[principal]}"
+    if "@" in (principal or ""):
+        return principal  # human user email
+    if principal in ("(unknown)", ""):
+        return "(unknown)"
+    return f"SP: {principal[:8]}…"  # unmapped service principal id
+
+
 def q_topnodes(since, wh, dbt_app):
     node = 'regexp_extract(statement_text, \'"node_id": ?"([^"]+)"\', 1)'
     return (
@@ -133,6 +168,7 @@ def q_freq_windows(since, wh, dbt_app):
 
 def collect(profile, warehouse, since, dbt_app):
     data = {"grains": {}}
+    spmap = sp_names(profile)
     for gname, gexpr in (("month", M), ("week", W)):
         prod = run_sql(profile, warehouse, q_product(gexpr, since))
         whusd = dict(
@@ -140,6 +176,7 @@ def collect(profile, warehouse, since, dbt_app):
         )
         ntype = run_sql(profile, warehouse, q_nodetype(gexpr, since, warehouse, dbt_app))
         cons = run_sql(profile, warehouse, q_consumer(gexpr, since, warehouse))
+        princ = run_sql(profile, warehouse, q_principal(gexpr, since, warehouse))
         # total WH exec-hr per period (all consumers) for prorating
         tot_hr = defaultdict(float)
         for period, consumer, hr in cons:
@@ -149,6 +186,10 @@ def collect(profile, warehouse, since, dbt_app):
             t = tot_hr.get(period, 0)
             return round(whusd.get(period, 0) * (float(hr or 0) / t), 2) if t else 0.0
 
+        # principals share a period's queries across many rows -> aggregate by label
+        pagg = defaultdict(float)
+        for period, principal, hr in princ:
+            pagg[(period, label_principal(principal, spmap))] += float(hr or 0)
         data["grains"][gname] = {
             "product": [{"period": r[0], "k": r[1], "usd": float(r[2])} for r in prod],
             "nodetype": [
@@ -163,6 +204,10 @@ def collect(profile, warehouse, since, dbt_app):
             ],
             "consumer": [
                 {"period": r[0], "k": r[1], "hr": float(r[2] or 0), "usd": prorate(r[0], r[2])} for r in cons
+            ],
+            "principal": [
+                {"period": p, "k": k, "hr": round(hr, 2), "usd": prorate(p, hr)}
+                for (p, k), hr in pagg.items()
             ],
         }
     data["topnodes"] = [

--- a/.claude/skills/dbt-databricks-cost-audit/scripts/dashboard_template.html
+++ b/.claude/skills/dbt-databricks-cost-audit/scripts/dashboard_template.html
@@ -1,0 +1,177 @@
+<style>
+  :root{
+    --bg:#ffffff; --panel:#f6f7f9; --ink:#12151a; --muted:#5b6472; --line:#e3e7ec;
+    --accent:#3b6ea5; --good:#2e7d59; --warn:#b5822b; --bad:#b3453b;
+    --c0:#3b6ea5;--c1:#c25a4a;--c2:#4a9d6b;--c3:#b5822b;--c4:#7a5ea8;--c5:#3f9aa8;--c6:#a8547f;--c7:#8a8f98;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#0e1116;--panel:#171b22;--ink:#e6e9ee;--muted:#9aa4b2;--line:#272d38;
+    --accent:#6fa8dc;--good:#5ec08c;--warn:#e0b563;--bad:#e07d72;
+    --c0:#6fa8dc;--c1:#e08573;--c2:#6fc793;--c3:#e0b563;--c4:#b79fe0;--c5:#68c6d4;--c6:#dc8bb4;--c7:#aab2be;
+  }}
+  :root[data-theme="dark"]{--bg:#0e1116;--panel:#171b22;--ink:#e6e9ee;--muted:#9aa4b2;--line:#272d38;--accent:#6fa8dc;--good:#5ec08c;--warn:#e0b563;--bad:#e07d72;--c0:#6fa8dc;--c1:#e08573;--c2:#6fc793;--c3:#e0b563;--c4:#b79fe0;--c5:#68c6d4;--c6:#dc8bb4;--c7:#aab2be;}
+  :root[data-theme="light"]{--bg:#ffffff;--panel:#f6f7f9;--ink:#12151a;--muted:#5b6472;--line:#e3e7ec;--accent:#3b6ea5;--good:#2e7d59;--warn:#b5822b;--bad:#b3453b;--c0:#3b6ea5;--c1:#c25a4a;--c2:#4a9d6b;--c3:#b5822b;--c4:#7a5ea8;--c5:#3f9aa8;--c6:#a8547f;--c7:#8a8f98;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+  .wrap{max-width:1040px;margin:0 auto;padding:24px 18px 60px}
+  h1{font-size:22px;margin:0 0 2px}
+  .sub{color:var(--muted);font-size:13px;margin-bottom:18px}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:10px;margin-bottom:14px}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:12px 14px}
+  .card .lbl{color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+  .card .val{font-size:22px;font-weight:650;margin-top:3px}
+  .card .note{font-size:11px;color:var(--muted);margin-top:2px}
+  .verdict{background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;padding:12px 14px;margin-bottom:18px;font-size:13px}
+  .verdict b{color:var(--ink)}
+  .controls{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-bottom:12px}
+  .seg{display:inline-flex;border:1px solid var(--line);border-radius:8px;overflow:hidden}
+  .seg button{background:transparent;color:var(--muted);border:0;padding:6px 12px;font:inherit;cursor:pointer}
+  .seg button.on{background:var(--accent);color:#fff}
+  .chartbox{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px;overflow-x:auto}
+  .legend{display:flex;flex-wrap:wrap;gap:10px 16px;margin-top:10px;font-size:12px}
+  .legend span{display:inline-flex;align-items:center;gap:6px;color:var(--muted)}
+  .sw{width:11px;height:11px;border-radius:2px;display:inline-block}
+  table{width:100%;border-collapse:collapse;font-size:12.5px;margin-top:8px}
+  th,td{text-align:right;padding:5px 8px;border-bottom:1px solid var(--line)}
+  th:first-child,td:first-child{text-align:left}
+  th{color:var(--muted);font-weight:600}
+  .tt{position:fixed;pointer-events:none;background:var(--ink);color:var(--bg);padding:5px 8px;border-radius:6px;font-size:12px;opacity:0;transition:opacity .08s;white-space:nowrap;z-index:9}
+  h2{font-size:15px;margin:26px 0 6px}
+  .muted{color:var(--muted)}
+</style>
+
+<div class="wrap">
+  <h1>dbt &amp; Databricks cost audit</h1>
+  <div class="sub" id="meta"></div>
+
+  <div class="cards" id="cards"></div>
+  <div class="verdict" id="verdict"></div>
+
+  <div class="controls">
+    <div class="seg" id="grain">
+      <button data-g="month" class="on">Monthly</button>
+      <button data-g="week">Weekly</button>
+    </div>
+    <div class="seg" id="view">
+      <button data-v="product" class="on">Total by product</button>
+      <button data-v="nodetype">dbt by node type</button>
+      <button data-v="consumer">Warehouse by consumer</button>
+    </div>
+  </div>
+
+  <div class="chartbox">
+    <svg id="chart" width="1000" height="360" role="img"></svg>
+    <div class="legend" id="legend"></div>
+  </div>
+
+  <h2>Top dbt nodes by execution time <span class="muted" id="nodespan"></span></h2>
+  <div class="chartbox">
+    <table id="nodes"><thead><tr><th>node</th><th>type</th><th>exec-hr</th><th>runs</th><th>TB read</th></tr></thead><tbody></tbody></table>
+  </div>
+</div>
+<div class="tt" id="tt"></div>
+
+<script>
+const DATA = /*__DATA__*/{};
+const COLORS=["--c0","--c1","--c2","--c3","--c4","--c5","--c6","--c7"];
+const cssv=n=>getComputedStyle(document.documentElement).getPropertyValue(n)||"#888";
+const usd=v=>"$"+Math.round(v).toLocaleString();
+let grain="month", view="product";
+
+// ---- aggregation helpers -------------------------------------------------
+function series(grain, view){
+  // returns {periods:[], cats:[], val:{period:{cat:usd}}, unit}
+  const rows = DATA.grains[grain][view];
+  const key = "usd";
+  const periods=[...new Set(rows.map(r=>r.period))].sort();
+  const totals={};
+  rows.forEach(r=>totals[r.k]=(totals[r.k]||0)+r[key]);
+  let cats=Object.keys(totals).sort((a,b)=>totals[b]-totals[a]);
+  const KEEP=7; let keep=cats.slice(0,KEEP), rest=new Set(cats.slice(KEEP));
+  const val={}; periods.forEach(p=>val[p]={});
+  rows.forEach(r=>{const c=rest.has(r.k)?"Other":r.k; val[r.period][c]=(val[r.period][c]||0)+r[key];});
+  if(rest.size) keep.push("Other");
+  return {periods,cats:keep,val};
+}
+// latest complete-ish month metrics for headline
+function metrics(){
+  const g=DATA.grains.month;
+  const months=[...new Set(g.product.map(r=>r.period))].sort();
+  const last=months[months.length-1];
+  const sum=(rows,f)=>rows.filter(f).reduce((a,r)=>a+r.usd,0);
+  const total=sum(g.product,r=>r.period===last);
+  const dbt=sum(g.nodetype,r=>r.period===last);
+  const test=sum(g.nodetype,r=>r.period===last&&r.k==="test");
+  const dbtHr=g.nodetype.filter(r=>r.period===last).reduce((a,r)=>a+r.hr,0);
+  const perHr=dbtHr?dbt/dbtHr:0;
+  const freqHr=(DATA.freq.find(r=>r.period===last)||{}).hr||0;
+  const freqUsd=freqHr*perHr;
+  return {last,total,dbt,test,freqUsd,months};
+}
+
+function renderCards(){
+  const m=metrics();
+  const c=[
+    ["Total Databricks",usd(m.total),m.last+" (month-to-date)"],
+    ["dbt (allocated)",usd(m.dbt),Math.round(100*m.dbt/m.total)+"% of total"],
+    ["Testing",usd(m.test),Math.round(100*m.test/m.total)+"% of total · "+Math.round(100*m.test/m.dbt)+"% of dbt"],
+    ["High-freq job (est)",usd(m.freqUsd),Math.round(100*m.freqUsd/m.dbt)+"% of dbt"],
+  ];
+  document.getElementById("cards").innerHTML=c.map(x=>
+    `<div class="card"><div class="lbl">${x[0]}</div><div class="val">${x[1]}</div><div class="note">${x[2]}</div></div>`).join("");
+  const suff=m.freqUsd<m.test;
+  document.getElementById("verdict").innerHTML=
+    `<b>Is eliminating the high-frequency job sufficient?</b> `+
+    (suff
+      ? `No. Testing (<b>${usd(m.test)}</b>/mo) costs more than the whole high-frequency job (<b>${usd(m.freqUsd)}</b>/mo), and most testing runs in the twice-daily main job. Killing the high-freq job removes ~${Math.round(100*m.freqUsd/m.dbt)}% of dbt spend but leaves the larger testing cost behind — you also need to decouple the full test suite from every build.`
+      : `Possibly. The high-frequency job (<b>${usd(m.freqUsd)}</b>/mo) is the single largest dbt lever this month.`);
+  document.getElementById("meta").textContent=
+    `Warehouse ${DATA.meta.warehouse} · dbt app "${DATA.meta.dbt_app}" · since ${DATA.meta.since} · $ for dbt/consumer views are the SQL-warehouse bill prorated by query execution time.`;
+  document.getElementById("nodespan").textContent=" (since "+DATA.meta.since+")";
+}
+
+function renderChart(){
+  const {periods,cats,val}=series(grain,view);
+  const svg=document.getElementById("chart");
+  const W=Math.max(1000, periods.length*(grain==="week"?34:120)+80), H=360, PADL=52,PADB=42,PADT=12;
+  svg.setAttribute("width",W); svg.setAttribute("viewBox",`0 0 ${W} ${H}`);
+  const max=Math.max(1,...periods.map(p=>cats.reduce((a,c)=>a+(val[p][c]||0),0)));
+  const nice=Math.pow(10,Math.floor(Math.log10(max)));const top=Math.ceil(max/nice)*nice;
+  const y=v=>PADT+(H-PADT-PADB)*(1-v/top);
+  const bw=Math.min(80,(W-PADL-20)/periods.length*0.7);
+  let s=`<line x1="${PADL}" y1="${y(0)}" x2="${W-8}" y2="${y(0)}" stroke="${cssv('--line')}"/>`;
+  for(let i=0;i<=4;i++){const gv=top*i/4;const yy=y(gv);
+    s+=`<line x1="${PADL}" y1="${yy}" x2="${W-8}" y2="${yy}" stroke="${cssv('--line')}" opacity=".5"/>`;
+    s+=`<text x="${PADL-6}" y="${yy+4}" text-anchor="end" font-size="10" fill="${cssv('--muted')}">${usd(gv)}</text>`;}
+  periods.forEach((p,i)=>{
+    const x=PADL+8+i*((W-PADL-20)/periods.length);let acc=0;
+    cats.forEach((c,ci)=>{const v=val[p][c]||0;if(v<=0)return;const h=(H-PADT-PADB)*v/top;const yy=y(acc)-h;acc+=v;
+      s+=`<rect x="${x}" y="${yy}" width="${bw}" height="${h}" fill="${cssv(COLORS[ci%8])}" data-p="${p}" data-c="${c}" data-v="${v}"/>`;});
+    const lbl=grain==="week"?p.slice(5):p;
+    s+=`<text x="${x+bw/2}" y="${H-PADB+14}" text-anchor="middle" font-size="10" fill="${cssv('--muted')}" transform="rotate(${grain==='week'?45:0} ${x+bw/2} ${H-PADB+14})">${lbl}</text>`;
+  });
+  svg.innerHTML=s;
+  document.getElementById("legend").innerHTML=cats.map((c,ci)=>{
+    const tot=periods.reduce((a,p)=>a+(val[p][c]||0),0);
+    return `<span><i class="sw" style="background:${cssv(COLORS[ci%8])}"></i>${c} · ${usd(tot)}</span>`;}).join("");
+  const tt=document.getElementById("tt");
+  svg.querySelectorAll("rect[data-c]").forEach(r=>{
+    r.addEventListener("mousemove",e=>{tt.style.opacity=1;tt.style.left=(e.clientX+12)+"px";tt.style.top=(e.clientY-8)+"px";
+      tt.textContent=`${r.dataset.p} · ${r.dataset.c}: ${usd(+r.dataset.v)}`;});
+    r.addEventListener("mouseleave",()=>tt.style.opacity=0);});
+}
+
+function renderNodes(){
+  const tb=document.querySelector("#nodes tbody");
+  tb.innerHTML=DATA.topnodes.map(n=>
+    `<tr><td>${n.node}</td><td class="muted">${n.type}</td><td>${n.hr.toFixed(1)}</td><td>${n.q.toLocaleString()}</td><td>${n.tb.toFixed(2)}</td></tr>`).join("");
+}
+
+document.getElementById("grain").addEventListener("click",e=>{const b=e.target.closest("button");if(!b)return;
+  grain=b.dataset.g;[...e.currentTarget.children].forEach(x=>x.classList.toggle("on",x===b));renderChart();});
+document.getElementById("view").addEventListener("click",e=>{const b=e.target.closest("button");if(!b)return;
+  view=b.dataset.v;[...e.currentTarget.children].forEach(x=>x.classList.toggle("on",x===b));renderChart();});
+new MutationObserver(()=>renderChart()).observe(document.documentElement,{attributes:true,attributeFilter:["data-theme"]});
+
+renderCards();renderChart();renderNodes();
+</script>

--- a/.claude/skills/dbt-databricks-cost-audit/scripts/dashboard_template.html
+++ b/.claude/skills/dbt-databricks-cost-audit/scripts/dashboard_template.html
@@ -55,7 +55,8 @@
     <div class="seg" id="view">
       <button data-v="product" class="on">Total by product</button>
       <button data-v="nodetype">dbt by node type</button>
-      <button data-v="consumer">Warehouse by consumer</button>
+      <button data-v="consumer">By application</button>
+      <button data-v="principal">By user / service principal</button>
     </div>
   </div>
 


### PR DESCRIPTION
## What

A reusable Claude skill, `dbt-databricks-cost-audit`, that attributes Databricks and dbt Cloud spend to its real drivers and generates a **self-contained interactive HTML dashboard** from the `system.billing` and `system.query` system tables.

```
.claude/skills/dbt-databricks-cost-audit/
  SKILL.md
  scripts/cost_audit.py            # pull + render
  scripts/dashboard_template.html  # self-contained, theme-aware
```

Run:
```bash
python scripts/cost_audit.py --profile databricks-gp --warehouse <id> --since 2026-01-01 --out cost_dashboard.html
# rebuild the viz without re-billing queries:
python scripts/cost_audit.py --warehouse <id> --from-json cost_dashboard.json --out cost_dashboard.html
```

The dashboard slices cost **monthly and weekly** by product, by warehouse consumer, and by **dbt node type (model vs test vs snapshot)**, with a headline that computes testing cost and an estimate of the high-frequency job's cost.

## Why / what it already told us

Answering the two questions that motivated it, from real data:
- **Testing is ~half of dbt's Databricks cost and climbing** (allocated): ~$275 (May) → ~$818 (Jun) → ~$1,023 (Jul MTD), ~22% of the entire bill.
- **Eliminating the high-frequency job is not sufficient on its own** — that job (~$700–850/mo est) is smaller than total testing cost, and most testing runs in the twice-daily main job. The full test suite needs decoupling from every build.

## Notes

- The `$` in the dbt/consumer views is the SQL-warehouse bill **prorated by query execution time** (serverless bills warehouse uptime, not per query); the dashboard states this.
- Generated `cost_dashboard.{html,json}` contain internal cost figures and are **not** committed — the PR ships only the tool.
- Requires a Databricks CLI profile with `system.*` read access and a SQL warehouse id.

Ticket: DATA-2147