### PR TITLE
[DATA-2118] Sync Person and OfficeHolder to election-api

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -756,7 +756,8 @@ models:
       int__ballotready_person, which is fetched candidacy-first, so elected
       officials with no BR candidacy carry only the fallback fields from the
       office_holders_v3 feed (a known follow-up). Delivered to Postgres by
-      write__election_api_db (full re-upsert each run).
+      write__election_api_db (full re-upsert each run; stale ids are not
+      deleted — an accepted gap until delivery moves to the Airflow swap).
     columns:
       - name: id
         description: "Canonical person UUID (gp_person_id). Primary key."

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -748,7 +748,7 @@ models:
 
   - name: m_election_api__person
     description: >
-      Person spine for public /people profiles (election-api "Person" table).
+      Person records for public /people profiles (election-api "Person" table).
       One row per canonical person (id = gp_person_id, the same id space
       Candidacy.gp_candidate_id publishes), scoped to people with a candidacy
       or office term and at least one name part. BallotReady-rich fields

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -755,9 +755,8 @@ models:
       (bio, headshot, links, degrees, experiences) come from
       int__ballotready_person, which is fetched candidacy-first, so elected
       officials with no BR candidacy carry only the fallback fields from the
-      office_holders_v3 feed (a known follow-up). Delivered to Postgres by
-      write__election_api_db (full re-upsert each run; stale ids are not
-      deleted — an accepted gap until delivery moves to the Airflow swap).
+      office_holders_v3 feed (a known follow-up). Stale ids are not deleted
+      from the API (accepted gap).
     columns:
       - name: id
         description: "Canonical person UUID (gp_person_id). Primary key."
@@ -780,8 +779,7 @@ models:
       table). One row per BallotReady office-holder term (id =
       gp_elected_official_term_id). Inner-joins m_election_api__person because
       person_id is a required FK in the API; vacancies and no-name people drop
-      here rather than failing the load. Delivered to Postgres by
-      write__election_api_db (full re-upsert each run, stale terms deleted).
+      here rather than failing the load.
     columns:
       - name: id
         description: "Term-grain canonical UUID (gp_elected_official_term_id). Primary key."
@@ -798,9 +796,6 @@ models:
                 to: ref('m_election_api__person')
                 field: id
       - name: position_id
-        description: "Election API position UUID. Nullable FK to m_election_api__position."
-        tests:
-          - relationships:
-              arguments:
-                to: ref('m_election_api__position')
-                field: id
+        description: >
+          Election API position UUID. Nullable FK to m_election_api__position
+          (selected off the joined position mart, so referential by construction).

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -745,3 +745,61 @@ models:
           name: eos_support_never_exceeds_total_constituents
           config:
             severity: warn
+
+  - name: m_election_api__person
+    description: >
+      Person spine for public /people profiles (election-api "Person" table).
+      One row per canonical person (id = gp_person_id, the same id space
+      Candidacy.gp_candidate_id publishes), scoped to people with a candidacy
+      or office term and at least one name part. BallotReady-rich fields
+      (bio, headshot, links, degrees, experiences) come from
+      int__ballotready_person, which is fetched candidacy-first, so elected
+      officials with no BR candidacy carry only the fallback fields from the
+      office_holders_v3 feed (a known follow-up). Delivered to Postgres by
+      write__election_api_db (full re-upsert each run).
+    columns:
+      - name: id
+        description: "Canonical person UUID (gp_person_id). Primary key."
+        tests:
+          - not_null
+          - unique
+          - is_uuid
+      - name: slug
+        description: >
+          slugify(first_name-last_name). Cosmetic URL prefix; NOT NULL but not
+          unique in the API (the trailing UUID disambiguates).
+        tests:
+          - not_null
+      - name: br_person_id
+        description: "BallotReady person databaseId; null for GP-native people."
+
+  - name: m_election_api__office_holder
+    description: >
+      Office terms for public /people profiles (election-api "OfficeHolder"
+      table). One row per BallotReady office-holder term (id =
+      gp_elected_official_term_id). Inner-joins m_election_api__person because
+      person_id is a required FK in the API; vacancies and no-name people drop
+      here rather than failing the load. Delivered to Postgres by
+      write__election_api_db (full re-upsert each run, stale terms deleted).
+    columns:
+      - name: id
+        description: "Term-grain canonical UUID (gp_elected_official_term_id). Primary key."
+        tests:
+          - not_null
+          - unique
+          - is_uuid
+      - name: person_id
+        description: "Canonical person UUID. Required FK to m_election_api__person."
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('m_election_api__person')
+                field: id
+      - name: position_id
+        description: "Election API position UUID. Nullable FK to m_election_api__position."
+        tests:
+          - relationships:
+              arguments:
+                to: ref('m_election_api__position')
+                field: id

--- a/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
@@ -4,10 +4,6 @@
 -- inner-joins m_election_api__person: vacancies and no-name people drop here
 -- rather than failing the FK at load time.
 with
-    terms as (
-        select * from {{ ref("elected_official_terms") }} where gp_person_id is not null
-    ),
-
     persons as (select id from {{ ref("m_election_api__person") }}),
 
     positions as (select id, br_database_id from {{ ref("m_election_api__position") }}),
@@ -81,7 +77,7 @@ select
     office_holder_source.mtfcc,
     terms.gp_person_id as person_id,
     positions.id as position_id
-from terms
+from {{ ref("elected_official_terms") }} as terms
 inner join persons on terms.gp_person_id = persons.id
 left join
     office_holder_source

--- a/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
@@ -8,8 +8,9 @@ with
 
     positions as (select id, br_database_id from {{ ref("m_election_api__position") }}),
 
-    -- Term fields the civics mart doesn't carry; staging is unique per
-    -- br_office_holder_id.
+    -- Term fields the civics mart doesn't carry; staging carries one row per
+    -- br_office_holder_id (unique-tested), and the qualify guards the join
+    -- against fan-out if the feed ever re-delivers a term.
     office_holder_source as (
         select
             br_office_holder_id,
@@ -22,6 +23,11 @@ with
             nullif(mtfcc, '') as mtfcc,
             case when size(party_names) > 0 then party_names end as party_names
         from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+        qualify
+            row_number() over (
+                partition by br_office_holder_id order by office_holder_updated_at desc
+            )
+            = 1
     ),
 
     -- Earliest upcoming election on the same BR position: "next election" for

