### PR TITLE
[DATA-2144] quality_bench: question bank (q01-q08) + gold-run answer keys (q01, q02)

### DIFF
--- a/analytics/diagnostics/quality_bench/grade.py
+++ b/analytics/diagnostics/quality_bench/grade.py
@@ -27,6 +27,18 @@ except ImportError:  # bare `python grade.py`: diagnostics/ isn't on sys.path ye
     from quality_bench.bank import Key, Question, load_key, load_manifest
 
 
+def load_keys_for_batch(keys_dir: Path, questions: list[Question], qids_in_batch: set[str]) -> dict[str, Key]:
+    """Load only the keys for questions actually present in the batch.
+
+    Keys are authored one gold run at a time, so the manifest may register
+    key files that do not exist yet; a batch that never ran those questions
+    must still grade (PR #660 review).
+    """
+    return {
+        q.id: load_key(keys_dir / q.key_file, expected_id=q.id) for q in questions if q.id in qids_in_batch
+    }
+
+
 def grade_run(run_state: dict, key: Key) -> dict:
     run_id = run_state["run_id"]
     # question_id/arm/rep are recovered by splitting run_id on "__". bank.load_manifest
@@ -170,7 +182,8 @@ def main() -> None:
     batch_dir = here / "results" / args.batch
     state = json.loads((batch_dir / "state.json").read_text())
     questions = load_manifest(here / "questions" / "manifest.yaml")
-    keys = {q.id: load_key(here / "keys" / q.key_file, expected_id=q.id) for q in questions}
+    qids_in_state = {rid.split("__")[0] for rid in state["runs"]}
+    keys = load_keys_for_batch(here / "keys", questions, qids_in_state)
 
     rows, blocks = [], {}
     judge_eligible = judge_ok = 0
@@ -198,7 +211,6 @@ def main() -> None:
     # Coverage denominator = every question with ANY recorded run, not only the
     # ok ones. A question whose runs all failed must still count against rule 1,
     # otherwise a silent drop would inflate the pass rate.
-    qids_in_state = {rid.split("__")[0] for rid in state["runs"]}
     denom_questions = [q for q in questions if q.id in qids_in_state]
     cells = {ck: grading.cell_consistency(bs, keys[ck[0]]) for ck, bs in blocks.items()}
     # Rep count comes from the recorded run ids, so a resumed or non-default

