### PR TITLE
Loader: type District.state as text (holds a country-scope US value)

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # post-merge. (During review this tracked the DATA-2100 feature branch so astro-dev ran the PR's loader;
 # repinned to @main for merge — it resolves to this PR's loader once merged.) See PR #607.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-22.1
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-22.3
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This

--- a/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
+++ b/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
@@ -362,7 +362,7 @@ CREATE TABLE public."District" (
     "updated_at" TIMESTAMPTZ,
     "type" TEXT,
     "name" TEXT,
-    "state" "USState"
+    "state" TEXT
 );
 
 CREATE TABLE public."DistrictStats" (

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -61,8 +61,10 @@ TABLE_SPECS: dict[str, TableSpec] = {
         pg_table="District",
         partition_by=None,
         # id is the salted-uuid string in the mart; Prisma types it @db.Uuid, so store UUID.
-        # state: the serving public."USState" enum, like Voter/DistrictVoter.
-        type_overrides={"id": "UUID", "state": '"USState"'},
+        # state: stays TEXT (no override), unlike Voter/DistrictVoter. District includes one
+        # country-scope row (type=Country, state="US") that the 51-value USState enum (50 states +
+        # DC) cannot hold, so this column can't be coerced to the enum on COPY like the others.
+        type_overrides={"id": "UUID"},
     ),
     "DistrictStats": TableSpec(
         pg_table="DistrictStats",


### PR DESCRIPTION
## Why
The `load_people_api` run failed at `copy`: `invalid input value for enum "USState": "US"` on the `District` table. The `District` mart legitimately contains one country-scope row (`type=Country`, `name=United States of America`, `state=US`). The `public."USState"` enum is 50 states + DC (confirmed by the people-api Prisma migrations — `"US"` was never added), so it cannot hold `"US"`. `Voter` and `DistrictVoter` are clean (all 51 states).

This affects the real prod `dbt` mart too (same `"US"` row), so it's a schema fix needed regardless of mart source. Pre-DATA-2168 this copied fine because the column was text.

## What
- `schema_spec.py`: drop the `state → "USState"` override on the `District` TableSpec (keep `id → UUID`). `Voter.State` and `DistrictVoter.state` keep the `USState` enum.
- `target_schema.sql`: `District."state"` → `TEXT` (Voter/DistrictVoter `"State" "USState"` unchanged).
- cache-bust bump so `astro deploy` reinstalls the loader.

Revises the earlier "USState for all three" call to: enum for Voter + DistrictVoter, text for District.

## Tests
Full suite 310 passed / 4 skipped; integration suite ran against real local Postgres (4 passed) — exercises `create_schema` + `copy` from `target_schema.sql`, confirming the text typing loads end-to-end. ruff/format/ty clean.

Note: `target_schema.sql` is normally regenerated by `emit-ddl` (needs Databricks); the one-line District edit is a reasoned match (removing the override reverts the column to the mart's native text type) and is covered by the integration test.