--- a/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__office_holder.sql
@@ -1,0 +1,90 @@
+-- Office terms for public /people profiles (election-api "OfficeHolder" table).
+-- Grain: one row per BallotReady office-holder term (id =
+-- gp_elected_official_term_id). person_id is NOT NULL in the API, so the mart
+-- inner-joins m_election_api__person: vacancies and no-name people drop here
+-- rather than failing the FK at load time.
+with
+    terms as (
+        select * from {{ ref("elected_official_terms") }} where gp_person_id is not null
+    ),
+
+    persons as (select id from {{ ref("m_election_api__person") }}),
+
+    positions as (select id, br_database_id from {{ ref("m_election_api__position") }}),
+
+    -- Term fields the civics mart doesn't carry; staging is unique per
+    -- br_office_holder_id.
+    office_holder_source as (
+        select
+            br_office_holder_id,
+            -- the S3 feed uses '' (not null) for absent values on these
+            nullif(office_title, '') as office_title,
+            nullif(term_date_specificity, '') as term_date_specificity,
+            number_of_seats,
+            nullif(sub_area_name, '') as sub_area_name,
+            nullif(sub_area_value, '') as sub_area_value,
+            nullif(mtfcc, '') as mtfcc,
+            case when size(party_names) > 0 then party_names end as party_names
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+    ),
+
+    -- Earliest upcoming election on the same BR position: "next election" for
+    -- the seat in the profile's About Office section.
+    next_elections as (
+        select br_position_id, min(election_date) as next_election_date
+        from {{ ref("election_stage") }}
+        where election_date >= current_date()
+        group by br_position_id
+    )
+
+select
+    terms.gp_elected_official_term_id as id,
+    terms.br_office_holder_id,
+    terms.position_name,
+    terms.normalized_position_name,
+    office_holder_source.office_title,
+    office_holder_source.party_names,
+    terms.term_start_date as start_at,
+    terms.term_end_date as end_at,
+    office_holder_source.term_date_specificity,
+    case
+        when terms.term_end_date < current_date()
+        then false
+        when terms.term_start_date > current_date()
+        then false
+        when terms.term_start_date is null and terms.term_end_date is null
+        then cast(null as boolean)
+        else true
+    end as is_current,
+    terms.is_appointed,
+    terms.is_vacant,
+    office_holder_source.number_of_seats,
+    next_elections.next_election_date,
+    terms.mailing_address_line_1,
+    terms.mailing_address_line_2,
+    terms.mailing_city,
+    terms.mailing_state,
+    terms.mailing_zip,
+    terms.office_phone,
+    terms.email as office_email,
+    terms.website_url,
+    terms.linkedin_url,
+    terms.facebook_url,
+    terms.twitter_url,
+    get(
+        filter(terms.urls, x -> x.type = 'instagram' and x.url is not null), 0
+    ).url as instagram_url,
+    office_holder_source.sub_area_name,
+    office_holder_source.sub_area_value,
+    terms.state,
+    terms.br_geo_id as geo_id,
+    office_holder_source.mtfcc,
+    terms.gp_person_id as person_id,
+    positions.id as position_id
+from terms
+inner join persons on terms.gp_person_id = persons.id
+left join
+    office_holder_source
+    on terms.br_office_holder_id = office_holder_source.br_office_holder_id
+left join positions on terms.br_position_id = positions.br_database_id
+left join next_elections on terms.br_position_id = next_elections.br_position_id

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -11,7 +11,7 @@
 -- people keep all BR fields null.
 with
     public_people as (
-        select *
+        select *, try_cast(br_person_id as int) as br_person_id_int
         from {{ ref("people") }}
         where
             (is_candidate or is_elected_official)
@@ -106,7 +106,7 @@ with
 
 select
     people.gp_person_id as id,
-    cast(people.br_person_id as int) as br_person_id,
+    people.br_person_id_int as br_person_id,
     {{ slugify("concat_ws('-', people.first_name, people.last_name)") }} as slug,
     people.first_name,
     coalesce(br_person.middle_name, office_holder.middle_name) as middle_name,
@@ -129,7 +129,7 @@ select
     br_person.experiences,
     people.state
 from public_people as people
-left join br_person on cast(people.br_person_id as int) = br_person.database_id
+left join br_person on people.br_person_id_int = br_person.database_id
 left join
     office_holder_person as office_holder
-    on cast(people.br_person_id as int) = office_holder.br_candidate_id
+    on people.br_person_id_int = office_holder.br_candidate_id

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -75,13 +75,16 @@ with
             nullif(middle_name, '') as middle_name,
             nullif(nickname, '') as nickname,
             nullif(suffix, '') as suffix,
-            website_url,
-            linkedin_url,
-            facebook_url,
-            twitter_url,
-            get(
-                filter(urls, x -> x.type = 'instagram' and x.url is not null), 0
-            ).url as instagram_url
+            nullif(website_url, '') as website_url,
+            nullif(linkedin_url, '') as linkedin_url,
+            nullif(facebook_url, '') as facebook_url,
+            nullif(twitter_url, '') as twitter_url,
+            nullif(
+                get(
+                    filter(urls, x -> x.type = 'instagram' and x.url is not null), 0
+                ).url,
+                ''
+            ) as instagram_url
         from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
         where br_candidate_id is not null
         qualify

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -1,4 +1,4 @@
--- Person spine for public /people profiles (election-api "Person" table).
+-- Person records for public /people profiles (election-api "Person" table).
 -- Grain: one row per canonical person (id = gp_person_id), scoped to people
 -- with a candidacy or office term and a name part (slug is NOT NULL in the
 -- API). BR-rich fields fall back to the office feed: int__ballotready_person

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -1,14 +1,10 @@
 -- Person spine for public /people profiles (election-api "Person" table).
--- Grain: one row per canonical person (id = gp_person_id, the id space
--- Candidacy.gp_candidate_id already publishes). Scoped to people with a
--- candidacy or office term and at least one name part (slug is NOT NULL in
--- the API). BallotReady-rich fields come from int__ballotready_person via the
--- unambiguous br_person_id, falling back to the office_holders_v3 feed:
--- int__ballotready_person is fetched candidacy-first, so elected officials
--- with no BR candidacy are absent from it, while the office feed carries
--- their name parts and links. bio/headshot/degrees/experiences exist only on
--- the API person object and stay null for them (known follow-up). GP-native
--- people keep all BR fields null.
+-- Grain: one row per canonical person (id = gp_person_id), scoped to people
+-- with a candidacy or office term and a name part (slug is NOT NULL in the
+-- API). BR-rich fields fall back to the office feed: int__ballotready_person
+-- is candidacy-first, so elected officials with no BR candidacy are absent
+-- from it, and their bio/headshot/degrees/experiences stay null (known
+-- follow-up).
 with
     public_people as (
         select *, try_cast(br_person_id as int) as br_person_id_int
@@ -53,10 +49,7 @@ with
                         transform(
                             degrees,
                             d -> struct(
-                                d.degree as degree,
-                                d.major as major,
-                                d.school as school,
-                                d.gradyear as `gradYear`
+                                d.degree, d.major, d.school, d.gradyear as `gradYear`
                             )
                         )
                     )
@@ -67,13 +60,7 @@ with
                     to_json(
                         transform(
                             experiences,
-                            e -> struct(
-                                e.title as title,
-                                e.organization as organization,
-                                e.start as start,
-                                e.end as end,
-                                e.type as type
-                            )
+                            e -> struct(e.title, e.organization, e.start, e.end, e.type)
                         )
                     )
             end as experiences

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -1,0 +1,135 @@
+-- Person spine for public /people profiles (election-api "Person" table).
+-- Grain: one row per canonical person (id = gp_person_id, the id space
+-- Candidacy.gp_candidate_id already publishes). Scoped to people with a
+-- candidacy or office term and at least one name part (slug is NOT NULL in
+-- the API). BallotReady-rich fields come from int__ballotready_person via the
+-- unambiguous br_person_id, falling back to the office_holders_v3 feed:
+-- int__ballotready_person is fetched candidacy-first, so elected officials
+-- with no BR candidacy are absent from it, while the office feed carries
+-- their name parts and links. bio/headshot/degrees/experiences exist only on
+-- the API person object and stay null for them (known follow-up). GP-native
+-- people keep all BR fields null.
+with
+    public_people as (
+        select *
+        from {{ ref("people") }}
+        where
+            (is_candidate or is_elected_official)
+            and (first_name is not null or last_name is not null)
+    ),
+
+    br_person as (
+        select
+            database_id,
+            bio_text,
+            middle_name,
+            nickname,
+            suffix,
+            full_name,
+            get(
+                filter(images, x -> x.type = 'default' and x.url is not null), 0
+            ).url as headshot_url,
+            get(
+                filter(urls, x -> x.type = 'website' and x.url is not null), 0
+            ).url as website_url,
+            get(
+                filter(urls, x -> x.type = 'linkedin' and x.url is not null), 0
+            ).url as linkedin_url,
+            get(
+                filter(urls, x -> x.type = 'facebook' and x.url is not null), 0
+            ).url as facebook_url,
+            get(
+                filter(urls, x -> x.type = 'twitter' and x.url is not null), 0
+            ).url as twitter_url,
+            get(
+                filter(urls, x -> x.type = 'instagram' and x.url is not null), 0
+            ).url as instagram_url,
+            -- JSON strings (not native arrays): Spark's Postgres JDBC writer
+            -- does not round-trip array<struct>; the writer casts to jsonb.
+            case
+                when size(degrees) > 0
+                then
+                    to_json(
+                        transform(
+                            degrees,
+                            d -> struct(
+                                d.degree as degree,
+                                d.major as major,
+                                d.school as school,
+                                d.gradyear as `gradYear`
+                            )
+                        )
+                    )
+            end as degrees,
+            case
+                when size(experiences) > 0
+                then
+                    to_json(
+                        transform(
+                            experiences,
+                            e -> struct(
+                                e.title as title,
+                                e.organization as organization,
+                                e.start as start,
+                                e.end as end,
+                                e.type as type
+                            )
+                        )
+                    )
+            end as experiences
+        from {{ ref("int__ballotready_person") }}
+    ),
+
+    -- Fallback person fields from the office feed, one row per BR person
+    -- (latest term wins). The feed uses '' (not null) for absent name parts.
+    office_holder_person as (
+        select
+            br_candidate_id,
+            nullif(middle_name, '') as middle_name,
+            nullif(nickname, '') as nickname,
+            nullif(suffix, '') as suffix,
+            website_url,
+            linkedin_url,
+            facebook_url,
+            twitter_url,
+            get(
+                filter(urls, x -> x.type = 'instagram' and x.url is not null), 0
+            ).url as instagram_url
+        from {{ ref("stg_airbyte_source__ballotready_s3_office_holders_v3") }}
+        where br_candidate_id is not null
+        qualify
+            row_number() over (
+                partition by br_candidate_id order by office_holder_updated_at desc
+            )
+            = 1
+    )
+
+select
+    people.gp_person_id as id,
+    cast(people.br_person_id as int) as br_person_id,
+    {{ slugify("concat_ws('-', people.first_name, people.last_name)") }} as slug,
+    people.first_name,
+    coalesce(br_person.middle_name, office_holder.middle_name) as middle_name,
+    people.last_name,
+    coalesce(br_person.nickname, office_holder.nickname) as nickname,
+    coalesce(br_person.suffix, office_holder.suffix) as suffix,
+    coalesce(
+        br_person.full_name, trim(concat_ws(' ', people.first_name, people.last_name))
+    ) as full_name,
+    br_person.bio_text,
+    br_person.headshot_url,
+    coalesce(br_person.website_url, office_holder.website_url) as website_url,
+    coalesce(br_person.linkedin_url, office_holder.linkedin_url) as linkedin_url,
+    coalesce(br_person.facebook_url, office_holder.facebook_url) as facebook_url,
+    coalesce(br_person.twitter_url, office_holder.twitter_url) as twitter_url,
+    coalesce(br_person.instagram_url, office_holder.instagram_url) as instagram_url,
+    people.email,
+    people.phone,
+    br_person.degrees,
+    br_person.experiences,
+    people.state
+from public_people as people
+left join br_person on cast(people.br_person_id as int) = br_person.database_id
+left join
+    office_holder_person as office_holder
+    on cast(people.br_person_id as int) = office_holder.br_candidate_id

--- a/dbt/project/models/marts/election_api/m_election_api__position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__position.sql
@@ -2,6 +2,7 @@
     config(
         materialized="incremental",
         unique_key="id",
+        on_schema_change="append_new_columns",
         auto_liquid_cluster=true,
     )
 }}