--- a/analytics/diagnostics/quality_bench/keys/q01_win_metric_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q01_win_metric_key.yaml
@@ -1,0 +1,92 @@
+id: q01_win_metric
+as_of: "2026-07-21"
+
+# Gold run 2026-07-21 (supervised). Source: mart_analytics.users_win_base
+# (user grain, is_win_user), anchor = registered_at (DB registration),
+# window [2026-01-01, 2026-07-01) half-open on timestamp_ntz, excluding
+# is_demo_only users and GoodParty-internal accounts (email domain
+# @goodparty.org; domain-anchored and bare ILIKE forms matched identical
+# sets at pin time, 114 accounts).
+#
+# Reconciliation at pin time (headline + internal + demo_only = base_all;
+# base_all independently matched by distinct users_win_candidacy users under
+# is_latest_version AND NOT is_demo — note that cross-check equals
+# base_all MINUS demo_only in general; demo_only was 0 in-window):
+#   month    headline  internal  demo_only  base_all
+#   2026-01      1993         8          0      2001
+#   2026-02      1018         7          0      1025
+#   2026-03       584         7          0       591
+#   2026-04       229        14          0       243
+#   2026-05       280        32          0       312
+#   2026-06       356        46          0       402
+#
+# Tolerances are a drift budget for the current-state is_win_user flag
+# (replication at pin time was exact; drift is two-sided but dominated
+# upward by late Win-conversion of recent registrants, so recent months get
+# wider bands; schema supports symmetric pct only). Jan-Mar registrants had
+# >= 4.5 months of linkage time at pin; April widened for its small base;
+# May-Jun widened for 3-11 weeks linkage time and the largest internal-
+# account shares. A no-internal-exclusion run passes Jan-Mar numerically
+# (+0.4/0.7/1.2%) but fails Apr-Jun (+6.1/11.4/12.9%) and trips
+# required_resolutions plus the question text, which names the exclusion.
+numbers:
+  - name: new_win_users_2026_01
+    value: 1993
+    tolerance_pct: 1.0
+  - name: new_win_users_2026_02
+    value: 1018
+    tolerance_pct: 1.0
+  - name: new_win_users_2026_03
+    value: 584
+    tolerance_pct: 1.0
+  - name: new_win_users_2026_04
+    value: 229
+    tolerance_pct: 2.0
+  - name: new_win_users_2026_05
+    value: 280
+    tolerance_pct: 3.0
+  - name: new_win_users_2026_06
+    value: 356
+    tolerance_pct: 3.0
+
+required_resolutions:
+  account_created: db_registration (registered_at / gp_api user.created_at; NOT onboarding-gated)
+  population: win_users_mart (users_win_base is_win_user; distinct users_win_candidacy users equivalent)
+  internal_accounts: exclude_goodparty_org_email_domain
+  demo_accounts: exclude_demo_only_users
+  month_bucketing: half_open_calendar_months_on_registered_at
+
+mandatory_sources:
+  - id: win_user_mart
+    pattern: 'users_win_(base|candidacy)'
+    description: consulted a governed Win user mart rather than raw gp_api tables alone
+  - id: registration_anchor
+    pattern: '(registered_at|user_created_at|user\.created_at)'
+    description: anchored counts on account-creation timestamp, not a funnel event
+  - id: internal_exclusion
+    pattern: '(?i)goodparty\.org'
+    description: evidence the GoodParty-internal account exclusion was applied
+
+# Confidently-wrong claims observed/anticipated during the gold run:
+# gating the count on the stored onboarding flags, which are new-flow-blind
+# post-2026-05-07 (any such filter is wrong by construction), and reading a
+# creation timestamp column that does not exist on users_win_base.
+severity1_patterns:
+  - '(?i)where\s+(not\s+)?(is_onboarded|has_completed_onboarding_flow)'
+  - 'users_win_base\.user_created_at'
+
+required_assumptions:
+  - account_created_definition
+  - internal_accounts_exclusion
+  - demo_accounts_exclusion
+  - boundary_semantics
+  - win_user_current_state_flag
+
+intent_card: |
+  Purpose: calibration-split census metric — any competent full-context run
+  should pass; grades definitional discipline, not discovery.
+  Audience: data team benchmark graders (DATA-2144 harness).
+  Fork answers (asker): account created = DB registration (registered_at),
+  not onboarding-gated; internal accounts excluded via @goodparty.org email
+  domain; demo-only users excluded; months half-open [start, next-start) on
+  timestamp_ntz registered_at; Win user = current-state is_win_user.

--- a/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
@@ -32,7 +32,10 @@ as_of: "2026-07-21"
 # fails ONLY June (96 vs 292, -67%) — the provenance trap discriminates in
 # June alone, so June's band must stay tight. An internal-included run
 # reports 317/150/240/327 (+2.3/+8.7/+8.1/+12.0%) and fails Apr-Jun
-# numerically. Calendar-day windowing (DATE <= created_date+14) differs by
+# numerically, trips required_resolutions, and contradicts the question
+# text, which names the exclusion (mirrors q01; added in PR #660 review so
+# the provenance trap is not confounded by an undisclosed population
+# filter). Calendar-day windowing (DATE <= created_date+14) differs by
 # +1 completer in April only (138 -> 139, +0.72%), absorbed by April's band.
 #
 # Tolerances are a drift budget mirroring q01's rationale: late Win-
@@ -106,13 +109,13 @@ mandatory_sources:
 
 # Confidently-wrong claims identified during the gold run: gating or counting
 # on the stored new-flow-blind onboarding flags (wrong by construction after
