### PR TITLE
[DATA-2166] Add hf_most_important_policy_item to public.Voter

### DIFF
--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -423,6 +423,7 @@ with
             `Water_Replacement_SubDistrict`,
             `Water_SubDistrict`,
             `Weed_District`,
+            `hf_most_important_policy_item`,
             dbt_valid_from
         from {{ ref("snapshot__int__l2_nationwide_uniform") }}
         where
@@ -809,6 +810,7 @@ with
             tbl_updated.`Water_Replacement_SubDistrict`,
             tbl_updated.`Water_SubDistrict`,
             tbl_updated.`Weed_District`,
+            tbl_updated.`hf_most_important_policy_item`,
             {% if is_incremental() %}
                 -- For incremental runs, preserve existing created_at for existing
                 -- records,

--- a/dbt/project/snapshots/snapshots__int_l2_nationwide_uniform.yaml
+++ b/dbt/project/snapshots/snapshots__int_l2_nationwide_uniform.yaml
@@ -1,6 +1,6 @@
 snapshots:
   - name: snapshot__int__l2_nationwide_uniform
-    relation: ref('int__l2_nationwide_uniform')
+    relation: ref('int__l2_nationwide_uniform_w_haystaq')
     description: >
       "Snapshot of the int__l2_nationwide_uniform table. Use `check_cols` strategy since in the source data there is no `updated_at`. The relevant `loaded_at` column is updated for each new dataset"
     config:
@@ -802,3 +802,4 @@ snapshots:
         - PRI_BLT_2002
         - PRI_BLT_2001
         - PRI_BLT_2000
+        - hf_most_important_policy_item

--- a/dbt/project/snapshots/snapshots__int_l2_nationwide_uniform.yaml
+++ b/dbt/project/snapshots/snapshots__int_l2_nationwide_uniform.yaml
@@ -803,3 +803,5 @@ snapshots:
         - PRI_BLT_2001
         - PRI_BLT_2000
         - hf_most_important_policy_item
+        - haystaq_flags_loaded_at
+        - haystaq_scores_loaded_at

--- a/people-api-loader/src/loader/people_api/schema/_serving_seed_extra.py
+++ b/people-api-loader/src/loader/people_api/schema/_serving_seed_extra.py
@@ -58,4 +58,12 @@ EXTRA_INDEXES: list[IndexDef] = [
         columns=['lower("LastName")'],
         where=None,
     ),
+    IndexDef(
+        table="Voter",
+        name="Voter_hf_most_important_policy_item_idx",
+        sql='CREATE INDEX "Voter_hf_most_important_policy_item_idx" ON public."Voter" USING btree ("hf_most_important_policy_item");',
+        unique=False,
+        columns=["hf_most_important_policy_item"],
+        where=None,
+    ),
 ]

--- a/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
+++ b/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
@@ -350,6 +350,7 @@ CREATE TABLE public."Voter" (
     "Water_Replacement_SubDistrict" TEXT,
     "Water_SubDistrict" TEXT,
     "Weed_District" TEXT,
+    "hf_most_important_policy_item" TEXT,
     "created_at" TIMESTAMPTZ,
     "updated_at" TIMESTAMPTZ,
     "Mailing_HHGender_Description" TEXT

--- a/people-api-loader/tests/test_integration_pg.py
+++ b/people-api-loader/tests/test_integration_pg.py
@@ -55,16 +55,17 @@ _DDL = (
 )
 _STATES = ["TX", "CA"]
 
-# A partitioned Voter carrying the "FirstName"/"LastName" columns the CRM name-search extras
-# index. Separate from _DDL (which omits them) so the extras test can drive the real committed
-# EXTRA_INDEXES SQL through the partitioned build path against a table that actually has the
-# indexed columns.
+# A partitioned Voter carrying the columns referenced by Voter EXTRA_INDEXES (name-search
+# plus plain-btree columns). Separate from _DDL (which omits them) so the extras test can drive
+# the real committed EXTRA_INDEXES SQL through the partitioned build path against a table that
+# actually has the indexed columns.
 _DDL_NAMES = (
     'CREATE TABLE public."Voter" (\n'
     '    "id" uuid NOT NULL,\n'
     '    "State" text NOT NULL,\n'
     '    "FirstName" text,\n'
-    '    "LastName" text\n'
+    '    "LastName" text,\n'
+    '    "hf_most_important_policy_item" text\n'
     ");"
 )
 

--- a/people-api-loader/tests/test_integration_pg.py
+++ b/people-api-loader/tests/test_integration_pg.py
@@ -274,10 +274,11 @@ def test_name_search_indexes_build_and_serve(pg_conn: psycopg.Connection) -> Non
             _exec(cur, insert, (str(uuid.uuid4()), state, first, last))
         _exec(cur, 'ANALYZE public."Voter"')
 
-    # Build every committed extra (2 trigram GIN, 2 lower() b-tree, 1 multicolumn b-tree) via the
-    # exact partitioned path build_indexes.run uses: parent ON ONLY, then a child per state attached.
+    # Build every committed extra (2 trigram GIN, 2 lower() b-tree, 1 multicolumn b-tree, 1 plain
+    # b-tree) via the exact partitioned path build_indexes.run uses: parent ON ONLY, then a child
+    # per state attached.
     extras = [i for i in _serving_seed_extra.EXTRA_INDEXES if i.table == "Voter"]
-    assert len(extras) == 5
+    assert len(extras) == 6
     for idx in extras:
         build_indexes._create_plain_parent_only(pg_conn, idx)
         for state in _STATES:


### PR DESCRIPTION
## What

Exposes the L2 haystaq column `hf_most_important_policy_item` on the loader-built `public."Voter"` serving table, with a plain full btree index, so it can be used for targeting/filtering.

## Why / approach

The column lives behind the haystaq join (`int__l2_nationwide_uniform_w_haystaq`), which the people-api Voter mart did not read. Rather than a one-off join, the source snapshot `snapshot__int__l2_nationwide_uniform` is repointed to `int__l2_nationwide_uniform_w_haystaq` (a row-preserving LEFT JOIN on `LALVOTERID`), making the full haystaq flag/score set available and snapshot-versioned. The mart then projects the one column; the loader seed declares it and builds the index.

- Snapshot: `relation` -> `int__l2_nationwide_uniform_w_haystaq`; `hf_most_important_policy_item` added to `check_cols`.
- Mart `m_people_api__voter`: column projected (updated_voters CTE + final select).
- Loader seed `target_schema.sql`: column declared on `Voter`.
- Loader `EXTRA_INDEXES`: `Voter_hf_most_important_policy_item_idx` (plain btree); integration extras count 5 -> 6; the name-search integration fixture now carries the column.

`County` and `Precinct` were also requested but already exist and are indexed, so no change was needed there.

## Verification

- dbt parse + compile: snapshot resolves to `_w_haystaq`; mart emits the column.
- Loader ruff / ruff-format / ty clean; full loader suite including the PG integration test: 304 passed / 0 failed (the index builds and attaches per state against a real Postgres).

## Deferred (operational, post-merge)

- dbt snapshot + mart full refresh to backfill the column into existing rows. Column existence does not depend on this; a normal mart run adds it (NULL until backfilled).
- Loader serving-cluster build picks up the column and index.

## Out of scope / follow-ups

- people-api filter-layer wiring (separate follow-up).
- Building `Voter."State"` as the `USState` enum (separate ticket).

Ticket: DATA-2166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