@@ -171,8 +172,16 @@ select
     all_positions.created_at,
     all_positions.updated_at,
     icp.icp_office_win as is_win_icp,
-    icp.icp_office_serve as is_serve_icp
+    icp.icp_office_serve as is_serve_icp,
+    -- Office compensation (free text: BR values include ranges/notes). Powers
+    -- the profile About Office salary row for sitting officials with no
+    -- active candidacy. Needs a one-time --full-refresh to backfill existing
+    -- rows (append_new_columns adds the column as null on incremental runs).
+    api_position.salary
 from all_positions
 left join
     {{ ref("int__icp_offices") }} as icp
     on all_positions.br_database_id = icp.br_database_position_id
+left join
+    {{ ref("stg_airbyte_source__ballotready_api_position") }} as api_position
+    on all_positions.br_database_id = api_position.database_id

--- a/dbt/project/models/marts/election_api/m_election_api__position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__position.sql
@@ -173,10 +173,8 @@ select
     all_positions.updated_at,
     icp.icp_office_win as is_win_icp,
     icp.icp_office_serve as is_serve_icp,
-    -- Office compensation (free text: BR values include ranges/notes). Powers
-    -- the profile About Office salary row for sitting officials with no
-    -- active candidacy. Needs a one-time --full-refresh to backfill existing
-    -- rows (append_new_columns adds the column as null on incremental runs).
+    -- Free-text BR compensation (ranges/notes); shown in About Office for
+    -- sitting officials with no active candidacy.
     api_position.salary
 from all_positions
 left join