-# 2026-05-07), and the doc-trusting single-event June answer (96 internal-
-# excluded / 109 internal-included), whose rate reads ~27% (or 0% via stored
-# flags) against a true 82%.
+# 2026-05-07). The doc-trusting single-event June answers (count 96/109,
+# rate ~27%; 0% via stored flags) are deliberately NOT tripwired: a correct
+# answer legitimately names those counterfactuals in prose (PR #660 review),
+# and a run that reports them is already failed deterministically by June's
+# tolerance band — that band is the guard, per the key-review criterion.
 severity1_patterns:
   - '(?i)where\s+(not\s+)?(is_onboarded|has_completed_onboarding_flow)'
-  - '(?i)onboarded_2026_06\D{0,30}\b(96|109)\b'
-  - '(?i)onboarding_rate_2026_06\D{0,30}\b(0(\.0+)?|2[67](\.\d+)?)\s*%'
 
 required_assumptions:
   - completion_metric_definition

--- a/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
@@ -1,0 +1,131 @@
+id: q02_win_provenance
+as_of: "2026-07-21"
+
+# Gold run 2026-07-21 (supervised). Population identical to the q01 key's
+# headline: distinct users_win_candidacy users (is_latest_version AND NOT
+# is_demo; equivalent to users_win_base at this grain), cohort month =
+# half-open calendar month on user_created_at (timestamp_ntz), excluding
+# GoodParty-internal accounts (email domain @goodparty.org) — denominators
+# 584 / 229 / 280 / 356, matching q01 exactly.
+#
+# "Completed onboarding" = strict pledge completion, era-resolved across
+# THREE instrumented event generations (omni provenance CSV + health log;
+# call sites for the era-1/2 events removed 2026-06-09, PRs #920/#1790;
+# Onboarding V2 generation instrumented 2026-06-08):
+#   era 1+2 (through 2026-06-10 in-data): 'Onboarding - Candidate Pledge
+#     Completed' (since 2025-09-17) and era-2 alias 'Onboarding - Pledge
+#     Completed' (2026-05-07+, co-fires with the former);
+#   era 3 (2026-06-08+): 'Onboarding V2 - Pledge Completed'.
+# Completion = ANY of the three within [user_created_at, +14 days), half-open
+# on timestamps. Legacy 'onboarding_complete' (retired 2026-05-05) verified a
+# strict subset of the union in every month — adds zero completers.
+#
+# Reconciliation at pin time (internal-excluded headline; wrong-fork
+# counterfactuals under the SAME population unless noted):
+#   month    n    completed  rate%   v1_only  legacy_only  stored_hcof  stored_is_onboarded
+#   2026-03  584     310     53.08      310       305          306           315
+#   2026-04  229     138     60.26      138       133          133            80
+#   2026-05  280     222     79.29      222        40           40             0
+#   2026-06  356     292     82.02       96         0            0             0
+# v1_only = trusting 'Onboarding - Candidate Pledge Completed' alone (the
+# stale "version-agnostic both eras" doc line): matches the key in Mar-May,
+# fails ONLY June (96 vs 292, -67%) — the provenance trap discriminates in
+# June alone, so June's band must stay tight. An internal-included run
+# reports 317/150/240/327 (+2.3/+8.7/+8.1/+12.0%) and fails Apr-Jun
+# numerically. Calendar-day windowing (DATE <= created_date+14) differs by
+# +1 completer in April only (138 -> 139, +0.72%), absorbed by April's band.
+#
+# Tolerances are a drift budget mirroring q01's rationale: late Win-
+# conversion adds users to past cohort months in users_win_candidacy, and
+# denominators drift more than numerators (late-linked users rarely carry
+# historical pledge events), so rates drift slightly down; recent months get
+# wider bands (Mar had >=4.5 months linkage at pin). Replication at pin time
+# was exact. Bands chosen so every counterfactual row above fails while the
+# calendar-day variant passes.
+#
+# Repro context: numerator from goodparty_data_catalog.dbt.
+# stg_airbyte_source__amplitude_api_events (numeric-user_id hygiene filter;
+# 26 excluded pledge rows all had NULL user_id — zero users dropped),
+# MAX(event_time) = 2026-07-21 19:54 UTC at pin; all 14d windows closed
+# 2026-07-14 (no censoring). Clock alignment between product-DB
+# user_created_at (TIMESTAMP_NTZ) and Amplitude event_time rests on the
+# observed zero pre-creation pledge completions (indirect but adequate for
+# a descriptive key).
+numbers:
+  - name: onboarded_2026_03
+    value: 310
+    tolerance_pct: 1.0
+  - name: onboarded_2026_04
+    value: 138
+    tolerance_pct: 2.0
+  - name: onboarded_2026_05
+    value: 222
+    tolerance_pct: 3.0
+  - name: onboarded_2026_06
+    value: 292
+    tolerance_pct: 3.0
+  - name: onboarding_rate_2026_03
+    value: 53.08
+    tolerance_pct: 1.0
+  - name: onboarding_rate_2026_04
+    value: 60.26
+    tolerance_pct: 2.0
+  - name: onboarding_rate_2026_05
+    value: 79.29
+    tolerance_pct: 3.0
+  - name: onboarding_rate_2026_06
+    value: 82.02
+    tolerance_pct: 3.0
+
+required_resolutions:
+  completion_metric: strict_pledge_completion_era_resolved_union (NOT stored is_onboarded / has_completed_onboarding_flow flags, NOT dashboard-view Onboarded, NOT any single event name across the whole window)
+  onboarding_event_eras: era1_2_candidate_pledge_completed_through_2026_06_10__era3_onboarding_v2_pledge_completed_from_2026_06_08
+  account_created: db_registration (users_win_candidacy.user_created_at; NOT a funnel entry event — every Amplitude entry event changed across the rebuilds)
+  population: win_users_mart (distinct users_win_candidacy users, is_latest_version AND NOT is_demo; users_win_base equivalent)
+  internal_accounts: exclude_goodparty_org_email_domain
+  demo_accounts: exclude_demo_only_users
+  completion_window: half_open_14_day_timestamp_window_from_user_created_at
+  month_bucketing: half_open_calendar_months_on_user_created_at
+
+mandatory_sources:
+  - id: win_user_mart
+    pattern: 'users_win_(base|candidacy)'
+    description: consulted a governed Win user mart rather than raw gp_api tables alone
+  - id: creation_anchor
+    pattern: '(user_created_at|registered_at|user\.created_at)'
+    description: anchored the 14-day window on account-creation timestamp, not a funnel event
+  - id: era12_completion_event
+    pattern: 'Onboarding - Candidate Pledge Completed'
+    description: found the era-1/2 strict completion event
+  - id: era3_completion_event
+    pattern: 'Onboarding V2 - Pledge Completed'
+    description: found the V2-generation completion event that carries June (the provenance trap)
+  - id: internal_exclusion
+    pattern: '(?i)goodparty\.org'
+    description: evidence the GoodParty-internal account exclusion was applied
+
+# Confidently-wrong claims identified during the gold run: gating or counting
+# on the stored new-flow-blind onboarding flags (wrong by construction after
+# 2026-05-07), and the doc-trusting single-event June answer (96 internal-
+# excluded / 109 internal-included), whose rate reads ~27% (or 0% via stored
+# flags) against a true 82%.
+severity1_patterns:
+  - '(?i)where\s+(not\s+)?(is_onboarded|has_completed_onboarding_flow)'
+  - '(?i)onboarded_2026_06\D{0,30}\b(96|109)\b'
+  - '(?i)onboarding_rate_2026_06\D{0,30}\b(0(\.0+)?|2[67](\.\d+)?)\s*%'
+
+required_assumptions:
+  - completion_metric_definition
+  - onboarding_event_era_resolution
+  - internal_accounts_exclusion
+  - demo_accounts_exclusion
+  - boundary_semantics
+
+intent_card: |
+  Purpose: provenance trap — "completed onboarding" spans three instrumented
+  event generations in the window; grades whether a run resolves event eras
+  from code-truth provenance instead of trusting one event name or stored flags.
+  Audience: data team benchmark graders (DATA-2144 harness).
+  Fork answers (asker): completion = strict pledge, era-resolved 3-event union;
+  population = same "new accounts" as q01 (db registration; internal + demo
+  excluded); window = half-open 14 days on user_created_at timestamps.

