### PR TITLE
Loader: read inspect_prod baseline from the connection string's schema

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # post-merge. (During review this tracked the DATA-2100 feature branch so astro-dev ran the PR's loader;
 # repinned to @main for merge — it resolves to this PR's loader once merged.) See PR #607.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-22.1
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-22.2
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This

--- a/people-api-loader/src/loader/people_api/db.py
+++ b/people-api-loader/src/loader/people_api/db.py
@@ -9,13 +9,19 @@ fetched and decrypted at connect time. Nothing connection-related lives in this 
 - `connect_new(cfg, run_date)`: the cluster provisioned by step 2. Param name
   `cfg.new_conn_param(run_date)`, written by provision with the generated master
   password embedded in the URL.
+
+Either value may instead be a Prisma-style URL carrying a `?schema=` query param (dev's
+Present-cluster string, pointed at a swain-db schema other than `public`); libpq has no such
+param, so `_conninfo_from_ssm` translates it to the libpq-native `search_path` equivalent.
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import psycopg
 from psycopg.conninfo import conninfo_to_dict, make_conninfo
@@ -26,6 +32,11 @@ from loader.people_api.config import LoaderConfig
 
 if TYPE_CHECKING:
     from psycopg import Connection
+
+# A bare identifier: what `?schema=` should ever legitimately carry (e.g. "green", "public").
+# Rejecting anything else is defense-in-depth against ever building a `-c search_path=...`
+# options string from something that isn't a plain schema name (never trust-then-inject).
+_SAFE_SCHEMA_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # TCP keepalives so a dropped connection (e.g. a severed bastion tunnel) surfaces as an error
 # in ~1 min rather than hanging indefinitely on a response that never arrives. connect_timeout
@@ -38,6 +49,49 @@ _KEEPALIVE_KW = {
     "keepalives_interval": "10",
     "keepalives_count": "5",
 }
+
+
+def _strip_schema_param(value: str) -> tuple[str, str | None]:
+    """Split a Prisma-style `?schema=` query param out of a `postgres(ql)://` URL.
+
+    Returns `(cleaned_value, schema)`. `value` is passed through unchanged (schema=None) when
+    it isn't a `postgres(ql)://` URL, or is one without a `schema` query param — libpq keyword
+    strings (`host=... dbname=...`) and plain URLs are untouched either way.
+    """
+    parsed = urlparse(value)
+    if parsed.scheme not in ("postgres", "postgresql"):
+        return value, None
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    remaining = [(k, v) for k, v in query_pairs if k != "schema"]
+    schemas = [v for k, v in query_pairs if k == "schema"]
+    if not schemas:
+        return value, None
+    schema = schemas[-1]
+    cleaned = urlunparse(parsed._replace(query=urlencode(remaining)))
+    return cleaned, schema
+
+
+def _conninfo_from_ssm(cfg: LoaderConfig, param_name: str) -> str:
+    """Fetch an SSM connection string and build its conninfo, keepalives baked in.
+
+    The value is usually a plain libpq/URL connection string, handed straight to
+    `make_conninfo`. Dev's Present-cluster string is Prisma-style instead — a
+    `postgresql://...?schema=green` URL — and libpq has no `schema` query param (psycopg
+    rejects it outright). So a `schema` param is parsed out here and translated into the
+    libpq-native equivalent, `options=-c search_path=<schema>`, rather than dropped. A
+    string without `?schema=` is untouched: no `options` is added, so its conninfo is
+    byte-for-byte what it always was.
+    """
+    raw = get_ssm_parameter(cfg, param_name)
+    cleaned, schema = _strip_schema_param(raw)
+    if schema is None:
+        return make_conninfo(cleaned, **_KEEPALIVE_KW)
+    if not _SAFE_SCHEMA_RE.match(schema):
+        raise ValueError(
+            f"refusing to use SSM parameter {param_name!r}'s schema {schema!r} as a "
+            "search_path: expected a simple identifier"
+        )
+    return make_conninfo(cleaned, options=f"-c search_path={schema}", **_KEEPALIVE_KW)
 
 
 def _apply_session_settings(conn: Connection, cfg: LoaderConfig) -> None:
@@ -65,7 +119,7 @@ def _connect(
     bastion would otherwise each open their own tunnel and flood sshd MaxStartups; sharing one
     forward multiplexes them as channels on a single SSH transport. Ignored when no bastion.
     """
-    conninfo = make_conninfo(get_ssm_parameter(cfg, param_name), **_KEEPALIVE_KW)
+    conninfo = _conninfo_from_ssm(cfg, param_name)
     if not cfg.bastion_enabled:
         # Direct: the SSM connection string, plus the keepalive params baked in above.
         with psycopg.connect(conninfo, autocommit=autocommit, connect_timeout=30) as conn:
@@ -100,7 +154,7 @@ def open_new_tunnel(cfg: LoaderConfig, run_date: str) -> Iterator[tuple[str, int
     if not cfg.bastion_enabled:
         yield None
         return
-    parts = conninfo_to_dict(make_conninfo(get_ssm_parameter(cfg, cfg.new_conn_param(run_date))))
+    parts = conninfo_to_dict(_conninfo_from_ssm(cfg, cfg.new_conn_param(run_date)))
     target_host = str(parts.get("host") or "")
     target_port = int(parts.get("port") or 5432)
     with open_tunnel(cfg, target_host, target_port) as fwd:
@@ -113,7 +167,9 @@ def connect_prod(cfg: LoaderConfig, *, autocommit: bool = True) -> Iterator[Conn
 
     `cfg.db_conn_param` names the SecureString parameter (e.g.
     `people-db-connection-string-{env}`); its decrypted value is a full libpq
-    connection string (or `postgresql://` URL) handed straight to psycopg.
+    connection string (or `postgresql://` URL, optionally with a `?schema=` param
+    that becomes this connection's `search_path`) handed to psycopg via
+    `_conninfo_from_ssm`.
     """
     with _connect(cfg, cfg.db_conn_param, autocommit=autocommit) as conn:
         yield conn
@@ -131,7 +187,9 @@ def connect_new(
 
     `cfg.new_conn_param(run_date)` names the SecureString parameter that provision
     wrote (`people-db-connection-string-{env}-{run_date}`); the decrypted value is the
-    full `postgresql://` URL, password and all, handed straight to psycopg.
+    full `postgresql://` URL, password and all (optionally with a `?schema=` param
+    that becomes this connection's `search_path`), handed to psycopg via
+    `_conninfo_from_ssm`.
 
     `forward` shares a tunnel opened by `open_new_tunnel` (see `_connect`); omit it for a
     one-off connection that opens (and closes) its own tunnel.

--- a/people-api-loader/src/loader/people_api/schema/serving_structure.py
+++ b/people-api-loader/src/loader/people_api/schema/serving_structure.py
@@ -79,7 +79,7 @@ def extract_indexes(cur: Any, tables: list[str]) -> list[IndexDef]:
         JOIN pg_class c ON c.oid = i.indexrelid
         JOIN pg_class t ON t.oid = i.indrelid
         JOIN pg_namespace n ON n.oid = t.relnamespace
-        WHERE n.nspname = 'public' AND t.relname = ANY(%s) AND NOT i.indisprimary
+        WHERE n.nspname = current_schema() AND t.relname = ANY(%s) AND NOT i.indisprimary
         ORDER BY t.relname, c.relname
         """,
         (tables,),

--- a/people-api-loader/src/loader/people_api/steps/inspect_prod.py
+++ b/people-api-loader/src/loader/people_api/steps/inspect_prod.py
@@ -44,7 +44,7 @@ _OPTIONAL_TABLES: tuple[str, ...] = ("DistrictVoter", "District", "DistrictStats
 def _has_column(cur: psycopg.Cursor, table: str, column: str) -> bool:
     cur.execute(
         "SELECT 1 FROM information_schema.columns "
-        "WHERE table_schema='public' AND table_name=%s AND column_name=%s",
+        "WHERE table_schema = current_schema() AND table_name=%s AND column_name=%s",
         (table, column),
     )
     return cur.fetchone() is not None
@@ -81,12 +81,12 @@ def _inspect_table(cur: psycopg.Cursor, table: str) -> TableInspection:
         else None
     )
     if pcol is None or not _has_column(cur, table, pcol):
-        cur.execute(f'SELECT count(*) FROM public."{table}"')  # ty: ignore[no-matching-overload]
+        cur.execute(f'SELECT count(*) FROM "{table}"')  # ty: ignore[no-matching-overload]
         return TableInspection(table=table, total_row_count=_scalar_int(cur))
 
     has_updated = _has_column(cur, table, "updated_at")
     cols = "count(*), max(updated_at)" if has_updated else "count(*)"
-    sql = f'SELECT "{pcol}", {cols} FROM public."{table}" GROUP BY "{pcol}"'
+    sql = f'SELECT "{pcol}", {cols} FROM "{table}" GROUP BY "{pcol}"'
     cur.execute(sql)  # ty: ignore[no-matching-overload]
 
     total = 0

--- a/people-api-loader/tests/test_connections.py
+++ b/people-api-loader/tests/test_connections.py
@@ -140,3 +140,60 @@ def test_statement_timeout_skipped_when_zero(monkeypatch: pytest.MonkeyPatch) ->
     with db.connect_prod(cfg):
         pass
     assert conn.executed == []  # 0 disables the timeout (no SET issued)
+
+
+# --- _conninfo_from_ssm: translate a Prisma-style `?schema=` param to libpq `search_path` ---
+
+
+def test_conninfo_from_ssm_translates_schema_param_to_search_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        db,
+        "get_ssm_parameter",
+        lambda cfg, name, **k: "postgresql://u:p@host:5432/db?schema=green",
+    )
+    cfg = cast(LoaderConfig, SimpleNamespace())
+    conninfo = db._conninfo_from_ssm(cfg, "some-param")
+    parts = conninfo_to_dict(conninfo)
+    assert "schema" not in conninfo
+    assert parts["options"] == "-c search_path=green"
+    assert parts["host"] == "host"
+    assert parts["dbname"] == "db"
+    assert parts["keepalives"] == "1"  # keepalives still baked in
+
+
+def test_conninfo_from_ssm_passthrough_url_without_schema_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db, "get_ssm_parameter", lambda cfg, name, **k: "postgresql://u:p@host:5432/db")
+    cfg = cast(LoaderConfig, SimpleNamespace())
+    conninfo = db._conninfo_from_ssm(cfg, "some-param")
+    parts = conninfo_to_dict(conninfo)
+    assert "options" not in parts  # no schema param -> conninfo unchanged (no options added)
+    assert parts["host"] == "host"
+    assert parts["keepalives"] == "1"
+
+
+def test_conninfo_from_ssm_passthrough_libpq_keyword_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        db, "get_ssm_parameter", lambda cfg, name, **k: "host=rds.internal dbname=d user=u port=5432"
+    )
+    cfg = cast(LoaderConfig, SimpleNamespace())
+    conninfo = db._conninfo_from_ssm(cfg, "some-param")
+    parts = conninfo_to_dict(conninfo)
+    assert "options" not in parts
+    assert parts["host"] == "rds.internal"
+    assert parts["keepalives"] == "1"
+
+
+@pytest.mark.parametrize("bad_schema", ["green; drop table x", "green\\", "green -c foo", "green bar"])
+def test_conninfo_from_ssm_rejects_unsafe_schema_value(
+    monkeypatch: pytest.MonkeyPatch, bad_schema: str
+) -> None:
+    from urllib.parse import quote
+
+    monkeypatch.setattr(
+        db,
+        "get_ssm_parameter",
+        lambda cfg, name, **k: f"postgresql://u:p@host:5432/db?schema={quote(bad_schema)}",
+    )
+    cfg = cast(LoaderConfig, SimpleNamespace())
+    with pytest.raises(ValueError, match="schema"):
+        db._conninfo_from_ssm(cfg, "some-param")

--- a/people-api-loader/tests/test_inspect_prod.py
+++ b/people-api-loader/tests/test_inspect_prod.py
@@ -34,6 +34,11 @@ def test_inspect_table_with_state_and_snapshot() -> None:
     sqls = executed_sql(conn)
     assert sum('GROUP BY "State"' in s for s in sqls) == 1
     assert not any(s.startswith("SELECT count(*)") for s in sqls)
+    # The table is unqualified (no "public." prefix) so it resolves through the connection's
+    # search_path, and the column probe reads current_schema() rather than a hardcoded 'public'.
+    assert any('FROM "Voter" GROUP BY "State"' in s for s in sqls)
+    assert not any("public." in s for s in sqls)
+    assert sum("current_schema()" in s for s in sqls) == 2  # "State" probe + "updated_at" probe
 
 
 def test_inspect_table_total_includes_null_state_rows() -> None:
@@ -58,6 +63,8 @@ def test_inspect_table_flat_table_is_total_only() -> None:
     assert ti.total_row_count == 7
     assert ti.per_state_row_counts == {}
     assert ti.per_state_snapshot_dates == {}
+    # Unqualified table name (no "public." prefix) — resolves through the connection's search_path.
+    assert executed_sql(conn) == ['SELECT count(*) FROM "District"']
 
 
 def test_inspect_table_partitioned_but_serving_column_absent_falls_back_to_count() -> None:
@@ -117,6 +124,17 @@ def test_run_optional_table_failure_is_skipped(monkeypatch: pytest.MonkeyPatch) 
     manifest = step.run(_CFG, "20260609")
     assert manifest.status == "complete"
     assert {t.table for t in manifest.tables} == {"Voter", "DistrictVoter", "District"}
+
+
+def test_has_column_queries_current_schema_not_hardcoded_public() -> None:
+    # The baseline must read whatever schema the connection's search_path resolves to (e.g.
+    # green on swain-db), not a hardcoded 'public' — see the module docstring.
+    conn = FakeConn().queue_result((1,))
+    assert step._has_column(conn.cursor(), "Voter", "State") is True  # ty: ignore[invalid-argument-type]
+    sql, params = conn.executed[0]
+    assert "current_schema()" in sql
+    assert "public" not in sql
+    assert params == ("Voter", "State")
 
 
 def test_index_drift_reports_both_directions() -> None:


### PR DESCRIPTION
## Why
The dev rebuild's `load_people_api` run failed at step 0 `inspect_prod` with `invalid URI query parameter: "schema"`. Root cause: the dev baseline SSM connection string (`people-db-connection-string-dev`) was changed on 2026-07-21 to a Prisma-style URL pointing at swain-db's `green` schema (`...?schema=green`). libpq/psycopg has no `schema` query param, and `inspect_prod` also hardcoded the `public` schema — so the loader couldn't read the intended `green` baseline.

`inspect_prod` reads the baseline with read-only `SELECT count(*)`; swain-db is never mutated.

## What
- **db.py:** new `_conninfo_from_ssm` strips a `?schema=<name>` param out of the URL and translates it to the libpq-native `options=-c search_path=<name>`. Connection strings without `?schema=` are byte-for-byte unchanged (no `options` added). The schema value is validated as a bare identifier before ever building the options string (no injection). Both `connect_prod` and `connect_new` route through it.
- **inspect_prod.py:** count queries drop the hardcoded `public.` (resolve via `search_path`); `_has_column` uses `current_schema()` instead of `table_schema='public'`.
- **serving_structure.py:** `extract_indexes` (advisory index-drift check) uses `current_schema()`; the PK/FK extractors (not on the baseline path) are untouched. cli.py's `extract-serving-structure` is unchanged in normal use (default search_path → `public`).
- **requirements.txt:** cache-bust bump so `astro deploy` reinstalls the loader.

## Tests
23 tests across `test_connections.py` (new `_conninfo_from_ssm` cases incl. injection rejection) and `test_inspect_prod.py` (unqualified SQL + `current_schema()`). Full suite 318 passed / 4 skipped; integration suite ran 4/4 against local pg; ruff/format/ty clean.