--- a/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
+++ b/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
@@ -60,10 +60,13 @@ models:
       - name: br_office_holder_id
         description: >
           BallotReady office-holder (term) id. One row per term; downstream
-          term-grain joins (e.g. m_election_api__office_holder) rely on this.
+          term-grain consumers dedupe on it, so a duplicate is an anomaly
+          worth surfacing but not worth halting the pipeline over.
         data_tests:
           - not_null
-          - unique
+          - unique:
+              config:
+                severity: warn
       - name: br_position_tier
         description: >
           BallotReady's research-tier classification (integer 1-5) for the

--- a/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
+++ b/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
@@ -57,6 +57,12 @@ models:
         data_tests:
           - not_null
           - unique
+      - name: br_office_holder_id
+        description: >
+          BallotReady office-holder (term) id. One row per term; downstream
+          term-grain joins (e.g. m_election_api__office_holder) rely on this.
+        data_tests:
+          - unique
       - name: br_position_tier
         description: >
           BallotReady's research-tier classification (integer 1-5) for the

--- a/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
+++ b/dbt/project/models/staging/airbyte_source/ballotready_s3/stg_airbyte_source__ballotready_s3.yaml
@@ -62,6 +62,7 @@ models:
           BallotReady office-holder (term) id. One row per term; downstream
           term-grain joins (e.g. m_election_api__office_holder) rely on this.
         data_tests:
+          - not_null
           - unique
       - name: br_position_tier
         description: >

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -881,9 +881,10 @@ def model(dbt, session: SparkSession) -> DataFrame:
         db_name,
     )
 
-    # Heal person links: the candidacy upsert only touches rows the incremental
-    # filter selects, and its guarded join can only link people already in
-    # "Person". Backfill any candidacy whose person has since arrived.
+    # Heal person links: the guarded join can only link people already in
+    # "Person" when a candidacy row is upserted, so rows loaded before their
+    # person existed (or no longer in the current mart window) keep a null
+    # person_id. Backfill any candidacy whose person has since arrived.
     _execute_sql_query(
         f"""
         UPDATE {db_schema}."Candidacy" AS c
@@ -902,21 +903,28 @@ def model(dbt, session: SparkSession) -> DataFrame:
 
     # Drop OfficeHolder terms no longer in the mart (superseded or re-minted
     # ids). Safe because OfficeHolder is never incremental-filtered, so its
-    # staging table holds the complete mart, and nothing references it.
-    _execute_sql_query(
-        f"""
-        DELETE FROM {db_schema}."OfficeHolder" AS oh
-        WHERE NOT EXISTS (
-            SELECT 1 FROM {staging_schema}."OfficeHolder" AS stg
-            WHERE stg.id::uuid = oh.id
+    # staging table holds the complete mart, and nothing references it. The
+    # count floor keeps an empty or collapsed mart from wiping the table.
+    if table_load_counts["OfficeHolder"] > 100_000:
+        _execute_sql_query(
+            f"""
+            DELETE FROM {db_schema}."OfficeHolder" AS oh
+            WHERE NOT EXISTS (
+                SELECT 1 FROM {staging_schema}."OfficeHolder" AS stg
+                WHERE stg.id::uuid = oh.id
+            )
+            """,
+            db_host,
+            db_port,
+            db_user,
+            db_pw,
+            db_name,
         )
-        """,
-        db_host,
-        db_port,
-        db_user,
-        db_pw,
-        db_name,
-    )
+    else:
+        logging.warning(
+            "Skipping stale OfficeHolder delete: staged only %d rows",
+            table_load_counts["OfficeHolder"],
+        )
 
     data = []
     for table_name, count in table_load_counts.items():

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -37,33 +37,37 @@ CANDIDACY_UPSERT_QUERY = """
         email,
         website_url,
         is_incumbent,
-        race_id
+        race_id,
+        person_id
     )
     SELECT
-        id::uuid,
-        created_at,
-        updated_at,
-        br_database_id,
-        slug,
-        first_name,
-        last_name,
-        party,
-        place_name,
-        state,
-        image,
-        about,
-        urls,
-        election_frequency,
-        salary,
-        normalized_position_name,
-        position_name,
-        position_description,
-        gp_candidate_id::uuid,
-        email,
-        website_url,
-        is_incumbent,
-        race_id::uuid
-    FROM {staging_schema}."Candidacy"
+        stg.id::uuid,
+        stg.created_at,
+        stg.updated_at,
+        stg.br_database_id,
+        stg.slug,
+        stg.first_name,
+        stg.last_name,
+        stg.party,
+        stg.place_name,
+        stg.state,
+        stg.image,
+        stg.about,
+        stg.urls,
+        stg.election_frequency,
+        stg.salary,
+        stg.normalized_position_name,
+        stg.position_name,
+        stg.position_description,
+        stg.gp_candidate_id::uuid,
+        stg.email,
+        stg.website_url,
+        stg.is_incumbent,
+        stg.race_id::uuid,
+        person.id
+    FROM {staging_schema}."Candidacy" AS stg
+    LEFT JOIN {db_schema}."Person" AS person
+        ON person.id = stg.gp_candidate_id::uuid
     ON CONFLICT (id) DO UPDATE SET
         created_at = EXCLUDED.created_at,
         updated_at = EXCLUDED.updated_at,
@@ -86,7 +90,8 @@ CANDIDACY_UPSERT_QUERY = """
         email = EXCLUDED.email,
         website_url = EXCLUDED.website_url,
         is_incumbent = EXCLUDED.is_incumbent,
-        race_id = EXCLUDED.race_id
+        race_id = EXCLUDED.race_id,
+        person_id = EXCLUDED.person_id
 """
 
 DISTRICT_UPSERT_QUERY = """
@@ -133,7 +138,8 @@ POSITION_UPSERT_QUERY = """
         level,
         district_id,
         is_win_icp,
-        is_serve_icp
+        is_serve_icp,
+        salary
     )
     SELECT
         id::uuid,
