### PR TITLE
[DATA-2175] Backfill zip coverage for LLM-unmatched override positions

### DIFF
--- a/dbt/project/models/intermediate/l2/int__zip_code_to_br_office.sql
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_br_office.sql
@@ -102,11 +102,13 @@ with
     ),
 
     -- Same zip->office linkage as above, but built from the override seed for
-    -- positions absent from the LLM snapshot (the match-driven path keys off
-    -- the snapshot, so they would otherwise get zero zip rows). Scoped to
-    -- snapshot-absent overrides, so existing overrides are untouched and the
-    -- unique key cannot collide. Reads the unfiltered zip->district source so a
-    -- new override backfills without a full refresh.
+    -- positions the LLM path can't place: those absent from the snapshot and
+    -- those present but unmatched (is_matched = false, which carry a
+    -- 'NOT_MATCHED' l2_district and so join to no zip district). Both would
+    -- otherwise get zero zip rows. Scoped to exclude only genuinely matched
+    -- positions, so LLM-matched rows are untouched and the unique key cannot
+    -- collide. Reads the unfiltered zip->district source so a new override
+    -- backfills without a full refresh.
     override_zip_to_br_office as (
         select
             tbl_zip.zip_code,
@@ -124,7 +126,7 @@ with
             tbl_override.l2_district_name,
             tbl_override.l2_district_type,
             true as is_matched,
-            'l2_br_match_overrides seed (no LLM match row)' as llm_reason,
+            'l2_br_match_overrides seed (no LLM match)' as llm_reason,
             null as confidence,
             null as embeddings,
             null as top_embedding_score
@@ -149,7 +151,7 @@ with
             tbl_override.br_database_id not in (
                 select br_database_id
                 from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
-                where br_database_id is not null
+                where br_database_id is not null and is_matched
             )
         qualify
             row_number() over (

--- a/dbt/project/models/intermediate/l2/int__zip_code_to_br_office.sql
+++ b/dbt/project/models/intermediate/l2/int__zip_code_to_br_office.sql
@@ -45,6 +45,31 @@ with
             and tbl_zip.zip_code >= zip_range.zip_code_range[0]
             and tbl_zip.zip_code <= zip_range.zip_code_range[1]
     ),
+    -- (br_database_id, district) pairs the LLM confidently placed.
+    llm_matched_districts as (
+        select
+            br_database_id,
+            lower(l2_district_type) as l2_district_type,
+            lower(l2_district_name) as l2_district_name
+        from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
+        where br_database_id is not null and is_matched
+    ),
+    -- Override rows the LLM did not already place at the same district: the
+    -- backfills (LLM absent or NOT_MATCHED) and the curated corrections (LLM
+    -- matched a different district). These are the rows the override path
+    -- emits and the rows the LLM path must yield. Overrides that agree with
+    -- the LLM are absent here and stay on the LLM path. Flat anti-join, shared
+    -- by both paths below (and mirrored in the coverage test).
+    active_overrides as (
+        select tbl_override.*
+        from {{ ref("l2_br_match_overrides") }} as tbl_override
+        left join
+            llm_matched_districts as llm
+            on llm.br_database_id = tbl_override.br_database_id
+            and llm.l2_district_type = lower(tbl_override.l2_district_type)
+            and llm.l2_district_name = lower(tbl_override.l2_district_name)
+        where llm.br_database_id is null
+    ),
     zip_code_to_br_office as (
         select
             tbl_zip.zip_code,
@@ -87,10 +112,22 @@ with
         -- judicial retention seats). Non-'State' district types are unaffected;
         -- curated statewide exceptions flow through override_zip_to_br_office.
         where
-            tbl_zip.district_type <> 'State'
-            or (
-                tbl_br_position.mtfcc = 'G4000'
-                and not coalesce(tbl_br_position.is_retention, false)
+            (
+                tbl_zip.district_type <> 'State'
+                or (
+                    tbl_br_position.mtfcc = 'G4000'
+                    and not coalesce(tbl_br_position.is_retention, false)
+                )
+            )
+            -- Yield positions an active override redirects; the override path
+            -- re-emits them under the correct district. Without this a
+            -- mismatched position (e.g. a ward seat the LLM matched to the
+            -- whole city) would carry both districts and violate
+            -- one-district-type-per-br.
+            and tbl_match.br_database_id not in (
+                select br_database_id
+                from active_overrides
+                where br_database_id is not null
             )
         qualify
             row_number() over (
@@ -101,14 +138,10 @@ with
             = 1
     ),
 
-    -- Same zip->office linkage as above, but built from the override seed for
-    -- positions the LLM path can't place: those absent from the snapshot and
-    -- those present but unmatched (is_matched = false, which carry a
-    -- 'NOT_MATCHED' l2_district and so join to no zip district). Both would
-    -- otherwise get zero zip rows. Scoped to exclude only genuinely matched
-    -- positions, so LLM-matched rows are untouched and the unique key cannot
-    -- collide. Reads the unfiltered zip->district source so a new override
-    -- backfills without a full refresh.
+    -- Same zip->office linkage as above, but built from active_overrides (the
+    -- override rows the LLM did not already place at the same district). Reads
+    -- the unfiltered zip->district source so a new override backfills without a
+    -- full refresh.
     override_zip_to_br_office as (
         select
             tbl_zip.zip_code,
@@ -126,7 +159,7 @@ with
             tbl_override.l2_district_name,
             tbl_override.l2_district_type,
             true as is_matched,
-            'l2_br_match_overrides seed (no LLM match)' as llm_reason,
+            'l2_br_match_overrides seed' as llm_reason,
             null as confidence,
             null as embeddings,
             null as top_embedding_score
@@ -137,7 +170,7 @@ with
             and tbl_zip.zip_code >= zip_range.zip_code_range[0]
             and tbl_zip.zip_code <= zip_range.zip_code_range[1]
         inner join
-            {{ ref("l2_br_match_overrides") }} as tbl_override
+            active_overrides as tbl_override
             on lower(tbl_zip.district_name) = lower(tbl_override.l2_district_name)
             and lower(tbl_zip.district_type) = lower(tbl_override.l2_district_type)
             and lower(tbl_zip.state_postal_code) = lower(tbl_override.state)
@@ -147,12 +180,6 @@ with
         left join
             {{ ref("stg_airbyte_source__ballotready_api_race") }} as tbl_br_race
             on tbl_br_position.database_id = tbl_br_race.position.databaseid
-        where
-            tbl_override.br_database_id not in (
-                select br_database_id
-                from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
-                where br_database_id is not null and is_matched
-            )
         qualify
             row_number() over (
                 partition by

--- a/dbt/project/tests/assert_override_positions_have_zip_coverage.sql
+++ b/dbt/project/tests/assert_override_positions_have_zip_coverage.sql
@@ -44,4 +44,6 @@ inner join
     on lower(a.state) = z.state
     and lower(a.l2_district_type) = z.district_type
     and lower(a.l2_district_name) = z.district_name
-where a.br_database_id not in (select br_database_id from covered)
+where
+    a.br_database_id
+    not in (select br_database_id from covered where br_database_id is not null)

--- a/dbt/project/tests/assert_override_positions_have_zip_coverage.sql
+++ b/dbt/project/tests/assert_override_positions_have_zip_coverage.sql
@@ -1,20 +1,29 @@
 -- Overrides the LLM path can't place must get zip->office coverage in
 -- int__zip_code_to_br_office (the override_zip_to_br_office injection),
 -- otherwise the position has a district but is invisible to the officepicker.
--- This covers overrides absent from the snapshot and those present but
--- unmatched (is_matched = false); only genuinely matched positions are placed
--- by the LLM path. Scoped to overrides whose L2 district has zips, so
+-- This covers overrides absent from the snapshot, those present but unmatched
+-- (NOT_MATCHED), and those the LLM matched to a different district than the
+-- override specifies. Only positions the LLM matched to the same district are
+-- placed by the LLM path. Scoped to overrides whose L2 district has zips, so
 -- districts with no L2 zip coverage do not produce false failures.
 with
+    llm_matched_districts as (
+        select
+            br_database_id,
+            lower(l2_district_type) as l2_district_type,
+            lower(l2_district_name) as l2_district_name
+        from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
+        where br_database_id is not null and is_matched
+    ),
     llm_unplaceable_overrides as (
         select o.br_database_id, o.state, o.l2_district_type, o.l2_district_name
         from {{ ref("l2_br_match_overrides") }} as o
-        where
-            o.br_database_id not in (
-                select br_database_id
-                from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
-                where br_database_id is not null and is_matched
-            )
+        left join
+            llm_matched_districts as llm
+            on llm.br_database_id = o.br_database_id
+            and llm.l2_district_type = lower(o.l2_district_type)
+            and llm.l2_district_name = lower(o.l2_district_name)
+        where llm.br_database_id is null
     ),
     districts_with_zips as (
         select distinct

--- a/dbt/project/tests/assert_override_positions_have_zip_coverage.sql
+++ b/dbt/project/tests/assert_override_positions_have_zip_coverage.sql
@@ -1,17 +1,19 @@
--- DATA-1958: snapshot-absent overrides must get zip->office coverage in
+-- Overrides the LLM path can't place must get zip->office coverage in
 -- int__zip_code_to_br_office (the override_zip_to_br_office injection),
 -- otherwise the position has a district but is invisible to the officepicker.
--- Scoped to overrides whose L2 district has zips, so districts with no L2 zip
--- coverage do not produce false failures.
+-- This covers overrides absent from the snapshot and those present but
+-- unmatched (is_matched = false); only genuinely matched positions are placed
+-- by the LLM path. Scoped to overrides whose L2 district has zips, so
+-- districts with no L2 zip coverage do not produce false failures.
 with
-    snapshot_absent_overrides as (
+    llm_unplaceable_overrides as (
         select o.br_database_id, o.state, o.l2_district_type, o.l2_district_name
         from {{ ref("l2_br_match_overrides") }} as o
         where
             o.br_database_id not in (
                 select br_database_id
                 from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
-                where br_database_id is not null
+                where br_database_id is not null and is_matched
             )
     ),
     districts_with_zips as (
@@ -27,7 +29,7 @@ with
         where br_database_id is not null
     )
 select a.br_database_id
-from snapshot_absent_overrides as a
+from llm_unplaceable_overrides as a
 inner join
     districts_with_zips as z
     on lower(a.state) = z.state


### PR DESCRIPTION
## Summary

The `override_zip_to_br_office` injection in `int__zip_code_to_br_office` only ran for override positions **absent** from the LLM match snapshot. Positions that are **present but unmatched** (`is_matched = false`) carry a `NOT_MATCHED` l2_district, so the match-driven path places them nowhere, and the override path excluded them because they have a snapshot row. The result: the position gets a district in `m_election_api__position` but no zip rows, so the office is invisible to the officepicker (empty `positions/search?zip=` and empty `getZipCodesByBrPositionId`).

This surfaced as a missing office: KY District Court Judge, 51st District (Henderson County), br_database_id 86432/86433.

## Change

- Scope the backfill exclusion to genuinely matched positions (`is_matched`), so unmatched overrides flow through `override_zip_to_br_office`.
- Widen `assert_override_positions_have_zip_coverage` to match. The test previously used the same `br_database_id not in (snapshot)` filter and shared the exact blind spot, so it passed despite the gap.

No collision risk: every `is_matched = false` override position has `l2_district_type = 'NOT_MATCHED'`, so it produces zero rows in the match-driven path and cannot duplicate the unique key.

## Verification

Built `int__zip_code_to_br_office` and reran its tests (18 pass, including the widened coverage test). Zip rows now generated:

| br_database_id | position | zips |
| --- | --- | --- |
| 86432 | KY District Judge, District 51, Div 1 | 10 (Henderson) |
| 86433 | KY District Judge, District 51, Div 2 | 10 (Henderson) |
| 86451 | KY District Judge, District 8, Div 1 | 10 (Warren) |
| 413282 | KY District Judge, District 22, Div 6 | 24 (Fayette) |

59 of 65 KY override positions were affected; likely other states too.

## Test plan
- [ ] CI dbt build + tests green
- [ ] After marts sync, `getZipCodesByBrPositionId` returns Henderson zips for 86432/86433
- [ ] Office appears when impersonating a Henderson County voter file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which BallotReady positions get zip rows in a core election/officepicker path; scope is narrow and matched rows are explicitly excluded to avoid unique-key collisions.
> 
> **Overview**
> **`override_zip_to_br_office`** in `int__zip_code_to_br_office` now treats override positions as already handled by the LLM path only when they have a **genuinely matched** snapshot row (`is_matched`), not merely any snapshot row. Override seeds for positions that appear in the LLM table but are **unmatched** (`NOT_MATCHED` districts) are included again, so they get zip→office rows from the override seed instead of zero coverage.
> 
> **`assert_override_positions_have_zip_coverage`** uses the same `is_matched` filter and renames the CTE to `llm_unplaceable_overrides`, so the test catches the same gap the model fix addresses. Comments and the override `llm_reason` string are updated to describe both absent-from-snapshot and unmatched-in-snapshot cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73037ffc081d275ab23680ddef603b5e2616d140. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Deploy note

This change corrects 54 override positions the LLM matched to the wrong district (e.g. Sioux Falls ward seats matched to the whole city). Their stale LLM-district rows must be purged with a one-time `dbt build --full-refresh --select int__zip_code_to_br_office` on deploy; an incremental merge cannot delete them.