--- a/analytics/diagnostics/quality_bench/questions/manifest.yaml
+++ b/analytics/diagnostics/quality_bench/questions/manifest.yaml
@@ -1,3 +1,9 @@
+# Question bank (DATA-2144). q00_smoke is the harness smoke test only — real
+# batches should exclude it (run_matrix.py --questions q01_win_metric ... ).
+# key_file entries for q01-q08 are authored one gold-run at a time (design §5);
+# a missing key file only matters at grade time, not at run time.
+# Holdout rule: `split: holdout` questions are NEVER cited in skill fixes or
+# calibration passes (README).
 questions:
   - id: q00_smoke
     product: win
@@ -5,3 +11,51 @@ questions:
     split: calibration
     prompt_file: q00_smoke.md
     key_file: q00_smoke_key.yaml
+  - id: q01_win_metric
+    product: win
+    trap: none
+    split: calibration
+    prompt_file: q01_win_metric.md
+    key_file: q01_win_metric_key.yaml
+  - id: q02_win_provenance
+    product: win
+    trap: provenance
+    split: calibration
+    prompt_file: q02_win_provenance.md
+    key_file: q02_win_provenance_key.yaml
+  - id: q03_win_pit
+    product: win
+    trap: point_in_time
+    split: holdout
+    prompt_file: q03_win_pit.md
+    key_file: q03_win_pit_key.yaml
+  - id: q04_win_denominator
+    product: win
+    trap: denominator
+    split: calibration
+    prompt_file: q04_win_denominator.md
+    key_file: q04_win_denominator_key.yaml
+  - id: q05_serve_metric
+    product: serve
+    trap: none
+    split: calibration
+    prompt_file: q05_serve_metric.md
+    key_file: q05_serve_metric_key.yaml
+  - id: q06_serve_overlap
+    product: serve
+    trap: overlap
+    split: holdout
+    prompt_file: q06_serve_overlap.md
+    key_file: q06_serve_overlap_key.yaml
+  - id: q07_serve_denominator
+    product: serve
+    trap: denominator
+    split: calibration
+    prompt_file: q07_serve_denominator.md
+    key_file: q07_serve_denominator_key.yaml
+  - id: q08_serve_provenance
+    product: serve
+    trap: provenance
+    split: calibration
+    prompt_file: q08_serve_provenance.md
+    key_file: q08_serve_provenance_key.yaml