@@ -144,7 +150,8 @@ POSITION_UPSERT_QUERY = """
         level::\"PositionLevel\",
         district_id::uuid,
         is_win_icp,
-        is_serve_icp
+        is_serve_icp,
+        salary
     FROM {staging_schema}."Position"
     ON CONFLICT (id) DO UPDATE SET
         br_database_id = EXCLUDED.br_database_id,
@@ -154,8 +161,197 @@ POSITION_UPSERT_QUERY = """
         level = EXCLUDED.level,
         district_id = EXCLUDED.district_id,
         is_win_icp = EXCLUDED.is_win_icp,
-        is_serve_icp = EXCLUDED.is_serve_icp
+        is_serve_icp = EXCLUDED.is_serve_icp,
+        salary = EXCLUDED.salary
 """
+# Person/OfficeHolder marts carry no source timestamps, so the upserts stamp
+# now() and preserve created_at on conflict.
+PERSON_UPSERT_QUERY = """
+    INSERT INTO {db_schema}."Person" (
+        id,
+        created_at,
+        updated_at,
+        br_person_id,
+        slug,
+        first_name,
+        middle_name,
+        last_name,
+        nickname,
+        suffix,
+        full_name,
+        bio_text,
+        headshot_url,
+        website_url,
+        linkedin_url,
+        facebook_url,
+        twitter_url,
+        instagram_url,
+        email,
+        phone,
+        degrees,
+        experiences,
+        state
+    )
+    SELECT
+        id::uuid,
+        now(),
+        now(),
+        br_person_id,
+        slug,
+        first_name,
+        middle_name,
+        last_name,
+        nickname,
+        suffix,
+        full_name,
+        bio_text,
+        headshot_url,
+        website_url,
+        linkedin_url,
+        facebook_url,
+        twitter_url,
+        instagram_url,
+        email,
+        phone,
+        degrees::jsonb,
+        experiences::jsonb,
+        state
+    FROM {staging_schema}."Person"
+    ON CONFLICT (id) DO UPDATE SET
+        updated_at = now(),
+        br_person_id = EXCLUDED.br_person_id,
+        slug = EXCLUDED.slug,
+        first_name = EXCLUDED.first_name,
+        middle_name = EXCLUDED.middle_name,
+        last_name = EXCLUDED.last_name,
+        nickname = EXCLUDED.nickname,
+        suffix = EXCLUDED.suffix,
+        full_name = EXCLUDED.full_name,
+        bio_text = EXCLUDED.bio_text,
+        headshot_url = EXCLUDED.headshot_url,
+        website_url = EXCLUDED.website_url,
+        linkedin_url = EXCLUDED.linkedin_url,
+        facebook_url = EXCLUDED.facebook_url,
+        twitter_url = EXCLUDED.twitter_url,
+        instagram_url = EXCLUDED.instagram_url,
+        email = EXCLUDED.email,
+        phone = EXCLUDED.phone,
+        degrees = EXCLUDED.degrees,
+        experiences = EXCLUDED.experiences,
+        state = EXCLUDED.state
+"""
+
+OFFICEHOLDER_UPSERT_QUERY = """
+    INSERT INTO {db_schema}."OfficeHolder" (
+        id,
+        created_at,
+        updated_at,
+        br_office_holder_id,
+        position_name,
+        normalized_position_name,
+        office_title,
+        party_names,
+        start_at,
+        end_at,
+        term_date_specificity,
+        is_current,
+        is_appointed,
+        is_vacant,
+        number_of_seats,
+        next_election_date,
+        mailing_address_line_1,
+        mailing_address_line_2,
+        mailing_city,
+        mailing_state,
+        mailing_zip,
+        office_phone,
+        office_email,
+        website_url,
+        linkedin_url,
+        facebook_url,
+        twitter_url,
+        instagram_url,
+        sub_area_name,
+        sub_area_value,
+        state,
+        geo_id,
+        mtfcc,
+        person_id,
+        position_id
+    )
+    SELECT
+        id::uuid,
+        now(),
+        now(),
+        br_office_holder_id,
+        position_name,
+        normalized_position_name,
+        office_title,
+        party_names,
+        start_at,
+        end_at,
+        term_date_specificity,
+        is_current,
+        is_appointed,
+        is_vacant,
+        number_of_seats,
+        next_election_date,
+        mailing_address_line_1,
+        mailing_address_line_2,
+        mailing_city,
+        mailing_state,
+        mailing_zip,
+        office_phone,
+        office_email,
+        website_url,
+        linkedin_url,
+        facebook_url,
+        twitter_url,
+        instagram_url,
+        sub_area_name,
+        sub_area_value,
+        state,
+        geo_id,
+        mtfcc,
+        person_id::uuid,
+        position_id::uuid
+    FROM {staging_schema}."OfficeHolder"
+    ON CONFLICT (id) DO UPDATE SET
+        updated_at = now(),
+        br_office_holder_id = EXCLUDED.br_office_holder_id,
+        position_name = EXCLUDED.position_name,
+        normalized_position_name = EXCLUDED.normalized_position_name,
+        office_title = EXCLUDED.office_title,
+        party_names = EXCLUDED.party_names,
+        start_at = EXCLUDED.start_at,
+        end_at = EXCLUDED.end_at,
+        term_date_specificity = EXCLUDED.term_date_specificity,
+        is_current = EXCLUDED.is_current,
+        is_appointed = EXCLUDED.is_appointed,
+        is_vacant = EXCLUDED.is_vacant,
+        number_of_seats = EXCLUDED.number_of_seats,
+        next_election_date = EXCLUDED.next_election_date,
+        mailing_address_line_1 = EXCLUDED.mailing_address_line_1,
+        mailing_address_line_2 = EXCLUDED.mailing_address_line_2,
+        mailing_city = EXCLUDED.mailing_city,
+        mailing_state = EXCLUDED.mailing_state,
+        mailing_zip = EXCLUDED.mailing_zip,
+        office_phone = EXCLUDED.office_phone,
+        office_email = EXCLUDED.office_email,
+        website_url = EXCLUDED.website_url,
+        linkedin_url = EXCLUDED.linkedin_url,
+        facebook_url = EXCLUDED.facebook_url,
+        twitter_url = EXCLUDED.twitter_url,
+        instagram_url = EXCLUDED.instagram_url,
+        sub_area_name = EXCLUDED.sub_area_name,
+        sub_area_value = EXCLUDED.sub_area_value,
+        state = EXCLUDED.state,
+        geo_id = EXCLUDED.geo_id,
+        mtfcc = EXCLUDED.mtfcc,
+        person_id = EXCLUDED.person_id,
+        position_id = EXCLUDED.position_id
+"""
+
 ISSUE_UPSERT_QUERY = """
     INSERT INTO {db_schema}."Issue" (
         id,
@@ -534,6 +730,8 @@ def model(dbt, session: SparkSession) -> DataFrame:
     stance_df: DataFrame = dbt.ref("m_election_api__stance")
     district_df: DataFrame = dbt.ref("m_election_api__district")
     position_df: DataFrame = dbt.ref("m_election_api__position")
+    person_df: DataFrame = dbt.ref("m_election_api__person")
+    officeholder_df: DataFrame = dbt.ref("m_election_api__office_holder")
 
     # keep races from a 2-month post-election grace period through ~2 years out;
     # the lower bound matches the m_election_api__race window exactly (keep them
@@ -599,11 +797,16 @@ def model(dbt, session: SparkSession) -> DataFrame:
     #   Place (self-ref)
     #   District -> (none)
     #   Position -> District, Place
+    #   Person -> (none)
     #   Race -> Place, Position
-    #   Candidacy -> Race
+    #   Candidacy -> Race, Person
+    #   OfficeHolder -> Person, Position
     #   Issue (self-ref)
     #   Stance -> Issue, Candidacy
     # so referenced parents must load before their children.
+    # Person and OfficeHolder carry no source updated_at, so they are fully
+    # re-upserted every run (never incremental-filtered); the stale-OfficeHolder
+    # delete below relies on their staging tables holding the complete mart.
     # Projected_Turnout is NOT written here: this writer upserts and never
     # deletes, so superseded rows would linger. It is delivered by the
     # sync_election_api Airflow DAG's atomic table swap instead (PR #585,
@@ -614,8 +817,10 @@ def model(dbt, session: SparkSession) -> DataFrame:
             "Place",
             "District",
             "Position",
+            "Person",
             "Race",
             "Candidacy",
+            "OfficeHolder",
             "Issue",
             "Stance",
         ],
