### PR TITLE
calib(data): document internal-account email proxy

### DIFF
--- a/.claude/skills/win-analytics-knowledge/references/sources.md
+++ b/.claude/skills/win-analytics-knowledge/references/sources.md
@@ -7,6 +7,7 @@ Part of the **win-analytics-knowledge** skill. Where Win-product data lives and 
 - **Business context:** Win analyses draw on six overlapping data domains (product DB, analytics mart, civics mart, Amplitude events, HubSpot surveys, L2 voter data).
 - **Entity grain:** varies by domain (see table). The primary working grain is one row per `campaign_version_id`.
 - **Standard hygiene filter:** on `users_win_candidacy`, `is_latest_version AND NOT is_demo`.
+- **Internal accounts:** no governed filter exists. The agreed proxy is `email ILIKE '%@goodparty.org'` (user grain). Exclude for external-facing user counts and name the exclusion as an assumption. Verified 2026-07-21 (2026 H1): domain-anchored and bare-substring forms matched identical sets; residual QA-pattern emails among remaining users ≤2/month.
 
 ## Routing triggers
 


### PR DESCRIPTION
Data-track calibration batch from the 2026-07-21 calibration log (q01 quality-bench gold run, DATA-2144 context).

**Finding:** no governed internal-user filter exists anywhere in the win-analytics-knowledge skill; the q01 gold run had to settle the exclusion as an ad-hoc fork, and the usefulness reviewer flagged it as undiscoverable for future runs.

**Edit:** `.claude/skills/win-analytics-knowledge/references/sources.md` — one bullet in the Quick reference documenting the agreed proxy (`email ILIKE '%@goodparty.org'`, user grain), the exclude-and-name-the-assumption convention, and the 2026-07-21 verification evidence (domain-anchored ≡ bare-substring in 2026 H1; residual QA-pattern emails ≤2/month).

Track: data. Wording owner-approved in session before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an analytics skill reference; no runtime, SQL, or data pipeline behavior changes.
> 
> **Overview**
> Adds a **Quick reference** bullet in `sources.md` so analysts know how to treat internal Good Party accounts when there is no governed filter in the warehouse.
> 
> The doc records the agreed user-grain proxy (`email ILIKE '%@goodparty.org'`), the convention to exclude those rows from external-facing user counts and state that as an assumption, and 2026-07-21 verification that domain-anchored vs bare-substring matching were equivalent in 2026 H1 with very few residual QA-pattern emails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924a1e4abe0bec39cd6a823b2b8763051f5de6cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->