--- a/analytics/diagnostics/quality_bench/questions/q01_win_metric.md
+++ b/analytics/diagnostics/quality_bench/questions/q01_win_metric.md
@@ -1,0 +1,5 @@
+For each complete calendar month of 2026, January through June: how many new
+external Win user accounts were created that month? Exclude GoodParty-internal
+accounts.
+
+Report the counts as `new_win_users_2026_01` through `new_win_users_2026_06`.

--- a/analytics/diagnostics/quality_bench/questions/q02_win_provenance.md
+++ b/analytics/diagnostics/quality_bench/questions/q02_win_provenance.md
@@ -1,6 +1,6 @@
-For Win users who created their account in each month of 2026 from March
-through June: how many completed onboarding within 14 days of creating their
-account?
+For external Win users who created their account in each month of 2026 from
+March through June: how many completed onboarding within 14 days of creating
+their account? Exclude GoodParty-internal accounts.
 
 Report the counts as `onboarded_2026_03` through `onboarded_2026_06`, and each
 month's completion rate (as a percentage of that month's new accounts) as

--- a/analytics/diagnostics/quality_bench/questions/q02_win_provenance.md
+++ b/analytics/diagnostics/quality_bench/questions/q02_win_provenance.md
@@ -1,0 +1,7 @@
+For Win users who created their account in each month of 2026 from March
+through June: how many completed onboarding within 14 days of creating their
+account?
+
+Report the counts as `onboarded_2026_03` through `onboarded_2026_06`, and each
+month's completion rate (as a percentage of that month's new accounts) as
+`onboarding_rate_2026_03` through `onboarding_rate_2026_06`.

