### PR TITLE
Cast L2 identifier columns to STRING before nationwide union

### DIFF
--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
@@ -83,6 +83,42 @@ PERFORMANCE_PERCENTAGE_COLUMNS = [
     "Voters_VotingPerformanceMinorElection",
 ]
 
+# Identifier/code columns that L2 types inconsistently across states (INT in most,
+# STRING in the states where a non-numeric value showed up). These are codes, not
+# quantities: ZIPs, precincts, district codes, and voter IDs. Cast every state to
+# STRING before the union so the reconciliation never coerces a state's STRING
+# value into INT (which fails under ANSI on a value like the ZIP '8731-') and so
+# leading zeros are preserved (e.g. a New Jersey ZIP 08731 is not stored as 8731).
+IDENTIFIER_STRING_COLUMNS = [
+    "Residence_Addresses_Zip",
+    "Precinct",
+    "State_House_District",
+    "State_Legislative_District",
+    "State_Senate_District",
+    "US_Congressional_District",
+    "2001_State_House_District",
+    "2001_State_Legislative_District",
+    "2001_State_Senate_District",
+    "2001_US_Congressional_District",
+    "2010_State_House_District",
+    "2010_State_Legislative_District",
+    "2010_State_Senate_District",
+    "2010_US_Congressional_District",
+    "ConsumerData_CSA_Code",
+    "Voters_CountyVoterID",
+    "Voters_StateVoterID",
+]
+
+
+def cast_identifier_columns_to_string(df: DataFrame) -> DataFrame:
+    """Cast identifier/code columns to STRING when present, so unioning states with
+    mixed source types produces a consistent STRING column instead of a failing or
+    lossy INT cast. Guarded on presence to respect unionByName(allowMissingColumns)."""
+    for column in IDENTIFIER_STRING_COLUMNS:
+        if column in df.columns:
+            df = df.withColumn(column, col(column).cast(StringType()))
+    return df
+
 
 def model(dbt, session: SparkSession) -> DataFrame:
     """
@@ -522,60 +558,68 @@ def model(dbt, session: SparkSession) -> DataFrame:
         )
         wy_df = wy_df.filter(col("loaded_at") > max_loaded_at)
 
+    # Normalize identifier/code columns to STRING on each state before unioning so
+    # the union never has to reconcile a STRING value into an INT column.
+    state_dfs = [
+        al_df,
+        ak_df,
+        az_df,
+        ar_df,
+        ca_df,
+        co_df,
+        ct_df,
+        de_df,
+        dc_df,
+        fl_df,
+        ga_df,
+        hi_df,
+        id_df,
+        il_df,
+        in_df,
+        ia_df,
+        ks_df,
+        ky_df,
+        la_df,
+        me_df,
+        md_df,
+        ma_df,
+        mi_df,
+        mn_df,
+        ms_df,
+        mo_df,
+        mt_df,
+        ne_df,
+        nv_df,
+        nh_df,
+        nj_df,
+        nm_df,
+        ny_df,
+        nc_df,
+        nd_df,
+        oh_df,
+        ok_df,
+        or_df,
+        pa_df,
+        ri_df,
+        sc_df,
+        sd_df,
+        tn_df,
+        tx_df,
+        ut_df,
+        vt_df,
+        va_df,
+        wa_df,
+        wv_df,
+        wi_df,
+        wy_df,
+    ]
+    state_dfs = [cast_identifier_columns_to_string(state_df) for state_df in state_dfs]
+
     # Use unionByName with allowMissingColumns=True to handle schema drift
     # when L2 delivers state updates with new columns in a staggered fashion
-    df = (
-        al_df.unionByName(ak_df, allowMissingColumns=True)
-        .unionByName(az_df, allowMissingColumns=True)
-        .unionByName(ar_df, allowMissingColumns=True)
-        .unionByName(ca_df, allowMissingColumns=True)
-        .unionByName(co_df, allowMissingColumns=True)
-        .unionByName(ct_df, allowMissingColumns=True)
-        .unionByName(de_df, allowMissingColumns=True)
-        .unionByName(dc_df, allowMissingColumns=True)
-        .unionByName(fl_df, allowMissingColumns=True)
-        .unionByName(ga_df, allowMissingColumns=True)
-        .unionByName(hi_df, allowMissingColumns=True)
-        .unionByName(id_df, allowMissingColumns=True)
-        .unionByName(il_df, allowMissingColumns=True)
-        .unionByName(in_df, allowMissingColumns=True)
-        .unionByName(ia_df, allowMissingColumns=True)
-        .unionByName(ks_df, allowMissingColumns=True)
-        .unionByName(ky_df, allowMissingColumns=True)
-        .unionByName(la_df, allowMissingColumns=True)
-        .unionByName(me_df, allowMissingColumns=True)
-        .unionByName(md_df, allowMissingColumns=True)
-        .unionByName(ma_df, allowMissingColumns=True)
-        .unionByName(mi_df, allowMissingColumns=True)
-        .unionByName(mn_df, allowMissingColumns=True)
-        .unionByName(ms_df, allowMissingColumns=True)
-        .unionByName(mo_df, allowMissingColumns=True)
-        .unionByName(mt_df, allowMissingColumns=True)
-        .unionByName(ne_df, allowMissingColumns=True)
-        .unionByName(nv_df, allowMissingColumns=True)
-        .unionByName(nh_df, allowMissingColumns=True)
-        .unionByName(nj_df, allowMissingColumns=True)
-        .unionByName(nm_df, allowMissingColumns=True)
-        .unionByName(ny_df, allowMissingColumns=True)
-        .unionByName(nc_df, allowMissingColumns=True)
-        .unionByName(nd_df, allowMissingColumns=True)
-        .unionByName(oh_df, allowMissingColumns=True)
-        .unionByName(ok_df, allowMissingColumns=True)
-        .unionByName(or_df, allowMissingColumns=True)
-        .unionByName(pa_df, allowMissingColumns=True)
-        .unionByName(ri_df, allowMissingColumns=True)
-        .unionByName(sc_df, allowMissingColumns=True)
-        .unionByName(sd_df, allowMissingColumns=True)
-        .unionByName(tn_df, allowMissingColumns=True)
-        .unionByName(tx_df, allowMissingColumns=True)
-        .unionByName(ut_df, allowMissingColumns=True)
-        .unionByName(vt_df, allowMissingColumns=True)
-        .unionByName(va_df, allowMissingColumns=True)
-        .unionByName(wa_df, allowMissingColumns=True)
-        .unionByName(wv_df, allowMissingColumns=True)
-        .unionByName(wi_df, allowMissingColumns=True)
-        .unionByName(wy_df, allowMissingColumns=True)
-    )
+    df = state_dfs[0]
+    for state_df in state_dfs[1:]:
+        df = df.unionByName(state_df, allowMissingColumns=True)
 
     # clean up columns with percentages
     for column in PERFORMANCE_PERCENTAGE_COLUMNS:


### PR DESCRIPTION
## Problem

`int__l2_nationwide_uniform` fails the dbt build with:

```
[CAST_INVALID_INPUT] The value '8731-' of the type "STRING" cannot be cast to "INT" ... SQLSTATE: 22018
```

`Residence_Addresses_Zip` is typed **INT in 50 state source tables** and **STRING only in New Mexico**, whose source recently received a non-numeric value (`'8731-'`, 2 rows) — Airbyte re-typed NM's column to STRING. `unionByName` reconciles the 51 states to INT, and casting `'8731-'` → INT throws under Databricks ANSI mode at the `saveAsTable` write.

This is a class of failure: ~24 L2 columns are typed inconsistently across states because Airbyte infers each state's type from its data.

## Fix

Normalize the identifier/code columns (ZIP, precinct, the 12 district columns, CSA code, and the two voter-ID columns) to STRING on **each state before the union**, so the reconciliation never coerces a STRING value into INT. A post-union cast can't help — the union's own coercion is what fails.

This preserves the raw value instead of nulling it via `try_cast`, keeps leading zeros, and matches how every downstream consumer already treats these columns:
- `int__zip_code_to_l2_district` reads zip as `StringType` (and already pads 4-char zips with a leading zero)
- `write__l2_databricks_to_gp_api` classifies zip as text, not an integer column
- `m_people_api__voter` / `write__people_api_db` pass it through

The DOUBLE score columns, the DATE column, and the numeric quantity columns (`RoomsCount`, `TaxMarketValueTotal`) are intentionally left untouched.

## Verification

- Reproduced the exact error: `cast(Residence_Addresses_Zip as int)` on NM's `'8731-'` → `CAST_INVALID_INPUT`.
- Confirmed the fix behavior: `cast(... as string)` returns `'8731-'` intact (2 rows), no data loss.
- Pre-commit (ruff, ruff-format) passes.

## Deploy note

Because `Residence_Addresses_Zip` changes INT → STRING on an existing incremental table, an ordinary incremental run will still fail (the merge can't coerce STRING into the INT target column, and `on_schema_change=append_new_columns` won't alter an existing column's type). **Deploy with a one-time full refresh:**

```
dbt build --full-refresh --select int__l2_nationwide_uniform
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)