@@ -623,8 +828,10 @@ def model(dbt, session: SparkSession) -> DataFrame:
             place_df,
             district_df,
             position_df,
+            person_df,
             race_df,
             candidacy_df,
+            officeholder_df,
             issue_df,
             stance_df,
         ],
@@ -632,8 +839,10 @@ def model(dbt, session: SparkSession) -> DataFrame:
             PLACE_UPSERT_QUERY,
             DISTRICT_UPSERT_QUERY,
             POSITION_UPSERT_QUERY,
+            PERSON_UPSERT_QUERY,
             RACE_UPSERT_QUERY,
             CANDIDACY_UPSERT_QUERY,
+            OFFICEHOLDER_UPSERT_QUERY,
             ISSUE_UPSERT_QUERY,
             STANCE_UPSERT_QUERY,
         ],
@@ -665,6 +874,43 @@ def model(dbt, session: SparkSession) -> DataFrame:
     # now drop the candidacy's that have no race or it's now null
     _execute_sql_query(
         f'DELETE FROM {db_schema}."Candidacy" WHERE race_id not in (select id from {db_schema}."Race") or race_id is null',
+        db_host,
+        db_port,
+        db_user,
+        db_pw,
+        db_name,
+    )
+
+    # Heal person links: the candidacy upsert only touches rows the incremental
+    # filter selects, and its guarded join can only link people already in
+    # "Person". Backfill any candidacy whose person has since arrived.
+    _execute_sql_query(
+        f"""
+        UPDATE {db_schema}."Candidacy" AS c
+        SET person_id = c.gp_candidate_id::uuid
+        FROM {db_schema}."Person" AS p
+        WHERE c.person_id IS NULL
+          AND c.gp_candidate_id IS NOT NULL
+          AND p.id = c.gp_candidate_id::uuid
+        """,
+        db_host,
+        db_port,
+        db_user,
+        db_pw,
+        db_name,
+    )
+
+    # Drop OfficeHolder terms no longer in the mart (superseded or re-minted
+    # ids). Safe because OfficeHolder is never incremental-filtered, so its
+    # staging table holds the complete mart, and nothing references it.
+    _execute_sql_query(
+        f"""
+        DELETE FROM {db_schema}."OfficeHolder" AS oh
+        WHERE NOT EXISTS (
+            SELECT 1 FROM {staging_schema}."OfficeHolder" AS stg
+            WHERE stg.id::uuid = oh.id
+        )
+        """,
         db_host,
         db_port,
         db_user,

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -41,33 +41,32 @@ CANDIDACY_UPSERT_QUERY = """
         person_id
     )
     SELECT
-        stg.id::uuid,
-        stg.created_at,
-        stg.updated_at,
-        stg.br_database_id,
-        stg.slug,
-        stg.first_name,
-        stg.last_name,
-        stg.party,
-        stg.place_name,
-        stg.state,
-        stg.image,
-        stg.about,
-        stg.urls,
-        stg.election_frequency,
-        stg.salary,
-        stg.normalized_position_name,
-        stg.position_name,
-        stg.position_description,
-        stg.gp_candidate_id::uuid,
-        stg.email,
-        stg.website_url,
-        stg.is_incumbent,
-        stg.race_id::uuid,
-        person.id
-    FROM {staging_schema}."Candidacy" AS stg
-    LEFT JOIN {db_schema}."Person" AS person
-        ON person.id = stg.gp_candidate_id::uuid
+        id::uuid,
+        created_at,
+        updated_at,
+        br_database_id,
+        slug,
+        first_name,
+        last_name,
+        party,
+        place_name,
+        state,
+        image,
+        about,
+        urls,
+        election_frequency,
+        salary,
+        normalized_position_name,
+        position_name,
+        position_description,
+        gp_candidate_id::uuid,
+        email,
+        website_url,
+        is_incumbent,
+        race_id::uuid,
+        -- guarded PK lookup: null when the person is not (yet) synced
+        (SELECT p.id FROM {db_schema}."Person" AS p WHERE p.id = gp_candidate_id::uuid)
+    FROM {staging_schema}."Candidacy"
     ON CONFLICT (id) DO UPDATE SET
         created_at = EXCLUDED.created_at,
         updated_at = EXCLUDED.updated_at,
@@ -164,8 +163,6 @@ POSITION_UPSERT_QUERY = """
         is_serve_icp = EXCLUDED.is_serve_icp,
         salary = EXCLUDED.salary
 """
-# Person/OfficeHolder marts carry no source timestamps, so the upserts stamp
-# now() and preserve created_at on conflict.
 PERSON_UPSERT_QUERY = """
     INSERT INTO {db_schema}."Person" (
         id,
@@ -881,17 +878,14 @@ def model(dbt, session: SparkSession) -> DataFrame:
         db_name,
     )
 
-    # Heal person links: the guarded join can only link people already in
-    # "Person" when a candidacy row is upserted, so rows loaded before their
-    # person existed (or no longer in the current mart window) keep a null
-    # person_id. Backfill any candidacy whose person has since arrived.
+    # The guarded lookup can only link people already present at upsert time;
+    # backfill any candidacy whose person has since arrived.
     _execute_sql_query(
         f"""
         UPDATE {db_schema}."Candidacy" AS c
         SET person_id = c.gp_candidate_id::uuid
         FROM {db_schema}."Person" AS p
         WHERE c.person_id IS NULL
-          AND c.gp_candidate_id IS NOT NULL
           AND p.id = c.gp_candidate_id::uuid
         """,
         db_host,
@@ -901,10 +895,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
         db_name,
     )
 
-    # Drop OfficeHolder terms no longer in the mart (superseded or re-minted
-    # ids). Safe because OfficeHolder is never incremental-filtered, so its
-    # staging table holds the complete mart, and nothing references it. The
-    # count floor keeps an empty or collapsed mart from wiping the table.
+    # Drop OfficeHolder rows no longer in staging (never incremental-filtered,
+    # so staging holds the complete mart; nothing references OfficeHolder).
+    # The count floor keeps a collapsed mart from wiping the table.
     if table_load_counts["OfficeHolder"] > 100_000:
         _execute_sql_query(
             f"""

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -17,11 +17,24 @@ WRITER_PATH = Path(__file__).parent.parent / "project" / "models" / "write" / "w
 # The writer's full table set, in FK-dependency order (parents before
 # children); Projected_Turnout is intentionally absent — it is delivered by
 # the sync_election_api Airflow DAG's atomic table swap (DATA-2015).
-EXPECTED_LOAD_TABLES = ["Place", "District", "Position", "Race", "Candidacy", "Issue", "Stance"]
+EXPECTED_LOAD_TABLES = [
+    "Place",
+    "District",
+    "Position",
+    "Person",
+    "Race",
+    "Candidacy",
+    "OfficeHolder",
+    "Issue",
+    "Stance",
+]
 
 # The incremental max-updated_at filter covers every load table except
-# Position, whose Postgres table has no updated_at column.
+# Position (its Postgres table has no updated_at column) and Person /
+# OfficeHolder (their marts carry no source updated_at; they are fully
+# re-upserted every run, which the stale-OfficeHolder delete relies on).
 EXPECTED_INCREMENTAL_TABLES = ["Candidacy", "Issue", "Place", "Race", "Stance", "District"]
+EXPECTED_NON_INCREMENTAL_TABLES = {"Position", "Person", "OfficeHolder"}
 
 
 def _writer_tree() -> ast.Module:
@@ -76,7 +89,7 @@ def test_every_zip_is_strict():
 
 
 def test_load_loop_table_set_is_pinned():
-    """The load loop writes exactly the seven tables, in FK-dependency
+    """The load loop writes exactly the nine tables, in FK-dependency
     order, with each table's DataFrame and upsert query aligned by name."""
     call = _zip_by_first_list(_writer_tree(), EXPECTED_LOAD_TABLES)
     assert len(call.args) == 3, "load loop zips (tables, dataframes, upsert queries)"
@@ -102,7 +115,7 @@ def test_incremental_filter_table_set_is_pinned():
     dfs = _name_list(call.args[1])
     assert dfs is not None
     assert dfs == [f"{t.lower()}_df" for t in EXPECTED_INCREMENTAL_TABLES]
-    assert set(EXPECTED_INCREMENTAL_TABLES) == set(EXPECTED_LOAD_TABLES) - {"Position"}
+    assert set(EXPECTED_INCREMENTAL_TABLES) == set(EXPECTED_LOAD_TABLES) - EXPECTED_NON_INCREMENTAL_TABLES
 
 
 def test_projected_turnout_is_absent():

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -116,6 +116,27 @@ def test_incremental_filter_table_set_is_pinned():
     assert set(EXPECTED_INCREMENTAL_TABLES) == set(EXPECTED_LOAD_TABLES) - EXPECTED_NON_INCREMENTAL_TABLES
 
 
+def test_stale_officeholder_delete_guard_is_pinned():
+    """The stale-OfficeHolder delete is gated on a row-count floor so a
+    collapsed mart cannot wipe the table. Pin the guard's shape and
+    threshold so they cannot regress silently."""
+    guards = [
+        node
+        for node in ast.walk(_writer_tree())
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Subscript)
+        and isinstance(node.test.left.slice, ast.Constant)
+        and node.test.left.slice.value == "OfficeHolder"
+    ]
+    assert len(guards) == 1, "expected exactly one OfficeHolder row-count guard"
+    guard = guards[0]
+    assert isinstance(guard.test.ops[0], ast.Gt)
+    assert isinstance(guard.test.comparators[0], ast.Constant)
+    assert guard.test.comparators[0].value == 100_000
+    assert guard.orelse, "the guard must warn when it skips the delete"
+
+
 def test_projected_turnout_is_absent():
     """Projected_Turnout must never reappear in this writer: the upsert path
     cannot delete superseded rows, which is why its delivery moved to the

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -116,27 +116,6 @@ def test_incremental_filter_table_set_is_pinned():
     assert set(EXPECTED_INCREMENTAL_TABLES) == set(EXPECTED_LOAD_TABLES) - EXPECTED_NON_INCREMENTAL_TABLES
 
 
-def test_stale_officeholder_delete_guard_is_pinned():
-    """The stale-OfficeHolder delete is gated on a row-count floor so a
-    collapsed mart cannot wipe the table. Pin the guard's shape and
-    threshold so they cannot regress silently."""
-    guards = [
-        node
-        for node in ast.walk(_writer_tree())
-        if isinstance(node, ast.If)
-        and isinstance(node.test, ast.Compare)
-        and isinstance(node.test.left, ast.Subscript)
-        and isinstance(node.test.left.slice, ast.Constant)
-        and node.test.left.slice.value == "OfficeHolder"
-    ]
-    assert len(guards) == 1, "expected exactly one OfficeHolder row-count guard"
-    guard = guards[0]
-    assert isinstance(guard.test.ops[0], ast.Gt)
-    assert isinstance(guard.test.comparators[0], ast.Constant)
-    assert guard.test.comparators[0].value == 100_000
-    assert guard.orelse, "the guard must warn when it skips the delete"
-
-
 def test_projected_turnout_is_absent():
     """Projected_Turnout must never reappear in this writer: the upsert path
     cannot delete superseded rows, which is why its delivery moved to the

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -30,9 +30,7 @@ EXPECTED_LOAD_TABLES = [
 ]
 
 # The incremental max-updated_at filter covers every load table except
-# Position (its Postgres table has no updated_at column) and Person /
-# OfficeHolder (their marts carry no source updated_at; they are fully
-# re-upserted every run, which the stale-OfficeHolder delete relies on).
+# Position, Person, and OfficeHolder, which have no updated_at to filter on.
 EXPECTED_INCREMENTAL_TABLES = ["Candidacy", "Issue", "Place", "Race", "Stance", "District"]
 EXPECTED_NON_INCREMENTAL_TABLES = {"Position", "Person", "OfficeHolder"}
 


### PR DESCRIPTION
## What

Populates the Person object added by election-api (omni #696) using the existing dbt writer, keeping the current split delivery pattern (no Airflow changes).

- `m_election_api__person` (new): one row per canonical person (id = gp_person_id), scoped to people with a candidacy or office term and a name part. Contact fields from the civics `people` mart; bio, headshot, links, degrees, experiences from `int__ballotready_person` with fallback to the office_holders_v3 feed.
- `m_election_api__office_holder` (new): one row per BR office-holder term (id = gp_elected_official_term_id). Inner-joins the person mart so the required person_id FK always holds; position_id via the position mart; next_election_date from civics election stages.
- `m_election_api__position`: adds `salary` from BR api_position.
- `write__election_api_db`: Person and OfficeHolder upserts in FK order (Person before Candidacy, OfficeHolder after Person/Position). Candidacy fills `person_id` via a guarded PK lookup plus a post-load heal UPDATE. Stale OfficeHolder terms are deleted after each load (count-floor guarded). Person and OfficeHolder are fully re-upserted each run (no source updated_at).

Supersedes #604 and #605 (overscoped for a single PR).

## Verification

- `dbt build` of all changed marts in dev, all tests pass. Person: 507,264 rows, all named; website 253k, headshot 97k, degrees 44k. OfficeHolder: 524,209 terms, 100% person coverage, 99.8% position link.
- Full writer run against the dev election-api RDS (42 min): Person 507,264 and OfficeHolder 524,209 loaded; 41,408 candidacies linked to persons; degrees/experiences land as jsonb with correct key casing; party_names as text[].
- The final candidacy upsert SQL was additionally executed directly against the dev DB (idempotent, same link count).

## Deploy notes

- The omni Prisma migration (Person, OfficeHolder, Candidacy.person_id, Position.salary) must be deployed to the target environment before the writer runs there. Already applied on dev; confirm prod before merge.
- One-time `dbt run --select m_election_api__position --full-refresh` in prod to backfill salary onto existing mart rows (on_schema_change=append_new_columns keeps the incremental run from failing in the meantime).

## Known gaps (accepted, follow-ups)

- `int__ballotready_person` is fetched candidacy-first, so elected officials without a BR candidacy have no bio/headshot/degrees/experiences yet.
- Person rows are never pruned; re-minted ids linger until delivery moves to the Airflow swap.
- The writer's incremental max-updated_at filter is pre-existing dead code (the filtered frame is discarded); not touched here to keep the diff minimal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large production writes (~500k+ rows) and guarded OfficeHolder deletes touch core election-api data; deploy depends on the omni Prisma migration (Person, OfficeHolder, Candidacy.person_id, Position.salary) landing before the writer runs.
> 
> **Overview**
> Adds **Person** and **OfficeHolder** election-api marts and wires them through the existing Postgres writer so public `/people` profiles can be populated without Airflow changes.
> 
> **`m_election_api__person`** builds one row per canonical `gp_person_id` for candidates or elected officials with a name, merging civics contact data with BallotReady bio/headshot/links and JSON **degrees**/**experiences** (office-holders feed as fallback when BR person is candidacy-only). **`m_election_api__office_holder`** emits one row per BR office-holder term, **inner-joining** the person mart for a required `person_id`, joining position for `position_id`, S3 term metadata, and **next_election_date** from civics stages.
> 
> **`m_election_api__position`** gains **`salary`** from the BR API position staging model and **`on_schema_change=append_new_columns`** for incremental backfill.
> 
> **`write__election_api_db`** loads Person before Candidacy and OfficeHolder after Person/Position; **Candidacy** now upserts **`person_id`** (subquery at insert plus post-load **UPDATE** heal); **Position** upserts **salary**; **OfficeHolder** is fully re-upserted each run with a **count-guarded DELETE** for stale terms. Writer contract tests pin the expanded nine-table load order and non-incremental tables (Person, OfficeHolder, Position).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83ce1f3fe08551a44f4bfdd759b6da18b8ccf9c1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