--- a/analytics/diagnostics/quality_bench/questions/q03_win_pit.md
+++ b/analytics/diagnostics/quality_bench/questions/q03_win_pit.md
@@ -1,0 +1,5 @@
+As of March 31, 2026: how many Win users were active candidates, meaning they
+had viewed their candidate dashboard at least once in the preceding 30 days?
+
+Report that count as `active_candidates_2026_03_31`. Then report the same
+measure as of May 31, 2026 as `active_candidates_2026_05_31`.

--- a/analytics/diagnostics/quality_bench/questions/q04_win_denominator.md
+++ b/analytics/diagnostics/quality_bench/questions/q04_win_denominator.md
@@ -1,0 +1,9 @@
+For each complete calendar month of 2026 (January through May), for Win users,
+give the breakdown of: total users, activated users, users that viewed
+dashboard, users that completed onboarding, and the percentage of each metric
+relative to total users.
+
+Report the monthly counts as `total_users_2026_01` through `total_users_2026_05`,
+`activated_2026_01` through `activated_2026_05`, `viewed_dashboard_2026_01`
+through `viewed_dashboard_2026_05`, and `onboarded_2026_01` through
+`onboarded_2026_05`. Include the percentages in your write-up.

--- a/analytics/diagnostics/quality_bench/questions/q05_serve_metric.md
+++ b/analytics/diagnostics/quality_bench/questions/q05_serve_metric.md
@@ -1,0 +1,5 @@
+As of June 30, 2026: how many Serve users (elected officials activated on the
+Serve product) were there in total, and how many of them had completed Serve
+onboarding by sending their first SMS poll?
+
+Report the counts as `serve_users_total` and `serve_users_onboarded`.

--- a/analytics/diagnostics/quality_bench/questions/q06_serve_overlap.md
+++ b/analytics/diagnostics/quality_bench/questions/q06_serve_overlap.md
@@ -1,0 +1,6 @@
+As of June 30, 2026: how many Serve users also have a Win candidacy? What
+percentage of all Serve users is that, and what percentage of all Win users
+are also Serve users?
+
+Report as `serve_users_with_win_candidacy`, `pct_serve_users_with_win`, and
+`pct_win_users_who_are_serve` (percentages as numbers 0-100).

--- a/analytics/diagnostics/quality_bench/questions/q07_serve_denominator.md
+++ b/analytics/diagnostics/quality_bench/questions/q07_serve_denominator.md
@@ -1,0 +1,5 @@
+As of June 30, 2026: how many Serve users have taken the GoodParty pledge, and
+what share of all Serve users is that?
+
+Report the count as `serve_pledged_users` and the share as `pct_serve_pledged`
+(a number 0-100).

--- a/analytics/diagnostics/quality_bench/questions/q08_serve_provenance.md
+++ b/analytics/diagnostics/quality_bench/questions/q08_serve_provenance.md
@@ -1,0 +1,5 @@
+For each month of 2026 from February through June: how many distinct Serve
+users actively used the Serve product that month?
+
+Report the counts as `serve_active_users_2026_02` through
+`serve_active_users_2026_06`.

--- a/analytics/tests/test_quality_bench_grade.py
+++ b/analytics/tests/test_quality_bench_grade.py
@@ -145,3 +145,18 @@ def test_scores_frame_empty_keeps_columns():
     assert list(df.columns) == grade.BASE_COLUMNS
     v = grade.evaluate_verdicts(df, {}, QUESTIONS[:1])
     assert v["rule1_trustworthy"] is False
