### PR TITLE
[DATA-2168] Loader: type Voter/DistrictVoter/District State as public.USState enum

### DIFF
--- a/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
+++ b/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE public."Voter" (
     "id" UUID,
     "LALVOTERID" TEXT,
-    "State" TEXT,
+    "State" "USState",
     "AbsenteeTypes_Description" TEXT,
     "Active" TEXT,
     "Age" TEXT,
@@ -362,7 +362,7 @@ CREATE TABLE public."District" (
     "updated_at" TIMESTAMPTZ,
     "type" TEXT,
     "name" TEXT,
-    "state" TEXT
+    "state" "USState"
 );
 
 CREATE TABLE public."DistrictStats" (
@@ -376,7 +376,7 @@ CREATE TABLE public."DistrictStats" (
 CREATE TABLE public."DistrictVoter" (
     "voter_id" UUID,
     "district_id" UUID,
-    "State" TEXT,
+    "State" "USState",
     "created_at" TIMESTAMPTZ,
     "updated_at" TIMESTAMPTZ
 );

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -52,7 +52,7 @@ TABLE_SPECS: dict[str, TableSpec] = {
     "Voter": TableSpec(
         pg_table="Voter",
         partition_by="State",
-        # State: the serving public."USState" enum (matches swain-db); the mart emits it as text
+        # State: the serving public."USState" enum (matches the serving cluster); the mart emits it as text
         # and Postgres coerces text -> enum on COPY.
         type_overrides={"id": "UUID", "State": '"USState"'},
         extra_columns=[("Mailing_HHGender_Description", "TEXT", True)],

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -52,14 +52,17 @@ TABLE_SPECS: dict[str, TableSpec] = {
     "Voter": TableSpec(
         pg_table="Voter",
         partition_by="State",
-        type_overrides={"id": "UUID"},
+        # State: the serving public."USState" enum (matches swain-db); the mart emits it as text
+        # and Postgres coerces text -> enum on COPY.
+        type_overrides={"id": "UUID", "State": '"USState"'},
         extra_columns=[("Mailing_HHGender_Description", "TEXT", True)],
     ),
     "District": TableSpec(
         pg_table="District",
         partition_by=None,
         # id is the salted-uuid string in the mart; Prisma types it @db.Uuid, so store UUID.
-        type_overrides={"id": "UUID"},
+        # state: the serving public."USState" enum, like Voter/DistrictVoter.
+        type_overrides={"id": "UUID", "state": '"USState"'},
     ),
     "DistrictStats": TableSpec(
         pg_table="DistrictStats",
@@ -88,7 +91,8 @@ TABLE_SPECS: dict[str, TableSpec] = {
             "voter_id": "UUID",
             "created_at": "TIMESTAMPTZ",
             "updated_at": "TIMESTAMPTZ",
-            "state": "TEXT",
+            # the serving public."USState" enum, matching Voter/District.
+            "state": '"USState"',
         },
         mart_column_map={
             "district_id": "district_id",

--- a/people-api-loader/src/loader/people_api/schema/table_ddl.py
+++ b/people-api-loader/src/loader/people_api/schema/table_ddl.py
@@ -40,9 +40,11 @@ _COLUMN_LINE_RE = re.compile(r'^\s*(?:"(?P<quoted>[^"]+)"|(?P<bare>[a-z_][a-zA-Z
 # type_override). Constraint lines and bare columns are not matched.
 # The type class is case-insensitive (a type_override such as buckets->jsonb emits lowercase) and
 # includes a comma so a precision/scale type (NUMERIC(12,2)) is captured whole; the non-greedy `*?`
-# + anchored tail still stops at the line-terminating comma, not the inner one.
+# + anchored tail still stops at the line-terminating comma, not the inner one. The type group also
+# accepts a quoted identifier (e.g. "USState", a Postgres enum) so a quoted enum column doesn't
+# silently drop out of extract_column_types (which would break its FORCE_NULL handling).
 _COLUMN_TYPE_RE = re.compile(
-    r'^\s*"(?P<name>[^"]+)"\s+(?P<type>[A-Za-z][A-Za-z0-9 (),]*?)(?:\s+NOT NULL)?,?\s*$'
+    r'^\s*"(?P<name>[^"]+)"\s+(?P<type>"[^"]+"|[A-Za-z][A-Za-z0-9 (),]*?)(?:\s+NOT NULL)?,?\s*$'
 )
 
 

--- a/people-api-loader/src/loader/people_api/steps/create_schema.py
+++ b/people-api-loader/src/loader/people_api/steps/create_schema.py
@@ -35,7 +35,7 @@ from loader.people_api.schema.table_ddl import extract_create_tables
 
 log = get_logger(__name__)
 
-# public."USState" labels, DC LAST, matching swain-db's public.USState order exactly.
+# public."USState" labels, DC LAST, matching the serving cluster's public.USState order exactly.
 _USSTATE_LABELS = (
     "AL",
     "AK",

--- a/people-api-loader/src/loader/people_api/steps/create_schema.py
+++ b/people-api-loader/src/loader/people_api/steps/create_schema.py
@@ -3,9 +3,10 @@
 Applies `CREATE TABLE` DDL for Voter, DistrictVoter, District, and DistrictStats,
 extracted from the committed, generated `target_schema.sql` (from `loader emit-ddl`;
 tables only — indexes/PK are deferred to build-indexes), after installing the
-aws_s3/aws_commons extensions. Voter and DistrictVoter are LIST-partitioned by
-"State" (one child partition per USState); District and DistrictStats are plain
-flat tables.
+aws_s3/aws_commons extensions and the public."USState" enum (Voter/DistrictVoter/
+District's State columns are typed against it). Voter and DistrictVoter are
+LIST-partitioned by "State" (one child partition per USState); District and
+DistrictStats are plain flat tables.
 
 Also creates a `green` compatibility schema with a pass-through view over each
 public table, so people-api (which references `green.<table>`) works unchanged
@@ -33,6 +34,70 @@ from loader.people_api.schema.states import STATES
 from loader.people_api.schema.table_ddl import extract_create_tables
 
 log = get_logger(__name__)
+
+# public."USState" labels, DC LAST, matching swain-db's public.USState order exactly.
+_USSTATE_LABELS = (
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+    "DC",
+)
+
+
+def build_usstate_enum_ddl() -> str:
+    """Guarded CREATE TYPE for public."USState" (Postgres has no CREATE TYPE IF NOT EXISTS)."""
+    labels = ", ".join(f"'{s}'" for s in _USSTATE_LABELS)
+    return (
+        'DO $$ BEGIN CREATE TYPE public."USState" AS ENUM (' + labels + "); "
+        "EXCEPTION WHEN duplicate_object THEN NULL; END $$;"
+    )
 
 
 def build_partitioned_ddl(
@@ -123,6 +188,8 @@ def run(cfg: LoaderConfig, run_date: str) -> SchemaManifest:
             # Trusted extension (no superuser on RDS); backs the gin_trgm_ops name indexes
             # build_indexes re-issues from the seed.
             cur.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        with conn.cursor() as cur:
+            cur.execute(build_usstate_enum_ddl())  # ty: ignore[no-matching-overload]
         for stmt in stmts:
             with conn.cursor() as cur:
                 cur.execute(stmt)  # ty: ignore[no-matching-overload]

--- a/people-api-loader/tests/test_create_schema.py
+++ b/people-api-loader/tests/test_create_schema.py
@@ -137,7 +137,7 @@ def test_build_green_view_ddl_covers_all_tables() -> None:
     assert len(stmts) == 1 + len(TABLE_SPECS)
 
 
-# public."USState" labels, DC LAST, matching swain-db's public.USState order exactly (mirrors
+# public."USState" labels, DC LAST, matching the serving cluster's public.USState order exactly (mirrors
 # the private _USSTATE_LABELS in create_schema.py so a drift there is caught here too).
 _USSTATE_LABELS = (
     "AL",
@@ -202,7 +202,7 @@ def test_build_usstate_enum_ddl_shape() -> None:
     for label in _USSTATE_LABELS:
         assert f"'{label}'" in ddl
     assert ddl.count("'") == 2 * len(_USSTATE_LABELS)  # exactly 51 quoted labels, no duplicates
-    # DC is last among the labels (matches swain-db's public.USState order).
+    # DC is last among the labels (matches the serving cluster's public.USState order).
     label_positions = [ddl.index(f"'{s}'") for s in _USSTATE_LABELS]
     assert label_positions == sorted(label_positions)
     assert _USSTATE_LABELS[-1] == "DC"
@@ -216,6 +216,15 @@ def test_usstate_type_created_before_voter_table(monkeypatch: pytest.MonkeyPatch
     enum_idx = next(i for i, s in enumerate(sql) if 'CREATE TYPE public."USState"' in s)
     voter_idx = next(i for i, s in enumerate(sql) if 'CREATE TABLE IF NOT EXISTS public."Voter" (' in s)
     assert enum_idx < voter_idx
+
+
+def test_states_and_usstate_labels_agree_as_a_set() -> None:
+    # STATES (partition keys) and _USSTATE_LABELS (enum labels) are separately ordered
+    # lists; guard that they cover the same 51 codes so adding a code to one but not the
+    # other surfaces here rather than at loader run time.
+    from loader.people_api.schema.states import STATES
+
+    assert set(STATES) == set(step._USSTATE_LABELS)
 
 
 def test_build_partitioned_ddl_parametrizes_table_and_column() -> None:

--- a/people-api-loader/tests/test_create_schema.py
+++ b/people-api-loader/tests/test_create_schema.py
@@ -137,6 +137,87 @@ def test_build_green_view_ddl_covers_all_tables() -> None:
     assert len(stmts) == 1 + len(TABLE_SPECS)
 
 
+# public."USState" labels, DC LAST, matching swain-db's public.USState order exactly (mirrors
+# the private _USSTATE_LABELS in create_schema.py so a drift there is caught here too).
+_USSTATE_LABELS = (
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+    "DC",
+)
+
+
+def test_build_usstate_enum_ddl_shape() -> None:
+    ddl = step.build_usstate_enum_ddl()
+    assert 'CREATE TYPE public."USState" AS ENUM' in ddl
+    assert "EXCEPTION WHEN duplicate_object THEN NULL" in ddl
+    assert len(_USSTATE_LABELS) == 51
+    for label in _USSTATE_LABELS:
+        assert f"'{label}'" in ddl
+    assert ddl.count("'") == 2 * len(_USSTATE_LABELS)  # exactly 51 quoted labels, no duplicates
+    # DC is last among the labels (matches swain-db's public.USState order).
+    label_positions = [ddl.index(f"'{s}'") for s in _USSTATE_LABELS]
+    assert label_positions == sorted(label_positions)
+    assert _USSTATE_LABELS[-1] == "DC"
+
+
+def test_usstate_type_created_before_voter_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConn()
+    _patch(monkeypatch, conn)
+    step.run(_CFG, "20260609")
+    sql = executed_sql(conn)
+    enum_idx = next(i for i, s in enumerate(sql) if 'CREATE TYPE public."USState"' in s)
+    voter_idx = next(i for i, s in enumerate(sql) if 'CREATE TABLE IF NOT EXISTS public."Voter" (' in s)
+    assert enum_idx < voter_idx
+
+
 def test_build_partitioned_ddl_parametrizes_table_and_column() -> None:
     parent, children = step.build_partitioned_ddl(
         'CREATE TABLE public."DistrictVoter" ("voter_id" uuid NOT NULL, "State" text NOT NULL);',

--- a/people-api-loader/tests/test_emit_ddl.py
+++ b/people-api-loader/tests/test_emit_ddl.py
@@ -43,7 +43,7 @@ def test_render_districtvoter_projects_and_renames_to_serving_shape() -> None:
         'CREATE TABLE public."DistrictVoter" (\n'
         '    "voter_id" UUID NOT NULL,\n'
         '    "district_id" UUID NOT NULL,\n'
-        '    "State" TEXT NOT NULL,\n'
+        '    "State" "USState" NOT NULL,\n'
         '    "created_at" TIMESTAMPTZ NOT NULL,\n'
         '    "updated_at" TIMESTAMPTZ NOT NULL\n'
         ");"

--- a/people-api-loader/tests/test_integration_pg.py
+++ b/people-api-loader/tests/test_integration_pg.py
@@ -36,7 +36,11 @@ from loader.people_api.schema import _serving_seed_extra
 from loader.people_api.schema.index_specs import IndexDef, PrimaryKey
 from loader.people_api.schema.table_ddl import extract_column_names, extract_create_tables
 from loader.people_api.steps import build_indexes, copy_s3, inspect_prod, validate
-from loader.people_api.steps.create_schema import build_green_view_ddl, build_partitioned_ddl
+from loader.people_api.steps.create_schema import (
+    build_green_view_ddl,
+    build_partitioned_ddl,
+    build_usstate_enum_ddl,
+)
 from tests._fakes import fake_connect
 
 _CFG = cast(LoaderConfig, SimpleNamespace(s3_bucket="b"))
@@ -54,6 +58,10 @@ _DDL = (
     ");"
 )
 _STATES = ["TX", "CA"]
+
+# A minimal Voter shape with "State" typed against the public."USState" enum (rather than text),
+# for the enum-specific partitioning/domain test below.
+_DDL_ENUM_STATE = 'CREATE TABLE public."Voter" (\n    "id" uuid NOT NULL,\n    "State" "USState" NOT NULL\n);'
 
 # A partitioned Voter carrying the columns referenced by Voter EXTRA_INDEXES (name-search
 # plus plain-btree columns). Separate from _DDL (which omits them) so the extras test can drive
@@ -353,3 +361,45 @@ def test_name_search_indexes_build_and_serve(pg_conn: psycopg.Connection) -> Non
             assert "Seq Scan" not in pre_plan, pre_plan
         finally:
             _exec(cur, "SET enable_seqscan = on")
+
+
+def test_state_column_is_a_real_usstate_enum(pg_conn: psycopg.Connection) -> None:
+    """ "State" is typed against public."USState" (not text): the column's catalog type is the
+    enum, partition routing on it still works, and an out-of-domain label is rejected by the
+    enum itself — proving it's a real enum, not text riding on the partition CHECK."""
+    with pg_conn.cursor() as cur:
+        _exec(cur, build_usstate_enum_ddl())  # guarded CREATE TYPE; safe if already present
+
+    create_sql = extract_create_tables(_DDL_ENUM_STATE)["Voter"]
+    parent, children = build_partitioned_ddl(create_sql, "Voter", "State", ["TX"])
+    with pg_conn.cursor() as cur:
+        _exec(cur, 'DROP TABLE IF EXISTS public."Voter" CASCADE')
+        _exec(cur, parent)
+        for child in children:
+            _exec(cur, child)
+
+    # (a) the column's real catalog type is public."USState", not text.
+    with pg_conn.cursor() as cur:
+        udt_schema = _scalar(
+            cur,
+            "SELECT udt_schema FROM information_schema.columns "
+            "WHERE table_schema='public' AND table_name='Voter' AND column_name='State'",
+        )
+        udt_name = _scalar(
+            cur,
+            "SELECT udt_name FROM information_schema.columns "
+            "WHERE table_schema='public' AND table_name='Voter' AND column_name='State'",
+        )
+    assert (udt_schema, udt_name) == ("public", "USState")
+
+    # (b) a row with State='TX' routes to the TX child partition.
+    column_list = ", ".join(f'"{c}"' for c in extract_column_names(create_sql))
+    insert = f'INSERT INTO public."Voter" ({column_list}) VALUES (%s, %s)'
+    with pg_conn.cursor() as cur:
+        _exec(cur, insert, (str(uuid.uuid4()), "TX"))
+        assert _scalar(cur, 'SELECT count(*) FROM ONLY public."Voter_TX"') == 1
+
+    # (c) an out-of-domain label ('ZZ') is rejected by the enum type itself (invalid input for
+    # the enum), not merely by the partition's implicit CHECK.
+    with pg_conn.cursor() as cur, pytest.raises(psycopg.errors.InvalidTextRepresentation):
+        _exec(cur, insert, (str(uuid.uuid4()), "ZZ"))

--- a/people-api-loader/tests/test_schema_spec.py
+++ b/people-api-loader/tests/test_schema_spec.py
@@ -102,7 +102,7 @@ def test_districtvoter_spec() -> None:
         "voter_id": "UUID",
         "created_at": "TIMESTAMPTZ",
         "updated_at": "TIMESTAMPTZ",
-        "state": "TEXT",
+        "state": '"USState"',
     }
     # The other tables' marts already match serving -> no column map.
     assert ss.TABLE_SPECS["Voter"].mart_column_map == {}

--- a/people-api-loader/tests/test_table_ddl.py
+++ b/people-api-loader/tests/test_table_ddl.py
@@ -60,6 +60,21 @@ def test_extract_column_types_from_generated_ddl() -> None:
     }
 
 
+def test_extract_column_types_captures_quoted_enum_type() -> None:
+    # State/state is typed against the public."USState" enum: a quoted type identifier. The
+    # unquoted-only pattern would silently drop this column (and thus its FORCE_NULL handling).
+    ddl = (
+        'CREATE TABLE public."Voter" (\n'
+        '    "id" UUID NOT NULL,\n'
+        '    "State" "USState",\n'
+        '    "LALVOTERID" TEXT\n'
+        ");"
+    )
+    types = extract_column_types(ddl)
+    assert types["State"] == '"USState"'
+    assert types == {"id": "UUID", "State": '"USState"', "LALVOTERID": "TEXT"}
+
+
 def test_extract_column_types_captures_lowercase_type() -> None:
     # A type_override can emit a lowercase PG type (DistrictStats' buckets -> jsonb). It must still
     # be captured; a uppercase-only pattern would silently drop it (and thus its FORCE_NULL handling).


### PR DESCRIPTION
## What

Types the `State`/`state` columns on the loader-built `public` serving tables as the Postgres enum `public."USState"` (instead of `text`), and keeps LIST-partitioning on it, for `Voter`, `DistrictVoter`, and `District`. Replicates the enum the serving cluster already uses, going forward on `public`.

## Why

people-api compares/filters State by casting to `public."USState"`. Building the loader column as the enum means people-api can read the new DB with its native enum path (drop `PEOPLE_STATE_ENUM=false`) — no coordinated code change at cutover.

## How

- `create_schema` creates `public."USState"` (guarded `DO/EXCEPTION`, `DC` last, matching the serving cluster's label order) before the tables.
- `target_schema.sql` and `schema_spec.py` type the three State columns as the enum; partition bounds (`FOR VALUES IN ('XX')`) coerce to the enum, no cast.
- `table_ddl.py` regex now captures a quoted enum column type (else it would drop out of `extract_column_types` and lose `FORCE_NULL`).
- The dbt mart is unchanged (emits text; Postgres coerces text→enum on COPY). The State domain is provably the 51 codes (hardcoded per-state `lit()` + dbt exact-set test + the unload filter), so COPY can't fail on a bad value.

## Tests

- Unit: enum DDL shape (51 labels, DC last, guard), the regex captures a quoted type, `run()` creates the type before the tables, and a `STATES` vs enum-label parity guard.
- Integration (`LOADER_INTEGRATION_PG=1`): builds the enum + an enum-partitioned Voter, asserts the column type is `public."USState"`, partition routing works, and an invalid label is rejected (proves a real enum). Full suite green; ruff/ruff-format/ty clean.

## Follow-up (omni, at cutover, not this PR)

Once this ships and a loader build materializes the enum: drop `PEOPLE_STATE_ENUM=false`, switch District's Prisma enum from `DistrictUSState` to `USState`, and remove the temporary `green` compatibility views (DATA-2169).

Ticket: DATA-2168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
