### PR TITLE
Loader: provisioned serving + astro cache-bust to redeploy merged loader

### DIFF
--- a/airflow/astro/docs/people_api_loader.md
+++ b/airflow/astro/docs/people_api_loader.md
@@ -13,8 +13,8 @@ data-loading revamp). Latest work is on the active feature branch (currently
 
 The loader is a Python CLI (`people-api-loader/`, `loader <step> --date <ds_nodash>`) that follows a
 train-deployment model: every refresh provisions a brand new Aurora cluster, loads and indexes it,
-resizes it to Serverless v2, and (at cutover) swaps it in as the serving database. The existing
-serving cluster is never mutated in place.
+resizes it to its serving instance class, and (at cutover) swaps it in as the serving database. The
+existing serving cluster is never mutated in place.
 
 The DAG is a thin sequencer. All parallelism lives inside the loader; each Airflow task is a single
 `BashOperator` invocation of one CLI subcommand. State flows between steps through S3 manifests
@@ -50,7 +50,7 @@ inspect_prod -> dbt_test_voter_gate -> unload -> provision -> create_schema -> c
 | `create_schema` | Apply CREATE TABLE statements from the committed snapshot for all four tables: `Voter` and `DistrictVoter` (partitioned by State with per-state LIST children) and `District` and `DistrictStats` (flat). |
 | `copy` | Parallel server-side `aws_s3.table_import_from_s3`: for partitioned tables (Voter, DistrictVoter), per-state per-file copy with rows routed to partitions by `"State"`; for flat tables (District, DistrictStats), whole-table copy. Idempotent per state/table (count / DELETE + reload). |
 | `build_indexes` | Scale the writer up to the **index-phase** class, then add primary keys and indexes for all four tables: for partitioned tables (Voter, DistrictVoter) build per-partition indexes and attach to parent; for flat tables (District, DistrictStats) build parent-level indexes. Then `ANALYZE` all tables. See below. |
-| `resize` | Flip the writer to Serverless v2 with the prod ACU range, swap in the serve parameter group, bump backup retention, enable deletion protection. |
+| `resize` | Flip the writer down to the serving instance class (`serve_instance_class`, prod default `db.r6g.4xlarge`; dev sets `LOADER_SERVE_INSTANCE_CLASS=db.t4g.medium`), swap in the serve parameter group, bump backup retention, enable deletion protection. |
 | `validate` | Row counts vs the `inspect_prod` baseline (per-state for partitioned tables within +/-10%, whole-table for flat tables), plus per-table schema/index structural checks (with `:<table>` suffix in check names). Failure halts the DAG. |
 | `scale_down_on_failure` | Not in the happy path — a `trigger_rule=one_failed` branch off `provision`→`resize`. On any post-provision failure it runs `loader scale-down`, flipping the writer to `db.serverless` to stop provisioned-instance cost. Skipped on a successful run. See "Failure cost guard" below. |
 
@@ -72,9 +72,11 @@ I/O/WAL-bound. So the loader uses two instance classes and scales between them:
 - `load_instance_class` = `db.r8g.16xlarge` (64 vCPU): the box `provision` creates; carries
   provision, create_schema, copy.
 - `index_instance_class` = `db.r8g.48xlarge` (192 vCPU): `build_indexes` scales the writer up to
-  this at its start (`_ensure_instance_class`), then `resize` flips down to Serverless v2.
+  this at its start (`_ensure_instance_class`), then `resize` flips down to `serve_instance_class`
+  (prod default `db.r6g.4xlarge`; dev `db.t4g.medium`) — a provisioned class, not Serverless v2.
 
-Overridable via `LOADER_LOAD_INSTANCE_CLASS` / `LOADER_INDEX_INSTANCE_CLASS`.
+Overridable via `LOADER_LOAD_INSTANCE_CLASS` / `LOADER_INDEX_INSTANCE_CLASS` /
+`LOADER_SERVE_INSTANCE_CLASS`.
 
 **Cost logic.** Index building is CPU-bound and embarrassingly parallel, so its cost in
 instance-hours is roughly flat across instance sizes for the parallel bulk (a smaller box just takes
@@ -112,21 +114,24 @@ writer. `_ensure_instance_class` waits for the class change to fully apply (poll
 class equals the target, status is available, and no class change is pending) before building,
 because Aurora reports `available` for a few seconds after the modify before it actually reboots.
 That poll and the tolerate-in-progress-fault retry are shared helpers in `core/aws.py`
-(`wait_instance_class_applied`, `retry_after_settle`), reused by `resize`'s Serverless v2 flip (which
-had the same stale-available reboot race) and by the on-failure scale-down. Airflow retries also
-cover a mid-build drop since every step is idempotent for its date.
+(`wait_instance_class_applied`, `retry_after_settle`), reused by `resize`'s provisioned serve-class
+flip (which has the same stale-available reboot race) and by the on-failure scale-down's Serverless
+v2 flip. Airflow retries also cover a mid-build drop since every step is idempotent for its date.
 
 ## Failure cost guard
 
-`resize` (which flips the writer to Serverless v2) is downstream of `build_indexes`, so a run that
-fails or is aborted mid-build never reaches it and would otherwise strand its scaled-up writer at
-full provisioned cost. The `scale_down_on_failure` task (`trigger_rule=one_failed`, upstreams
+`resize` (which flips the writer down to the serving instance class) is downstream of
+`build_indexes`, so a run that fails or is aborted mid-build never reaches it and would otherwise
+strand its scaled-up writer at full index-class cost. The `scale_down_on_failure` task
+(`trigger_rule=one_failed`, upstreams
 `provision`/`create_schema`/`copy`/`build_indexes`/`resize`) runs `loader scale-down`, which flips
-the writer to `db.serverless` to stop that cost. It deliberately skips the serve lockdown that
-`resize` applies (no serve parameter group, backup-retention bump, deletion protection, or reboot),
-so the failed run's cluster and loaded data survive for resume/forensics and stay easy to
-`teardown`. It is skipped on a fully successful run (where `resize` already made the writer
-serverless). Limit: it fires on an organic failure or a task marked failed, but not if the whole DAG
+the writer to `db.serverless` to stop that cost — Serverless v2 (min ACU) is the cheapest holding
+state for a cluster kept only for resume/forensics, distinct from the provisioned class the healthy
+path serves from. It deliberately skips the serve lockdown that `resize` applies (no serve parameter
+group, backup-retention bump, deletion protection, or reboot), so the failed run's cluster and
+loaded data survive for resume/forensics and stay easy to `teardown`. It is skipped on a fully
+successful run (where `resize` already sized the writer to the serving class). Limit: it fires on an
+organic failure or a task marked failed, but not if the whole DAG
 run is hard-deleted — that still needs a manual `loader teardown`/`scale-down`.
 
 ## Validation
@@ -193,8 +198,9 @@ come from SSM SecureStrings, never an env-var password.
   (`https://<deployment>.pm.astronomer.run/<ns>/api/v2/dags/load_people_api/dagRuns/<run>/...`) with
   a short-TTL `astro deployment token create` bearer works when the web session JWT expires. The API
   `duration` field is stale for running tasks; read log timestamps.
-- **Teardown.** `resize` leaves a Serverless v2 cluster; teardown is not in this DAG. Clean up
-  abandoned run clusters (`gp-people-db-<date>-<env>`) to avoid idle cost.
+- **Teardown.** `resize` leaves a provisioned serving cluster (prod `db.r6g.4xlarge`, dev
+  `db.t4g.medium`); teardown is not in this DAG. Clean up abandoned run clusters
+  (`gp-people-db-<date>-<env>`) to avoid idle cost.
 
 ## Before merge
 

--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # post-merge. (During review this tracked the DATA-2100 feature branch so astro-dev ran the PR's loader;
 # repinned to @main for merge — it resolves to this PR's loader once merged.) See PR #607.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-16.8
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-22.1
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This

--- a/people-api-loader/src/loader/core/aws.py
+++ b/people-api-loader/src/loader/core/aws.py
@@ -135,6 +135,35 @@ def flip_writer_to_serverless(
     wait_instance_class_applied(rds_client, instance_id, _SERVERLESS_CLASS)
 
 
+def flip_writer_to_provisioned(
+    rds_client: BaseClient, cluster_id: str, instance_id: str, *, instance_class: str
+) -> None:
+    """Flip the writer instance to a provisioned `instance_class`, tolerating in-progress
+    modifies and waiting until the class change actually applies. Callers layer any extra
+    lockdown (serve param group, backup, deletion protection, reboot) on top; this is only the
+    class conversion.
+
+    Generic RDS helper: no people-api knowledge (the class and ids are passed in, not read off a
+    consumer's config). Unlike `flip_writer_to_serverless`, a provisioned class needs no
+    cluster-level `ServerlessV2ScalingConfiguration` — only the instance-level modify. `cluster_id`
+    is accepted for call-site symmetry with `flip_writer_to_serverless`; it is not used to
+    reconfigure the cluster here.
+    """
+    instance_waiter = rds_client.get_waiter("db_instance_available")
+
+    def _wait_instance() -> None:
+        instance_waiter.wait(DBInstanceIdentifier=instance_id, WaiterConfig={"Delay": 30, "MaxAttempts": 40})
+
+    retry_after_settle(
+        lambda: rds_client.modify_db_instance(
+            DBInstanceIdentifier=instance_id, DBInstanceClass=instance_class, ApplyImmediately=True
+        ),
+        fault_code="InvalidDBInstanceStateFault",
+        settle=_wait_instance,
+    )
+    wait_instance_class_applied(rds_client, instance_id, target=instance_class)
+
+
 @cache
 def _session(
     profile: str | None,

--- a/people-api-loader/src/loader/people_api/cli.py
+++ b/people-api-loader/src/loader/people_api/cli.py
@@ -165,7 +165,7 @@ def build_indexes(
 
 @app.command()
 def resize(run_date: RunDateArg) -> None:
-    """Step 6 — swap writer to db.serverless + serve-tuned params."""
+    """Step 6 — swap writer to the serving instance class + serve-tuned params."""
     from loader.people_api.steps import resize as step
 
     cfg = _setup(run_date)

--- a/people-api-loader/src/loader/people_api/config.py
+++ b/people-api-loader/src/loader/people_api/config.py
@@ -62,18 +62,26 @@ DEFAULT_AWS_ACCOUNT_ID = _PLACEHOLDER
 DEFAULT_S3_IMPORT_ROLE_ARN = _PLACEHOLDER
 
 
-# Load-phase instance sizing. Prod serving is serverless; load uses provisioned (see the
-# loader DAG spec, airflow/astro/docs/people_api_loader.md). We use TWO classes:
-# provision/create_schema/copy run on the smaller `load_instance_class` (copy is I/O/WAL-bound,
-# not CPU-bound), and build_indexes scales the writer UP to `index_instance_class` (build_indexes
-# is cleanly CPU-bound and scales with vCPU — see steps/build_indexes.py). resize then flips
-# the writer to serverless. Override per-env with LOADER_LOAD_INSTANCE_CLASS /
-# LOADER_INDEX_INSTANCE_CLASS; keep _DEFAULT_BUILDERS in build_indexes.py in step with the
-# index box's vCPU.
+# Load-phase instance sizing. Prod serving is a provisioned instance (see the loader DAG
+# spec, airflow/astro/docs/people_api_loader.md). We use THREE classes: provision/
+# create_schema/copy run on the smaller `load_instance_class` (copy is I/O/WAL-bound, not
+# CPU-bound), build_indexes scales the writer UP to `index_instance_class` (build_indexes
+# is cleanly CPU-bound and scales with vCPU — see steps/build_indexes.py), and resize then
+# flips the writer DOWN to `serve_instance_class` — the class the API actually reads from
+# (prod default db.r6g.4xlarge). Override per-env with LOADER_LOAD_INSTANCE_CLASS /
+# LOADER_INDEX_INSTANCE_CLASS / LOADER_SERVE_INSTANCE_CLASS (e.g. dev sets
+# LOADER_SERVE_INSTANCE_CLASS=db.t4g.medium); keep _DEFAULT_BUILDERS in build_indexes.py in
+# step with the index box's vCPU.
+#
+# scale_down's failure-cost guard is unrelated to serving: on a post-provision failure it
+# flips the writer to Serverless v2 (db.serverless) purely to stop the provisioned-instance
+# cost while keeping the cluster + loaded data around for resume/forensics — see
+# `scale_down_min_acu` / `scale_down_max_acu` below and steps/scale_down.py.
 DEFAULT_LOAD_INSTANCE_CLASS = "db.r8g.16xlarge"
 DEFAULT_INDEX_INSTANCE_CLASS = "db.r8g.48xlarge"
-DEFAULT_SERVE_MIN_ACU = 0.5
-DEFAULT_SERVE_MAX_ACU = 128.0
+DEFAULT_SERVE_INSTANCE_CLASS = "db.r6g.4xlarge"
+DEFAULT_SCALE_DOWN_MIN_ACU = 0.5
+DEFAULT_SCALE_DOWN_MAX_ACU = 128.0
 DEFAULT_ENGINE_VERSION = "16.8"
 
 # Env-var name reserved for the master password. MUST NEVER be set — included
@@ -138,8 +146,10 @@ class LoaderConfig(BaseLoaderConfig):
     engine_version: str
     load_instance_class: str
     index_instance_class: str
-    serve_min_acu: float
-    serve_max_acu: float
+    serve_instance_class: str
+    # Failure-cost guard only (steps/scale_down.py) — NOT the serving class, see comment above.
+    scale_down_min_acu: float
+    scale_down_max_acu: float
 
     # PG table name -> Databricks mart FQN (column/type source for emit-ddl).
     mart_fqns: dict[str, str]
@@ -216,8 +226,9 @@ class LoaderConfig(BaseLoaderConfig):
             engine_version=_env("LOADER_ENGINE_VERSION", DEFAULT_ENGINE_VERSION),
             load_instance_class=_env("LOADER_LOAD_INSTANCE_CLASS", DEFAULT_LOAD_INSTANCE_CLASS),
             index_instance_class=_env("LOADER_INDEX_INSTANCE_CLASS", DEFAULT_INDEX_INSTANCE_CLASS),
-            serve_min_acu=float(os.environ.get("LOADER_SERVE_MIN_ACU", DEFAULT_SERVE_MIN_ACU)),
-            serve_max_acu=float(os.environ.get("LOADER_SERVE_MAX_ACU", DEFAULT_SERVE_MAX_ACU)),
+            serve_instance_class=_env("LOADER_SERVE_INSTANCE_CLASS", DEFAULT_SERVE_INSTANCE_CLASS),
+            scale_down_min_acu=float(os.environ.get("LOADER_SCALE_DOWN_MIN_ACU", DEFAULT_SCALE_DOWN_MIN_ACU)),
+            scale_down_max_acu=float(os.environ.get("LOADER_SCALE_DOWN_MAX_ACU", DEFAULT_SCALE_DOWN_MAX_ACU)),
             mart_fqns=mart_fqns,
             _tags=tags,
         )

--- a/people-api-loader/src/loader/people_api/manifests.py
+++ b/people-api-loader/src/loader/people_api/manifests.py
@@ -149,8 +149,6 @@ class IndexManifest(ManifestBase):
 class ResizeManifest(ManifestBase):
     step: Literal["resize"] = "resize"
     final_instance_class: str
-    min_acu: float
-    max_acu: float
     backup_retention_days: int
     deletion_protection: bool
 

--- a/people-api-loader/src/loader/people_api/steps/resize.py
+++ b/people-api-loader/src/loader/people_api/steps/resize.py
@@ -1,10 +1,10 @@
-"""Step 6 — resize the loaded cluster to Serverless v2 + serve params, lock down (DATA-1854).
+"""Step 6 — resize the loaded cluster to its serving instance class + serve params, lock down.
 
 After the load/index phase on the provisioned load instance, flip the writer to
-db.serverless with the prod-matching ACU range, swap the load parameter group for the
-serve group (reboot applies it), bump backup retention to prod's 14 days, and enable
-deletion protection. The rds-s3-import role is intentionally left attached (future
-incremental loads reuse it).
+`cfg.serve_instance_class` (a provisioned class, prod default db.r6g.4xlarge), swap the load
+parameter group for the serve group (reboot applies it), bump backup retention to prod's 14
+days, and enable deletion protection. The rds-s3-import role is intentionally left attached
+(future incremental loads reuse it).
 
 Idempotent: a completed manifest short-circuits.
 """
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from loader.core.aws import flip_writer_to_serverless, rds, retry_after_settle
+from loader.core.aws import flip_writer_to_provisioned, rds, retry_after_settle
 from loader.core.log import bind, get_logger
 from loader.people_api.config import LoaderConfig
 from loader.people_api.manifests import (
@@ -25,7 +25,6 @@ from loader.people_api.manifests import (
 
 log = get_logger(__name__)
 
-_SERVERLESS_CLASS = "db.serverless"
 _BACKUP_RETENTION_DAYS = 14
 
 
@@ -71,40 +70,29 @@ def run(cfg: LoaderConfig, run_date: str) -> ResizeManifest:
         settle=_wait_cluster,
     )
     # The lockdown modify above puts the cluster into 'modifying'; wait for it to settle before
-    # issuing the shared conversion's own modify_db_cluster (ServerlessV2ScalingConfiguration).
-    # Without this, the conversion's modify hits InvalidDBClusterStateFault on essentially every
-    # normal run — retry_after_settle inside it self-heals that, but that path exists for genuine
-    # partial-rerun collisions, not to absorb an expected fault on every happy-path run.
+    # issuing the writer's class-change modify_db_instance below. This keeps the class-change
+    # modify from landing while the cluster is still applying the lockdown settings.
     _wait_cluster()
-    # Shared conversion (cluster ServerlessV2ScalingConfiguration + writer instance class), same
-    # sequence scale_down uses.
-    flip_writer_to_serverless(
-        rds_client, cluster_id, instance_id, min_acu=cfg.serve_min_acu, max_acu=cfg.serve_max_acu
-    )
+    # Shared conversion (writer instance class only — no cluster-level call for a provisioned
+    # class, unlike the Serverless v2 flip scale_down still uses on failure).
+    flip_writer_to_provisioned(rds_client, cluster_id, instance_id, instance_class=cfg.serve_instance_class)
     # A single db_instance_available waiter is NOT enough here: Aurora keeps reporting the
     # instance 'available' for a few seconds after a class-change modify before it flips to
     # 'modifying' and reboots, so a plain `_wait()` can return on the stale state — and the
     # explicit reboot below would then race the conversion's own delayed reboot
-    # (InvalidDBInstanceStateFault). flip_writer_to_serverless already rides through the
+    # (InvalidDBInstanceStateFault). flip_writer_to_provisioned already rides through the
     # class-change reboot via wait_instance_class_applied; reboot here applies the serve
     # parameter group, then wait for available again.
     rds_client.reboot_db_instance(DBInstanceIdentifier=instance_id)
     _wait()
-    log.info(
-        "resize.applied",
-        instance_class=_SERVERLESS_CLASS,
-        min_acu=cfg.serve_min_acu,
-        max_acu=cfg.serve_max_acu,
-    )
+    log.info("resize.applied", instance_class=cfg.serve_instance_class)
 
     manifest = ResizeManifest(
         run_date=run_date,
         status="complete",
         started_at=started,
         finished_at=datetime.now(UTC),
-        final_instance_class=_SERVERLESS_CLASS,
-        min_acu=cfg.serve_min_acu,
-        max_acu=cfg.serve_max_acu,
+        final_instance_class=cfg.serve_instance_class,
         backup_retention_days=_BACKUP_RETENTION_DAYS,
         deletion_protection=True,
     )

--- a/people-api-loader/src/loader/people_api/steps/scale_down.py
+++ b/people-api-loader/src/loader/people_api/steps/scale_down.py
@@ -40,6 +40,6 @@ def run(cfg: LoaderConfig, run_date: str) -> None:
 
     log.info("scale_down.start", instance=instance_id, from_class=current)
     flip_writer_to_serverless(
-        rds_client, cluster_id, instance_id, min_acu=cfg.serve_min_acu, max_acu=cfg.serve_max_acu
+        rds_client, cluster_id, instance_id, min_acu=cfg.scale_down_min_acu, max_acu=cfg.scale_down_max_acu
     )
     log.info("scale_down.applied", instance=instance_id, instance_class=_SERVERLESS_CLASS)

--- a/people-api-loader/tests/test_aws.py
+++ b/people-api-loader/tests/test_aws.py
@@ -241,12 +241,16 @@ class _FakeFlipWaiter:
 
 
 class _FakeFlipRds:
-    """Minimal RDS double for flip_writer_to_serverless: records calls, can raise once per op."""
+    """Minimal RDS double for flip_writer_to_serverless/flip_writer_to_provisioned: records
+    calls, can raise once per op."""
 
-    def __init__(self, raise_on: dict[str, str] | None = None) -> None:
+    def __init__(
+        self, raise_on: dict[str, str] | None = None, *, describe_sequence: list[dict] | None = None
+    ) -> None:
         self.calls: list[tuple[str, dict]] = []
         self._raise_on = raise_on or {}
         self._raised: set[str] = set()
+        self._describe_sequence = describe_sequence or _SETTLED_SERVERLESS
         self._describe_calls = 0
 
     def _maybe_raise(self, op: str) -> None:
@@ -265,9 +269,9 @@ class _FakeFlipRds:
 
     def describe_db_instances(self, **kw: object) -> dict:
         self.calls.append(("describe_instance", kw))
-        idx = min(self._describe_calls, len(_SETTLED_SERVERLESS) - 1)
+        idx = min(self._describe_calls, len(self._describe_sequence) - 1)
         self._describe_calls += 1
-        return {"DBInstances": [_SETTLED_SERVERLESS[idx]]}
+        return {"DBInstances": [self._describe_sequence[idx]]}
 
     def get_waiter(self, name: str) -> _FakeFlipWaiter:
         return _FakeFlipWaiter()
@@ -320,3 +324,48 @@ def test_flip_writer_to_serverless_retries_after_transient_faults(monkeypatch: p
     ops = [c[0] for c in rds_client.calls]
     assert ops.count("modify_cluster") == 2
     assert ops.count("modify_instance") == 2
+
+
+_SETTLED_PROVISIONED = [
+    {"DBInstanceClass": "db.r6g.4xlarge", "DBInstanceStatus": "available", "PendingModifiedValues": {}}
+]
+
+
+def test_flip_writer_to_provisioned_issues_instance_only_conversion() -> None:
+    rds_client = _FakeFlipRds(describe_sequence=_SETTLED_PROVISIONED)
+
+    aws.flip_writer_to_provisioned(
+        rds_client,  # ty: ignore[invalid-argument-type]
+        "cluster-1",
+        "writer-1",
+        instance_class="db.r6g.4xlarge",
+    )
+
+    ops = [c[0] for c in rds_client.calls]
+    # No cluster-level call at all: a provisioned class needs no ServerlessV2ScalingConfiguration.
+    assert "modify_cluster" not in ops
+    by = dict(rds_client.calls)
+    assert by["modify_instance"] == {
+        "DBInstanceIdentifier": "writer-1",
+        "DBInstanceClass": "db.r6g.4xlarge",
+        "ApplyImmediately": True,
+    }
+
+
+def test_flip_writer_to_provisioned_retries_after_transient_fault(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(aws.time, "sleep", lambda *a, **k: None)
+    rds_client = _FakeFlipRds(
+        raise_on={"modify_instance": "InvalidDBInstanceStateFault"},
+        describe_sequence=_SETTLED_PROVISIONED,
+    )
+
+    aws.flip_writer_to_provisioned(
+        rds_client,  # ty: ignore[invalid-argument-type]
+        "cluster-1",
+        "writer-1",
+        instance_class="db.r6g.4xlarge",
+    )  # must not raise — the fault is tolerated (settle, then re-issue)
+
+    ops = [c[0] for c in rds_client.calls]
+    assert ops.count("modify_instance") == 2
+    assert "modify_cluster" not in ops

--- a/people-api-loader/tests/test_cluster_lifecycle_moto.py
+++ b/people-api-loader/tests/test_cluster_lifecycle_moto.py
@@ -8,8 +8,9 @@ behind moto's RDS) and manifest S3 IO are patched.
 
 moto limitations worked around: it doesn't model the aurora-iopt1 storage type, so
 provision's _STORAGE_TYPE is overridden to a moto-supported value (the real value lives in
-the constant), and it doesn't model the provisioned->serverless instance-state transition,
-so resize's reboot-ordering is covered by static review + the unit test, not here.
+the constant), and it doesn't model the real Aurora class-change reboot sequencing (the
+stale-'available' race `wait_instance_class_applied` rides through), so resize's
+reboot-ordering is covered by static review + the unit test, not here.
 """
 
 from __future__ import annotations
@@ -107,7 +108,7 @@ def test_resize_applies_lockdown(monkeypatch: pytest.MonkeyPatch) -> None:
 
     manifest = resize_step.run(cfg, _DATE)
 
-    assert manifest.final_instance_class == "db.serverless"
+    assert manifest.final_instance_class == cfg.serve_instance_class
     cluster = rds.describe_db_clusters(DBClusterIdentifier=cfg.new_cluster_id(_DATE))["DBClusters"][0]
     assert cluster["BackupRetentionPeriod"] == 14
     assert cluster["DeletionProtection"] is True

--- a/people-api-loader/tests/test_resize.py
+++ b/people-api-loader/tests/test_resize.py
@@ -1,4 +1,4 @@
-"""resize: flip to serverless v2 + serve params + lock-down, write manifest."""
+"""resize: flip writer to the provisioned serving class + serve params + lock-down, write manifest."""
 
 from __future__ import annotations
 
@@ -12,11 +12,15 @@ from loader.core import aws
 from loader.people_api.config import LoaderConfig
 from loader.people_api.steps import resize as step
 
+# Deliberately distinct from both DEFAULT_SERVE_INSTANCE_CLASS ("db.r6g.4xlarge") and the dev
+# override ("db.t4g.medium") so these tests catch resize reading a hardcoded default instead of
+# cfg.serve_instance_class.
+_TEST_SERVE_CLASS = "db.r6g.2xlarge"
+
 _CFG = cast(
     LoaderConfig,
     SimpleNamespace(
-        serve_min_acu=0.5,
-        serve_max_acu=128.0,
+        serve_instance_class=_TEST_SERVE_CLASS,
         new_cluster_id=lambda rd: f"gp-people-db-{rd}",
         new_writer_instance_id=lambda rd: f"gp-people-db-{rd}-writer",
         new_serve_param_group=lambda rd: f"gp-people-db-{rd}-serve",
@@ -29,8 +33,8 @@ class _FakeWaiter:
         return None
 
 
-_SETTLED_SERVERLESS = [
-    {"DBInstanceClass": "db.serverless", "DBInstanceStatus": "available", "PendingModifiedValues": {}}
+_SETTLED_PROVISIONED = [
+    {"DBInstanceClass": _TEST_SERVE_CLASS, "DBInstanceStatus": "available", "PendingModifiedValues": {}}
 ]
 
 
@@ -46,10 +50,11 @@ class FakeRds:
         self._raise_on = raise_on or {}  # op -> ClientError code to raise after recording
         self._persistent = persistent  # raise every time (bad state) vs once (in-progress)
         self._raised: set[str] = set()
-        # The serverless-flip wait (loader.core.aws.wait_instance_class_applied) polls
-        # describe_db_instances; defaults to already-settled db.serverless so it terminates on
-        # the first poll. Held on the last item once exhausted (mirrors a real poll settling).
-        self._describe_sequence = describe_sequence or _SETTLED_SERVERLESS
+        # The class-change wait (loader.core.aws.wait_instance_class_applied) polls
+        # describe_db_instances; defaults to already-settled at the target class so it
+        # terminates on the first poll. Held on the last item once exhausted (mirrors a real
+        # poll settling).
+        self._describe_sequence = describe_sequence or _SETTLED_PROVISIONED
         self._describe_calls = 0
 
     def _maybe_raise(self, op: str) -> None:
@@ -79,7 +84,7 @@ class FakeRds:
         return _FakeWaiter()
 
 
-def test_resize_applies_serverless_and_writes_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resize_applies_provisioned_class_and_writes_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
     rds_client = FakeRds()
     captured: dict = {}
     monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
@@ -89,21 +94,23 @@ def test_resize_applies_serverless_and_writes_manifest(monkeypatch: pytest.Monke
     manifest = step.run(_CFG, "20260616")
 
     assert manifest.status == "complete"
-    assert manifest.final_instance_class == "db.serverless"
-    assert (manifest.min_acu, manifest.max_acu) == (0.5, 128.0)
+    assert manifest.final_instance_class == _TEST_SERVE_CLASS
     assert manifest.backup_retention_days == 14 and manifest.deletion_protection is True
-    # Two modify_db_cluster calls: resize's own lockdown (param group/backup/deletion
-    # protection), and the shared flip_writer_to_serverless conversion (ServerlessV2Scaling).
+    assert not hasattr(manifest, "min_acu")
+    assert not hasattr(manifest, "max_acu")
+    # Exactly one modify_db_cluster call: resize's own lockdown (param group/backup/deletion
+    # protection). flip_writer_to_provisioned only touches the instance — no
+    # ServerlessV2ScalingConfiguration / cluster-level call for a provisioned class.
     cluster_calls = [kw for op, kw in rds_client.calls if op == "modify_cluster"]
-    assert len(cluster_calls) == 2
-    lockdown = next(c for c in cluster_calls if "DBClusterParameterGroupName" in c)
-    conversion = next(c for c in cluster_calls if "ServerlessV2ScalingConfiguration" in c)
+    assert len(cluster_calls) == 1
+    lockdown = cluster_calls[0]
     assert lockdown["DBClusterParameterGroupName"] == "gp-people-db-20260616-serve"
     assert lockdown["BackupRetentionPeriod"] == 14
     assert lockdown["DeletionProtection"] is True
-    assert conversion["ServerlessV2ScalingConfiguration"] == {"MinCapacity": 0.5, "MaxCapacity": 128.0}
+    assert all("ServerlessV2ScalingConfiguration" not in kw for _op, kw in rds_client.calls)
     by = dict(rds_client.calls)
-    assert by["modify_instance"]["DBInstanceClass"] == "db.serverless"
+    assert by["modify_instance"]["DBInstanceClass"] == _TEST_SERVE_CLASS
+    assert by["modify_instance"]["ApplyImmediately"] is True
 
 
 def test_resize_retries_in_progress_modify(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -123,11 +130,11 @@ def test_resize_retries_in_progress_modify(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert manifest.status == "complete"
     ops = [c[0] for c in rds_client.calls]
-    # the lockdown modify_cluster hit the fault once (raise + re-issue = 2 calls); the
-    # conversion's own modify_cluster (ServerlessV2Scaling) then succeeds straight away (the fake
-    # raises "modify_cluster" only once, regardless of call site) = 3 total. modify_instance
-    # (from the conversion) hit its own fault once (raise + re-issue = 2), then reboot.
-    assert ops.count("modify_cluster") == 3
+    # The lockdown modify_cluster hit the fault once (raise + re-issue = 2 calls); there is no
+    # separate conversion-level modify_cluster for a provisioned class (flip_writer_to_provisioned
+    # only touches the instance), so 2 total. modify_instance (the class-change conversion) hit
+    # its own fault once (raise + re-issue = 2), then reboot.
+    assert ops.count("modify_cluster") == 2
     assert ops.count("modify_instance") == 2
     assert "reboot" in ops
 
@@ -145,17 +152,17 @@ def test_resize_reboot_waits_for_class_applied_not_just_available(monkeypatch: p
             {
                 "DBInstanceClass": "db.r8g.16xlarge",
                 "DBInstanceStatus": "available",
-                "PendingModifiedValues": {"DBInstanceClass": "db.serverless"},
+                "PendingModifiedValues": {"DBInstanceClass": _TEST_SERVE_CLASS},
             },
             # now actually modifying
             {
                 "DBInstanceClass": "db.r8g.16xlarge",
                 "DBInstanceStatus": "modifying",
-                "PendingModifiedValues": {"DBInstanceClass": "db.serverless"},
+                "PendingModifiedValues": {"DBInstanceClass": _TEST_SERVE_CLASS},
             },
             # settled on the target class
             {
-                "DBInstanceClass": "db.serverless",
+                "DBInstanceClass": _TEST_SERVE_CLASS,
                 "DBInstanceStatus": "available",
                 "PendingModifiedValues": {},
             },
@@ -168,7 +175,7 @@ def test_resize_reboot_waits_for_class_applied_not_just_available(monkeypatch: p
     manifest = step.run(_CFG, "20260616")
 
     assert manifest.status == "complete"
-    assert manifest.final_instance_class == "db.serverless"
+    assert manifest.final_instance_class == _TEST_SERVE_CLASS
     ops = [c[0] for c in rds_client.calls]
     reboot_idx = ops.index("reboot")
     # at least 3 describes happened before reboot (rode through stale-available + modifying)
@@ -190,55 +197,27 @@ def test_resize_propagates_persistent_modify_fault(monkeypatch: pytest.MonkeyPat
     assert "m" not in wrote  # no complete manifest written
 
 
-class _ClusterSettleWaiter(_FakeWaiter):
-    """Cluster waiter stub that flips the fake cluster back to 'available' and records the wait,
-    so tests can assert *when* it happened relative to modify_db_cluster calls."""
+def test_resize_waits_for_cluster_settle_before_instance_class_modify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # resize's lockdown modify_db_cluster leaves the cluster 'modifying'. Assert resize's
+    # explicit cluster-settle wait happens strictly between that lockdown modify_db_cluster and
+    # the writer's class-change modify_db_instance — i.e. resize waits proactively before
+    # touching the instance, rather than relying on a fault-triggered retry.
+    class _ClusterSettleWaiter(_FakeWaiter):
+        def __init__(self, rds_client: FakeRds) -> None:
+            self._rds = rds_client
 
-    def __init__(self, rds_client: _StrictSettleFakeRds) -> None:
-        self._rds = rds_client
+        def wait(self, **kwargs: object) -> None:
+            self._rds.calls.append(("wait_cluster", dict(kwargs)))
 
-    def wait(self, **kwargs: object) -> None:
-        self._rds.calls.append(("wait_cluster", dict(kwargs)))
-        self._rds.cluster_modifying = False
+    class _WaitTrackingFakeRds(FakeRds):
+        def get_waiter(self, name: str) -> _FakeWaiter:
+            if name == "db_cluster_available":
+                return _ClusterSettleWaiter(self)
+            return _FakeWaiter()
 
-
-class _StrictSettleFakeRds(FakeRds):
-    """Models the real AWS behavior the sequencing bug depends on: a modify_db_cluster call that
-    lands while the cluster is still 'modifying' from a prior modify_db_cluster raises
-    InvalidDBClusterStateFault. Unlike the base FakeRds (which raises a fixed number of times
-    regardless of cluster state), this fake tracks actual cluster state, so it only faults if a
-    second modify_db_cluster is issued WITHOUT an intervening cluster-settle wait -- exactly the
-    gap this task fixes.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.cluster_modifying = False
-
-    def modify_db_cluster(self, **kw: Any) -> None:
-        self.calls.append(("modify_cluster", kw))
-        if self.cluster_modifying:
-            raise ClientError(
-                {"Error": {"Code": "InvalidDBClusterStateFault", "Message": "still modifying"}},
-                "ModifyDBCluster",
-            )
-        self.cluster_modifying = True
-
-    def get_waiter(self, name: str) -> _FakeWaiter:
-        if name == "db_cluster_available":
-            return _ClusterSettleWaiter(self)
-        return _FakeWaiter()
-
-
-def test_resize_waits_for_cluster_settle_before_conversion_modify(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Models the sequencing bug: resize's lockdown modify_db_cluster leaves the cluster
-    # 'modifying'; flip_writer_to_serverless's own modify_db_cluster (ServerlessV2Scaling) would
-    # fault with InvalidDBClusterStateFault if issued before the cluster settles back to
-    # 'available'. retry_after_settle inside the helper WOULD absorb that fault (wait + retry
-    # once), but that turns a rare diagnostic warning into routine per-run noise. Assert resize's
-    # explicit cluster-settle wait keeps the conversion's modify a single-shot call (no fault, no
-    # retry) on the normal run.
-    rds_client = _StrictSettleFakeRds()
+    rds_client = _WaitTrackingFakeRds()
     monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
     monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
     monkeypatch.setattr(step, "write_manifest", lambda cfg, m: "uri")
@@ -247,15 +226,10 @@ def test_resize_waits_for_cluster_settle_before_conversion_modify(monkeypatch: p
 
     assert manifest.status == "complete"
     ops = [op for op, _ in rds_client.calls]
-    cluster_modify_idxs = [i for i, op in enumerate(ops) if op == "modify_cluster"]
-    # Exactly two modify_db_cluster calls total (lockdown + conversion): if the explicit wait
-    # were missing, the conversion's modify would fault and retry_after_settle would re-issue it,
-    # producing a THIRD modify_cluster call.
-    assert len(cluster_modify_idxs) == 2
-    # An explicit cluster-settle wait happened strictly between the lockdown modify and the
-    # conversion modify -- i.e. resize waited proactively, rather than relying on the helper's
-    # fault-triggered retry.
-    assert "wait_cluster" in ops[cluster_modify_idxs[0] + 1 : cluster_modify_idxs[1]]
+    modify_cluster_idx = ops.index("modify_cluster")
+    modify_instance_idx = ops.index("modify_instance")
+    assert modify_cluster_idx < modify_instance_idx
+    assert "wait_cluster" in ops[modify_cluster_idx + 1 : modify_instance_idx]
 
 
 def test_resize_skips_completed_manifest(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/people-api-loader/tests/test_scale_down.py
+++ b/people-api-loader/tests/test_scale_down.py
@@ -15,8 +15,8 @@ from loader.people_api.steps import scale_down as step
 _CFG = cast(
     LoaderConfig,
     SimpleNamespace(
-        serve_min_acu=0.5,
-        serve_max_acu=128.0,
+        scale_down_min_acu=0.5,
+        scale_down_max_acu=128.0,
         new_cluster_id=lambda rd: f"gp-people-db-{rd}",
         new_writer_instance_id=lambda rd: f"gp-people-db-{rd}-writer",
     ),


### PR DESCRIPTION
Combines two changes needed before the next dev-cluster rebuild:

## 1. Serve on a provisioned instance class (not Serverless v2)
The `resize` step (step 6) now flips the served writer to a provisioned instance class instead of Serverless v2:
- `serve_instance_class` config, env `LOADER_SERVE_INSTANCE_CLASS`, **prod default `db.r6g.4xlarge`**; astro-dev sets `db.t4g.medium`.
- New `flip_writer_to_provisioned` in `core/aws.py` (instance-level `modify_db_instance` + `wait_instance_class_applied`; no cluster-level ServerlessV2 config).
- `ResizeManifest` drops `min_acu`/`max_acu`, keeps `final_instance_class`.
- The on-failure cost guard (`scale_down`) is unchanged and still flips to cheap Serverless v2 to hold a failed cluster — its ACU fields were renamed to `scale_down_min_acu`/`scale_down_max_acu` (env `LOADER_SCALE_DOWN_*`) to keep the two concerns distinct.
- Loader DAG doc updated to match.

Load/index phases are untouched (still the big `db.r8g` classes), so no load-perf impact.

## 2. Astro cache-bust bump
Bumps the `requirements.txt` cache-bust token so `astro deploy` reinstalls the loader `@main` — picking up the merged enum (#657), the `hf_most_important_policy_item` column, the green→public compat views, and the provisioned-serving change above.

Tests: full loader suite 310 passed + integration suite 4 passed; ruff/format/ty clean.