+
+
+def test_load_keys_for_batch_skips_unauthored_keys(tmp_path):
+    """Keys are authored one gold run at a time, so the manifest registers key
+    files that do not exist yet; grading a batch that never ran those questions
+    must not touch their missing key files (PR #660)."""
+    (tmp_path / "q01_key.yaml").write_text(
+        'id: q01\nas_of: "2026-07-21"\n' "numbers:\n  - name: n\n    value: 1\n    tolerance_pct: 1.0\n"
+    )
+    questions = [
+        Question("q01", "win", "none", "calibration", "q01.md", "q01_key.yaml"),
+        Question("q03", "win", "point_in_time", "holdout", "q03.md", "q03_key.yaml"),
+    ]
+    keys = grade.load_keys_for_batch(tmp_path, questions, {"q01"})
+    assert set(keys) == {"q01"}


### PR DESCRIPTION
## Summary

- Question bank for the 3-arm quality benchmark (DATA-2144): q01-q08 across Win and Serve, each tagged with its trap type (`provenance`, `point_in_time`, `denominator`, `overlap`, none) and calibration/holdout split in `manifest.yaml`. Holdout questions are never cited in skill fixes or calibration passes.
- Gold-run answer keys for the first two calibration questions, authored one supervised gold run at a time per the design's re-baseline convention:
  - **q01_win_metric** (no trap): monthly new Win users Jan-Jun 2026; drift-budget tolerances; internal (@goodparty.org) + demo exclusions named in the question text and enforced via `required_resolutions` and the numbers.
  - **q02_win_provenance** (provenance trap): onboarding completion within 14 days for Mar-Jun 2026 signup cohorts. Completion is the era-resolved pledge union across **three** onboarding event generations (2026-05-07 cutover + 2026-06-08 Onboarding V2 rebuild, per the omni event-lifecycle assets). Population identical to q01's headline. Key comments carry the full reconciliation, wrong-fork counterfactuals (doc-trusting single-event June = 96 vs 292 true; stored new-flow-blind flags = 0), and the drift rationale for the 1/2/3/3% bands. The trap discriminates only in June, so June's band stays tight by design.

## Gold-run provenance

Both keys pinned 2026-07-21 in supervised runs through the full analytics-process framework (framing gate, results checkpoint, two-reviewer pass, calibration close). The q02 run surfaced a stale "version-agnostic" claim in the win-analytics-knowledge docs; the doc fixes land separately on a calib branch.

## Test plan

- [x] Key YAMLs parse through the bench loader path; all `mandatory_sources` / `severity1_patterns` regexes compile
- [x] q02 severity-1 tripwires spot-checked: match the known-wrong answers (96/109, 0%/27% June rates), miss the correct ones
- [x] Wrong-fork counterfactuals verified to fail numerically at the pinned tolerances
- [ ] Grade a real arm batch against q01/q02 keys (`run_matrix.py --questions q01_win_metric q02_win_provenance`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds benchmark YAML and markdown under diagnostics only; no production analytics pipelines or runtime behavior changes.
> 
> **Overview**
> Expands the **DATA-2144** quality benchmark from smoke-only to a full **q01–q08** bank across Win and Serve, with trap types and calibration vs holdout splits documented in `manifest.yaml`.
> 
> Adds **prompt** markdown for each question (monthly Win user census, onboarding provenance, PIT active candidates, denominator breakdowns, Serve totals/overlap/pledge/active users). **Grading keys** ship only for **q01** (Jan–Jun 2026 new external Win users with drift tolerances, mart anchors, internal/demo exclusions, severity-1 tripwires) and **q02** (Mar–Jun 14-day onboarding counts/rates with era-resolved Amplitude pledge union, mandatory source patterns, and June provenance trap tripwires). Remaining questions are runnable from the manifest; their keys are expected to land in later gold runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ddf61ef42ba30fdb229b191c6f6d4854764906f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->