### PR TITLE
[DATA-2164] quality_bench: additive arm construction + floor leakage test

### DIFF
--- a/.claude/skills/serve-analytics-knowledge/SKILL.md
+++ b/.claude/skills/serve-analytics-knowledge/SKILL.md
@@ -27,7 +27,7 @@ addition through the calibration pass.
 |---|---|---|
 | What a metric *means* / its governed definition | [`references/canonical_metrics.md`](references/canonical_metrics.md) | invent a new definition for a concept that has a row |
 | Which table to start from, the Serve data domains, the event landscape | [`references/sources.md`](references/sources.md) | |
-| When an event was added/retired in code, its lifecycle status, what superseded it | the omni event-lifecycle assets — [`event-lifecycle-assets.md`](../analytics-process/references/event-lifecycle-assets.md) (process skill; cross-product) | infer an event's existence era from data-observed first-seen dates |
+| When an event was added/retired in code, its lifecycle status, what superseded it | the omni event-lifecycle assets — `event-lifecycle-assets.md` in the analytics-process skill (cross-product; when installed) | infer an event's existence era from data-observed first-seen dates |
 | Engagement / activity measurement, the broad-engagement family, the MAU collapse | [`references/methodology_defaults.md`](references/methodology_defaults.md) | headline any poll-anchored series without its collapse caveat |
 | Slicing dimensions (office, level, state, funnel stage) | [`references/segmentation.md`](references/segmentation.md) | assume office/level/state segmentation exists (pending officeholder ingestion) |
 | Serve's analysis defaults (resolved scoping, default cohorts, the working-set builder, reviewer doc pointers) | [`references/methodology_defaults.md`](references/methodology_defaults.md) | count server-emitted events (`session_id = -1`) as engagement |

--- a/.claude/skills/serve-analytics-knowledge/references/methodology_defaults.md
+++ b/.claude/skills/serve-analytics-knowledge/references/methodology_defaults.md
@@ -1,7 +1,7 @@
 # Serve methodology defaults
 
 Part of the **serve-analytics-knowledge** skill. The Serve-product defaults consumed by the
-process skill's [methodology.md](../../analytics-process/references/methodology.md): that doc
+analytics-process skill's `methodology.md` (when installed): that doc
 owns the product-agnostic discipline (scoping checklist, folder patterns, binning,
 verification protocol); this one owns what is true *for Serve* — the resolved scoping
 decisions, the default cohorts, and the working-set builder.

--- a/.claude/skills/serve-analytics-knowledge/references/sources.md
+++ b/.claude/skills/serve-analytics-knowledge/references/sources.md
@@ -64,7 +64,7 @@ Two things to know:
 For when an event was added or retired in code, its current lifecycle status, or what
 superseded it, use the **omni event-lifecycle assets** (provenance CSV, event-health log,
 gp-meta metadata). They are cross-product and live with the process skill:
-[event-lifecycle-assets.md](../../analytics-process/references/event-lifecycle-assets.md)
+`event-lifecycle-assets.md` in the analytics-process skill (when installed)
 owns the full description — what each asset answers, freshness contracts, and the
 stay-in-omni design constraint. They are the tool that dated the two Serve event
 generations above.

--- a/.claude/skills/win-analytics-knowledge/SKILL.md
+++ b/.claude/skills/win-analytics-knowledge/SKILL.md
@@ -22,7 +22,7 @@ the analyst workflow and patterns, see the **analytics-process** skill.
 |---|---|---|
 | What a metric *means* / its governed definition | [`references/canonical_metrics.md`](references/canonical_metrics.md) | invent a new definition for a concept that has a row |
 | Which table to start from, the data domains, the civics mart structure | [`references/sources.md`](references/sources.md) | |
-| When an event was added/retired in code, its lifecycle status, what superseded it | the omni event-lifecycle assets — [`event-lifecycle-assets.md`](../analytics-process/references/event-lifecycle-assets.md) (process skill; cross-product) | infer an event's existence era from data-observed first-seen dates |
+| When an event was added/retired in code, its lifecycle status, what superseded it | the omni event-lifecycle assets — `event-lifecycle-assets.md` in the analytics-process skill (cross-product; when installed) | infer an event's existence era from data-observed first-seen dates |
 | IDs, join keys, join recipes (user→outcome, survey 2-hop, viability) | [`references/joins.md`](references/joins.md) | join `hs_contact_id` to `users_win_candidacy.hubspot_id` (company id) |
 | Win/loss outcome, vote share, self-reported outcome, PMF / satisfaction | [`references/outcomes.md`](references/outcomes.md) | use `candidacy_result` for binary win/loss |
 | Engagement / activation metrics, the Amplitude event landscape, onboarding flow versions, UTM | [`references/engagement.md`](references/engagement.md) | use `is_onboarded` / `has_completed_onboarding_flow` across the 2026-05-07 cutover |

--- a/.claude/skills/win-analytics-knowledge/references/engagement.md
+++ b/.claude/skills/win-analytics-knowledge/references/engagement.md
@@ -16,7 +16,7 @@ stream they're computed from.
 - IF the analysis spans the **2026-05-07 onboarding cutover or the 2026-06-08 Onboarding V2 rebuild** → resolve events per era (see Onboarding flow versions); do NOT use `is_onboarded` / `has_completed_onboarding_flow`, and do NOT treat any single completion event as version-agnostic.
 - IF a dashboard-view metric touches **2026-05 or later** → use the 2-event dashboard union; the legacy event died 2026-06-13 (see Dashboard surface migration).
 - IF you need to classify raw `event_type` values into product families → use the `int__amplitude_event_catalog` model / `amplitude_event_family` macro (taxonomy below).
-- IF you need when an event was added/retired **in code**, its lifecycle status, or its supersession lineage → the omni event-lifecycle assets; see [event-lifecycle-assets.md](../../analytics-process/references/event-lifecycle-assets.md) (process skill; cross-product). The catalog's `first_seen_date` is data-observed, not code-truth.
+- IF you need when an event was added/retired **in code**, its lifecycle status, or its supersession lineage → the omni event-lifecycle assets; see `event-lifecycle-assets.md` in the analytics-process skill (cross-product; when installed). The catalog's `first_seen_date` is data-observed, not code-truth.
 - IF the question is about acquisition channel / UTM → see Channel / UTM below.
 - IF the question is about self-reported win/loss from the Did-You-Win modal → that's an outcome; see [outcomes.md](outcomes.md).
 

--- a/.claude/skills/win-analytics-knowledge/references/joins.md
+++ b/.claude/skills/win-analytics-knowledge/references/joins.md
@@ -93,4 +93,4 @@ For user-level analyses, collapse with explicit handling of "which candidacy rep
 - [viability.md](viability.md) — the forward-stable viability join rationale.
 - [outcomes.md](outcomes.md) — the PMF/CSAT survey join in context.
 - [gotchas.md](gotchas.md) — the `hubspot_id` company-vs-contact trap and multi-cycle traps.
-- [data-matching skill](../../data-matching/SKILL.md) — matching external tables to ICP flags by email / race ID / position ID.
+- the data-matching skill (when installed) — matching external tables to ICP flags by email / race ID / position ID.

--- a/.claude/skills/win-analytics-knowledge/references/methodology_defaults.md
+++ b/.claude/skills/win-analytics-knowledge/references/methodology_defaults.md
@@ -1,7 +1,7 @@
 # Win methodology defaults
 
 Part of the **win-analytics-knowledge** skill. The Win-product defaults consumed by the
-process skill's [methodology.md](../../analytics-process/references/methodology.md):
+analytics-process skill's `methodology.md` (when installed):
 that doc owns the product-agnostic discipline (scoping checklist, folder patterns, binning,
 verification protocol); this one owns what is true *for Win* — the resolved scoping
 decisions, the default cohorts, and the working-set builder.

--- a/.claude/skills/win-analytics-knowledge/references/sources.md
+++ b/.claude/skills/win-analytics-knowledge/references/sources.md
@@ -60,7 +60,7 @@ Field availability differs across these halves — see [gotchas.md](gotchas.md).
 For when an event was added or retired in code, its current lifecycle status, or what
 superseded it, use the omni event-lifecycle assets (provenance CSV, event-health log, gp-meta
 metadata). They are cross-product and live with the process skill:
-[event-lifecycle-assets.md](../../analytics-process/references/event-lifecycle-assets.md)
+`event-lifecycle-assets.md` in the analytics-process skill (when installed)
 owns the full description — what each asset answers, freshness contracts, and the stay-in-omni
 design constraint. Do not infer an event's existence era from data-observed first-seen dates.
 

--- a/analytics/diagnostics/quality_bench/README.md
+++ b/analytics/diagnostics/quality_bench/README.md
@@ -25,9 +25,10 @@ the two failure modes the unit tests can't:
    confirm the transcript shows the `Skill`/`Agent` tools firing rather than a
    permission denial. Headless `claude -p` only allows what
    `.claude/settings.local.json` lists, so if either is denied, add it to
-   `SETTINGS_JSON` in `prep_arms.py` and re-prep the arms. While reading that
-   transcript, also check that the knowledge skills' dead relative links (into
-   skill folders prep deletes) do not visibly derail the run.
+   `SETTINGS_JSON` in `prep_arms.py` and re-prep the arms. (Dead relative
+   links are no longer a runtime concern to watch for here — `prep_arms.py`'s
+   integrity gate now fails the prep step outright if any md link inside an
+   arm doesn't resolve, so a prepped arm can't reach a run with one.)
 
 ## No-decision gates
 
@@ -42,11 +43,14 @@ closed:
    (answer keys) or sibling runs. Gate: container-grade isolation
    (ClickUp 86ajmyk2q), or per-batch transcript spot-checks for out-of-arm
    reads accepted in writing for that batch.
-3. Arms are not one-factor treatments — floor inventory leaks table
-   descriptions to the bare arm; knowledge arm carries dead links; full vs
-   bare differs in repo access, not just the framework. Gate: DATA-2164
-   (additive arm construction + leakage test), or the verdict writeup carries
-   these as explicit alternative explanations.
+3. ~~Arms are not one-factor treatments~~ **Closed by DATA-2164**: arms are
+   now built additively from one substrate with per-arm manifests and
+   integrity gates (dead-link + canary-leakage checks), so bare/knowledge/full
+   differ only by declared treatment layers, not by incidental repo access or
+   description leakage. The intent-card driver (surfacing which skill section
+   an answer actually used) is deferred to its own follow-up ticket under
+   DATA-2142; the interim is the noninteractive contract plus the
+   pre-first-batch skill-engagement probe (checklist item 2 above).
 4. No evidence artifacts or execution metadata — source checks are transcript
    greps, judge output is not persisted with provenance, and rule 3 overhead
    claims have no token/cost data behind them. Gate: ClickUp 86ajmykh4.
@@ -55,16 +59,31 @@ closed:
    unimplemented — verdicts are pre-registered directionally but not yet
    defensible as an experiment. Gate: ClickUp 86ajmykh4.
 
-## Arm ref
+## Arm construction (amended 2026-07-22, DATA-2164)
 
-`prep_arms.py` builds the `full` and `knowledge` arms as `git archive` exports
-of `--ref` (default `main`) — plain directories with no `.git`, so the deleted
-answer keys can't be recovered from history. Until this branch
-(`data-2143-quality-bench`) merges, `main` lacks the Databricks deps it added,
-so arms cut from `main` can't query the warehouse — pass
-`--ref data-2143-quality-bench` explicitly:
+**Pre-registration amendment (Tristan sign-off 2026-07-21):** the full arm is
+no longer "the repo as deployed" (a git-archive export of main). All arms are
+built additively from one substrate: bare = substrate; knowledge = substrate
++ the two product-knowledge skills + their analysis libs; full = knowledge +
+the analytics-process skill + its two claimed reviewer agents. The claim under
+test is therefore "the skills as a treatment," not "the repo as deployed."
+Rationale: subtractive arms were not one-factor contrasts (dead cross-skill
+links in the knowledge arm; repo content only in full/knowledge; curated dbt
+descriptions leaking into the floor), so wins were not attributable to the
+intended treatment (PR #636 human review).
 
-    uv run python diagnostics/quality_bench/prep_arms.py --ref data-2143-quality-bench
+`prep_arms.py` exports treatment layers from `--ref` (default `main`) via
+per-path `git archive`, writes a per-arm `manifest.json` (file, sha256,
+contributing layer), and fails unless integrity passes: every relative md
+link resolves inside the arm, and no canary phrase (canaries.yaml) from an
+excluded layer appears anywhere in the arm or the floor. Batch resume is
+gated on the manifest hashes (state.json `arms_sha256`).
+
+Until this branch merges, pass `--ref data-2164-additive-arms` (or whichever
+branch carries the current skill/lib content) explicitly, since `main` may
+lag the layers under test:
+
+    uv run python diagnostics/quality_bench/prep_arms.py --ref data-2164-additive-arms
 
 After the branch merges, the default (`main`) is correct and the flag can be
 dropped.
@@ -137,7 +156,7 @@ framework quality. Run it with a cheap model and only 2 arms:
 
     cd analytics
     uv run python diagnostics/quality_bench/floor_gen.py
-    uv run python diagnostics/quality_bench/prep_arms.py --ref data-2143-quality-bench
+    uv run python diagnostics/quality_bench/prep_arms.py --ref data-2164-additive-arms
     uv run python diagnostics/quality_bench/run_matrix.py --batch smoke --reps 1 --arms bare full --model sonnet
     uv run python diagnostics/quality_bench/grade.py --batch smoke
 

--- a/analytics/diagnostics/quality_bench/canaries.yaml
+++ b/analytics/diagnostics/quality_bench/canaries.yaml
@@ -1,0 +1,31 @@
+# Distinctive verbatim phrases from treatment content, used by integrity.py
+# leakage scans. Grader-side; never shipped into an arm. See integrity.py
+# for the model and tests/test_quality_bench_integrity.py for freshness.
+canaries:
+  - layer: knowledge
+    source: .claude/skills/win-analytics-knowledge/SKILL.md
+    phrase: "narrow it to the **one** governed definition"
+  - layer: knowledge
+    source: .claude/skills/win-analytics-knowledge/references/gotchas.md
+    phrase: "Closed-cohort retention declines by construction"
+  - layer: knowledge
+    source: .claude/skills/serve-analytics-knowledge/references/sources.md
+    phrase: "broad-engagement working set built by"
+  - layer: knowledge
+    source: analytics/lib/win_analysis.py
+    phrase: 'an event is "Win" when its taxonomy'
+  - layer: knowledge
+    source: analytics/lib/serve_analysis.py
+    phrase: "Implements the **broad Serve engagement** definition"
+  - layer: process
+    source: .claude/skills/analytics-process/SKILL.md
+    phrase: "route the executed analysis through the two adversarial reviewer agents"
+  - layer: process
+    source: .claude/agents/product-data-scientist.md
+    phrase: "from a methodological-rigor perspective"
+  - layer: process
+    source: .claude/agents/product-manager.md
+    phrase: "from a usefulness and clarity perspective"
+  - layer: knowledge
+    source: .claude/skills/serve-analytics-knowledge/SKILL.md
+    phrase: "Serve's analysis defaults (resolved scoping, default cohorts, the working-set builder, reviewer doc pointers)"

--- a/analytics/diagnostics/quality_bench/floor.md
+++ b/analytics/diagnostics/quality_bench/floor.md
@@ -18,884 +18,899 @@ Run Python via: `uv run --project {{UV_PROJECT}} python <script.py>`
 The warehouse catalog is `goodparty_data_catalog`; analytics marts live in the
 `dbt` schema (query as `goodparty_data_catalog.dbt.<table>`).
 
-## Table inventory (mechanically generated)
+## Table inventory (mechanically generated: names and neutral metadata only)
 
-| table | description |
-|---|---|
-| campaigns | Goodparty.org application campaigns… |
-| clean_states | (no description) |
-| deid_voters | De-identified nationwide voter data for MBAN Analytics program (2026)… |
-| election_api_race_filing_address_overrides | (no description) |
-| fips_codes | (no description) |
-| haystaq_issue_tags | (no description) |
-| hubspot_call_dispositions | (no description) |
-| hubspot_contact_property_columns | (no description) |
-| icp_normalized_position_names | (no description) |
-| int__amplitude_event_catalog | Read-only catalog of Amplitude events: macro-derived family classification plus volume/recency from the event stream, joined to Amplitude Govern metad… |
-| int__amplitude_event_taxonomy | Single source of truth for Amplitude event-family classification… |
-| int__amplitude_serve_activity | User x month intermediate aggregating Serve MAU activity from Amplitude… |
-| int__amplitude_user_milestones | User-grain intermediate model that aggregates milestone events from stg_airbyte_source__amplitude_api_events into one row per user_id for analytics.us… |
-| int__amplitude_win_activity | User x month intermediate aggregating Win product engagement from Amplitude… |
-| int__amplitude_win_activity_weekly | User x week intermediate aggregating Win product engagement from Amplitude… |
-| int__ballotready_candidacy | This model retrieves and processes candidate data from the CivicEngine API since the source candidacies_v3 csv file does not contain all the fields ne… |
-| int__ballotready_candidate_identity | Canonical BallotReady candidate identity inputs, one deterministic row per br_candidate_id… |
-| int__ballotready_endorsement | This model retrieves and processes candidate endorsement data from the CivicEngine API… |
-| int__ballotready_filing_period | This model retrieves and processes filing period data from the CivicEngine API… |
-| int__ballotready_geofence | This model retrieves and processes geofence data from the CivicEngine API. |
-| int__ballotready_issue | This model retrieves and processes issue data from the CivicEngine API: https://developers.civicengine.com/docs/api/graphql/reference/objects/issue It… |
-| int__ballotready_normalized_position | This model retrieves normalized position data from the CivicEngine API… |
-| int__ballotready_party | This model retrieves and processes candidate endorsement data from the CivicEngine API… |
-| int__ballotready_person | This model retrieves and processes person data from the CivicEngine API. |
-| int__ballotready_position_election_frequency | This model retrieves and processes position election frequency data from the CivicEngine API… |
-| int__ballotready_position_to_place | Intermediate model that maps positions to places from the BallotReady API |
-| int__ballotready_stance | This model retrieves and processes candidate stance data from the CivicEngine API… |
-| int__civics_candidacy_2025 | Historical archive of candidacies from the general mart with elections on or before 2025-12-31… |
-| int__civics_candidacy_ballotready | BallotReady candidacies transformed into civics mart candidacy schema… |
-| int__civics_candidacy_ddhq | DDHQ candidacies transformed into civics mart candidacy schema… |
-| int__civics_candidacy_gp_api | Product Database campaigns transformed into the civics mart candidacy schema… |
-| int__civics_candidacy_stage_2025 | Historical archive of candidacy stages (primary, general, general runoff) from elections on or before 2025-12-31… |
-| int__civics_candidacy_stage_ballotready | BallotReady candidacy stages transformed into civics mart candidacy_stage schema… |
-| int__civics_candidacy_stage_ddhq | DDHQ candidacy stages — the foundational DDHQ intermediate model… |
-| int__civics_candidacy_stage_gp_api | Product Database campaigns × BR election_stage rows for same position+year… |
-| int__civics_candidacy_stage_techspeed | TechSpeed candidacy stages transformed into civics mart candidacy_stage schema… |
-| int__civics_candidacy_techspeed | TechSpeed candidates transformed into civics mart candidacy schema… |
-| int__civics_candidate_2025 | Historical archive of candidates from the general mart with elections on or before 2025-12-31… |
-| int__civics_candidate_ballotready | BallotReady candidates transformed into civics mart candidate schema… |
-| int__civics_candidate_ddhq | DDHQ candidates transformed into civics mart candidate schema… |
-| int__civics_candidate_gp_api | Product Database (gp_api_db) users transformed into the civics mart candidate schema… |
-| int__civics_candidate_techspeed | TechSpeed candidates transformed into civics mart candidate schema… |
-| int__civics_elected_official_ballotready | BallotReady office holders, term-grain… |
-| int__civics_elected_official_ballotready_person | BR-only person-grain rollup of int__civics_elected_official_ballotready… |
-| int__civics_elected_official_canonical_ids | Deterministic crosswalk: TechSpeed ts_officeholder_id ↔ BallotReady canonical IDs (term-grain UUID, person-grain UUID, raw BR keys)… |
-| int__civics_elected_official_ddhq | (no description) |
-| int__civics_elected_official_ddhq_matched_votes | DDHQ general-winner votes matched to each elected official via the matcha elected_official entity resolution: a DDHQ winner that shares a Splink clust… |
-| int__civics_elected_official_gp_api | Product Database elected offices transformed into the civics mart elected_officials schema… |
-| int__civics_elected_official_gp_api_bridge | Term-grain bridge from gp-api elected_office records to BR+TS terms, derived from the EO Splink cluster output… |
-| int__civics_elected_official_gp_api_person | Person-grain rollup of gp-api elected officials… |
-| int__civics_elected_official_techspeed | TechSpeed office holders transformed into the civics mart elected_officials schema… |
-| int__civics_elected_official_techspeed_person | TS-side person-grain rollup… |
-| int__civics_election_2025 | Historical archive of elections from the general mart with election dates on or before 2025-12-31… |
-| int__civics_election_ballotready | BallotReady elections transformed into civics mart election schema… |
-| int__civics_election_ddhq | DDHQ elections transformed into civics mart election schema… |
-| int__civics_election_stage_2025 | Historical archive of election stages (primary, general, general runoff) from elections on or before 2025-12-31… |
-| int__civics_election_stage_ballotready | BallotReady election stages transformed into civics mart election_stage schema… |
-| int__civics_election_stage_ddhq | DDHQ election results transformed into civics mart election_stage schema… |
-| int__civics_election_stage_techspeed | TechSpeed election stages transformed into civics mart election_stage schema… |
-| int__civics_election_techspeed | TechSpeed elections transformed into civics mart election schema… |
-| int__civics_er_canonical_election_stages | Direct election-stage ER crosswalk: maps DDHQ / TechSpeed election stages that clustered with a BallotReady race (gp-data-matcha election_stage entity… |
-| int__civics_er_canonical_ids | Entity resolution crosswalk: provider raw keys → canonical gp_* IDs (BR's cluster-derived ids on BR-anchored clusters, the earliest-member mint on non… |
-| int__civics_minted_candidacy_ids | Minted gp_candidacy_id per clustered candidacy-stage record… |
-| int__civics_minted_election_stage_ids | Minted gp_election_stage_id per clustered election-stage record… |
-| int__civics_person_canonical_ids | Canonical gp_person_id per record… |
-| int__civics_person_edges | Deterministic person edges… |
-| int__civics_person_groups | Person groups… |
-| int__civics_person_nodes | Person record universe… |
-| int__civics_position_office_type | One row per BallotReady position with the canonical office_type, derived from the normalized position name (DATA-1972)… |
-| int__civics_viability_scoring | Viability scores for all candidacies in the civics mart, produced by an MLflow model waterfall (best-available model wins via COALESCE)… |
-| int__ddhq_election_results_clean | Intermediate model that pulls selected properties from DDHQ election results |
-| int__ddhq_election_results_embeddings | Intermediate model that creates embeddings for the election results |
-| int__ddhq_races | Race-level union of DDHQ reported and upcoming races from the DDHQ Elections gsheet… |
-| int__district_census_allocation | THE SUBSTRATE (DATA-1992, epic DATA-1359)… |
-| int__enhanced_place | Intermediate model that enhances the place data from the BallotReady API |
-| int__enhanced_place_w_parent | Intermediate model that enhances the place data from the BallotReady API with its parent place |
-| int__enhanced_position | Intermediate model that enhances the position data from the BallotReady API |
-| int__enhanced_position_w_parent | Intermediate model that enhances the position data from the BallotReady API with its parent position |
-| int__enhanced_race | Intermediate model that enhances the race data from the BallotReady API |
-| int__er_election_stage_candidacy_clusters | (no description) |
-| int__er_prematch_candidacy_stages | Entity resolution prematch table: BallotReady x TechSpeed x DDHQ x GP API candidacy-stages unioned into a standardized schema for Splink probabilistic… |
-| int__er_prematch_elected_officials | Entity resolution prematch table at term grain… |
-| int__er_prematch_election_stages | Entity resolution prematch input for the matcha election_stage entity type… |
-| int__general_candidacy | This model creates the candidacies object in the mart layer using the hubspot data |
-| int__general_candidacy_clean_for_ddhq | This model creates the candidacies object in preparation of the mart layer using the candidacy data… |
-| int__general_candidacy_embeddings_for_ddhq | Intermediate model that creates embeddings for the general candidacy data |
-| int__general_states_zip_code_range | "Intermediate model that pulls selected properties from HubSpot contacts… |
-| int__geo_id_attributes | Intermediate model that maps geo_id to its components and parent geo_id |
-| int__gp_ai_candidacies | Intermediate model that creates the candidacies object in the intermediate layer using the HubSpot data… |
-| int__gp_ai_election_match | DEPRECATED (DATA-1834): Frozen snapshot of DDHQ-HubSpot AI election match results from Dec 2, 2025… |
-| int__gp_ai_start_election_match | Intermediate model that starts the election match process for GP AI |
-| int__hs_companies_recent | (no description) |
-| int__hs_companies_with_contacts | (no description) |
-| int__hubspot_calls | HubSpot engagement calls, deduped to one row per call_id and enriched with the disposition label and outcome_family classification from the hubspot_ca… |
-| int__hubspot_candidate_codes | "Intermediate model that generates unique candidate codes by concatenating and cleaning first name, last name, state, and office type from HubSpot con… |
-| int__hubspot_companies_archive_2025 | Archived HubSpot companies prioritizing 2025 election dates… |
-| int__hubspot_companies_w_contacts_2025 | Archived HubSpot companies joined with contacts from 2026-01-22 snapshot… |
-| int__hubspot_contact_calls | One row per HubSpot contact_id with at least one logged call… |
-| int__hubspot_contacts | "Intermediate model that pulls selected properties from HubSpot contacts… |
-| int__hubspot_contacts_2025 | Archived HubSpot contacts from 2026-01-22 snapshot… |
-| int__hubspot_contacts_archive_2025 | Archived HubSpot contacts prioritizing 2025 election dates… |
-| int__hubspot_contacts_w_companies | "Intermediate model that pulls selected properties from HubSpot contacts… |
-| int__hubspot_contest | "Intermediate model that pulls selected properties from HubSpot contacts… |
-| int__hubspot_contest_2025 | (no description) |
-| int__hubspot_prospect_contacts | One row per HubSpot contact, with lifecycle/stage/activation/pledge fields and resolved position-based ICP from int__hubspot_contacts… |
-| int__icp_offices | ICP offices with voter counts per district (state, district type, and district name) |
-| int__l2_block_district_map | One row per (census block, state, district_type, normalized district_name) with the L2 voter count in that intersection (voters_in_block_district) and… |
-| int__l2_district_aggregations | Intermediate model that aggregates L2 district data for downstream use. |
-| int__l2_nationwide_haystaq_flags | Combined Haystaq issue model flags from all states (loaded from per-state L2 Haystaq flags tables) |
-| int__l2_nationwide_haystaq_scores | Combined Haystaq issue model scores from all states (loaded from per-state L2 Haystaq scores tables) |
-| int__l2_nationwide_uniform | Combined uniform voter file data from all states |
-| int__l2_nationwide_uniform_w_haystaq | Nationwide uniform voter file data with Haystaq flags and scores joined on LALVOTERID |
-| int__model_prediction_voter_turnout | Turnout projections data load from model predictions |
-| int__place_fast_facts | Intermediate model that adds fast facts to places |
-| int__place_fun_facts | Intermediate model that adds fun facts to places |
-| int__position_fast_facts | Intermediate model that adds fast facts to positions |
-| int__position_fun_facts | Intermediate model that adds fun facts to positions |
-| int__race_to_positions | Intermediate model that maps races to positions from the BallotReady API |
-| int__serve_active_user | The single source of truth for the "active serve user" behavioral definition (epic DATA-1359), one row per user… |
-| int__serve_block_coverage | The count-once engine (DATA-1993, epic DATA-1359)… |
-| int__serve_district_resolution | Resolves each serve org to its L2 district: the serve-cohort entry point onto the District/Census substrate (a downstream consumer; election-api quara… |
-| int__voter_turnout_lgbm_inference | Nationwide district-level voter-turnout projections from the LightGBM models (DATA-2015)… |
-| int__zip_code_to_br_office | Zip code to BR office mapping |
-| int__zip_code_to_l2_district | Zip code to L2 district mapping… |
-| l2_br_match_overrides | (no description) |
-| l2_column_classification | (no description) |
-| load__l2_haystaq_s3_to_databricks | This model loads Haystaq issue model data from S3 to Databricks. |
-| load__l2_haystaq_sftp_to_s3 | This model loads Haystaq issue model data from the L2 SFTP server to S3. |
-| load__l2_s3_to_databricks | This model loads data from S3 to Databricks. |
-| load__l2_sftp_to_s3 | This model loads data from the L2 SFTP server to S3. |
-| m_election_api__candidacy | Mart model that serves the Election API |
-| m_election_api__district | Mart model that serves districts to the Election API, part of projected turnout |
-| m_election_api__district_top_issues | District-level Haystaq issue scores per L2 district, covering every L2 district with an `is_matched = true` row in the LLM L2-to-BallotReady district … |
-| m_election_api__elected_official_support | Support metrics for the product's elected offices, one row per gp-api elected_office instance (elected_office_id, tied to a user/official)… |
-| m_election_api__issue | Mart model that serves the Election API |
-| m_election_api__place | Mart model that serves the Election API |
-| m_election_api__position | Mart model that serves the Election API |
-| m_election_api__projected_turnout | Turnout projections data load from model predictions |
-| m_election_api__race | Mart model that serves the Election API |
-| m_election_api__stance | Mart model that serves the Election API |
-| m_election_api__zip_to_position | Maps zip codes to future election positions for the OfficePicker product… |
-| m_general__candidacy | This model creates the candidacies object in the mart layer using the hubspot data |
-| m_general__candidacy_preview | This model creates the candidacy preview object in the mart layer using the hubspot data |
-| m_general__candidacy_stage | This model creates the candidacy stage object in the mart layer using DDHQ data and matches |
-| m_general__candidacy_v2 | (no description) |
-| m_general__candidate | This model creates the candidate object in the mart layer using the hubspot data |
-| m_general__candidate_v2 | This model creates the candidate v2 object in the mart layer using the hubspot data |
-| m_general__contest | This model creates the contest object in the mart layer using the hubspot data |
-| m_general__election | This model creates the election object in the mart layer using the hubspot data |
-| m_general__election_stage | This model creates the election stage object in the mart layer using DDHQ data |
-| m_people_api__district | This model creates the district table in the mart layer using the election_api district table. |
-| m_people_api__districtstats | District statistics aggregating voter demographic data per district… |
-| m_people_api__districtvoter | This model creates the district voter table in the mart layer using the voter table. |
-| m_people_api__voter | This model creates the voter table in the mart layer using the hubspot data |
-| metricflow_time_spine | Daily time spine for the dbt semantic layer (MetricFlow)… |
-| nicknames | (no description) |
-| serve_agent_voters_columns | (no description) |
-| snapshot__hubspot_api_companies | (no description) |
-| snapshot__hubspot_api_contacts | (no description) |
-| snapshot__hubspot_api_deals | (no description) |
-| snapshot__int__civics_person_canonical_ids | (no description) |
-| snapshot__int__l2_nationwide_uniform | (no description) |
-| states_zip_code_range | (no description) |
-| stg_airbyte_internal__raw_gp_api_db_campaign | Parsed and deduplicated campaign data from Airbyte's insert-only raw stream… |
-| stg_airbyte_source__amplitude_api_active_users | Staging model for Amplitude Active Users Counts stream - tracks daily active user counts with incremental sync |
-| stg_airbyte_source__amplitude_api_annotations | Staging model for Amplitude Annotations stream - contains chart annotations and notes |
-| stg_airbyte_source__amplitude_api_average_session_length | Staging model for Amplitude Average Session Length stream - tracks daily average session duration with incremental sync |
-| stg_airbyte_source__amplitude_api_cohorts | Staging model for Amplitude Cohorts stream - contains user cohort definitions and metadata |
-| stg_airbyte_source__amplitude_api_events | Staging model for Amplitude Events stream - contains individual user events with incremental sync |
-| stg_airbyte_source__amplitude_api_events_list | Staging model for Amplitude Events List stream - contains metadata about tracked events |
-| stg_airbyte_source__amplitude_taxonomy_event_type | Staging model for the Amplitude Govern taxonomy stream - one row per event_type with human-curated metadata… |
-| stg_airbyte_source__ballotready_api_election | Election data scan from [`elections` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/elections) |
-| stg_airbyte_source__ballotready_api_issue | Issue data scan from [`issues` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/issues) |
-| stg_airbyte_source__ballotready_api_mtfcc | MTFCC data scan from [`mtfcc` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/mtfcc)… |
-| stg_airbyte_source__ballotready_api_place | Place data scan from [`places` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/places) |
-| stg_airbyte_source__ballotready_api_position | Position data scan from [`positions` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/positions) |
-| stg_airbyte_source__ballotready_api_position_to_place | Position data scan from [`positions` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/positions) |
-| stg_airbyte_source__ballotready_api_race | Race data scan from [`races` query](https://developers.civicengine.com/docs/api/graphql/reference/queries/races) |
-| stg_airbyte_source__ballotready_s3_candidacies_v3 | Candidacies data load from ballotready csvs in s3 bucket |
-| stg_airbyte_source__ballotready_s3_office_holders_v3 | Office Holders data load from ballotready csvs in s3 bucket |
-| stg_airbyte_source__ballotready_s3_recruitment_v1 | Recruitment data load from ballotready csvs in s3 bucket |
-| stg_airbyte_source__ballotready_s3_uscities_v1_77 | US Cities data load from ballotready csvs in s3 bucket |
-| stg_airbyte_source__ballotready_s3_uscounties_v1_73 | US Counties data load from ballotready csvs in s3 bucket |
-| stg_airbyte_source__ddhq_elections_gsheet_reported_races | Race-level rows from the DDHQ Elections gsheet for races whose results have been reported… |
-| stg_airbyte_source__ddhq_elections_gsheet_upcoming_races | Race-level rows from the DDHQ Elections gsheet for races whose results have not yet been reported… |
-| stg_airbyte_source__ddhq_gdrive_election_results | Election results data load from ddhq google drive |
-| stg_airbyte_source__ddhq_gdrive_election_results_invalid | DDHQ election results rows that fail data quality checks… |
-| stg_airbyte_source__gp_api_db_annotation | Annotation records (notes, chats, bug reports) attached to EO Meeting Briefing artifacts… |
-| stg_airbyte_source__gp_api_db_annotation_bug_report | raw data load from gp_api_db postgres db from table `annotation_bug_report` |
-| stg_airbyte_source__gp_api_db_annotation_note | raw data load from gp_api_db postgres db from table `annotation_note` |
-| stg_airbyte_source__gp_api_db_annotation_note_attachment | raw data load from gp_api_db postgres db from table `annotation_note_attachment` |
-| stg_airbyte_source__gp_api_db_annotation_review | raw data load from gp_api_db postgres db from table `annotation_review` |
-| stg_airbyte_source__gp_api_db_artifact_feedback | Positive/negative feedback submitted on EO Meeting Briefing artifacts… |
-| stg_airbyte_source__gp_api_db_artifact_review | Automated/human review verdicts on EO artifacts (currently briefings)… |
-| stg_airbyte_source__gp_api_db_campaign | raw data load from gp_api_db postgres db from table `campaign` |
-| stg_airbyte_source__gp_api_db_campaign_position | raw data load from gp_api_db postgres db from table `campaign_position` |
-| stg_airbyte_source__gp_api_db_chat_conversation | Chat conversations collected from EO Meeting Briefings… |
-| stg_airbyte_source__gp_api_db_chat_message | raw data load from gp_api_db postgres db from table `chat_message` |
-| stg_airbyte_source__gp_api_db_community_issue | Community issues surfaced for an organization, ranked and categorized… |
-| stg_airbyte_source__gp_api_db_domain | raw data load from gp_api_db postgres db from table `domain` |
-| stg_airbyte_source__gp_api_db_ecanvasser | Staging model for eCanvasser stream - contains eCanvasser configuration and sync information |
-| stg_airbyte_source__gp_api_db_ecanvasser_contact | Staging model for eCanvasser Contact stream - contains voter contact information from eCanvasser |
-| stg_airbyte_source__gp_api_db_ecanvasser_house | Staging model for eCanvasser House stream - contains household information from eCanvasser |
-| stg_airbyte_source__gp_api_db_ecanvasser_interaction | Staging model for eCanvasser Interaction stream - contains interaction records between contacts and canvassers |
-| stg_airbyte_source__gp_api_db_elected_office | raw data load from gp_api_db postgres db from table `elected_office` |
-| stg_airbyte_source__gp_api_db_election_type | raw data load from gp_api_db postgres db from table `election_type` |
-| stg_airbyte_source__gp_api_db_experiment_run | Experiment runs from the gp-api experiment pipeline… |
-| stg_airbyte_source__gp_api_db_meeting_briefing | EO Meeting Briefing artifacts generated for an elected office and meeting date… |
-| stg_airbyte_source__gp_api_db_organization | raw data load from gp_api_db postgres db from table `organization` |
-| stg_airbyte_source__gp_api_db_outreach | Staging model for Outreach stream - contains outreach campaign information and configuration |
-| stg_airbyte_source__gp_api_db_path_to_victory | raw data load from gp_api_db postgres db from table `path_to_victory` |
-| stg_airbyte_source__gp_api_db_poll | raw data load from gp_api_db postgres db from table `poll` |
-| stg_airbyte_source__gp_api_db_poll_individual_message | raw data load from gp_api_db postgres db from table `poll_individual_message` |
-| stg_airbyte_source__gp_api_db_poll_issues | raw data load from gp_api_db postgres db from table `poll_issues` |
-| stg_airbyte_source__gp_api_db_position | raw data load from gp_api_db postgres db from table `position` |
-| stg_airbyte_source__gp_api_db_race_opponent_contrast | AI-generated candidate/opponent contrast statements for a race… |
-| stg_airbyte_source__gp_api_db_race_opponent_research | Opponent research runs for a race… |
-| stg_airbyte_source__gp_api_db_race_opponent_standout_action | AI-generated standout actions attributed to an opponent… |
-| stg_airbyte_source__gp_api_db_race_opponent_summary | AI-generated opponent research summaries for a race… |
-| stg_airbyte_source__gp_api_db_tcr_compliance | raw data load from gp_api_db postgres db from table `tcr_compliance` |
-| stg_airbyte_source__gp_api_db_top_issue | raw data load from gp_api_db postgres db from table `top_issue` |
-| stg_airbyte_source__gp_api_db_user | raw data load from gp_api_db postgres db from table `user` |
-| stg_airbyte_source__gp_api_db_website | raw data load from gp_api_db postgres db from table `website` |
-| stg_airbyte_source__gp_api_db_website_contact | raw data load from gp_api_db postgres db from table `website_contact` |
-| stg_airbyte_source__gp_api_db_website_view | raw data load from gp_api_db postgres db from table `website_view` |
-| stg_airbyte_source__hubspot_api_companies | Companies data load from HubSpot API |
-| stg_airbyte_source__hubspot_api_contacts | Contacts data loaded from the HubSpot API… |
-| stg_airbyte_source__hubspot_api_deals | Deals data load from HubSpot API |
-| stg_airbyte_source__hubspot_api_engagements | Engagements data load from HubSpot API |
-| stg_airbyte_source__hubspot_api_engagements_calls | Staged HubSpot Call engagements… |
-| stg_airbyte_source__hubspot_api_feedback_submissions | Staged HubSpot Feedback Survey submissions… |
-| stg_airbyte_source__hubspot_api_owners | Owners data load from HubSpot API |
-| stg_airbyte_source__hubspot_api_owners_archived | Archived owners data load from HubSpot API |
-| stg_airbyte_source__hubspot_api_tickets | Tickets data load from HubSpot API |
-| stg_airbyte_source__stripe_api_accounts | Staging model for Stripe Accounts stream - contains account information and settings with Full Refresh sync |
-| stg_airbyte_source__stripe_api_application_fees | Staging model for Stripe Application Fees stream - contains application fees charged on transactions with Incremental sync |
-| stg_airbyte_source__stripe_api_application_fees_refunds | Staging model for Stripe Application Fee Refunds stream - contains refunded application fees with Incremental sync |
-| stg_airbyte_source__stripe_api_balance_transactions | Staging model for Stripe Balance Transactions stream - contains account balance movements with Incremental sync |
-| stg_airbyte_source__stripe_api_charges | Staging model for Stripe Charges stream - contains payment charge transactions with Incremental sync |
-| stg_airbyte_source__stripe_api_customer_balance_transactions | Staging model for Stripe Customer Balance Transactions stream - contains customer account balance changes with Incremental sync |
-| stg_airbyte_source__stripe_api_customers | Staging model for Stripe Customers stream - contains customer records and account information with Incremental sync |
-| stg_airbyte_source__stripe_api_events | Staging model for Stripe Events stream - contains webhook events and API activity logs with Incremental sync… |
-| stg_airbyte_source__stripe_api_invoice_items | Staging model for Stripe Invoice Items stream - contains invoice line items and billing details with Incremental sync |
-| stg_airbyte_source__stripe_api_invoice_line_items | Staging model for Stripe Invoice Line Items stream - contains detailed billing breakdowns with Full Refresh sync |
-| stg_airbyte_source__stripe_api_invoices | Staging model for Stripe Invoices stream - contains invoice records and billing information with Incremental sync |
-| stg_airbyte_source__stripe_api_payouts | Staging model for Stripe Payouts stream - contains payout transactions to connected accounts with Incremental sync |
-| stg_airbyte_source__stripe_api_persons | Staging model for Stripe Persons stream - contains person records for connected accounts with Incremental sync |
-| stg_airbyte_source__stripe_api_plans | Staging model for Stripe Plans stream - contains subscription plans and pricing tiers with Incremental sync |
-| stg_airbyte_source__stripe_api_prices | Staging model for Stripe Prices stream - contains pricing information for products with Incremental sync |
-| stg_airbyte_source__stripe_api_products | Staging model for Stripe Products stream - contains product catalog and inventory information with Incremental sync |
-| stg_airbyte_source__stripe_api_promotion_codes | Staging model for Stripe Promotion Codes stream - contains promotion codes and discount campaigns with Incremental sync |
-| stg_airbyte_source__stripe_api_refunds | Staging model for Stripe Refunds stream - contains refund transactions and processing details with Incremental sync |
-| stg_airbyte_source__stripe_api_subscription_items | Staging model for Stripe Subscription Items stream - contains subscription line items and plan details with Full Refresh sync |
-| stg_airbyte_source__stripe_api_subscription_schedule | Staging model for Stripe Subscription Schedule stream - contains subscription scheduling and recurring payment plans with Incremental sync |
-| stg_airbyte_source__stripe_api_subscriptions | Staging model for Stripe Subscriptions stream - contains subscription records and recurring billing information with Incremental sync |
-| stg_airbyte_source__stripe_api_transactions | Staging model for Stripe Transactions stream - contains financial transactions and payment processing records with Incremental sync |
-| stg_airbyte_source__stripe_api_transfer_reversals | Staging model for Stripe Transfer Reversals stream - contains transfer reversal transactions and dispute handling with Full Refresh sync |
-| stg_airbyte_source__stripe_api_transfers | Staging model for Stripe Transfers stream - contains transfer transactions between accounts with Incremental sync |
-| stg_airbyte_source__techspeed_gdrive_candidates | Candidates data from TechSpeed Google Drive… |
-| stg_airbyte_source__techspeed_gdrive_candidates_invalid | TechSpeed candidate rows that fail data quality checks… |
-| stg_airbyte_source__techspeed_gdrive_marketing_data_enrichment | Marketing data enrichment load from TechSpeed Google Drive |
-| stg_airbyte_source__techspeed_gdrive_officeholders | Officeholders data load from TechSpeed Google Drive |
-| stg_airflow_source__l2_expired_voters | Staged view of expired L2 voter IDs ingested by the Airflow l2_expired_voters DAG… |
-| stg_airflow_source__l2_expired_voters_loads | Load metadata for the l2_expired_voters DAG… |
-| stg_census__block_population | 2020 decennial census population per census block, unioned from the two research-staged NHGIS extracts… |
-| stg_dbt_source__l2_s3_ak_demographic | AK (Alaska) Demographic data |
-| stg_dbt_source__l2_s3_ak_demographic_data_dictionary | Staging model for AK (Alaska) demographic data dictionary |
-| stg_dbt_source__l2_s3_ak_haystaq_dna_flags | Staging model for AK Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ak_haystaq_dna_scores | Staging model for AK Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ak_uniform | Staging model for AK (Alaska) uniform |
-| stg_dbt_source__l2_s3_ak_uniform_data_dictionary | Staging model for AK (Alaska) uniform data dictionary |
-| stg_dbt_source__l2_s3_ak_vote_history | Staging model for AK (Alaska) vote history |
-| stg_dbt_source__l2_s3_ak_vote_history_data_dictionary | Staging model for AK (Alaska) vote history data dictionary |
-| stg_dbt_source__l2_s3_al_demographic | Staging model for AL (Alabama) demographic |
-| stg_dbt_source__l2_s3_al_demographic_data_dictionary | Staging model for AL (Alabama) demographic data dictionary |
-| stg_dbt_source__l2_s3_al_haystaq_dna_flags | Staging model for AL Haystaq DNA flags |
-| stg_dbt_source__l2_s3_al_haystaq_dna_scores | Staging model for AL Haystaq DNA scores |
-| stg_dbt_source__l2_s3_al_uniform | Staging model for AL (Alabama) uniform |
-| stg_dbt_source__l2_s3_al_uniform_data_dictionary | Staging model for AL (Alabama) uniform data dictionary |
-| stg_dbt_source__l2_s3_al_vote_history | Staging model for AL (Alabama) vote history |
-| stg_dbt_source__l2_s3_al_vote_history_data_dictionary | Staging model for AL (Alabama) vote history data dictionary |
-| stg_dbt_source__l2_s3_ar_demographic | Staging model for AR (Arkansas) demographic |
-| stg_dbt_source__l2_s3_ar_demographic_data_dictionary | Staging model for AR (Arkansas) demographic data dictionary |
-| stg_dbt_source__l2_s3_ar_haystaq_dna_flags | Staging model for AR Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ar_haystaq_dna_scores | Staging model for AR Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ar_uniform | Staging model for AR (Arkansas) uniform |
-| stg_dbt_source__l2_s3_ar_uniform_data_dictionary | Staging model for AR (Arkansas) uniform data dictionary |
-| stg_dbt_source__l2_s3_ar_vote_history | Staging model for AR (Arkansas) vote history |
-| stg_dbt_source__l2_s3_ar_vote_history_data_dictionary | Staging model for AR (Arkansas) vote history data dictionary |
-| stg_dbt_source__l2_s3_az_demographic | Staging model for AZ (Arizona) demographic |
-| stg_dbt_source__l2_s3_az_demographic_data_dictionary | Staging model for AZ (Arizona) demographic data dictionary |
-| stg_dbt_source__l2_s3_az_haystaq_dna_flags | Staging model for AZ Haystaq DNA flags |
-| stg_dbt_source__l2_s3_az_haystaq_dna_scores | Staging model for AZ Haystaq DNA scores |
-| stg_dbt_source__l2_s3_az_uniform | Staging model for AZ (Arizona) uniform |
-| stg_dbt_source__l2_s3_az_uniform_data_dictionary | Staging model for AZ (Arizona) uniform data dictionary |
-| stg_dbt_source__l2_s3_az_vote_history | Staging model for AZ (Arizona) vote history |
-| stg_dbt_source__l2_s3_az_vote_history_data_dictionary | Staging model for AZ (Arizona) vote history data dictionary |
-| stg_dbt_source__l2_s3_ca_demographic | Staging model for CA (California) demographic |
-| stg_dbt_source__l2_s3_ca_demographic_data_dictionary | Staging model for CA (California) demographic data dictionary |
-| stg_dbt_source__l2_s3_ca_haystaq_dna_flags | Staging model for CA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ca_haystaq_dna_scores | Staging model for CA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ca_uniform | Staging model for CA (California) uniform |
-| stg_dbt_source__l2_s3_ca_uniform_data_dictionary | Staging model for CA (California) uniform data dictionary |
-| stg_dbt_source__l2_s3_ca_vote_history | Staging model for CA (California) vote history |
-| stg_dbt_source__l2_s3_ca_vote_history_data_dictionary | Staging model for CA (California) vote history data dictionary |
-| stg_dbt_source__l2_s3_co_demographic | Staging model for CO (Colorado) demographic |
-| stg_dbt_source__l2_s3_co_demographic_data_dictionary | Staging model for CO (Colorado) demographic data dictionary |
-| stg_dbt_source__l2_s3_co_haystaq_dna_flags | Staging model for CO Haystaq DNA flags |
-| stg_dbt_source__l2_s3_co_haystaq_dna_scores | Staging model for CO Haystaq DNA scores |
-| stg_dbt_source__l2_s3_co_uniform | Staging model for CO (Colorado) uniform |
-| stg_dbt_source__l2_s3_co_uniform_data_dictionary | Staging model for CO (Colorado) uniform data dictionary |
-| stg_dbt_source__l2_s3_co_vote_history | Staging model for CO (Colorado) vote history |
-| stg_dbt_source__l2_s3_co_vote_history_data_dictionary | Staging model for CO (Colorado) vote history data dictionary |
-| stg_dbt_source__l2_s3_ct_demographic | Staging model for CT (Connecticut) demographic |
-| stg_dbt_source__l2_s3_ct_demographic_data_dictionary | Staging model for CT (Connecticut) demographic data dictionary |
-| stg_dbt_source__l2_s3_ct_haystaq_dna_flags | Staging model for CT Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ct_haystaq_dna_scores | Staging model for CT Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ct_uniform | Staging model for CT (Connecticut) uniform |
-| stg_dbt_source__l2_s3_ct_uniform_data_dictionary | Staging model for CT (Connecticut) uniform data dictionary |
-| stg_dbt_source__l2_s3_ct_vote_history | Staging model for CT (Connecticut) vote history |
-| stg_dbt_source__l2_s3_ct_vote_history_data_dictionary | Staging model for CT (Connecticut) vote history data dictionary |
-| stg_dbt_source__l2_s3_dc_demographic | Staging model for DC (District of Columbia) demographic |
-| stg_dbt_source__l2_s3_dc_demographic_data_dictionary | Staging model for DC (District of Columbia) demographic data dictionary |
-| stg_dbt_source__l2_s3_dc_haystaq_dna_flags | Staging model for DC Haystaq DNA flags |
-| stg_dbt_source__l2_s3_dc_haystaq_dna_scores | Staging model for DC Haystaq DNA scores |
-| stg_dbt_source__l2_s3_dc_uniform | Staging model for DC (District of Columbia) uniform |
-| stg_dbt_source__l2_s3_dc_uniform_data_dictionary | Staging model for DC (District of Columbia) uniform data dictionary |
-| stg_dbt_source__l2_s3_dc_vote_history | Staging model for DC (District of Columbia) vote history |
-| stg_dbt_source__l2_s3_dc_vote_history_data_dictionary | Staging model for DC (District of Columbia) vote history data dictionary |
-| stg_dbt_source__l2_s3_de_demographic | Staging model for DE (Delaware) demographic |
-| stg_dbt_source__l2_s3_de_demographic_data_dictionary | Staging model for DE (Delaware) demographic data dictionary |
-| stg_dbt_source__l2_s3_de_haystaq_dna_flags | Staging model for DE Haystaq DNA flags |
-| stg_dbt_source__l2_s3_de_haystaq_dna_scores | Staging model for DE Haystaq DNA scores |
-| stg_dbt_source__l2_s3_de_uniform | Staging model for DE (Delaware) uniform |
-| stg_dbt_source__l2_s3_de_uniform_data_dictionary | Staging model for DE (Delaware) uniform data dictionary |
-| stg_dbt_source__l2_s3_de_vote_history | Staging model for DE (Delaware) vote history |
-| stg_dbt_source__l2_s3_de_vote_history_data_dictionary | Staging model for DE (Delaware) vote history data dictionary |
-| stg_dbt_source__l2_s3_fl_demographic | Staging model for FL (Florida) demographic |
-| stg_dbt_source__l2_s3_fl_demographic_data_dictionary | Staging model for FL (Florida) demographic data dictionary |
-| stg_dbt_source__l2_s3_fl_haystaq_dna_flags | Staging model for FL Haystaq DNA flags |
-| stg_dbt_source__l2_s3_fl_haystaq_dna_scores | Staging model for FL Haystaq DNA scores |
-| stg_dbt_source__l2_s3_fl_uniform | Staging model for FL (Florida) uniform |
-| stg_dbt_source__l2_s3_fl_uniform_data_dictionary | Staging model for FL (Florida) uniform data dictionary |
-| stg_dbt_source__l2_s3_fl_vote_history | Staging model for FL (Florida) vote history |
-| stg_dbt_source__l2_s3_fl_vote_history_data_dictionary | Staging model for FL (Florida) vote history data dictionary |
-| stg_dbt_source__l2_s3_ga_demographic | Staging model for GA (Georgia) demographic |
-| stg_dbt_source__l2_s3_ga_demographic_data_dictionary | Staging model for GA (Georgia) demographic data dictionary |
-| stg_dbt_source__l2_s3_ga_haystaq_dna_flags | Staging model for GA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ga_haystaq_dna_scores | Staging model for GA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ga_uniform | Staging model for GA (Georgia) uniform |
-| stg_dbt_source__l2_s3_ga_uniform_data_dictionary | Staging model for GA (Georgia) uniform data dictionary |
-| stg_dbt_source__l2_s3_ga_vote_history | Staging model for GA (Georgia) vote history |
-| stg_dbt_source__l2_s3_ga_vote_history_data_dictionary | Staging model for GA (Georgia) vote history data dictionary |
-| stg_dbt_source__l2_s3_hi_demographic | Staging model for HI (Hawaii) demographic |
-| stg_dbt_source__l2_s3_hi_demographic_data_dictionary | Staging model for HI (Hawaii) demographic data dictionary |
-| stg_dbt_source__l2_s3_hi_haystaq_dna_flags | Staging model for HI Haystaq DNA flags |
-| stg_dbt_source__l2_s3_hi_haystaq_dna_scores | Staging model for HI Haystaq DNA scores |
-| stg_dbt_source__l2_s3_hi_uniform | Staging model for HI (Hawaii) uniform |
-| stg_dbt_source__l2_s3_hi_uniform_data_dictionary | Staging model for HI (Hawaii) uniform data dictionary |
-| stg_dbt_source__l2_s3_hi_vote_history | Staging model for HI (Hawaii) vote history |
-| stg_dbt_source__l2_s3_hi_vote_history_data_dictionary | Staging model for HI (Hawaii) vote history data dictionary |
-| stg_dbt_source__l2_s3_ia_demographic | Staging model for IA (Iowa) demographic |
-| stg_dbt_source__l2_s3_ia_demographic_data_dictionary | Staging model for IA (Iowa) demographic data dictionary |
-| stg_dbt_source__l2_s3_ia_haystaq_dna_flags | Staging model for IA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ia_haystaq_dna_scores | Staging model for IA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ia_uniform | Staging model for IA (Iowa) uniform |
-| stg_dbt_source__l2_s3_ia_uniform_data_dictionary | Staging model for IA (Iowa) uniform data dictionary |
-| stg_dbt_source__l2_s3_ia_vote_history | Staging model for IA (Iowa) vote history |
-| stg_dbt_source__l2_s3_ia_vote_history_data_dictionary | Staging model for IA (Iowa) vote history data dictionary |
-| stg_dbt_source__l2_s3_id_demographic | Staging model for ID (Idaho) demographic |
-| stg_dbt_source__l2_s3_id_demographic_data_dictionary | Staging model for ID (Idaho) demographic data dictionary |
-| stg_dbt_source__l2_s3_id_haystaq_dna_flags | Staging model for ID Haystaq DNA flags |
-| stg_dbt_source__l2_s3_id_haystaq_dna_scores | Staging model for ID Haystaq DNA scores |
-| stg_dbt_source__l2_s3_id_uniform | Staging model for ID (Idaho) uniform |
-| stg_dbt_source__l2_s3_id_uniform_data_dictionary | Staging model for ID (Idaho) uniform data dictionary |
-| stg_dbt_source__l2_s3_id_vote_history | Staging model for ID (Idaho) vote history |
-| stg_dbt_source__l2_s3_id_vote_history_data_dictionary | Staging model for ID (Idaho) vote history data dictionary |
-| stg_dbt_source__l2_s3_il_demographic | Staging model for IL (Illinois) demographic |
-| stg_dbt_source__l2_s3_il_demographic_data_dictionary | Staging model for IL (Illinois) demographic data dictionary |
-| stg_dbt_source__l2_s3_il_haystaq_dna_flags | Staging model for IL Haystaq DNA flags |
-| stg_dbt_source__l2_s3_il_haystaq_dna_scores | Staging model for IL Haystaq DNA scores |
-| stg_dbt_source__l2_s3_il_uniform | Staging model for IL (Illinois) uniform |
-| stg_dbt_source__l2_s3_il_uniform_data_dictionary | Staging model for IL (Illinois) uniform data dictionary |
-| stg_dbt_source__l2_s3_il_vote_history | Staging model for IL (Illinois) vote history |
-| stg_dbt_source__l2_s3_il_vote_history_data_dictionary | Staging model for IL (Illinois) vote history data dictionary |
-| stg_dbt_source__l2_s3_in_demographic | Staging model for IN (Indiana) demographic |
-| stg_dbt_source__l2_s3_in_demographic_data_dictionary | Staging model for IN (Indiana) demographic data dictionary |
-| stg_dbt_source__l2_s3_in_haystaq_dna_flags | Staging model for IN Haystaq DNA flags |
-| stg_dbt_source__l2_s3_in_haystaq_dna_scores | Staging model for IN Haystaq DNA scores |
-| stg_dbt_source__l2_s3_in_uniform | Staging model for IN (Indiana) uniform |
-| stg_dbt_source__l2_s3_in_uniform_data_dictionary | Staging model for IN (Indiana) uniform data dictionary |
-| stg_dbt_source__l2_s3_in_vote_history | Staging model for IN (Indiana) vote history |
-| stg_dbt_source__l2_s3_in_vote_history_data_dictionary | Staging model for IN (Indiana) vote history data dictionary |
-| stg_dbt_source__l2_s3_ks_demographic | Staging model for KS (Kansas) demographic |
-| stg_dbt_source__l2_s3_ks_demographic_data_dictionary | Staging model for KS (Kansas) demographic data dictionary |
-| stg_dbt_source__l2_s3_ks_haystaq_dna_flags | Staging model for KS Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ks_haystaq_dna_scores | Staging model for KS Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ks_uniform | Staging model for KS (Kansas) uniform |
-| stg_dbt_source__l2_s3_ks_uniform_data_dictionary | Staging model for KS (Kansas) uniform data dictionary |
-| stg_dbt_source__l2_s3_ks_vote_history | Staging model for KS (Kansas) vote history |
-| stg_dbt_source__l2_s3_ks_vote_history_data_dictionary | Staging model for KS (Kansas) vote history data dictionary |
-| stg_dbt_source__l2_s3_ky_demographic | Staging model for KY (Kentucky) demographic |
-| stg_dbt_source__l2_s3_ky_demographic_data_dictionary | Staging model for KY (Kentucky) demographic data dictionary |
-| stg_dbt_source__l2_s3_ky_haystaq_dna_flags | Staging model for KY Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ky_haystaq_dna_scores | Staging model for KY Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ky_uniform | Staging model for KY (Kentucky) uniform |
-| stg_dbt_source__l2_s3_ky_uniform_data_dictionary | Staging model for KY (Kentucky) uniform data dictionary |
-| stg_dbt_source__l2_s3_ky_vote_history | Staging model for KY (Kentucky) vote history |
-| stg_dbt_source__l2_s3_ky_vote_history_data_dictionary | Staging model for KY (Kentucky) vote history data dictionary |
-| stg_dbt_source__l2_s3_la_demographic | Staging model for LA (Louisiana) demographic |
-| stg_dbt_source__l2_s3_la_demographic_data_dictionary | Staging model for LA (Louisiana) demographic data dictionary |
-| stg_dbt_source__l2_s3_la_haystaq_dna_flags | Staging model for LA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_la_haystaq_dna_scores | Staging model for LA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_la_uniform | Staging model for LA (Louisiana) uniform |
-| stg_dbt_source__l2_s3_la_uniform_data_dictionary | Staging model for LA (Louisiana) uniform data dictionary |
-| stg_dbt_source__l2_s3_la_vote_history | Staging model for LA (Louisiana) vote history |
-| stg_dbt_source__l2_s3_la_vote_history_data_dictionary | Staging model for LA (Louisiana) vote history data dictionary |
-| stg_dbt_source__l2_s3_ma_demographic | Staging model for MA (Massachusetts) demographic |
-| stg_dbt_source__l2_s3_ma_demographic_data_dictionary | Staging model for MA (Massachusetts) demographic data dictionary |
-| stg_dbt_source__l2_s3_ma_haystaq_dna_flags | Staging model for MA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ma_haystaq_dna_scores | Staging model for MA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ma_uniform | Staging model for MA (Massachusetts) uniform |
-| stg_dbt_source__l2_s3_ma_uniform_data_dictionary | Staging model for MA (Massachusetts) uniform data dictionary |
-| stg_dbt_source__l2_s3_ma_vote_history | Staging model for MA (Massachusetts) vote history |
-| stg_dbt_source__l2_s3_ma_vote_history_data_dictionary | Staging model for MA (Massachusetts) vote history data dictionary |
-| stg_dbt_source__l2_s3_md_demographic | Staging model for MD (Maryland) demographic |
-| stg_dbt_source__l2_s3_md_demographic_data_dictionary | Staging model for MD (Maryland) demographic data dictionary |
-| stg_dbt_source__l2_s3_md_haystaq_dna_flags | Staging model for MD Haystaq DNA flags |
-| stg_dbt_source__l2_s3_md_haystaq_dna_scores | Staging model for MD Haystaq DNA scores |
-| stg_dbt_source__l2_s3_md_uniform | Staging model for MD (Maryland) uniform |
-| stg_dbt_source__l2_s3_md_uniform_data_dictionary | Staging model for MD (Maryland) uniform data dictionary |
-| stg_dbt_source__l2_s3_md_vote_history | Staging model for MD (Maryland) vote history |
-| stg_dbt_source__l2_s3_md_vote_history_data_dictionary | Staging model for MD (Maryland) vote history data dictionary |
-| stg_dbt_source__l2_s3_me_demographic | Staging model for ME (Maine) demographic |
-| stg_dbt_source__l2_s3_me_demographic_data_dictionary | Staging model for ME (Maine) demographic data dictionary |
-| stg_dbt_source__l2_s3_me_haystaq_dna_flags | Staging model for ME Haystaq DNA flags |
-| stg_dbt_source__l2_s3_me_haystaq_dna_scores | Staging model for ME Haystaq DNA scores |
-| stg_dbt_source__l2_s3_me_uniform | Staging model for ME (Maine) uniform |
-| stg_dbt_source__l2_s3_me_uniform_data_dictionary | Staging model for ME (Maine) uniform data dictionary |
-| stg_dbt_source__l2_s3_me_vote_history | Staging model for ME (Maine) vote history |
-| stg_dbt_source__l2_s3_me_vote_history_data_dictionary | Staging model for ME (Maine) vote history data dictionary |
-| stg_dbt_source__l2_s3_mi_demographic | Staging model for MI (Michigan) demographic |
-| stg_dbt_source__l2_s3_mi_demographic_data_dictionary | Staging model for MI (Michigan) demographic data dictionary |
-| stg_dbt_source__l2_s3_mi_haystaq_dna_flags | Staging model for MI Haystaq DNA flags |
-| stg_dbt_source__l2_s3_mi_haystaq_dna_scores | Staging model for MI Haystaq DNA scores |
-| stg_dbt_source__l2_s3_mi_uniform | Staging model for MI (Michigan) uniform |
-| stg_dbt_source__l2_s3_mi_uniform_data_dictionary | Staging model for MI (Michigan) uniform data dictionary |
-| stg_dbt_source__l2_s3_mi_vote_history | Staging model for MI (Michigan) vote history |
-| stg_dbt_source__l2_s3_mi_vote_history_data_dictionary | Staging model for MI (Michigan) vote history data dictionary |
-| stg_dbt_source__l2_s3_mn_demographic | Staging model for MN (Minnesota) demographic |
-| stg_dbt_source__l2_s3_mn_demographic_data_dictionary | Staging model for MN (Minnesota) demographic data dictionary |
-| stg_dbt_source__l2_s3_mn_haystaq_dna_flags | Staging model for MN Haystaq DNA flags |
-| stg_dbt_source__l2_s3_mn_haystaq_dna_scores | Staging model for MN Haystaq DNA scores |
-| stg_dbt_source__l2_s3_mn_uniform | Staging model for MN (Minnesota) uniform |
-| stg_dbt_source__l2_s3_mn_uniform_data_dictionary | Staging model for MN (Minnesota) uniform data dictionary |
-| stg_dbt_source__l2_s3_mn_vote_history | Staging model for MN (Minnesota) vote history |
-| stg_dbt_source__l2_s3_mn_vote_history_data_dictionary | Staging model for MN (Minnesota) vote history data dictionary |
-| stg_dbt_source__l2_s3_mo_demographic | Staging model for MO (Missouri) demographic |
-| stg_dbt_source__l2_s3_mo_demographic_data_dictionary | Staging model for MO (Missouri) demographic data dictionary |
-| stg_dbt_source__l2_s3_mo_haystaq_dna_flags | Staging model for MO Haystaq DNA flags |
-| stg_dbt_source__l2_s3_mo_haystaq_dna_scores | Staging model for MO Haystaq DNA scores |
-| stg_dbt_source__l2_s3_mo_uniform | Staging model for MO (Missouri) uniform |
-| stg_dbt_source__l2_s3_mo_uniform_data_dictionary | Staging model for MO (Missouri) uniform data dictionary |
-| stg_dbt_source__l2_s3_mo_vote_history | Staging model for MO (Missouri) vote history |
-| stg_dbt_source__l2_s3_mo_vote_history_data_dictionary | Staging model for MO (Missouri) vote history data dictionary |
-| stg_dbt_source__l2_s3_ms_demographic | Staging model for MS (Mississippi) demographic |
-| stg_dbt_source__l2_s3_ms_demographic_data_dictionary | Staging model for MS (Mississippi) demographic data dictionary |
-| stg_dbt_source__l2_s3_ms_haystaq_dna_flags | Staging model for MS Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ms_haystaq_dna_scores | Staging model for MS Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ms_uniform | Staging model for MS (Mississippi) uniform |
-| stg_dbt_source__l2_s3_ms_uniform_data_dictionary | Staging model for MS (Mississippi) uniform data dictionary |
-| stg_dbt_source__l2_s3_ms_vote_history | Staging model for MS (Mississippi) vote history |
-| stg_dbt_source__l2_s3_ms_vote_history_data_dictionary | Staging model for MS (Mississippi) vote history data dictionary |
-| stg_dbt_source__l2_s3_mt_demographic | Staging model for MT (Montana) demographic |
-| stg_dbt_source__l2_s3_mt_demographic_data_dictionary | Staging model for MT (Montana) demographic data dictionary |
-| stg_dbt_source__l2_s3_mt_haystaq_dna_flags | Staging model for MT Haystaq DNA flags |
-| stg_dbt_source__l2_s3_mt_haystaq_dna_scores | Staging model for MT Haystaq DNA scores |
-| stg_dbt_source__l2_s3_mt_uniform | Staging model for MT (Montana) uniform |
-| stg_dbt_source__l2_s3_mt_uniform_data_dictionary | Staging model for MT (Montana) uniform data dictionary |
-| stg_dbt_source__l2_s3_mt_vote_history | Staging model for MT (Montana) vote history |
-| stg_dbt_source__l2_s3_mt_vote_history_data_dictionary | Staging model for MT (Montana) vote history data dictionary |
-| stg_dbt_source__l2_s3_nc_demographic | Staging model for NC (North Carolina) demographic |
-| stg_dbt_source__l2_s3_nc_demographic_data_dictionary | Staging model for NC (North Carolina) demographic data dictionary |
-| stg_dbt_source__l2_s3_nc_haystaq_dna_flags | Staging model for NC Haystaq DNA flags |
-| stg_dbt_source__l2_s3_nc_haystaq_dna_scores | Staging model for NC Haystaq DNA scores |
-| stg_dbt_source__l2_s3_nc_uniform | Staging model for NC (North Carolina) uniform |
-| stg_dbt_source__l2_s3_nc_uniform_data_dictionary | Staging model for NC (North Carolina) uniform data dictionary |
-| stg_dbt_source__l2_s3_nc_vote_history | Staging model for NC (North Carolina) vote history |
-| stg_dbt_source__l2_s3_nc_vote_history_data_dictionary | Staging model for NC (North Carolina) vote history data dictionary |
-| stg_dbt_source__l2_s3_nd_demographic | Staging model for ND (North Dakota) demographic |
-| stg_dbt_source__l2_s3_nd_demographic_data_dictionary | Staging model for ND (North Dakota) demographic data dictionary |
-| stg_dbt_source__l2_s3_nd_haystaq_dna_flags | Staging model for ND Haystaq DNA flags |
-| stg_dbt_source__l2_s3_nd_haystaq_dna_scores | Staging model for ND Haystaq DNA scores |
-| stg_dbt_source__l2_s3_nd_uniform | Staging model for ND (North Dakota) uniform |
-| stg_dbt_source__l2_s3_nd_uniform_data_dictionary | Staging model for ND (North Dakota) uniform data dictionary |
-| stg_dbt_source__l2_s3_nd_vote_history | Staging model for ND (North Dakota) vote history |
-| stg_dbt_source__l2_s3_nd_vote_history_data_dictionary | Staging model for ND (North Dakota) vote history data dictionary |
-| stg_dbt_source__l2_s3_ne_demographic | Staging model for NE (Nebraska) demographic |
-| stg_dbt_source__l2_s3_ne_demographic_data_dictionary | Staging model for NE (Nebraska) demographic data dictionary |
-| stg_dbt_source__l2_s3_ne_haystaq_dna_flags | Staging model for NE Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ne_haystaq_dna_scores | Staging model for NE Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ne_uniform | Staging model for NE (Nebraska) uniform |
-| stg_dbt_source__l2_s3_ne_uniform_data_dictionary | Staging model for NE (Nebraska) uniform data dictionary |
-| stg_dbt_source__l2_s3_ne_vote_history | Staging model for NE (Nebraska) vote history |
-| stg_dbt_source__l2_s3_ne_vote_history_data_dictionary | Staging model for NE (Nebraska) vote history data dictionary |
-| stg_dbt_source__l2_s3_nh_demographic | Staging model for NH (New Hampshire) demographic |
-| stg_dbt_source__l2_s3_nh_demographic_data_dictionary | Staging model for NH (New Hampshire) demographic data dictionary |
-| stg_dbt_source__l2_s3_nh_haystaq_dna_flags | Staging model for NH Haystaq DNA flags |
-| stg_dbt_source__l2_s3_nh_haystaq_dna_scores | Staging model for NH Haystaq DNA scores |
-| stg_dbt_source__l2_s3_nh_uniform | Staging model for NH (New Hampshire) uniform |
-| stg_dbt_source__l2_s3_nh_uniform_data_dictionary | Staging model for NH (New Hampshire) uniform data dictionary |
-| stg_dbt_source__l2_s3_nh_vote_history | Staging model for NH (New Hampshire) vote history |
-| stg_dbt_source__l2_s3_nh_vote_history_data_dictionary | Staging model for NH (New Hampshire) vote history data dictionary |
-| stg_dbt_source__l2_s3_nj_demographic | Staging model for NJ (New Jersey) demographic |
-| stg_dbt_source__l2_s3_nj_demographic_data_dictionary | Staging model for NJ (New Jersey) demographic data dictionary |
-| stg_dbt_source__l2_s3_nj_haystaq_dna_flags | Staging model for NJ Haystaq DNA flags |
-| stg_dbt_source__l2_s3_nj_haystaq_dna_scores | Staging model for NJ Haystaq DNA scores |
-| stg_dbt_source__l2_s3_nj_uniform | Staging model for NJ (New Jersey) uniform |
-| stg_dbt_source__l2_s3_nj_uniform_data_dictionary | Staging model for NJ (New Jersey) uniform data dictionary |
-| stg_dbt_source__l2_s3_nj_vote_history | Staging model for NJ (New Jersey) vote history |
-| stg_dbt_source__l2_s3_nj_vote_history_data_dictionary | Staging model for NJ (New Jersey) vote history data dictionary |
-| stg_dbt_source__l2_s3_nm_demographic | Staging model for NM (New Mexico) demographic |
-| stg_dbt_source__l2_s3_nm_demographic_data_dictionary | Staging model for NM (New Mexico) demographic data dictionary |
-| stg_dbt_source__l2_s3_nm_haystaq_dna_flags | Staging model for NM Haystaq DNA flags |
-| stg_dbt_source__l2_s3_nm_haystaq_dna_scores | Staging model for NM Haystaq DNA scores |
-| stg_dbt_source__l2_s3_nm_uniform | Staging model for NM (New Mexico) uniform |
-| stg_dbt_source__l2_s3_nm_uniform_data_dictionary | Staging model for NM (New Mexico) uniform data dictionary |
-| stg_dbt_source__l2_s3_nm_vote_history | Staging model for NM (New Mexico) vote history |
-| stg_dbt_source__l2_s3_nm_vote_history_data_dictionary | Staging model for NM (New Mexico) vote history data dictionary |
-| stg_dbt_source__l2_s3_nv_demographic | Staging model for NV (Nevada) demographic |
-| stg_dbt_source__l2_s3_nv_demographic_data_dictionary | Staging model for NV (Nevada) demographic data dictionary |
-| stg_dbt_source__l2_s3_nv_haystaq_dna_flags | Staging model for NV Haystaq DNA flags |
-| stg_dbt_source__l2_s3_nv_haystaq_dna_scores | Staging model for NV Haystaq DNA scores |
-| stg_dbt_source__l2_s3_nv_uniform | Staging model for NV (Nevada) uniform |
-| stg_dbt_source__l2_s3_nv_uniform_data_dictionary | Staging model for NV (Nevada) uniform data dictionary |
-| stg_dbt_source__l2_s3_nv_vote_history | Staging model for NV (Nevada) vote history |
-| stg_dbt_source__l2_s3_nv_vote_history_data_dictionary | Staging model for NV (Nevada) vote history data dictionary |
-| stg_dbt_source__l2_s3_ny_demographic | Staging model for NY (New York) demographic |
-| stg_dbt_source__l2_s3_ny_demographic_data_dictionary | Staging model for NY (New York) demographic data dictionary |
-| stg_dbt_source__l2_s3_ny_haystaq_dna_flags | Staging model for NY Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ny_haystaq_dna_scores | Staging model for NY Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ny_uniform | Staging model for NY (New York) uniform |
-| stg_dbt_source__l2_s3_ny_uniform_data_dictionary | Staging model for NY (New York) uniform data dictionary |
-| stg_dbt_source__l2_s3_ny_vote_history | Staging model for NY (New York) vote history |
-| stg_dbt_source__l2_s3_ny_vote_history_data_dictionary | Staging model for NY (New York) vote history data dictionary |
-| stg_dbt_source__l2_s3_oh_demographic | Staging model for OH (Ohio) demographic |
-| stg_dbt_source__l2_s3_oh_demographic_data_dictionary | Staging model for OH (Ohio) demographic data dictionary |
-| stg_dbt_source__l2_s3_oh_haystaq_dna_flags | Staging model for OH Haystaq DNA flags |
-| stg_dbt_source__l2_s3_oh_haystaq_dna_scores | Staging model for OH Haystaq DNA scores |
-| stg_dbt_source__l2_s3_oh_uniform | Staging model for OH (Ohio) uniform |
-| stg_dbt_source__l2_s3_oh_uniform_data_dictionary | Staging model for OH (Ohio) uniform data dictionary |
-| stg_dbt_source__l2_s3_oh_vote_history | Staging model for OH (Ohio) vote history |
-| stg_dbt_source__l2_s3_oh_vote_history_data_dictionary | Staging model for OH (Ohio) vote history data dictionary |
-| stg_dbt_source__l2_s3_ok_demographic | Staging model for OK (Oklahoma) demographic |
-| stg_dbt_source__l2_s3_ok_demographic_data_dictionary | Staging model for OK (Oklahoma) demographic data dictionary |
-| stg_dbt_source__l2_s3_ok_haystaq_dna_flags | Staging model for OK Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ok_haystaq_dna_scores | Staging model for OK Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ok_uniform | Staging model for OK (Oklahoma) uniform |
-| stg_dbt_source__l2_s3_ok_uniform_data_dictionary | Staging model for OK (Oklahoma) uniform data dictionary |
-| stg_dbt_source__l2_s3_ok_vote_history | Staging model for OK (Oklahoma) vote history |
-| stg_dbt_source__l2_s3_ok_vote_history_data_dictionary | Staging model for OK (Oklahoma) vote history data dictionary |
-| stg_dbt_source__l2_s3_or_demographic | Staging model for OR (Oregon) demographic |
-| stg_dbt_source__l2_s3_or_demographic_data_dictionary | Staging model for OR (Oregon) demographic data dictionary |
-| stg_dbt_source__l2_s3_or_haystaq_dna_flags | Staging model for OR Haystaq DNA flags |
-| stg_dbt_source__l2_s3_or_haystaq_dna_scores | Staging model for OR Haystaq DNA scores |
-| stg_dbt_source__l2_s3_or_uniform | Staging model for OR (Oregon) uniform |
-| stg_dbt_source__l2_s3_or_uniform_data_dictionary | Staging model for OR (Oregon) uniform data dictionary |
-| stg_dbt_source__l2_s3_or_vote_history | Staging model for OR (Oregon) vote history |
-| stg_dbt_source__l2_s3_or_vote_history_data_dictionary | Staging model for OR (Oregon) vote history data dictionary |
-| stg_dbt_source__l2_s3_pa_demographic | Staging model for PA (Pennsylvania) demographic |
-| stg_dbt_source__l2_s3_pa_demographic_data_dictionary | Staging model for PA (Pennsylvania) demographic data dictionary |
-| stg_dbt_source__l2_s3_pa_haystaq_dna_flags | Staging model for PA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_pa_haystaq_dna_scores | Staging model for PA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_pa_uniform | Staging model for PA (Pennsylvania) uniform |
-| stg_dbt_source__l2_s3_pa_uniform_data_dictionary | Staging model for PA (Pennsylvania) uniform data dictionary |
-| stg_dbt_source__l2_s3_pa_vote_history | Staging model for PA (Pennsylvania) vote history |
-| stg_dbt_source__l2_s3_pa_vote_history_data_dictionary | Staging model for PA (Pennsylvania) vote history data dictionary |
-| stg_dbt_source__l2_s3_ri_demographic | Staging model for RI (Rhode Island) demographic |
-| stg_dbt_source__l2_s3_ri_demographic_data_dictionary | Staging model for RI (Rhode Island) demographic data dictionary |
-| stg_dbt_source__l2_s3_ri_haystaq_dna_flags | Staging model for RI Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ri_haystaq_dna_scores | Staging model for RI Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ri_uniform | Staging model for RI (Rhode Island) uniform |
-| stg_dbt_source__l2_s3_ri_uniform_data_dictionary | Staging model for RI (Rhode Island) uniform data dictionary |
-| stg_dbt_source__l2_s3_ri_vote_history | Staging model for RI (Rhode Island) vote history |
-| stg_dbt_source__l2_s3_ri_vote_history_data_dictionary | Staging model for RI (Rhode Island) vote history data dictionary |
-| stg_dbt_source__l2_s3_sc_demographic | Staging model for SC (South Carolina) demographic |
-| stg_dbt_source__l2_s3_sc_demographic_data_dictionary | Staging model for SC (South Carolina) demographic data dictionary |
-| stg_dbt_source__l2_s3_sc_haystaq_dna_flags | Staging model for SC Haystaq DNA flags |
-| stg_dbt_source__l2_s3_sc_haystaq_dna_scores | Staging model for SC Haystaq DNA scores |
-| stg_dbt_source__l2_s3_sc_uniform | Staging model for SC (South Carolina) uniform |
-| stg_dbt_source__l2_s3_sc_uniform_data_dictionary | Staging model for SC (South Carolina) uniform data dictionary |
-| stg_dbt_source__l2_s3_sc_vote_history | Staging model for SC (South Carolina) vote history |
-| stg_dbt_source__l2_s3_sc_vote_history_data_dictionary | Staging model for SC (South Carolina) vote history data dictionary |
-| stg_dbt_source__l2_s3_sd_demographic | Staging model for SD (South Dakota) demographic |
-| stg_dbt_source__l2_s3_sd_demographic_data_dictionary | Staging model for SD (South Dakota) demographic data dictionary |
-| stg_dbt_source__l2_s3_sd_haystaq_dna_flags | Staging model for SD Haystaq DNA flags |
-| stg_dbt_source__l2_s3_sd_haystaq_dna_scores | Staging model for SD Haystaq DNA scores |
-| stg_dbt_source__l2_s3_sd_uniform | Staging model for SD (South Dakota) uniform |
-| stg_dbt_source__l2_s3_sd_uniform_data_dictionary | Staging model for SD (South Dakota) uniform data dictionary |
-| stg_dbt_source__l2_s3_sd_vote_history | Staging model for SD (South Dakota) vote history |
-| stg_dbt_source__l2_s3_sd_vote_history_data_dictionary | Staging model for SD (South Dakota) vote history data dictionary |
-| stg_dbt_source__l2_s3_tn_demographic | Staging model for TN (Tennessee) demographic |
-| stg_dbt_source__l2_s3_tn_demographic_data_dictionary | Staging model for TN (Tennessee) demographic data dictionary |
-| stg_dbt_source__l2_s3_tn_haystaq_dna_flags | Staging model for TN Haystaq DNA flags |
-| stg_dbt_source__l2_s3_tn_haystaq_dna_scores | Staging model for TN Haystaq DNA scores |
-| stg_dbt_source__l2_s3_tn_uniform | Staging model for TN (Tennessee) uniform |
-| stg_dbt_source__l2_s3_tn_uniform_data_dictionary | Staging model for TN (Tennessee) uniform data dictionary |
-| stg_dbt_source__l2_s3_tn_vote_history | Staging model for TN (Tennessee) vote history |
-| stg_dbt_source__l2_s3_tn_vote_history_data_dictionary | Staging model for TN (Tennessee) vote history data dictionary |
-| stg_dbt_source__l2_s3_tx_demographic | Staging model for TX (Texas) demographic |
-| stg_dbt_source__l2_s3_tx_demographic_data_dictionary | Staging model for TX (Texas) demographic data dictionary |
-| stg_dbt_source__l2_s3_tx_haystaq_dna_flags | Staging model for TX Haystaq DNA flags |
-| stg_dbt_source__l2_s3_tx_haystaq_dna_scores | Staging model for TX Haystaq DNA scores |
-| stg_dbt_source__l2_s3_tx_uniform | Staging model for TX (Texas) uniform |
-| stg_dbt_source__l2_s3_tx_uniform_data_dictionary | Staging model for TX (Texas) uniform data dictionary |
-| stg_dbt_source__l2_s3_tx_vote_history | Staging model for TX (Texas) vote history |
-| stg_dbt_source__l2_s3_tx_vote_history_data_dictionary | Staging model for TX (Texas) vote history data dictionary |
-| stg_dbt_source__l2_s3_ut_demographic | taging model for UT (Utah) demographic |
-| stg_dbt_source__l2_s3_ut_demographic_data_dictionary | Staging model for UT (Utah) demographic data dictionary |
-| stg_dbt_source__l2_s3_ut_haystaq_dna_flags | Staging model for UT Haystaq DNA flags |
-| stg_dbt_source__l2_s3_ut_haystaq_dna_scores | Staging model for UT Haystaq DNA scores |
-| stg_dbt_source__l2_s3_ut_uniform | Staging model for UT (Utah) uniform |
-| stg_dbt_source__l2_s3_ut_uniform_data_dictionary | Staging model for UT (Utah) uniform data dictionary |
-| stg_dbt_source__l2_s3_ut_vote_history | Staging model for UT (Utah) vote history |
-| stg_dbt_source__l2_s3_ut_vote_history_data_dictionary | Staging model for UT (Utah) vote history data dictionary |
-| stg_dbt_source__l2_s3_va_demographic | Staging model for VA (Virginia) demographic |
-| stg_dbt_source__l2_s3_va_demographic_data_dictionary | Staging model for VA (Virginia) demographic data dictionary |
-| stg_dbt_source__l2_s3_va_haystaq_dna_flags | Staging model for VA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_va_haystaq_dna_scores | Staging model for VA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_va_uniform | Staging model for VA (Virginia) uniform |
-| stg_dbt_source__l2_s3_va_uniform_data_dictionary | Staging model for VA (Virginia) uniform data dictionary |
-| stg_dbt_source__l2_s3_va_vote_history | Staging model for VA (Virginia) vote history |
-| stg_dbt_source__l2_s3_va_vote_history_data_dictionary | Staging model for VA (Virginia) vote history data dictionary |
-| stg_dbt_source__l2_s3_vt_demographic | Staging model for VT (Vermont) demographic |
-| stg_dbt_source__l2_s3_vt_demographic_data_dictionary | Staging model for VT (Vermont) demographic data dictionary |
-| stg_dbt_source__l2_s3_vt_haystaq_dna_flags | Staging model for VT Haystaq DNA flags |
-| stg_dbt_source__l2_s3_vt_haystaq_dna_scores | Staging model for VT Haystaq DNA scores |
-| stg_dbt_source__l2_s3_vt_uniform | Staging model for VT (Vermont) uniform |
-| stg_dbt_source__l2_s3_vt_uniform_data_dictionary | Staging model for VT (Vermont) uniform data dictionary |
-| stg_dbt_source__l2_s3_vt_vote_history | Staging model for VT (Vermont) vote history |
-| stg_dbt_source__l2_s3_vt_vote_history_data_dictionary | Staging model for VT (Vermont) vote history data dictionary |
-| stg_dbt_source__l2_s3_wa_demographic | Staging model for WA (Washington) demographic |
-| stg_dbt_source__l2_s3_wa_demographic_data_dictionary | Staging model for WA (Washington) demographic data dictionary |
-| stg_dbt_source__l2_s3_wa_haystaq_dna_flags | Staging model for WA Haystaq DNA flags |
-| stg_dbt_source__l2_s3_wa_haystaq_dna_scores | Staging model for WA Haystaq DNA scores |
-| stg_dbt_source__l2_s3_wa_uniform | Staging model for WA (Washington) uniform |
-| stg_dbt_source__l2_s3_wa_uniform_data_dictionary | Staging model for WA (Washington) uniform data dictionary |
-| stg_dbt_source__l2_s3_wa_vote_history | Staging model for WA (Washington) vote history |
-| stg_dbt_source__l2_s3_wa_vote_history_data_dictionary | Staging model for WA (Washington) vote history data dictionary |
-| stg_dbt_source__l2_s3_wi_demographic | Staging model for WI (Wisconsin) demographic |
-| stg_dbt_source__l2_s3_wi_demographic_data_dictionary | Staging model for WI (Wisconsin) demographic data dictionary |
-| stg_dbt_source__l2_s3_wi_haystaq_dna_flags | Staging model for WI Haystaq DNA flags |
-| stg_dbt_source__l2_s3_wi_haystaq_dna_scores | Staging model for WI Haystaq DNA scores |
-| stg_dbt_source__l2_s3_wi_uniform | Staging model for WI (Wisconsin) uniform |
-| stg_dbt_source__l2_s3_wi_uniform_data_dictionary | Staging model for WI (Wisconsin) uniform data dictionary |
-| stg_dbt_source__l2_s3_wi_vote_history | Staging model for WI (Wisconsin) vote history |
-| stg_dbt_source__l2_s3_wi_vote_history_data_dictionary | Staging model for WI (Wisconsin) vote history data dictionary |
-| stg_dbt_source__l2_s3_wv_demographic | Staging model for WV (West Virginia) demographic |
-| stg_dbt_source__l2_s3_wv_demographic_data_dictionary | Staging model for WV (West Virginia) demographic data dictionary |
-| stg_dbt_source__l2_s3_wv_haystaq_dna_flags | Staging model for WV Haystaq DNA flags |
-| stg_dbt_source__l2_s3_wv_haystaq_dna_scores | Staging model for WV Haystaq DNA scores |
-| stg_dbt_source__l2_s3_wv_uniform | Staging model for WV (West Virginia) uniform |
-| stg_dbt_source__l2_s3_wv_uniform_data_dictionary | Staging model for WV (West Virginia) uniform data dictionary |
-| stg_dbt_source__l2_s3_wv_vote_history | Staging model for WV (West Virginia) vote history |
-| stg_dbt_source__l2_s3_wv_vote_history_data_dictionary | Staging model for WV (West Virginia) vote history data dictionary |
-| stg_dbt_source__l2_s3_wy_demographic | Staging model for WY (Wyoming) demographic |
-| stg_dbt_source__l2_s3_wy_demographic_data_dictionary | Staging model for WY (Wyoming) demographic data dictionary |
-| stg_dbt_source__l2_s3_wy_haystaq_dna_flags | Staging model for WY Haystaq DNA flags |
-| stg_dbt_source__l2_s3_wy_haystaq_dna_scores | Staging model for WY Haystaq DNA scores |
-| stg_dbt_source__l2_s3_wy_uniform | Staging model for WY (Wyoming) uniform |
-| stg_dbt_source__l2_s3_wy_uniform_data_dictionary | Staging model for WY (Wyoming) uniform data dictionary |
-| stg_dbt_source__l2_s3_wy_vote_history | Staging model for WY (Wyoming) vote history |
-| stg_dbt_source__l2_s3_wy_vote_history_data_dictionary | Staging model for WY (Wyoming) vote history data dictionary |
-| stg_er_source__clustered_candidacy_stages | Staged cluster assignments from the Splink entity resolution pipeline… |
-| stg_er_source__clustered_elected_officials | Match groups bridging gp-api elected-office records to BR+TS terms… |
-| stg_er_source__clustered_election_stages | Staged cluster assignments from the election-stage Splink entity resolution pipeline… |
-| stg_er_source__pairwise_candidacy_stages | Staged pairwise predictions from the Splink entity resolution pipeline… |
-| stg_er_source__pairwise_elected_officials | Staged pairwise predictions from the elected officials entity resolution pipeline… |
-| stg_model_predictions__ballots_projected_2026_v2 | Turnout projections for 2026 (v2 replacing original even years 2026 data) |
-| stg_model_predictions__ballots_projected_2027 | Turnout projections for 2027 |
-| stg_model_predictions__ballots_projected_2028 | Turnout projections for 2028 |
-| stg_model_predictions__candidacy_br_matches_20251204 | fuzzy matching between BallotReady election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__candidacy_br_matches_prenov2025_20251205 | fuzzy matching between BallotReady election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__candidacy_ddhq_matches_20250826 | gemini outputs to string match DDHQ election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__candidacy_ddhq_matches_20250909 | gemini outputs to string match DDHQ election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__candidacy_ddhq_matches_20250916 | gemini outputs to string match DDHQ election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__candidacy_ddhq_matches_20251016 | gemini outputs to string match DDHQ election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__candidacy_ddhq_matches_20251112 | gemini outputs to string match DDHQ election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__candidacy_ddhq_matches_20251202 | gemini outputs to string match DDHQ election results and candidacies sourced from m_general__candidacy |
-| stg_model_predictions__llm_l2_br_match_20250806 | gemini outputs to string match L2 districts to BallotReady positions/offices |
-| stg_model_predictions__llm_l2_br_match_20250811 | gemini outputs to string match L2 districts to BallotReady positions/offices |
-| stg_model_predictions__llm_l2_br_match_20260126 | gemini outputs to string match L2 districts to BallotReady positions/offices |
-| stg_model_predictions__manual_llm_election_results_20251208 | manually orchestrated LLM election decision results for candidacies sourced from m_general__candidacy |
-| stg_model_predictions__turnout_projections_even_years_20250709 | Turnout projections data load from model predictions |
-| stg_model_predictions__turnout_projections_model2odd | Turnout projections data load from model predictions |
-| stg_model_predictions__viability_scores | Viability scores data load from model predictions |
-| stg_nhgis__block_population | 2020 decennial census population per census block, unioned from the two research-staged NHGIS extracts… |
-| stg_segment_storage_source__gp_api_account_password_reset_requested | (no description) |
-| stg_segment_storage_source__gp_api_campaign_verify_token_status_update | (no description) |
-| stg_segment_storage_source__gp_api_content_builder_generation_completed | (no description) |
-| stg_segment_storage_source__gp_api_content_builder_generation_started | (no description) |
-| stg_segment_storage_source__gp_api_identifies | Segment identify calls from GP API linking anonymous IDs to known users |
-| stg_segment_storage_source__gp_api_onboarding_user_created | (no description) |
-| stg_segment_storage_source__gp_api_peerly_identity_id_created | Segment event fired when a Peerly identity ID is created for 10DLC compliance |
-| stg_segment_storage_source__gp_api_poll_results_synthesis_complete | (no description) |
-| stg_segment_storage_source__gp_api_tracks | Segment track calls from GP API capturing user actions and events |
-| stg_segment_storage_source__gp_api_users | Segment user profiles from GP API with traits and properties |
-| stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_completed | (no description) |
-| stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_pin_submitted | Segment event fired when a user submits their 10DLC compliance PIN |
-| stg_segment_storage_source__web_app__10_dlc_compliance_pin_verification_completed | Segment web app event fired when 10DLC compliance PIN verification completes |
-| stg_segment_storage_source__web_app__10_dlc_compliance_registration_submitted | (no description) |
-| stg_segment_storage_source__web_app_account_password_reset_completed | (no description) |
-| stg_segment_storage_source__web_app_ai_assistant_ask_a_question | (no description) |
-| stg_segment_storage_source__web_app_ai_assistant_click_new_chat | (no description) |
-| stg_segment_storage_source__web_app_ai_assistant_click_view_chat_history | (no description) |
-| stg_segment_storage_source__web_app_ai_content_generation_start | (no description) |
-| stg_segment_storage_source__web_app_campaign_assistant_chatbot_input | (no description) |
-| stg_segment_storage_source__web_app_candidacy_did_you_win_modal_completed | (no description) |
-| stg_segment_storage_source__web_app_candidacy_did_you_win_modal_viewed | (no description) |
-| stg_segment_storage_source__web_app_candidate_website_continued | (no description) |
-| stg_segment_storage_source__web_app_candidate_website_edited | (no description) |
-| stg_segment_storage_source__web_app_candidate_website_published | (no description) |
-| stg_segment_storage_source__web_app_candidate_website_purchased_domain | (no description) |
-| stg_segment_storage_source__web_app_candidate_website_selected_domain | (no description) |
-| stg_segment_storage_source__web_app_candidate_website_started | (no description) |
-| stg_segment_storage_source__web_app_candidate_website_started_domain_selection | (no description) |
-| stg_segment_storage_source__web_app_content_builder_click_content | (no description) |
-| stg_segment_storage_source__web_app_content_builder_click_continue_questions | (no description) |
-| stg_segment_storage_source__web_app_content_builder_click_generate | (no description) |
-| stg_segment_storage_source__web_app_content_builder_close_additional_inputs | (no description) |
-| stg_segment_storage_source__web_app_content_builder_editor_click_regenerate | (no description) |
-| stg_segment_storage_source__web_app_content_builder_editor_open_version_picker | (no description) |
-| stg_segment_storage_source__web_app_content_builder_editor_submit_regenerate | (no description) |
-| stg_segment_storage_source__web_app_content_builder_select_template | (no description) |
-| stg_segment_storage_source__web_app_content_builder_submit_additional_inputs | (no description) |
-| stg_segment_storage_source__web_app_custom_voter_file_created | (no description) |
-| stg_segment_storage_source__web_app_dashboard_candidate_dashboard_viewed | (no description) |
-| stg_segment_storage_source__web_app_dashboard_path_to_victory_exit_understand_path_to_victory | (no description) |
-| stg_segment_storage_source__web_app_download_voter_file_attempt | (no description) |
-| stg_segment_storage_source__web_app_download_voter_file_failure | (no description) |
-| stg_segment_storage_source__web_app_download_voter_file_success | (no description) |
-| stg_segment_storage_source__web_app_exposure | (no description) |
-| stg_segment_storage_source__web_app_identifies | Segment identify calls from web app linking anonymous IDs to known users |
-| stg_segment_storage_source__web_app_invalid_party | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_ai_assistant | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_community | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_contacts | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_content_builder | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_dashboard | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_door_knocking | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_my_profile | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_polls | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_resources | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_voter_data | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_voter_outreach | (no description) |
-| stg_segment_storage_source__web_app_navigation_dashboard_click_website | (no description) |
-| stg_segment_storage_source__web_app_navigation_top_avatar_dropdown_click_logout | (no description) |
-| stg_segment_storage_source__web_app_navigation_top_avatar_dropdown_click_settings | (no description) |
-| stg_segment_storage_source__web_app_navigation_top_avatar_dropdown_close_dropdown | (no description) |
-| stg_segment_storage_source__web_app_navigation_top_click_avatar_dropdown | (no description) |
-| stg_segment_storage_source__web_app_navigation_top_click_logo | (no description) |
-| stg_segment_storage_source__web_app_onboarding_candidate_affiliation_completed | (no description) |
-| stg_segment_storage_source__web_app_onboarding_candidate_office_completed | (no description) |
-| stg_segment_storage_source__web_app_onboarding_candidate_office_searched | (no description) |
-| stg_segment_storage_source__web_app_onboarding_candidate_pledge_completed | (no description) |
-| stg_segment_storage_source__web_app_onboarding_click_finish_later | (no description) |
-| stg_segment_storage_source__web_app_onboarding_complete | (no description) |
-| stg_segment_storage_source__web_app_onboarding_complete_step_click_go_to_dashboard | (no description) |
-| stg_segment_storage_source__web_app_onboarding_office_step_click_can_t_see_office | (no description) |
-| stg_segment_storage_source__web_app_onboarding_office_step_click_next | (no description) |
-| stg_segment_storage_source__web_app_onboarding_office_step_office_selected | (no description) |
-| stg_segment_storage_source__web_app_onboarding_party_step_click_submit | (no description) |
-| stg_segment_storage_source__web_app_onboarding_pledge_step_click_submit | (no description) |
-| stg_segment_storage_source__web_app_onboarding_registration_completed | (no description) |
-| stg_segment_storage_source__web_app_outreach_action_clicked | (no description) |
-| stg_segment_storage_source__web_app_outreach_click_create | (no description) |
-| stg_segment_storage_source__web_app_outreach_door_knocking_complete | (no description) |
-| stg_segment_storage_source__web_app_outreach_phone_banking_complete | (no description) |
-| stg_segment_storage_source__web_app_outreach_view_accessed | (no description) |
-| stg_segment_storage_source__web_app_p2p_upgrade_modal_click_button | (no description) |
-| stg_segment_storage_source__web_app_p2p_upgrade_modal_exit | (no description) |
-| stg_segment_storage_source__web_app_p2p_upgrade_modal_modal_shown | (no description) |
-| stg_segment_storage_source__web_app_pages | Segment page view events from web app tracking user navigation |
-| stg_segment_storage_source__web_app_polls_create_poll_clicked | (no description) |
-| stg_segment_storage_source__web_app_polls_poll_question_viewed | (no description) |
-| stg_segment_storage_source__web_app_polls_poll_results_issue_details_viewed | (no description) |
-| stg_segment_storage_source__web_app_polls_poll_results_overview_viewed | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_click_exit_top_nav | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_click_go_to_stripe | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_click_next | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_click_upload | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_hover_ein_number_help | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_hover_upload_help | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_toggle_ein_requirement | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_complete | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_confirm_office | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_edit_office | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_modal_click_button | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_modal_exit | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_modal_modal_shown | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_service_agreement_page_click_finish | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_splash_page_click_upgrade | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_splash_page_exit | (no description) |
-| stg_segment_storage_source__web_app_pro_upgrade_submit_edit_office | (no description) |
-| stg_segment_storage_source__web_app_profile_campaign_details_click_save | (no description) |
-| stg_segment_storage_source__web_app_profile_fun_fact_click_save | (no description) |
-| stg_segment_storage_source__web_app_profile_office_details_click_edit | (no description) |
-| stg_segment_storage_source__web_app_profile_running_against_cancel_add_new | (no description) |
-| stg_segment_storage_source__web_app_profile_running_against_click_add_new | (no description) |
-| stg_segment_storage_source__web_app_profile_running_against_click_edit | (no description) |
-| stg_segment_storage_source__web_app_profile_running_against_click_save | (no description) |
-| stg_segment_storage_source__web_app_profile_running_against_submit_add_new | (no description) |
-| stg_segment_storage_source__web_app_profile_running_against_submit_edit | (no description) |
-| stg_segment_storage_source__web_app_profile_top_issues_click_finish_entering_issues | (no description) |
-| stg_segment_storage_source__web_app_profile_why_section_click_save | (no description) |
-| stg_segment_storage_source__web_app_question_complete | (no description) |
-| stg_segment_storage_source__web_app_resources_resource_clicked | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_age | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_audience | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_gender | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_political_party | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_audience_enter_audience_request | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_back | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_exit | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_next | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_script_click_add_your_own_script | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_script_click_generate_a_new_script | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_script_click_use_a_saved_script | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_script_select_saved_script | (no description) |
-| stg_segment_storage_source__web_app_schedule_text_campaign_script_submit_added_script | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_add_image_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_constituency_profile_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_getting_started_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_meet_your_constituents_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_poll_preview_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_poll_strategy_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_poll_value_props_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_sms_poll_sent | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_success_page_viewed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_sworn_in_completed | (no description) |
-| stg_segment_storage_source__web_app_serve_onboarding_sworn_in_viewed | (no description) |
-| stg_segment_storage_source__web_app_set_password_click_set_password | (no description) |
-| stg_segment_storage_source__web_app_settings_account_settings_click_upgrade | (no description) |
-| stg_segment_storage_source__web_app_settings_delete_account_click_delete | (no description) |
-| stg_segment_storage_source__web_app_settings_delete_account_submit_delete | (no description) |
-| stg_segment_storage_source__web_app_settings_notifications_toggle_email | (no description) |
-| stg_segment_storage_source__web_app_settings_personal_info_click_save | (no description) |
-| stg_segment_storage_source__web_app_settings_personal_info_click_upload | (no description) |
-| stg_segment_storage_source__web_app_sign_in_click_create_account | (no description) |
-| stg_segment_storage_source__web_app_sign_in_click_forgot_password | (no description) |
-| stg_segment_storage_source__web_app_sign_up_click_login | (no description) |
-| stg_segment_storage_source__web_app_tracks | Segment track calls from web app capturing user actions and events |
-| stg_segment_storage_source__web_app_users | Segment user profiles from web app with traits and properties |
-| stg_segment_storage_source__web_app_usersnap_submission | (no description) |
-| stg_segment_storage_source__web_app_voter_data_click_create_custom_voter_file | (no description) |
-| stg_segment_storage_source__web_app_voter_data_click_detail_view | (no description) |
-| stg_segment_storage_source__web_app_voter_data_custom_voter_file_click_create | (no description) |
-| stg_segment_storage_source__web_app_voter_data_custom_voter_file_click_next | (no description) |
-| stg_segment_storage_source__web_app_voter_data_custom_voter_file_exit_modal | (no description) |
-| stg_segment_storage_source__web_app_voter_data_custom_voter_file_select_channel | (no description) |
-| stg_segment_storage_source__web_app_voter_data_custom_voter_file_select_purpose | (no description) |
-| stg_segment_storage_source__web_app_voter_data_file_detail_click_back | (no description) |
-| stg_segment_storage_source__web_app_voter_data_file_detail_click_custom_file_info_icon | (no description) |
-| stg_segment_storage_source__web_app_voter_data_file_detail_click_download_csv | (no description) |
-| stg_segment_storage_source__web_app_voter_data_file_detail_click_view_audience_filters | (no description) |
-| stg_segment_storage_source__web_app_voter_outreach_10dlc_compliance_form_submitted | (no description) |
-| stg_segment_storage_source__web_app_voter_outreach_10dlc_compliance_started | (no description) |
-| stg_segment_storage_source__web_app_voter_outreach_campaign_completed | (no description) |
-| us_states | (no description) |
-| users | Goodparty.org application users, with aggregate campaign counts appended… |
-| write__election_api_db | This model writes data to the election api database. |
-| write__l2_databricks_to_gp_api | This model writes data from Databricks to the voter db in gp-api. |
-| write__l2_databricks_to_people_api | This model writes data from Databricks to the people api database. |
+Column names/types for any table: `DESCRIBE goodparty_data_catalog.dbt.<table>`
+or query `goodparty_data_catalog.information_schema.columns`.
+
+| table | type | columns |
+|---|---|---|
+| campaigns | MANAGED | 22 |
+| clean_states | MANAGED | 2 |
+| deid_voters | MANAGED | 315 |
+| election_api_race_filing_address_overrides | MANAGED | 4 |
+| fips_codes | MANAGED | 3 |
+| haystaq_issue_tags | MANAGED | 6 |
+| hubspot_call_dispositions | MANAGED | 5 |
+| hubspot_contact_property_columns | MANAGED | 12 |
+| icp_normalized_position_names | MANAGED | 5 |
+| int__amplitude_event_catalog | MANAGED | 17 |
+| int__amplitude_event_taxonomy | MANAGED | 6 |
+| int__amplitude_serve_activity | VIEW | 7 |
+| int__amplitude_user_milestones | VIEW | 18 |
+| int__amplitude_win_activity | VIEW | 14 |
+| int__amplitude_win_activity_weekly | VIEW | 15 |
+| int__ballotready_candidacy | MANAGED | 15 |
+| int__ballotready_candidate_identity | MANAGED | 6 |
+| int__ballotready_endorsement | MANAGED | 4 |
+| int__ballotready_filing_period | MANAGED | 8 |
+| int__ballotready_geofence | MANAGED | 14 |
+| int__ballotready_issue | MANAGED | 9 |
+| int__ballotready_normalized_position | MANAGED | 8 |
+| int__ballotready_party | MANAGED | 4 |
+| int__ballotready_person | MANAGED | 19 |
+| int__ballotready_position_election_frequency | MANAGED | 7 |
+| int__ballotready_position_to_place | VIEW | 4 |
+| int__ballotready_stance | MANAGED | 4 |
+| int__civics_candidacy_2025 | MANAGED | 32 |
+| int__civics_candidacy_ballotready | MANAGED | 31 |
+| int__civics_candidacy_ddhq | MANAGED | 30 |
+| int__civics_candidacy_gp_api | MANAGED | 32 |
+| int__civics_candidacy_stage_2025 | MANAGED | 19 |
+| int__civics_candidacy_stage_ballotready | MANAGED | 20 |
+| int__civics_candidacy_stage_ddhq | MANAGED | 35 |
+| int__civics_candidacy_stage_gp_api | MANAGED | 19 |
+| int__civics_candidacy_stage_techspeed | MANAGED | 18 |
+| int__civics_candidacy_techspeed | MANAGED | 34 |
+| int__civics_candidate_2025 | MANAGED | 20 |
+| int__civics_candidate_ballotready | MANAGED | 21 |
+| int__civics_candidate_ddhq | MANAGED | 20 |
+| int__civics_candidate_gp_api | MANAGED | 19 |
+| int__civics_candidate_techspeed | MANAGED | 19 |
+| int__civics_elected_official_ballotready | MANAGED | 48 |
+| int__civics_elected_official_ballotready_person | MANAGED | 35 |
+| int__civics_elected_official_canonical_ids | MANAGED | 6 |
+| int__civics_elected_official_ddhq | MANAGED | 12 |
+| int__civics_elected_official_ddhq_matched_votes | MANAGED | 3 |
+| int__civics_elected_official_gp_api | MANAGED | 37 |
+| int__civics_elected_official_gp_api_bridge | MANAGED | 12 |
+| int__civics_elected_official_gp_api_person | MANAGED | 22 |
+| int__civics_elected_official_techspeed | MANAGED | 32 |
+| int__civics_elected_official_techspeed_person | MANAGED | 28 |
+| int__civics_election_2025 | MANAGED | 25 |
+| int__civics_election_ballotready | MANAGED | 25 |
+| int__civics_election_ddhq | MANAGED | 26 |
+| int__civics_election_stage_2025 | MANAGED | 9 |
+| int__civics_election_stage_ballotready | MANAGED | 29 |
+| int__civics_election_stage_ddhq | MANAGED | 30 |
+| int__civics_election_stage_techspeed | MANAGED | 28 |
+| int__civics_election_techspeed | MANAGED | 25 |
+| int__civics_er_canonical_election_stages | MANAGED | 3 |
+| int__civics_er_canonical_ids | MANAGED | 10 |
+| int__civics_minted_candidacy_ids | MANAGED | 7 |
+| int__civics_minted_election_stage_ids | MANAGED | 7 |
+| int__civics_person_canonical_ids | MANAGED | 8 |
+| int__civics_person_edges | MANAGED | 4 |
+| int__civics_person_groups | MANAGED | 5 |
+| int__civics_person_nodes | MANAGED | 2 |
+| int__civics_position_office_type | MANAGED | 3 |
+| int__civics_viability_scoring | MANAGED | 6 |
+| int__ddhq_election_results_clean | MANAGED | 20 |
+| int__ddhq_election_results_embeddings | MANAGED | 22 |
+| int__ddhq_races | VIEW | 12 |
+| int__district_census_allocation | MANAGED | 13 |
+| int__enhanced_place | MANAGED | 19 |
+| int__enhanced_place_w_parent | MANAGED | 19 |
+| int__enhanced_position | MANAGED | 18 |
+| int__enhanced_position_w_parent | MANAGED | 17 |
+| int__enhanced_race | MANAGED | 34 |
+| int__er_election_stage_candidacy_clusters | MANAGED | 3 |
+| int__er_prematch_candidacy_stages | MANAGED | 25 |
+| int__er_prematch_elected_officials | MANAGED | 31 |
+| int__er_prematch_election_stages | VIEW | 21 |
+| int__general_candidacy | MANAGED | 48 |
+| int__general_candidacy_clean_for_ddhq | MANAGED | 50 |
+| int__general_candidacy_embeddings_for_ddhq | MANAGED | 51 |
+| int__general_states_zip_code_range | VIEW | 2 |
+| int__geo_id_attributes | MANAGED | 6 |
+| int__gp_ai_candidacies | VIEW | 13 |
+| int__gp_ai_election_match | MANAGED | 37 |
+| int__gp_ai_start_election_match | MANAGED | 9 |
+| int__hs_companies_recent | VIEW | 34 |
+| int__hs_companies_with_contacts | VIEW | 47 |
+| int__hubspot_calls | VIEW | 28 |
+| int__hubspot_candidate_codes | MANAGED | 6 |
+| int__hubspot_companies_archive_2025 | VIEW | 530 |
+| int__hubspot_companies_w_contacts_2025 | MANAGED | 47 |
+| int__hubspot_contact_calls | VIEW | 15 |
+| int__hubspot_contacts | VIEW | 47 |
+| int__hubspot_contacts_2025 | MANAGED | 39 |
+| int__hubspot_contacts_archive_2025 | VIEW | 889 |
+| int__hubspot_contacts_w_companies | MANAGED | 68 |
+| int__hubspot_contest | VIEW | 29 |
+| int__hubspot_contest_2025 | MANAGED | 24 |
+| int__hubspot_prospect_contacts | VIEW | 51 |
+| int__icp_offices | VIEW | 16 |
+| int__l2_block_district_map | MANAGED | 7 |
+| int__l2_district_aggregations | MANAGED | 8 |
+| int__l2_nationwide_haystaq_flags | MANAGED | 187 |
+| int__l2_nationwide_haystaq_scores | MANAGED | 406 |
+| int__l2_nationwide_uniform | MANAGED | 807 |
+| int__l2_nationwide_uniform_w_haystaq | MANAGED | 1396 |
+| int__model_prediction_voter_turnout | MANAGED | 8 |
+| int__place_fast_facts | MANAGED | 16 |
+| int__place_fun_facts | MANAGED | 16 |
+| int__position_fast_facts | MANAGED | 16 |
+| int__position_fun_facts | MANAGED | 16 |
+| int__race_to_positions | MANAGED | 3 |
+| int__serve_active_user | MANAGED | 4 |
+| int__serve_block_coverage | MANAGED | 5 |
+| int__serve_district_resolution | MANAGED | 24 |
+| int__voter_turnout_lgbm_inference | MANAGED | 8 |
+| int__zip_code_to_br_office | MANAGED | 19 |
+| int__zip_code_to_l2_district | MANAGED | 7 |
+| l2_br_match_overrides | MANAGED | 6 |
+| l2_column_classification | MANAGED | 6 |
+| load__l2_haystaq_s3_to_databricks | MANAGED | 9 |
+| load__l2_haystaq_sftp_to_s3 | MANAGED | 7 |
+| load__l2_s3_to_databricks | MANAGED | 9 |
+| load__l2_sftp_to_s3 | MANAGED | 7 |
+| m_election_api__candidacy | MANAGED | 24 |
+| m_election_api__district | MANAGED | 9 |
+| m_election_api__district_top_issues | MANAGED | 16 |
+| m_election_api__elected_official_support | MANAGED | 5 |
+| m_election_api__issue | MANAGED | 8 |
+| m_election_api__office_holder | MANAGED | 33 |
+| m_election_api__person | MANAGED | 21 |
+| m_election_api__place | MANAGED | 18 |
+| m_election_api__position | MANAGED | 12 |
+| m_election_api__projected_turnout | MANAGED | 9 |
+| m_election_api__race | MANAGED | 36 |
+| m_election_api__stance | MANAGED | 9 |
+| m_election_api__zip_to_position | MANAGED | 14 |
+| m_general__candidacy | MANAGED | 68 |
+| m_general__candidacy_preview | MANAGED | 80 |
+| m_general__candidacy_stage | MANAGED | 16 |
+| m_general__candidacy_v2 | MANAGED | 26 |
+| m_general__candidate | MANAGED | 20 |
+| m_general__candidate_v2 | MANAGED | 19 |
+| m_general__contest | MANAGED | 39 |
+| m_general__election | MANAGED | 21 |
+| m_general__election_stage | MANAGED | 9 |
+| m_people_api__district | VIEW | 6 |
+| m_people_api__districtstats | MANAGED | 5 |
+| m_people_api__districtvoter | MANAGED | 7 |
+| m_people_api__voter | MANAGED | 353 |
+| metricflow_time_spine | MANAGED | 1 |
+| nicknames | MANAGED | 3 |
+| serve_agent_voters_columns | MANAGED | 6 |
+| snapshot__hubspot_api_companies | MANAGED | 534 |
+| snapshot__hubspot_api_contacts | MANAGED | 893 |
+| snapshot__hubspot_api_deals | MANAGED | 667 |
+| snapshot__int__civics_person_canonical_ids | MANAGED | 12 |
+| snapshot__int__l2_nationwide_uniform | MANAGED | 1414 |
+| states_zip_code_range | MANAGED | 2 |
+| stg_airbyte_internal__raw_gp_api_db_campaign | VIEW | 23 |
+| stg_airbyte_source__amplitude_api_active_users | VIEW | 6 |
+| stg_airbyte_source__amplitude_api_annotations | VIEW | 8 |
+| stg_airbyte_source__amplitude_api_average_session_length | VIEW | 6 |
+| stg_airbyte_source__amplitude_api_cohorts | VIEW | 30 |
+| stg_airbyte_source__amplitude_api_events | VIEW | 59 |
+| stg_airbyte_source__amplitude_api_events_list | VIEW | 17 |
+| stg_airbyte_source__amplitude_taxonomy_event_type | VIEW | 15 |
+| stg_airbyte_source__ballotready_api_election | VIEW | 21 |
+| stg_airbyte_source__ballotready_api_issue | VIEW | 9 |
+| stg_airbyte_source__ballotready_api_mtfcc | VIEW | 8 |
+| stg_airbyte_source__ballotready_api_place | VIEW | 25 |
+| stg_airbyte_source__ballotready_api_position | VIEW | 50 |
+| stg_airbyte_source__ballotready_api_position_to_place | VIEW | 9 |
+| stg_airbyte_source__ballotready_api_race | VIEW | 19 |
+| stg_airbyte_source__ballotready_s3_candidacies_v3 | VIEW | 47 |
+| stg_airbyte_source__ballotready_s3_office_holders_v3 | VIEW | 56 |
+| stg_airbyte_source__ballotready_s3_recruitment_v1 | VIEW | 47 |
+| stg_airbyte_source__ballotready_s3_uscities_v1_77 | VIEW | 97 |
+| stg_airbyte_source__ballotready_s3_uscounties_v1_73 | VIEW | 84 |
+| stg_airbyte_source__ddhq_elections_gsheet_reported_races | VIEW | 11 |
+| stg_airbyte_source__ddhq_elections_gsheet_upcoming_races | VIEW | 11 |
+| stg_airbyte_source__ddhq_gdrive_election_results | VIEW | 34 |
+| stg_airbyte_source__ddhq_gdrive_election_results_invalid | VIEW | 12 |
+| stg_airbyte_source__gp_api_db_annotation | VIEW | 18 |
+| stg_airbyte_source__gp_api_db_annotation_bug_report | VIEW | 7 |
+| stg_airbyte_source__gp_api_db_annotation_note | VIEW | 8 |
+| stg_airbyte_source__gp_api_db_annotation_note_attachment | VIEW | 15 |
+| stg_airbyte_source__gp_api_db_annotation_review | VIEW | 10 |
+| stg_airbyte_source__gp_api_db_artifact_feedback | VIEW | 14 |
+| stg_airbyte_source__gp_api_db_artifact_review | VIEW | 13 |
+| stg_airbyte_source__gp_api_db_campaign | VIEW | 22 |
+| stg_airbyte_source__gp_api_db_campaign_position | VIEW | 12 |
+| stg_airbyte_source__gp_api_db_chat_conversation | VIEW | 13 |
+| stg_airbyte_source__gp_api_db_chat_message | VIEW | 10 |
+| stg_airbyte_source__gp_api_db_community_issue | VIEW | 17 |
+| stg_airbyte_source__gp_api_db_domain | VIEW | 14 |
+| stg_airbyte_source__gp_api_db_ecanvasser | VIEW | 11 |
+| stg_airbyte_source__gp_api_db_ecanvasser_contact | VIEW | 27 |
+| stg_airbyte_source__gp_api_db_ecanvasser_house | VIEW | 11 |
+| stg_airbyte_source__gp_api_db_ecanvasser_interaction | VIEW | 16 |
+| stg_airbyte_source__gp_api_db_elected_office | VIEW | 11 |
+| stg_airbyte_source__gp_api_db_election_type | VIEW | 10 |
+| stg_airbyte_source__gp_api_db_experiment_run | VIEW | 21 |
+| stg_airbyte_source__gp_api_db_meeting_briefing | VIEW | 15 |
+| stg_airbyte_source__gp_api_db_organization | VIEW | 11 |
+| stg_airbyte_source__gp_api_db_outreach | VIEW | 23 |
+| stg_airbyte_source__gp_api_db_path_to_victory | VIEW | 9 |
+| stg_airbyte_source__gp_api_db_poll | VIEW | 18 |
+| stg_airbyte_source__gp_api_db_poll_individual_message | VIEW | 15 |
+| stg_airbyte_source__gp_api_db_poll_issues | VIEW | 13 |
+| stg_airbyte_source__gp_api_db_position | VIEW | 9 |
+| stg_airbyte_source__gp_api_db_race_opponent_contrast | VIEW | 20 |
+| stg_airbyte_source__gp_api_db_race_opponent_research | VIEW | 16 |
+| stg_airbyte_source__gp_api_db_race_opponent_standout_action | VIEW | 15 |
+| stg_airbyte_source__gp_api_db_race_opponent_summary | VIEW | 11 |
+| stg_airbyte_source__gp_api_db_tcr_compliance | VIEW | 21 |
+| stg_airbyte_source__gp_api_db_top_issue | VIEW | 8 |
+| stg_airbyte_source__gp_api_db_user | VIEW | 20 |
+| stg_airbyte_source__gp_api_db_website | VIEW | 11 |
+| stg_airbyte_source__gp_api_db_website_contact | VIEW | 13 |
+| stg_airbyte_source__gp_api_db_website_view | VIEW | 8 |
+| stg_airbyte_source__hubspot_api_companies | VIEW | 38 |
+| stg_airbyte_source__hubspot_api_contacts | VIEW | 353 |
+| stg_airbyte_source__hubspot_api_deals | VIEW | 648 |
+| stg_airbyte_source__hubspot_api_engagements | VIEW | 111 |
+| stg_airbyte_source__hubspot_api_engagements_calls | VIEW | 25 |
+| stg_airbyte_source__hubspot_api_feedback_submissions | VIEW | 24 |
+| stg_airbyte_source__hubspot_api_owners | VIEW | 14 |
+| stg_airbyte_source__hubspot_api_owners_archived | VIEW | 14 |
+| stg_airbyte_source__hubspot_api_tickets | VIEW | 371 |
+| stg_airbyte_source__stripe_api_accounts | VIEW | 27 |
+| stg_airbyte_source__stripe_api_application_fees | VIEW | 20 |
+| stg_airbyte_source__stripe_api_application_fees_refunds | VIEW | 13 |
+| stg_airbyte_source__stripe_api_balance_transactions | VIEW | 20 |
+| stg_airbyte_source__stripe_api_charges | VIEW | 55 |
+| stg_airbyte_source__stripe_api_customer_balance_transactions | VIEW | 18 |
+| stg_airbyte_source__stripe_api_customers | VIEW | 35 |
+| stg_airbyte_source__stripe_api_events | VIEW | 13 |
+| stg_airbyte_source__stripe_api_invoice_items | VIEW | 29 |
+| stg_airbyte_source__stripe_api_invoice_line_items | VIEW | 33 |
+| stg_airbyte_source__stripe_api_invoices | VIEW | 94 |
+| stg_airbyte_source__stripe_api_payouts | VIEW | 36 |
+| stg_airbyte_source__stripe_api_persons | VIEW | 33 |
+| stg_airbyte_source__stripe_api_plans | VIEW | 29 |
+| stg_airbyte_source__stripe_api_prices | VIEW | 25 |
+| stg_airbyte_source__stripe_api_products | VIEW | 27 |
+| stg_airbyte_source__stripe_api_promotion_codes | VIEW | 18 |
+| stg_airbyte_source__stripe_api_refunds | VIEW | 20 |
+| stg_airbyte_source__stripe_api_subscription_items | VIEW | 29 |
+| stg_airbyte_source__stripe_api_subscription_schedule | VIEW | 24 |
+| stg_airbyte_source__stripe_api_subscriptions | VIEW | 55 |
+| stg_airbyte_source__stripe_api_transactions | VIEW | 23 |
+| stg_airbyte_source__stripe_api_transfer_reversals | VIEW | 14 |
+| stg_airbyte_source__stripe_api_transfers | VIEW | 29 |
+| stg_airbyte_source__techspeed_gdrive_candidates | VIEW | 60 |
+| stg_airbyte_source__techspeed_gdrive_candidates_invalid | VIEW | 12 |
+| stg_airbyte_source__techspeed_gdrive_marketing_data_enrichment | VIEW | 21 |
+| stg_airbyte_source__techspeed_gdrive_officeholders | VIEW | 48 |
+| stg_airflow_source__l2_expired_voters | VIEW | 6 |
+| stg_airflow_source__l2_expired_voters_loads | VIEW | 4 |
+| stg_census__block_population | VIEW | 4 |
+| stg_census_acs__geo_estimates | MANAGED | 86 |
+| stg_dbt_source__l2_s3_ak_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ak_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ak_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ak_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ak_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ak_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ak_vote_history | VIEW | 520 |
+| stg_dbt_source__l2_s3_ak_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_al_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_al_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_al_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_al_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_al_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_al_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_al_vote_history | VIEW | 919 |
+| stg_dbt_source__l2_s3_al_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ar_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ar_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ar_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ar_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ar_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ar_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ar_vote_history | VIEW | 236 |
+| stg_dbt_source__l2_s3_ar_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_az_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_az_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_az_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_az_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_az_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_az_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_az_vote_history | VIEW | 453 |
+| stg_dbt_source__l2_s3_az_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ca_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ca_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ca_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ca_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ca_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ca_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ca_vote_history | VIEW | 975 |
+| stg_dbt_source__l2_s3_ca_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_co_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_co_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_co_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_co_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_co_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_co_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_co_vote_history | VIEW | 693 |
+| stg_dbt_source__l2_s3_co_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ct_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ct_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ct_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ct_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ct_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ct_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ct_vote_history | VIEW | 965 |
+| stg_dbt_source__l2_s3_ct_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_dc_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_dc_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_dc_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_dc_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_dc_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_dc_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_dc_vote_history | VIEW | 212 |
+| stg_dbt_source__l2_s3_dc_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_de_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_de_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_de_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_de_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_de_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_de_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_de_vote_history | VIEW | 319 |
+| stg_dbt_source__l2_s3_de_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_fl_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_fl_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_fl_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_fl_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_fl_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_fl_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_fl_vote_history | VIEW | 921 |
+| stg_dbt_source__l2_s3_fl_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ga_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ga_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ga_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ga_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ga_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ga_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ga_vote_history | VIEW | 995 |
+| stg_dbt_source__l2_s3_ga_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_hi_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_hi_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_hi_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_hi_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_hi_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_hi_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_hi_vote_history | VIEW | 144 |
+| stg_dbt_source__l2_s3_hi_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ia_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ia_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ia_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ia_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ia_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ia_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ia_vote_history | VIEW | 969 |
+| stg_dbt_source__l2_s3_ia_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_id_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_id_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_id_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_id_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_id_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_id_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_id_vote_history | VIEW | 213 |
+| stg_dbt_source__l2_s3_id_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_il_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_il_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_il_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_il_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_il_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_il_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_il_vote_history | VIEW | 435 |
+| stg_dbt_source__l2_s3_il_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_in_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_in_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_in_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_in_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_in_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_in_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_in_vote_history | VIEW | 535 |
+| stg_dbt_source__l2_s3_in_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ks_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ks_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ks_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ks_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ks_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ks_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ks_vote_history | VIEW | 899 |
+| stg_dbt_source__l2_s3_ks_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ky_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ky_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ky_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_ky_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_ky_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ky_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ky_vote_history | VIEW | 163 |
+| stg_dbt_source__l2_s3_ky_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_la_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_la_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_la_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_la_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_la_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_la_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_la_vote_history | VIEW | 955 |
+| stg_dbt_source__l2_s3_la_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ma_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ma_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ma_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ma_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ma_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ma_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ma_vote_history | VIEW | 939 |
+| stg_dbt_source__l2_s3_ma_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_md_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_md_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_md_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_md_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_md_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_md_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_md_vote_history | VIEW | 251 |
+| stg_dbt_source__l2_s3_md_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_me_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_me_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_me_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_me_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_me_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_me_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_me_vote_history | VIEW | 185 |
+| stg_dbt_source__l2_s3_me_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mi_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_mi_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mi_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_mi_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_mi_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_mi_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mi_vote_history | VIEW | 833 |
+| stg_dbt_source__l2_s3_mi_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mn_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_mn_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mn_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_mn_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_mn_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_mn_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mn_vote_history | VIEW | 975 |
+| stg_dbt_source__l2_s3_mn_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mo_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_mo_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mo_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_mo_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_mo_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_mo_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mo_vote_history | VIEW | 917 |
+| stg_dbt_source__l2_s3_mo_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ms_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ms_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ms_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ms_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ms_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ms_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ms_vote_history | VIEW | 989 |
+| stg_dbt_source__l2_s3_ms_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mt_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_mt_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mt_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_mt_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_mt_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_mt_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_mt_vote_history | VIEW | 980 |
+| stg_dbt_source__l2_s3_mt_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nc_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_nc_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nc_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_nc_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_nc_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_nc_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nc_vote_history | VIEW | 998 |
+| stg_dbt_source__l2_s3_nc_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nd_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_nd_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nd_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_nd_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_nd_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_nd_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nd_vote_history | VIEW | 296 |
+| stg_dbt_source__l2_s3_nd_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ne_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ne_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ne_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ne_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ne_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ne_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ne_vote_history | VIEW | 949 |
+| stg_dbt_source__l2_s3_ne_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nh_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_nh_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nh_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_nh_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_nh_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_nh_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nh_vote_history | VIEW | 605 |
+| stg_dbt_source__l2_s3_nh_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nj_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_nj_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nj_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_nj_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_nj_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_nj_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nj_vote_history | VIEW | 1007 |
+| stg_dbt_source__l2_s3_nj_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nm_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_nm_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nm_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_nm_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_nm_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_nm_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nm_vote_history | VIEW | 996 |
+| stg_dbt_source__l2_s3_nm_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nv_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_nv_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nv_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_nv_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_nv_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_nv_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_nv_vote_history | VIEW | 260 |
+| stg_dbt_source__l2_s3_nv_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ny_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ny_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ny_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ny_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ny_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ny_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ny_vote_history | VIEW | 1007 |
+| stg_dbt_source__l2_s3_ny_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_oh_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_oh_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_oh_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_oh_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_oh_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_oh_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_oh_vote_history | VIEW | 441 |
+| stg_dbt_source__l2_s3_oh_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ok_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ok_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ok_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ok_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ok_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ok_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ok_vote_history | VIEW | 709 |
+| stg_dbt_source__l2_s3_ok_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_or_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_or_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_or_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_or_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_or_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_or_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_or_vote_history | VIEW | 871 |
+| stg_dbt_source__l2_s3_or_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_pa_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_pa_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_pa_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_pa_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_pa_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_pa_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_pa_vote_history | VIEW | 599 |
+| stg_dbt_source__l2_s3_pa_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ri_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ri_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ri_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_ri_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_ri_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ri_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ri_vote_history | VIEW | 228 |
+| stg_dbt_source__l2_s3_ri_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_sc_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_sc_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_sc_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_sc_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_sc_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_sc_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_sc_vote_history | VIEW | 895 |
+| stg_dbt_source__l2_s3_sc_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_sd_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_sd_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_sd_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_sd_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_sd_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_sd_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_sd_vote_history | VIEW | 981 |
+| stg_dbt_source__l2_s3_sd_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_tn_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_tn_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_tn_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_tn_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_tn_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_tn_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_tn_vote_history | VIEW | 911 |
+| stg_dbt_source__l2_s3_tn_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_tx_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_tx_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_tx_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_tx_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_tx_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_tx_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_tx_vote_history | VIEW | 939 |
+| stg_dbt_source__l2_s3_tx_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ut_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_ut_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ut_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_ut_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_ut_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_ut_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_ut_vote_history | VIEW | 363 |
+| stg_dbt_source__l2_s3_ut_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_va_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_va_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_va_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_va_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_va_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_va_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_va_vote_history | VIEW | 475 |
+| stg_dbt_source__l2_s3_va_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_vt_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_vt_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_vt_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_vt_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_vt_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_vt_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_vt_vote_history | VIEW | 833 |
+| stg_dbt_source__l2_s3_vt_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wa_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_wa_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wa_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_wa_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_wa_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_wa_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wa_vote_history | VIEW | 801 |
+| stg_dbt_source__l2_s3_wa_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wi_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_wi_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wi_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_wi_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_wi_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_wi_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wi_vote_history | VIEW | 307 |
+| stg_dbt_source__l2_s3_wi_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wv_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_wv_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wv_haystaq_dna_flags | VIEW | 163 |
+| stg_dbt_source__l2_s3_wv_haystaq_dna_scores | VIEW | 328 |
+| stg_dbt_source__l2_s3_wv_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_wv_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wv_vote_history | VIEW | 983 |
+| stg_dbt_source__l2_s3_wv_vote_history_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wy_demographic | VIEW | 699 |
+| stg_dbt_source__l2_s3_wy_demographic_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wy_haystaq_dna_flags | VIEW | 154 |
+| stg_dbt_source__l2_s3_wy_haystaq_dna_scores | VIEW | 305 |
+| stg_dbt_source__l2_s3_wy_uniform | VIEW | 805 |
+| stg_dbt_source__l2_s3_wy_uniform_data_dictionary | VIEW | 5 |
+| stg_dbt_source__l2_s3_wy_vote_history | VIEW | 106 |
+| stg_dbt_source__l2_s3_wy_vote_history_data_dictionary | VIEW | 5 |
+| stg_er_source__clustered_candidacy_stages | VIEW | 23 |
+| stg_er_source__clustered_elected_officials | VIEW | 30 |
+| stg_er_source__clustered_election_stages | VIEW | 17 |
+| stg_er_source__pairwise_candidacy_stages | VIEW | 73 |
+| stg_er_source__pairwise_elected_officials | VIEW | 89 |
+| stg_model_predictions__ballots_projected_2026_v2 | VIEW | 8 |
+| stg_model_predictions__ballots_projected_2027 | VIEW | 8 |
+| stg_model_predictions__ballots_projected_2028 | VIEW | 8 |
+| stg_model_predictions__candidacy_br_matches_20251204 | VIEW | 17 |
+| stg_model_predictions__candidacy_br_matches_prenov2025_20251205 | VIEW | 17 |
+| stg_model_predictions__candidacy_ddhq_matches_20250826 | VIEW | 29 |
+| stg_model_predictions__candidacy_ddhq_matches_20250909 | VIEW | 29 |
+| stg_model_predictions__candidacy_ddhq_matches_20250916 | VIEW | 29 |
+| stg_model_predictions__candidacy_ddhq_matches_20251016 | VIEW | 30 |
+| stg_model_predictions__candidacy_ddhq_matches_20251112 | VIEW | 36 |
+| stg_model_predictions__candidacy_ddhq_matches_20251202 | VIEW | 36 |
+| stg_model_predictions__llm_l2_br_match_20250806 | VIEW | 11 |
+| stg_model_predictions__llm_l2_br_match_20250811 | VIEW | 11 |
+| stg_model_predictions__llm_l2_br_match_20260126 | VIEW | 11 |
+| stg_model_predictions__manual_llm_election_results_20251208 | VIEW | 5 |
+| stg_model_predictions__turnout_projections_even_years_20250709 | VIEW | 8 |
+| stg_model_predictions__turnout_projections_model2odd | VIEW | 8 |
+| stg_model_predictions__viability_scores | VIEW | 3 |
+| stg_nhgis__block_population | VIEW | 4 |
+| stg_segment_storage_source__gp_api_account_password_reset_requested | VIEW | 16 |
+| stg_segment_storage_source__gp_api_campaign_verify_token_status_update | VIEW | 16 |
+| stg_segment_storage_source__gp_api_content_builder_generation_completed | VIEW | 18 |
+| stg_segment_storage_source__gp_api_content_builder_generation_started | VIEW | 19 |
+| stg_segment_storage_source__gp_api_identifies | VIEW | 247 |
+| stg_segment_storage_source__gp_api_onboarding_user_created | VIEW | 16 |
+| stg_segment_storage_source__gp_api_peerly_identity_id_created | VIEW | 19 |
+| stg_segment_storage_source__gp_api_poll_results_synthesis_complete | VIEW | 39 |
+| stg_segment_storage_source__gp_api_tracks | VIEW | 28 |
+| stg_segment_storage_source__gp_api_users | VIEW | 243 |
+| stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_completed | VIEW | 15 |
+| stg_segment_storage_source__gp_api_voter_outreach_10dlc_compliance_pin_submitted | VIEW | 17 |
+| stg_segment_storage_source__web_app__10_dlc_compliance_pin_verification_completed | VIEW | 38 |
+| stg_segment_storage_source__web_app__10_dlc_compliance_registration_submitted | VIEW | 40 |
+| stg_segment_storage_source__web_app_account_password_reset_completed | VIEW | 36 |
+| stg_segment_storage_source__web_app_ai_assistant_ask_a_question | VIEW | 45 |
+| stg_segment_storage_source__web_app_ai_assistant_click_new_chat | VIEW | 39 |
+| stg_segment_storage_source__web_app_ai_assistant_click_view_chat_history | VIEW | 44 |
+| stg_segment_storage_source__web_app_ai_content_generation_start | VIEW | 44 |
+| stg_segment_storage_source__web_app_campaign_assistant_chatbot_input | VIEW | 45 |
+| stg_segment_storage_source__web_app_candidacy_did_you_win_modal_completed | VIEW | 40 |
+| stg_segment_storage_source__web_app_candidacy_did_you_win_modal_viewed | VIEW | 40 |
+| stg_segment_storage_source__web_app_candidate_website_continued | VIEW | 44 |
+| stg_segment_storage_source__web_app_candidate_website_edited | VIEW | 40 |
+| stg_segment_storage_source__web_app_candidate_website_published | VIEW | 39 |
+| stg_segment_storage_source__web_app_candidate_website_purchased_domain | VIEW | 42 |
+| stg_segment_storage_source__web_app_candidate_website_selected_domain | VIEW | 46 |
+| stg_segment_storage_source__web_app_candidate_website_started | VIEW | 44 |
+| stg_segment_storage_source__web_app_candidate_website_started_domain_selection | VIEW | 44 |
+| stg_segment_storage_source__web_app_content_builder_click_content | VIEW | 43 |
+| stg_segment_storage_source__web_app_content_builder_click_continue_questions | VIEW | 40 |
+| stg_segment_storage_source__web_app_content_builder_click_generate | VIEW | 43 |
+| stg_segment_storage_source__web_app_content_builder_close_additional_inputs | VIEW | 44 |
+| stg_segment_storage_source__web_app_content_builder_editor_click_regenerate | VIEW | 48 |
+| stg_segment_storage_source__web_app_content_builder_editor_open_version_picker | VIEW | 46 |
+| stg_segment_storage_source__web_app_content_builder_editor_submit_regenerate | VIEW | 41 |
+| stg_segment_storage_source__web_app_content_builder_select_template | VIEW | 45 |
+| stg_segment_storage_source__web_app_content_builder_submit_additional_inputs | VIEW | 63 |
+| stg_segment_storage_source__web_app_custom_voter_file_created | VIEW | 44 |
+| stg_segment_storage_source__web_app_dashboard_candidate_dashboard_viewed | VIEW | 48 |
+| stg_segment_storage_source__web_app_dashboard_path_to_victory_exit_understand_path_to_victory | VIEW | 44 |
+| stg_segment_storage_source__web_app_download_voter_file_attempt | VIEW | 40 |
+| stg_segment_storage_source__web_app_download_voter_file_failure | VIEW | 41 |
+| stg_segment_storage_source__web_app_download_voter_file_success | VIEW | 41 |
+| stg_segment_storage_source__web_app_exposure | VIEW | 37 |
+| stg_segment_storage_source__web_app_identifies | VIEW | 61 |
+| stg_segment_storage_source__web_app_invalid_party | VIEW | 40 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_ai_assistant | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_community | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_contacts | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_content_builder | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_dashboard | VIEW | 45 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_door_knocking | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_my_profile | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_polls | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_resources | VIEW | 45 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_voter_data | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_voter_outreach | VIEW | 45 |
+| stg_segment_storage_source__web_app_navigation_dashboard_click_website | VIEW | 44 |
+| stg_segment_storage_source__web_app_navigation_top_avatar_dropdown_click_logout | VIEW | 46 |
+| stg_segment_storage_source__web_app_navigation_top_avatar_dropdown_click_settings | VIEW | 45 |
+| stg_segment_storage_source__web_app_navigation_top_avatar_dropdown_close_dropdown | VIEW | 47 |
+| stg_segment_storage_source__web_app_navigation_top_click_avatar_dropdown | VIEW | 46 |
+| stg_segment_storage_source__web_app_navigation_top_click_logo | VIEW | 48 |
+| stg_segment_storage_source__web_app_onboarding_candidate_affiliation_completed | VIEW | 40 |
+| stg_segment_storage_source__web_app_onboarding_candidate_office_completed | VIEW | 44 |
+| stg_segment_storage_source__web_app_onboarding_candidate_office_searched | VIEW | 50 |
+| stg_segment_storage_source__web_app_onboarding_candidate_pledge_completed | VIEW | 39 |
+| stg_segment_storage_source__web_app_onboarding_click_finish_later | VIEW | 40 |
+| stg_segment_storage_source__web_app_onboarding_complete | VIEW | 40 |
+| stg_segment_storage_source__web_app_onboarding_complete_step_click_go_to_dashboard | VIEW | 39 |
+| stg_segment_storage_source__web_app_onboarding_office_step_click_can_t_see_office | VIEW | 39 |
+| stg_segment_storage_source__web_app_onboarding_office_step_click_next | VIEW | 41 |
+| stg_segment_storage_source__web_app_onboarding_office_step_office_selected | VIEW | 40 |
+| stg_segment_storage_source__web_app_onboarding_party_step_click_submit | VIEW | 40 |
+| stg_segment_storage_source__web_app_onboarding_pledge_step_click_submit | VIEW | 39 |
+| stg_segment_storage_source__web_app_onboarding_registration_completed | VIEW | 48 |
+| stg_segment_storage_source__web_app_outreach_action_clicked | VIEW | 46 |
+| stg_segment_storage_source__web_app_outreach_click_create | VIEW | 44 |
+| stg_segment_storage_source__web_app_outreach_door_knocking_complete | VIEW | 50 |
+| stg_segment_storage_source__web_app_outreach_phone_banking_complete | VIEW | 50 |
+| stg_segment_storage_source__web_app_outreach_view_accessed | VIEW | 44 |
+| stg_segment_storage_source__web_app_p2p_upgrade_modal_click_button | VIEW | 51 |
+| stg_segment_storage_source__web_app_p2p_upgrade_modal_exit | VIEW | 45 |
+| stg_segment_storage_source__web_app_p2p_upgrade_modal_modal_shown | VIEW | 50 |
+| stg_segment_storage_source__web_app_pages | VIEW | 53 |
+| stg_segment_storage_source__web_app_polls_create_poll_clicked | VIEW | 42 |
+| stg_segment_storage_source__web_app_polls_poll_question_viewed | VIEW | 37 |
+| stg_segment_storage_source__web_app_polls_poll_results_issue_details_viewed | VIEW | 37 |
+| stg_segment_storage_source__web_app_polls_poll_results_overview_viewed | VIEW | 46 |
+| stg_segment_storage_source__web_app_pro_upgrade_click_exit_top_nav | VIEW | 41 |
+| stg_segment_storage_source__web_app_pro_upgrade_click_go_to_stripe | VIEW | 39 |
+| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_click_next | VIEW | 39 |
+| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_click_upload | VIEW | 40 |
+| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_hover_ein_number_help | VIEW | 39 |
+| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_hover_name_of_campaign_committee_help | VIEW | 38 |
+| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_hover_upload_help | VIEW | 39 |
+| stg_segment_storage_source__web_app_pro_upgrade_committee_check_page_toggle_ein_requirement | VIEW | 40 |
+| stg_segment_storage_source__web_app_pro_upgrade_complete | VIEW | 41 |
+| stg_segment_storage_source__web_app_pro_upgrade_confirm_office | VIEW | 39 |
+| stg_segment_storage_source__web_app_pro_upgrade_edit_office | VIEW | 39 |
+| stg_segment_storage_source__web_app_pro_upgrade_modal_click_button | VIEW | 48 |
+| stg_segment_storage_source__web_app_pro_upgrade_modal_exit | VIEW | 48 |
+| stg_segment_storage_source__web_app_pro_upgrade_modal_modal_shown | VIEW | 50 |
+| stg_segment_storage_source__web_app_pro_upgrade_service_agreement_page_click_finish | VIEW | 39 |
+| stg_segment_storage_source__web_app_pro_upgrade_splash_page_click_upgrade | VIEW | 46 |
+| stg_segment_storage_source__web_app_pro_upgrade_splash_page_exit | VIEW | 46 |
+| stg_segment_storage_source__web_app_pro_upgrade_submit_edit_office | VIEW | 39 |
+| stg_segment_storage_source__web_app_profile_campaign_details_click_save | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_fun_fact_click_save | VIEW | 39 |
+| stg_segment_storage_source__web_app_profile_office_details_click_edit | VIEW | 39 |
+| stg_segment_storage_source__web_app_profile_running_against_cancel_add_new | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_running_against_click_add_new | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_running_against_click_edit | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_running_against_click_save | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_running_against_submit_add_new | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_running_against_submit_edit | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_top_issues_click_finish_entering_issues | VIEW | 40 |
+| stg_segment_storage_source__web_app_profile_why_section_click_save | VIEW | 39 |
+| stg_segment_storage_source__web_app_question_complete | VIEW | 41 |
+| stg_segment_storage_source__web_app_resources_resource_clicked | VIEW | 42 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_age | VIEW | 46 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_audience | VIEW | 46 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_gender | VIEW | 46 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_audience_check_political_party | VIEW | 46 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_audience_enter_audience_request | VIEW | 44 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_back | VIEW | 45 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_exit | VIEW | 45 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_next | VIEW | 45 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_script_click_add_your_own_script | VIEW | 44 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_script_click_generate_a_new_script | VIEW | 44 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_script_click_use_a_saved_script | VIEW | 44 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_script_select_saved_script | VIEW | 44 |
+| stg_segment_storage_source__web_app_schedule_text_campaign_script_submit_added_script | VIEW | 44 |
+| stg_segment_storage_source__web_app_serve_onboarding_add_image_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_constituency_profile_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_getting_started_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_meet_your_constituents_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_poll_preview_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_poll_strategy_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_poll_value_props_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_sms_poll_sent | VIEW | 40 |
+| stg_segment_storage_source__web_app_serve_onboarding_success_page_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_serve_onboarding_sworn_in_completed | VIEW | 41 |
+| stg_segment_storage_source__web_app_serve_onboarding_sworn_in_viewed | VIEW | 39 |
+| stg_segment_storage_source__web_app_set_password_click_set_password | VIEW | 30 |
+| stg_segment_storage_source__web_app_settings_account_settings_click_upgrade | VIEW | 44 |
+| stg_segment_storage_source__web_app_settings_delete_account_click_delete | VIEW | 44 |
+| stg_segment_storage_source__web_app_settings_delete_account_submit_delete | VIEW | 44 |
+| stg_segment_storage_source__web_app_settings_notifications_toggle_email | VIEW | 44 |
+| stg_segment_storage_source__web_app_settings_personal_info_click_save | VIEW | 43 |
+| stg_segment_storage_source__web_app_settings_personal_info_click_upload | VIEW | 43 |
+| stg_segment_storage_source__web_app_sign_in_click_create_account | VIEW | 46 |
+| stg_segment_storage_source__web_app_sign_in_click_forgot_password | VIEW | 47 |
+| stg_segment_storage_source__web_app_sign_up_click_login | VIEW | 46 |
+| stg_segment_storage_source__web_app_tracks | VIEW | 34 |
+| stg_segment_storage_source__web_app_users | VIEW | 58 |
+| stg_segment_storage_source__web_app_usersnap_submission | VIEW | 45 |
+| stg_segment_storage_source__web_app_voter_data_click_create_custom_voter_file | VIEW | 41 |
+| stg_segment_storage_source__web_app_voter_data_click_detail_view | VIEW | 43 |
+| stg_segment_storage_source__web_app_voter_data_custom_voter_file_click_create | VIEW | 39 |
+| stg_segment_storage_source__web_app_voter_data_custom_voter_file_click_next | VIEW | 39 |
+| stg_segment_storage_source__web_app_voter_data_custom_voter_file_exit_modal | VIEW | 40 |
+| stg_segment_storage_source__web_app_voter_data_custom_voter_file_select_channel | VIEW | 40 |
+| stg_segment_storage_source__web_app_voter_data_custom_voter_file_select_purpose | VIEW | 40 |
+| stg_segment_storage_source__web_app_voter_data_file_detail_click_back | VIEW | 41 |
+| stg_segment_storage_source__web_app_voter_data_file_detail_click_custom_file_info_icon | VIEW | 38 |
+| stg_segment_storage_source__web_app_voter_data_file_detail_click_download_csv | VIEW | 41 |
+| stg_segment_storage_source__web_app_voter_data_file_detail_click_view_audience_filters | VIEW | 39 |
+| stg_segment_storage_source__web_app_voter_outreach_10dlc_compliance_form_submitted | VIEW | 40 |
+| stg_segment_storage_source__web_app_voter_outreach_10dlc_compliance_started | VIEW | 45 |
+| stg_segment_storage_source__web_app_voter_outreach_campaign_completed | VIEW | 50 |
+| us_states | MANAGED | 2 |
+| users | MANAGED | 20 |
+| write__election_api_db | MANAGED | 4 |
+| write__l2_databricks_to_gp_api | MANAGED | 9 |
+| write__l2_databricks_to_people_api | MANAGED | 5 |
+
+## Shared operational facts
+
+Deliberately shared with every arm (plumbing, not analytical knowledge):
+
+- Analytics marts live in the `dbt` schema. The `dbt_staging` schema is
+  retired; staging models are `dbt.stg_*`.
+- Naming prefixes follow standard dbt convention: `stg_` staging, `int__`
+  intermediate; other tables are marts.
 
 ## Output contract (required)
 

--- a/analytics/diagnostics/quality_bench/floor_gen.py
+++ b/analytics/diagnostics/quality_bench/floor_gen.py
@@ -1,8 +1,10 @@
 # analytics/diagnostics/quality_bench/floor_gen.py
-"""Assemble the common floor (design §6): static plumbing text + a mechanically
-generated table inventory. The inventory is deliberately mechanical (names +
-warehouse comments), never curated skill prose — the bare arm must know WHAT
-exists, not what anything means."""
+"""Assemble the common floor: static plumbing text + a mechanically generated
+table inventory. DATA-2164: the inventory carries identifiers and neutral
+type/size metadata ONLY (no warehouse comments — dbt model descriptions are
+curated prose, i.e. treatment content). The bare arm must know WHAT exists,
+never what anything means; column-level detail is available to every arm via
+live DESCRIBE / information_schema queries."""
 
 from __future__ import annotations
 
@@ -12,11 +14,17 @@ from pathlib import Path
 import pandas as pd
 
 INVENTORY_SQL = """
-select table_name, comment
-from goodparty_data_catalog.information_schema.tables
-where table_schema = 'dbt'
-  and not endswith(table_name, '__dbt_tmp')
-order by table_name
+select
+  t.table_name,
+  t.table_type,
+  count(c.column_name) as n_columns
+from goodparty_data_catalog.information_schema.tables t
+left join goodparty_data_catalog.information_schema.columns c
+  on c.table_schema = t.table_schema and c.table_name = t.table_name
+where t.table_schema = 'dbt'
+  and not endswith(t.table_name, '__dbt_tmp')
+group by t.table_name, t.table_type
+order by t.table_name
 """
 
 RunQuery = Callable[[str], pd.DataFrame]
@@ -24,23 +32,9 @@ RunQuery = Callable[[str], pd.DataFrame]
 
 def build_inventory_md(run_query: RunQuery) -> str:
     df = run_query(INVENTORY_SQL)
-    lines = ["| table | description |", "|---|---|"]
+    lines = ["| table | type | columns |", "|---|---|---|"]
     for _, row in df.iterrows():
-        if isinstance(row["comment"], str) and row["comment"]:
-            # Collapse whitespace runs (incl. newlines) to single spaces and escape pipes
-            comment = " ".join(str(row["comment"]).split()).replace("|", "\\|")
-            # Mechanical truncation: the floor states WHAT exists, not what it
-            # means — keep only the first sentence and cap length so richer
-            # curated prose (a treatment) never leaks in via a comment.
-            first_sentence = comment.split(". ")[0]
-            cut = first_sentence != comment
-            if len(first_sentence) > 150:
-                first_sentence = first_sentence[:150]
-                cut = True
-            comment = first_sentence + ("…" if cut else "")
-        else:
-            comment = "(no description)"
-        lines.append(f"| {row['table_name']} | {comment} |")
+        lines.append(f"| {row['table_name']} | {row['table_type']} | {int(row['n_columns'])} |")
     return "\n".join(lines)
 
 

--- a/analytics/diagnostics/quality_bench/floor_static.md
+++ b/analytics/diagnostics/quality_bench/floor_static.md
@@ -18,9 +18,21 @@ Run Python via: `uv run --project {{UV_PROJECT}} python <script.py>`
 The warehouse catalog is `goodparty_data_catalog`; analytics marts live in the
 `dbt` schema (query as `goodparty_data_catalog.dbt.<table>`).
 
-## Table inventory (mechanically generated)
+## Table inventory (mechanically generated: names and neutral metadata only)
+
+Column names/types for any table: `DESCRIBE goodparty_data_catalog.dbt.<table>`
+or query `goodparty_data_catalog.information_schema.columns`.
 
 {{TABLE_INVENTORY}}
+
+## Shared operational facts
+
+Deliberately shared with every arm (plumbing, not analytical knowledge):
+
+- Analytics marts live in the `dbt` schema. The `dbt_staging` schema is
+  retired; staging models are `dbt.stg_*`.
+- Naming prefixes follow standard dbt convention: `stg_` staging, `int__`
+  intermediate; other tables are marts.
 
 ## Output contract (required)
 

--- a/analytics/diagnostics/quality_bench/integrity.py
+++ b/analytics/diagnostics/quality_bench/integrity.py
@@ -49,3 +49,32 @@ def check_text_leakage(text: str, allowed_layers: set[str], canaries: list[Canar
         for c in canaries
         if c.layer not in allowed_layers and c.phrase in text
     ]
+
+
+def relative_md_targets(text: str):
+    """Yield relative .md link targets, skipping external URLs and fragments.
+    Shared with tests/test_skill_doc_links.py (same semantics)."""
+    for match in LINK_RE.finditer(text):
+        target = match.group(1).split("#", 1)[0].strip()
+        if not target or target.startswith(("http://", "https://", "mailto:", "/")):
+            continue
+        if target.endswith(".md"):
+            yield target
+
+
+def check_links(arm_dir: Path) -> list[str]:
+    """Every relative markdown link inside the arm must resolve inside it."""
+    failures = []
+    for md in sorted(arm_dir.rglob("*.md")):
+        for target in relative_md_targets(md.read_text(errors="ignore")):
+            if not (md.parent / target).resolve().is_file():
+                failures.append(f"dead link: {md.relative_to(arm_dir)} -> {target}")
+    return failures
+
+
+def check_arm_leakage(arm_dir: Path, allowed_layers: set[str], canaries: list[Canary]) -> list[str]:
+    failures = []
+    for f in sorted(p for p in arm_dir.rglob("*") if p.is_file()):
+        hits = check_text_leakage(f.read_text(errors="ignore"), allowed_layers, canaries)
+        failures.extend(f"{f.relative_to(arm_dir)}: {h}" for h in hits)
+    return failures

--- a/analytics/diagnostics/quality_bench/integrity.py
+++ b/analytics/diagnostics/quality_bench/integrity.py
@@ -65,9 +65,11 @@ def relative_md_targets(text: str):
 def check_links(arm_dir: Path) -> list[str]:
     """Every relative markdown link inside the arm must resolve inside it."""
     failures = []
+    arm_root = arm_dir.resolve()
     for md in sorted(arm_dir.rglob("*.md")):
         for target in relative_md_targets(md.read_text(errors="ignore")):
-            if not (md.parent / target).resolve().is_file():
+            resolved = (md.parent / target).resolve()
+            if not (resolved.is_file() and resolved.is_relative_to(arm_root)):
                 failures.append(f"dead link: {md.relative_to(arm_dir)} -> {target}")
     return failures
 

--- a/analytics/diagnostics/quality_bench/integrity.py
+++ b/analytics/diagnostics/quality_bench/integrity.py
@@ -19,6 +19,10 @@ import yaml
 
 LINK_RE = re.compile(r"\]\(([^)]+)\)")
 
+# deps come from PyPI, not treatment layers; keep in step with
+# prep_arms.build_manifest's skip set
+SKIP_DIRS = {".venv", "__pycache__"}
+
 
 @dataclass(frozen=True)
 class Canary:
@@ -67,6 +71,8 @@ def check_links(arm_dir: Path) -> list[str]:
     failures = []
     arm_root = arm_dir.resolve()
     for md in sorted(arm_dir.rglob("*.md")):
+        if SKIP_DIRS & set(md.relative_to(arm_dir).parts):
+            continue
         for target in relative_md_targets(md.read_text(errors="ignore")):
             resolved = (md.parent / target).resolve()
             if not (resolved.is_file() and resolved.is_relative_to(arm_root)):
@@ -77,6 +83,8 @@ def check_links(arm_dir: Path) -> list[str]:
 def check_arm_leakage(arm_dir: Path, allowed_layers: set[str], canaries: list[Canary]) -> list[str]:
     failures = []
     for f in sorted(p for p in arm_dir.rglob("*") if p.is_file()):
+        if SKIP_DIRS & set(f.relative_to(arm_dir).parts):
+            continue
         hits = check_text_leakage(f.read_text(errors="ignore"), allowed_layers, canaries)
         failures.extend(f"{f.relative_to(arm_dir)}: {h}" for h in hits)
     return failures

--- a/analytics/diagnostics/quality_bench/integrity.py
+++ b/analytics/diagnostics/quality_bench/integrity.py
@@ -1,0 +1,51 @@
+# analytics/diagnostics/quality_bench/integrity.py
+"""Post-prep integrity checks (DATA-2164): dead-link scan, canary staleness
+and leakage. Grader-side only — quality_bench/ is not in any arm layer, so
+none of this (including canaries.yaml) ever ships into an arm.
+
+Canary model: canaries.yaml lists distinctive verbatim phrases from treatment
+content, tagged with the layer that owns them (knowledge | process). A phrase
+appearing in the floor or in an arm that does not include its layer means
+treatment content leaked through the substrate or the floor generator.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+LINK_RE = re.compile(r"\]\(([^)]+)\)")
+
+
+@dataclass(frozen=True)
+class Canary:
+    layer: str
+    source: str  # repo-relative path the phrase lives in
+    phrase: str  # verbatim substring
+
+
+def load_canaries(path: Path) -> list[Canary]:
+    data = yaml.safe_load(path.read_text())
+    return [Canary(**c) for c in data["canaries"]]
+
+
+def check_canary_staleness(canaries: list[Canary], repo_root: Path) -> list[str]:
+    """A canary whose phrase no longer exists in its source is dead weight:
+    the leakage scan would be grepping for nothing. Fails loudly instead."""
+    failures = []
+    for c in canaries:
+        src = repo_root / c.source
+        if not src.is_file() or c.phrase not in src.read_text(errors="ignore"):
+            failures.append(f"stale canary: {c.source}: {c.phrase!r}")
+    return failures
+
+
+def check_text_leakage(text: str, allowed_layers: set[str], canaries: list[Canary]) -> list[str]:
+    return [
+        f"canary leaked ({c.layer}): {c.phrase!r}"
+        for c in canaries
+        if c.layer not in allowed_layers and c.phrase in text
+    ]

--- a/analytics/diagnostics/quality_bench/prep_arms.py
+++ b/analytics/diagnostics/quality_bench/prep_arms.py
@@ -81,12 +81,15 @@ SETTINGS_JSON = {
     }
 }
 
+# Keep version pins in step with analytics/pyproject.toml: the arms run the
+# exported analysis libs (win/serve_analysis), which are developed and tested
+# against the analytics env's resolution — notably pandas <3.
 ARM_PYPROJECT = """\
 [project]
 name = "bench-env"
 version = "0.1.0"
 requires-python = ">=3.14"
-dependencies = ["pandas>=2.3.1", "databricks-sql-connector>=3", "databricks-sdk>=0.20"]
+dependencies = ["pandas>=2.3.1,<3.0.0", "databricks-sql-connector>=3", "databricks-sdk>=0.20"]
 
 [tool.uv]
 package = false
@@ -121,7 +124,23 @@ def _export_paths(repo_root: Path, dest: Path, ref: str, paths: list[str]) -> li
     with tarfile.open(fileobj=io.BytesIO(proc.stdout)) as tar:
         names = [m.name for m in tar.getmembers() if m.isfile()]
         tar.extractall(dest, filter="data")
+    _verify_export_coverage(paths, names, ref)
     return names
+
+
+def _verify_export_coverage(paths: list[str], names: list[str], ref: str) -> None:
+    """Every requested path must have contributed at least one extracted file.
+
+    git archive hard-fails on a fully-unmatched pathspec, but this invariant
+    is git-version behavior, not ours — encode it locally so arm construction
+    never depends on it. A path is covered when the archive contains the path
+    itself (a file) or something under it (a directory)."""
+    uncovered = [p for p in paths if not any(n == p or n.startswith(p + "/") for n in names)]
+    if uncovered:
+        raise RuntimeError(
+            f"git archive at {ref} produced no files for {uncovered}; "
+            "renamed or emptied layer paths must fail prep, not thin the arm"
+        )
 
 
 def build_substrate(repo_root: Path, dest: Path, floor_text: str, ref: str) -> None:
@@ -159,10 +178,14 @@ def prep_arm(
     for layer in ARM_LAYERS[arm]:
         for extracted in _export_paths(repo_root, dest, ref, LAYERS[layer]):
             layer_of[extracted] = layer
-    manifest = build_manifest(arm, ref, dest, layer_of)
-    (dest / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    # Sync before the manifest so uv.lock (dependency resolution) is part of
+    # run provenance: a re-prep that resolves different deps changes the
+    # manifest, and run_matrix's arms_sha256 gate then refuses to mix it into
+    # an existing batch. The .venv itself stays excluded (build artifacts).
     if sync:
         subprocess.run(["uv", "sync"], cwd=dest / "analytics", check=True)
+    manifest = build_manifest(arm, ref, dest, layer_of)
+    (dest / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
     return dest
 
 

--- a/analytics/diagnostics/quality_bench/prep_arms.py
+++ b/analytics/diagnostics/quality_bench/prep_arms.py
@@ -1,18 +1,26 @@
 # analytics/diagnostics/quality_bench/prep_arms.py
-"""Build the three arm environments (design §6).
+"""Build the three arm environments additively (DATA-2164 pre-registration
+amendment; original subtractive design was §6).
 
-Contamination rules enforced here:
-- quality_bench/ (keys, questions, harness) is deleted from every run arm.
-- full/knowledge arms are `git archive` exports, not worktrees: the arm is a
-  plain directory with no .git and no history, so the answer keys are not
-  recoverable from git even though quality_bench was deleted from the checkout.
+One-factor construction: every arm = the same substrate plus zero or more
+treatment layers. Nothing is built by deletion, so treatment content can only
+be present in an arm because a layer explicitly put it there, and
+manifest.json records which layer contributed every file.
+
+Contamination rules:
+- Treatment layers are per-path `git archive <ref> -- <paths>` exports: no
+  .git, no history. quality_bench/ (keys, questions, harness) is not in any
+  layer, so it is absent from every arm by construction.
 - Arms live at fresh paths, so project-keyed auto-memory does not attach.
-- bare is a plain scratch dir: floor only, no repo content, no skills.
+- The substrate is identical across arms (same floor CLAUDE.md, same
+  analytics/ scaffold, same settings), so bare vs knowledge vs full differ
+  ONLY by treatment layers.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import io
 import json
 import shutil
@@ -21,14 +29,37 @@ import tarfile
 from pathlib import Path
 
 try:
+    from quality_bench import integrity
     from quality_bench.bank import ARMS
 except ImportError:  # bare `python prep_arms.py`: diagnostics/ isn't on sys.path yet
     import sys
 
     sys.path.insert(0, str(Path(__file__).parents[1]))
+    from quality_bench import integrity
     from quality_bench.bank import ARMS
 
-KNOWLEDGE_SKILLS = ["win-analytics-knowledge", "serve-analytics-knowledge"]
+# Treatment layers: repo-relative paths exported verbatim from --ref.
+LAYERS: dict[str, list[str]] = {
+    "knowledge": [
+        ".claude/skills/win-analytics-knowledge",
+        ".claude/skills/serve-analytics-knowledge",
+        "analytics/lib/win_analysis.py",
+        "analytics/lib/serve_analysis.py",
+    ],
+    "process": [
+        ".claude/skills/analytics-process",
+        ".claude/agents/product-data-scientist.md",
+        ".claude/agents/product-manager.md",
+    ],
+}
+# code-critic (repo review) and data-matching are deliberately NOT layers:
+# they are not part of the pre-registered treatment.
+ARM_LAYERS: dict[str, list[str]] = {
+    "bare": [],
+    "knowledge": ["knowledge"],
+    "full": ["knowledge", "process"],
+}
+SUBSTRATE_EXPORTS = ["analytics/lib/databricks_conn.py"]
 
 SETTINGS_JSON = {
     "permissions": {
@@ -50,7 +81,7 @@ SETTINGS_JSON = {
     }
 }
 
-BARE_PYPROJECT = """\
+ARM_PYPROJECT = """\
 [project]
 name = "bench-env"
 version = "0.1.0"
@@ -62,8 +93,10 @@ package = false
 """
 
 
-def _fill(floor_text: str, lib_path: str, uv_project: str) -> str:
-    return floor_text.replace("{{LIB_PATH}}", lib_path).replace("{{UV_PROJECT}}", uv_project)
+def _fill(floor_text: str) -> str:
+    """All arms share the analytics/ scaffold, so the floor placeholders fill
+    identically everywhere (this used to differ between bare and the rest)."""
+    return floor_text.replace("{{LIB_PATH}}", "analytics/lib").replace("{{UV_PROJECT}}", "analytics")
 
 
 def _write_settings(arm_dir: Path) -> None:
@@ -72,64 +105,62 @@ def _write_settings(arm_dir: Path) -> None:
     (d / "settings.local.json").write_text(json.dumps(SETTINGS_JSON, indent=2))
 
 
-def _export(repo_root: Path, dest: Path, ref: str) -> None:
-    """Export the repo at `ref` into `dest` as a plain directory (no .git).
-
-    `git archive` streams a tar of the tracked tree at `ref`; extracting it gives
-    the arm the repo content without any git history, so the deleted answer keys
-    stay unrecoverable. Any leftover dir (e.g. a crashed prior run) is cleared
-    first via rmtree.
-    """
-    if dest.exists():
-        shutil.rmtree(dest)
+def _export_paths(repo_root: Path, dest: Path, ref: str, paths: list[str]) -> list[str]:
+    """git-archive `paths` at `ref` into `dest`; return the extracted file
+    paths (dest-relative). Errors loudly if any path is missing at ref, so a
+    renamed skill cannot silently produce a thinner arm."""
     proc = subprocess.run(
-        ["git", "archive", ref],
+        ["git", "archive", ref, "--", *paths],
         cwd=repo_root,
         check=False,
         capture_output=True,
     )
     if proc.returncode != 0:
         stderr = proc.stderr.decode(errors="replace").strip()
-        raise RuntimeError(f"git archive failed for {ref} in {repo_root}: {stderr}")
-    dest.mkdir(parents=True)
+        raise RuntimeError(f"git archive failed for {ref} -- {paths} in {repo_root}: {stderr}")
     with tarfile.open(fileobj=io.BytesIO(proc.stdout)) as tar:
+        names = [m.name for m in tar.getmembers() if m.isfile()]
         tar.extractall(dest, filter="data")
+    return names
+
+
+def build_substrate(repo_root: Path, dest: Path, floor_text: str, ref: str) -> None:
+    dest.mkdir(parents=True)
+    _export_paths(repo_root, dest, ref, SUBSTRATE_EXPORTS)
+    (dest / "CLAUDE.md").write_text(_fill(floor_text))
+    (dest / "analytics" / "pyproject.toml").write_text(ARM_PYPROJECT)
+    _write_settings(dest)
+
+
+def build_manifest(arm: str, ref: str, dest: Path, layer_of: dict[str, str]) -> dict:
+    files = {}
+    skip = {".venv", "__pycache__"}
+    for f in sorted(p for p in dest.rglob("*") if p.is_file()):
+        if f.name == "manifest.json" or skip & set(f.relative_to(dest).parts):
+            continue
+        rel = str(f.relative_to(dest))
+        files[rel] = {
+            "sha256": hashlib.sha256(f.read_bytes()).hexdigest(),
+            "layer": layer_of.get(rel, "substrate"),
+        }
+    return {"arm": arm, "ref": ref, "files": files}
 
 
 def prep_arm(
     arm: str, repo_root: Path, arms_root: Path, floor_text: str, ref: str = "main", sync: bool = True
 ) -> Path:
-    if arm not in ARMS:
-        raise ValueError(f"unknown arm {arm!r}; expected one of {ARMS}")
+    if arm not in ARM_LAYERS:
+        raise ValueError(f"unknown arm {arm!r}; expected one of {sorted(ARM_LAYERS)}")
     dest = arms_root / arm
-
-    if arm == "bare":
-        if dest.exists():
-            shutil.rmtree(dest)
-        env = dest / "env"
-        env.mkdir(parents=True)
-        (dest / "CLAUDE.md").write_text(_fill(floor_text, "env", "env"))
-        shutil.copy(repo_root / "analytics" / "lib" / "databricks_conn.py", env / "databricks_conn.py")
-        (env / "pyproject.toml").write_text(BARE_PYPROJECT)
-        _write_settings(dest)
-        if sync:
-            subprocess.run(["uv", "sync"], cwd=env, check=True)
-        return dest
-
-    _export(repo_root, dest, ref)
-    shutil.rmtree(dest / "analytics" / "diagnostics" / "quality_bench", ignore_errors=True)
-    claude_md = dest / "CLAUDE.md"
-    existing = claude_md.read_text() if claude_md.exists() else ""
-    claude_md.write_text(existing + "\n\n" + _fill(floor_text, "analytics/lib", "analytics"))
-
-    if arm == "knowledge":
-        skills = dest / ".claude" / "skills"
-        for child in skills.iterdir() if skills.exists() else []:
-            if child.name not in KNOWLEDGE_SKILLS:
-                shutil.rmtree(child)
-        shutil.rmtree(dest / ".claude" / "agents", ignore_errors=True)
-
-    _write_settings(dest)
+    if dest.exists():
+        shutil.rmtree(dest)
+    build_substrate(repo_root, dest, floor_text, ref)
+    layer_of: dict[str, str] = {}
+    for layer in ARM_LAYERS[arm]:
+        for extracted in _export_paths(repo_root, dest, ref, LAYERS[layer]):
+            layer_of[extracted] = layer
+    manifest = build_manifest(arm, ref, dest, layer_of)
+    (dest / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
     if sync:
         subprocess.run(["uv", "sync"], cwd=dest / "analytics", check=True)
     return dest
@@ -141,10 +172,23 @@ if __name__ == "__main__":
         "--arms-root", type=Path, default=Path.home() / ".cache" / "gp_quality_bench" / "arms"
     )
     parser.add_argument("--ref", default="main")
+    parser.add_argument(
+        "--no-sync", action="store_true", help="skip `uv sync` in each arm (tests/CI; runs need synced arms)"
+    )
     args = parser.parse_args()
     here = Path(__file__).parent
     repo_root = here.parents[2]
     floor_text = (here / "floor.md").read_text()
+    canaries = integrity.load_canaries(here / "canaries.yaml")
+    failures = integrity.check_canary_staleness(canaries, repo_root)
+    failures += [f"floor: {f}" for f in integrity.check_text_leakage(floor_text, set(), canaries)]
+    if failures:
+        raise SystemExit("pre-prep integrity failed:\n" + "\n".join(failures))
     for arm in ARMS:
-        path = prep_arm(arm, repo_root, args.arms_root, floor_text, ref=args.ref)
-        print(f"prepped {arm}: {path}")
+        path = prep_arm(arm, repo_root, args.arms_root, floor_text, ref=args.ref, sync=not args.no_sync)
+        arm_failures = integrity.check_links(path)
+        arm_failures += integrity.check_arm_leakage(path, set(ARM_LAYERS[arm]), canaries)
+        if arm_failures:
+            raise SystemExit(f"arm {arm!r} failed integrity:\n" + "\n".join(arm_failures))
+        n = len(json.loads((path / "manifest.json").read_text())["files"])
+        print(f"prepped {arm}: {path} ({n} files, integrity ok)")

--- a/analytics/diagnostics/quality_bench/run_matrix.py
+++ b/analytics/diagnostics/quality_bench/run_matrix.py
@@ -38,13 +38,15 @@ def save_state(state_file: Path, state: dict) -> None:
     tmp.replace(state_file)
 
 
-def bench_fingerprint(here: Path, model: str) -> dict:
-    """Hash the inputs that shape run answers: question prompts, the floor, and
-    the model. Keys are deliberately exempt (grader-side, applied uniformly at
-    grade time, so a key edit cannot mix run provenance); binding arm content
-    and prep config is the fuller BatchConfig follow-up. The harness git sha is
-    recorded for provenance but not gated, so an unrelated commit does not force
-    a full re-run."""
+def bench_fingerprint(here: Path, model: str, arm_dirs: dict[str, Path] | None = None) -> dict:
+    """Hash the inputs that shape run answers: question prompts, the floor, the
+    model, and each arm's manifest. Keys are deliberately exempt (grader-side,
+    applied uniformly at grade time, so a key edit cannot mix run provenance).
+    Arm content is now part of run provenance via the per-arm manifest.json
+    (file hashes + layer attribution, DATA-2164): changed arm content blocks
+    resume same as changed questions or model. The harness git sha is recorded
+    for provenance but not gated, so an unrelated commit does not force a full
+    re-run."""
     h = hashlib.sha256()
     for p in [*sorted((here / "questions").glob("*")), here / "floor.md"]:
         if p.is_file():
@@ -53,9 +55,14 @@ def bench_fingerprint(here: Path, model: str) -> dict:
     git = subprocess.run(
         ["git", "rev-parse", "--short", "HEAD"], cwd=here, capture_output=True, text=True, check=False
     )
+    arms = {}
+    for arm, d in sorted((arm_dirs or {}).items()):
+        m = d / "manifest.json"
+        arms[arm] = hashlib.sha256(m.read_bytes()).hexdigest() if m.exists() else "missing"
     return {
         "inputs_sha256": h.hexdigest(),
         "model": model,
+        "arms_sha256": json.dumps(arms, sort_keys=True),
         "harness_git_sha": git.stdout.strip() if git.returncode == 0 else "unknown",
     }
 
@@ -68,7 +75,7 @@ def resume_guard(state: dict, fingerprint: dict) -> None:
     if old is None:
         state["fingerprint"] = fingerprint
         return
-    changed = [k for k in ("inputs_sha256", "model") if old.get(k) != fingerprint[k]]
+    changed = [k for k in ("inputs_sha256", "model", "arms_sha256") if old.get(k) != fingerprint.get(k)]
     if changed:
         raise SystemExit(
             f"refusing to resume: {', '.join(changed)} changed since this batch was created; "
@@ -302,16 +309,18 @@ def main() -> None:
     batch_dir.mkdir(parents=True, exist_ok=True)
     state_file = batch_dir / "state.json"
     state = json.loads(state_file.read_text()) if state_file.exists() else {"runs": {}}
-    resume_guard(state, bench_fingerprint(here, args.model))
+
+    arm_dirs = {arm: args.arms_root / arm for arm in args.arms}
+    for d in arm_dirs.values():
+        if not d.exists():
+            raise SystemExit(f"arm dir missing: {d} — run prep_arms.py first")
+
+    resume_guard(state, bench_fingerprint(here, args.model, arm_dirs))
     save_state(state_file, state)
 
     questions = load_manifest(here / "questions" / "manifest.yaml")
     if args.questions:
         questions = [q for q in questions if q.id in set(args.questions)]
-    arm_dirs = {arm: args.arms_root / arm for arm in args.arms}
-    for d in arm_dirs.values():
-        if not d.exists():
-            raise SystemExit(f"arm dir missing: {d} — run prep_arms.py first")
 
     runs = build_runs(questions, arm_dirs, args.reps, here / "questions")
     todo = [r for r in runs if not state["runs"].get(r.run_id, {}).get("ok")]

--- a/analytics/tests/test_quality_bench_floor.py
+++ b/analytics/tests/test_quality_bench_floor.py
@@ -1,4 +1,3 @@
-# analytics/tests/test_quality_bench_floor.py
 from pathlib import Path
 
 import pandas as pd
@@ -9,65 +8,53 @@ STATIC_DIR = Path(__file__).parent.parent / "diagnostics" / "quality_bench"
 
 def fake_run_query(sql: str) -> pd.DataFrame:
     assert "information_schema" in sql
+    assert "comment" not in sql.lower(), "inventory must not select curated comments"
     return pd.DataFrame(
         {
-            "table_name": ["users_win_base", "stg_x", "stg_with_issues"],
-            "comment": ["Win users mart", None, "Comment with\nnewline and | pipe"],
+            "table_name": ["users_win_base", "stg_x"],
+            "table_type": ["MANAGED", "VIEW"],
+            "n_columns": [12, 3],
         }
     )
 
 
-def test_build_inventory_md():
-    md = floor_gen.build_inventory_md(fake_run_query)
-    assert "users_win_base" in md
-    assert "Win users mart" in md
-    assert "(no description)" in md  # None comment rendered
-
-
-def test_build_inventory_md_sanitizes_comments():
-    """Comments with newlines and pipes must be escaped for markdown tables."""
+def test_build_inventory_md_is_identifiers_and_neutral_metadata_only():
     md = floor_gen.build_inventory_md(fake_run_query)
     lines = md.split("\n")
-    # Each line should start with '|' for a valid markdown table
+    assert lines[0] == "| table | type | columns |"
+    assert "| users_win_base | MANAGED | 12 |" in md
+    assert "| stg_x | VIEW | 3 |" in md
     for line in lines:
         assert line.startswith("|"), f"Malformed row: {line}"
-    # Check that newline was collapsed to space and pipe was escaped
-    assert "Comment with newline and \\| pipe" in md
-    # Verify no unescaped pipes in comments (only column separators)
-    content_lines = [line for line in lines if "stg_with_issues" in line]
-    assert len(content_lines) == 1, "Comment with newline should not span multiple rows"
 
 
-def fake_run_query_verbose(sql: str) -> pd.DataFrame:
-    return pd.DataFrame(
-        {
-            "table_name": ["multi_sentence", "long_single"],
-            "comment": [
-                "Win activation mart. Joins campaigns to sessions and derives the "
-                "activated flag using the governed 3-era logic; do not reuse.",
-                "A" * 400,
-            ],
-        }
-    )
+def test_curated_comment_prose_cannot_reach_the_floor():
+    """DATA-2164 floor leakage: even if the query returned prose-bearing
+    columns, the renderer only emits name/type/count fields."""
+
+    def poisoned(sql: str) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "table_name": ["t"],
+                "table_type": ["MANAGED"],
+                "n_columns": [1],
+                "comment": ["governed 3-era activation logic, do not reuse"],
+            }
+        )
+
+    md = floor_gen.build_inventory_md(poisoned)
+    assert "governed 3-era" not in md
 
 
-def test_build_inventory_md_truncates_to_first_sentence_and_caps_length():
-    md = floor_gen.build_inventory_md(fake_run_query_verbose)
-    ms_line = next(line for line in md.split("\n") if "multi_sentence" in line)
-    # Only the first sentence survives; the curated remainder is dropped.
-    assert "Win activation mart" in ms_line
-    assert "governed 3-era logic" not in ms_line
-    assert ms_line.rstrip().endswith("…|") or "…" in ms_line
-    # The 400-char single "sentence" is capped at 150 chars (+ ellipsis).
-    ls_line = next(line for line in md.split("\n") if "long_single" in line)
-    a_run = ls_line.count("A")
-    assert a_run == 150, f"expected 150 A's, got {a_run}"
-    assert "…" in ls_line
+def test_build_floor_fills_template(tmp_path):
+    static = tmp_path / "floor_static.md"
+    static.write_text("head\n{{TABLE_INVENTORY}}\ntail")
+    out = floor_gen.build_floor(static, fake_run_query)
+    assert out.startswith("head\n| table |")
+    assert out.endswith("tail")
 
 
-def test_build_floor_fills_inventory_only():
-    floor = floor_gen.build_floor(STATIC_DIR / "floor_static.md", fake_run_query)
-    assert "users_win_base" in floor
-    assert "{{TABLE_INVENTORY}}" not in floor
-    # arm-specific slots are left for prep_arms
-    assert "{{LIB_PATH}}" in floor and "{{UV_PROJECT}}" in floor
+def test_real_floor_static_has_allowlist_section():
+    text = (STATIC_DIR / "floor_static.md").read_text()
+    assert "## Shared operational facts" in text
+    assert "{{TABLE_INVENTORY}}" in text

--- a/analytics/tests/test_quality_bench_floor.py
+++ b/analytics/tests/test_quality_bench_floor.py
@@ -58,3 +58,5 @@ def test_real_floor_static_has_allowlist_section():
     text = (STATIC_DIR / "floor_static.md").read_text()
     assert "## Shared operational facts" in text
     assert "{{TABLE_INVENTORY}}" in text
+    assert "{{LIB_PATH}}" in text
+    assert "{{UV_PROJECT}}" in text

--- a/analytics/tests/test_quality_bench_integrity.py
+++ b/analytics/tests/test_quality_bench_integrity.py
@@ -66,3 +66,30 @@ def test_real_canaries_are_fresh():
     layers = {c.layer for c in canaries}
     assert layers == {"knowledge", "process"}
     assert integrity.check_canary_staleness(canaries, REPO_ROOT) == []
+
+
+def test_check_links_flags_dead_relative_md_link(tmp_path):
+    arm = tmp_path / "arm"
+    (arm / "docs").mkdir(parents=True)
+    (arm / "docs" / "a.md").write_text("see [b](b.md) and [gone](../missing/c.md)")
+    (arm / "docs" / "b.md").write_text("fine")
+    failures = integrity.check_links(arm)
+    assert len(failures) == 1
+    assert "missing/c.md" in failures[0]
+
+
+def test_check_links_ignores_external_and_fragment_links(tmp_path):
+    arm = tmp_path / "arm"
+    arm.mkdir()
+    (arm / "a.md").write_text("[x](https://example.com/p.md) [y](#anchor) [z](mailto:a@b.md)")
+    assert integrity.check_links(arm) == []
+
+
+def test_check_arm_leakage_scans_all_files(tmp_path):
+    canaries = integrity.load_canaries(_write_canaries(tmp_path))
+    arm = tmp_path / "arm"
+    (arm / "analytics" / "lib").mkdir(parents=True)
+    (arm / "analytics" / "lib" / "notes.py").write_text("# the moon is made of governed cheese")
+    hits = integrity.check_arm_leakage(arm, set(), canaries)
+    assert len(hits) == 1 and "notes.py" in hits[0]
+    assert integrity.check_arm_leakage(arm, {"knowledge"}, canaries) == []

--- a/analytics/tests/test_quality_bench_integrity.py
+++ b/analytics/tests/test_quality_bench_integrity.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+from quality_bench import integrity
+
+QB_DIR = Path(__file__).parent.parent / "diagnostics" / "quality_bench"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CANARIES_YAML = """\
+canaries:
+  - layer: knowledge
+    source: skills/win/SKILL.md
+    phrase: "the moon is made of governed cheese"
+  - layer: process
+    source: skills/process/SKILL.md
+    phrase: "adversarial reviewer cadence"
+"""
+
+
+def _write_canaries(tmp_path: Path) -> Path:
+    p = tmp_path / "canaries.yaml"
+    p.write_text(CANARIES_YAML)
+    return p
+
+
+def test_load_canaries(tmp_path):
+    canaries = integrity.load_canaries(_write_canaries(tmp_path))
+    assert len(canaries) == 2
+    assert canaries[0].layer == "knowledge"
+    assert canaries[0].phrase == "the moon is made of governed cheese"
+
+
+def test_staleness_flags_missing_phrase_and_missing_file(tmp_path):
+    canaries = integrity.load_canaries(_write_canaries(tmp_path))
+    repo = tmp_path / "repo"
+    (repo / "skills" / "win").mkdir(parents=True)
+    (repo / "skills" / "win" / "SKILL.md").write_text("the moon is made of governed cheese, per DATA-1")
+    # process source file absent entirely
+    failures = integrity.check_canary_staleness(canaries, repo)
+    assert len(failures) == 1
+    assert "skills/process/SKILL.md" in failures[0]
+
+
+def test_staleness_passes_when_all_present(tmp_path):
+    canaries = integrity.load_canaries(_write_canaries(tmp_path))
+    repo = tmp_path / "repo"
+    (repo / "skills" / "win").mkdir(parents=True)
+    (repo / "skills" / "process").mkdir(parents=True)
+    (repo / "skills" / "win" / "SKILL.md").write_text("x the moon is made of governed cheese y")
+    (repo / "skills" / "process" / "SKILL.md").write_text("follow the adversarial reviewer cadence")
+    assert integrity.check_canary_staleness(canaries, repo) == []
+
+
+def test_text_leakage_respects_allowed_layers(tmp_path):
+    canaries = integrity.load_canaries(_write_canaries(tmp_path))
+    text = "inventory says the moon is made of governed cheese"
+    assert integrity.check_text_leakage(text, set(), canaries)  # bare/floor: leak
+    assert integrity.check_text_leakage(text, {"knowledge"}, canaries) == []  # knowledge arm: allowed
+
+
+def test_real_canaries_are_fresh():
+    """Every canary in the committed canaries.yaml exists verbatim in its
+    source file, so the leakage scan is actually scanning for live treatment
+    content. A reworded skill must break this test, forcing a canary refresh."""
+    canaries = integrity.load_canaries(QB_DIR / "canaries.yaml")
+    assert len(canaries) >= 8
+    layers = {c.layer for c in canaries}
+    assert layers == {"knowledge", "process"}
+    assert integrity.check_canary_staleness(canaries, REPO_ROOT) == []

--- a/analytics/tests/test_quality_bench_integrity.py
+++ b/analytics/tests/test_quality_bench_integrity.py
@@ -103,3 +103,18 @@ def test_check_arm_leakage_scans_all_files(tmp_path):
     hits = integrity.check_arm_leakage(arm, set(), canaries)
     assert len(hits) == 1 and "notes.py" in hits[0]
     assert integrity.check_arm_leakage(arm, {"knowledge"}, canaries) == []
+
+
+def test_check_links_skips_venv(tmp_path):
+    arm = tmp_path / "arm"
+    (arm / ".venv" / "lib" / "pkg").mkdir(parents=True)
+    (arm / ".venv" / "lib" / "pkg" / "README.md").write_text("see [CHANGELOG](CHANGELOG.md)")
+    assert integrity.check_links(arm) == []
+
+
+def test_check_arm_leakage_skips_venv(tmp_path):
+    canaries = integrity.load_canaries(_write_canaries(tmp_path))
+    arm = tmp_path / "arm"
+    (arm / ".venv" / "pkg").mkdir(parents=True)
+    (arm / ".venv" / "pkg" / "notes.txt").write_text("the moon is made of governed cheese")
+    assert integrity.check_arm_leakage(arm, set(), canaries) == []

--- a/analytics/tests/test_quality_bench_integrity.py
+++ b/analytics/tests/test_quality_bench_integrity.py
@@ -62,7 +62,9 @@ def test_real_canaries_are_fresh():
     source file, so the leakage scan is actually scanning for live treatment
     content. A reworded skill must break this test, forcing a canary refresh."""
     canaries = integrity.load_canaries(QB_DIR / "canaries.yaml")
-    assert len(canaries) >= 8
+    # Exact count: a floor would let a deleted canary pass silently (staleness
+    # only checks entries that remain). Adding a canary means bumping this.
+    assert len(canaries) == 9
     layers = {c.layer for c in canaries}
     assert layers == {"knowledge", "process"}
     assert integrity.check_canary_staleness(canaries, REPO_ROOT) == []

--- a/analytics/tests/test_quality_bench_integrity.py
+++ b/analytics/tests/test_quality_bench_integrity.py
@@ -85,6 +85,16 @@ def test_check_links_ignores_external_and_fragment_links(tmp_path):
     assert integrity.check_links(arm) == []
 
 
+def test_check_links_flags_link_escaping_arm_to_sibling(tmp_path):
+    arm = tmp_path / "arm"
+    arm.mkdir()
+    (tmp_path / "outside.md").write_text("sibling arm content")
+    (arm / "escape.md").write_text("see [out](../outside.md)")
+    failures = integrity.check_links(arm)
+    assert len(failures) == 1
+    assert "outside.md" in failures[0]
+
+
 def test_check_arm_leakage_scans_all_files(tmp_path):
     canaries = integrity.load_canaries(_write_canaries(tmp_path))
     arm = tmp_path / "arm"

--- a/analytics/tests/test_quality_bench_prep.py
+++ b/analytics/tests/test_quality_bench_prep.py
@@ -167,6 +167,34 @@ def test_missing_layer_path_at_ref_raises(fake_repo, tmp_path):
         prep_arms.prep_arm("full", fake_repo, tmp_path / "arms", FLOOR, sync=False)
 
 
+def test_one_factor_contrast_pinned_by_hashes(fake_repo, tmp_path):
+    """The one-factor guarantee at the content level: substrate must be
+    byte-identical (same hash) across all three arms, and every file the
+    knowledge layer contributes to the knowledge arm must show up in the
+    full arm with the same hash and layer label — full only ever adds on
+    top of knowledge, never replaces it."""
+    manifests = {a: _manifest(_prep(a, fake_repo, tmp_path)) for a in ("bare", "knowledge", "full")}
+
+    substrate_by_arm = {
+        arm: {rel: f["sha256"] for rel, f in m["files"].items() if f["layer"] == "substrate"}
+        for arm, m in manifests.items()
+    }
+    rels = set(substrate_by_arm["bare"])
+    assert rels and rels == set(substrate_by_arm["knowledge"]) == set(substrate_by_arm["full"])
+    for rel in rels:
+        hashes = {substrate_by_arm[a][rel] for a in ("bare", "knowledge", "full")}
+        assert len(hashes) == 1, f"{rel} substrate hash diverges across arms: {hashes}"
+
+    knowledge_files = manifests["knowledge"]["files"]
+    full_files = manifests["full"]["files"]
+    knowledge_layer_rels = [rel for rel, f in knowledge_files.items() if f["layer"] == "knowledge"]
+    assert knowledge_layer_rels
+    for rel in knowledge_layer_rels:
+        assert rel in full_files
+        assert full_files[rel]["sha256"] == knowledge_files[rel]["sha256"]
+        assert full_files[rel]["layer"] == "knowledge"
+
+
 def test_cli_help_works_under_bare_python():
     analytics_root = Path(__file__).parent.parent
     proc = subprocess.run(

--- a/analytics/tests/test_quality_bench_prep.py
+++ b/analytics/tests/test_quality_bench_prep.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -206,3 +207,68 @@ def test_cli_help_works_under_bare_python():
     )
     assert proc.returncode == 0, proc.stderr
     assert "--arms-root" in proc.stdout
+
+
+def _run_prep_cli(
+    fake_repo: Path, tmp_path: Path, canaries_yaml: str, arms_subdir: str = "arms"
+) -> subprocess.CompletedProcess:
+    """Run the prep CLI as a real subprocess against the fake repo, by copying
+    the harness modules in. The CLI resolves repo_root from its own file
+    location (`here.parents[2]`), so the harness must live at
+    <repo>/analytics/diagnostics/quality_bench for that resolution to land on
+    fake_repo instead of the real one."""
+    dest = fake_repo / "analytics" / "diagnostics" / "quality_bench"
+    dest.mkdir(parents=True, exist_ok=True)
+    real_qb = Path(prep_arms.__file__).parent
+    for name in ("prep_arms.py", "integrity.py", "bank.py", "__init__.py"):
+        shutil.copy(real_qb / name, dest / name)
+    (dest / "floor.md").write_text("# floor\nlib {{LIB_PATH}} proj {{UV_PROJECT}}\n")
+    (dest / "canaries.yaml").write_text(canaries_yaml)
+    return subprocess.run(
+        [sys.executable, str(dest / "prep_arms.py"), "--arms-root", str(tmp_path / arms_subdir), "--no-sync"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_cli_passes_integrity_on_clean_repo(fake_repo, tmp_path):
+    canaries_yaml = (
+        'canaries:\n  - {layer: process, source: .claude/agents/product-manager.md, phrase: "pm prose"}\n'
+    )
+    proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml)
+    assert proc.returncode == 0, proc.stderr
+    assert "integrity ok" in proc.stdout
+
+
+def test_cli_fails_when_treatment_canary_leaks_into_floor(fake_repo, tmp_path):
+    """A clean run passes first; then floor.md is poisoned in place (the
+    harness dir left behind by the clean run) and the CLI is rerun directly,
+    to confirm the pre-prep floor-leakage gate fires on its own, not just as
+    a side effect of a fresh copy."""
+    canaries_yaml = (
+        'canaries:\n  - {layer: process, source: .claude/agents/product-manager.md, phrase: "pm prose"}\n'
+    )
+    proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml, arms_subdir="arms")
+    assert proc.returncode == 0, proc.stderr
+
+    dest = fake_repo / "analytics" / "diagnostics" / "quality_bench"
+    (dest / "floor.md").write_text("# floor with pm prose leaked in\n")
+    proc = subprocess.run(
+        [sys.executable, str(dest / "prep_arms.py"), "--arms-root", str(tmp_path / "arms2"), "--no-sync"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode != 0
+    assert "canary leaked" in proc.stderr
+
+
+def test_cli_fails_on_stale_canary(fake_repo, tmp_path):
+    canaries_yaml = (
+        "canaries:\n  - {layer: process, source: .claude/agents/product-manager.md, "
+        'phrase: "not actually in the file"}\n'
+    )
+    proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml)
+    assert proc.returncode != 0
+    assert "stale canary" in proc.stderr

--- a/analytics/tests/test_quality_bench_prep.py
+++ b/analytics/tests/test_quality_bench_prep.py
@@ -196,7 +196,7 @@ def test_one_factor_contrast_pinned_by_hashes(fake_repo, tmp_path):
         assert full_files[rel]["layer"] == "knowledge"
 
 
-def test_cli_help_works_under_bare_python():
+def test_cli_help_works_via_path_shim():
     analytics_root = Path(__file__).parent.parent
     proc = subprocess.run(
         [sys.executable, "diagnostics/quality_bench/prep_arms.py", "--help"],

--- a/analytics/tests/test_quality_bench_prep.py
+++ b/analytics/tests/test_quality_bench_prep.py
@@ -272,3 +272,41 @@ def test_cli_fails_on_stale_canary(fake_repo, tmp_path):
     proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml)
     assert proc.returncode != 0
     assert "stale canary" in proc.stderr
+
+
+def test_verify_export_coverage_passes_for_dir_and_file():
+    prep_arms._verify_export_coverage(
+        [".claude/skills/win-analytics-knowledge", "analytics/lib/databricks_conn.py"],
+        [".claude/skills/win-analytics-knowledge/SKILL.md", "analytics/lib/databricks_conn.py"],
+        "main",
+    )
+
+
+def test_verify_export_coverage_raises_on_uncovered_path():
+    """A prefix-overlapping sibling must not mask a missing path: files under
+    win-analytics-knowledge do not cover a pathspec named win."""
+    with pytest.raises(RuntimeError, match="no files for"):
+        prep_arms._verify_export_coverage(
+            [".claude/skills/win"],
+            [".claude/skills/win-analytics-knowledge/SKILL.md"],
+            "main",
+        )
+
+
+def test_manifest_includes_dependency_resolution_when_synced(fake_repo, tmp_path, monkeypatch):
+    """uv.lock is run provenance: sync happens before the manifest, so a
+    re-prep that resolves different deps changes arms_sha256 and blocks
+    resuming an existing batch with mixed dependency provenance."""
+    real_run = prep_arms.subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        if cmd[0] == "uv":
+            (kwargs["cwd"] / "uv.lock").write_text("resolution v1")
+            return subprocess.CompletedProcess(cmd, 0)
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(prep_arms.subprocess, "run", fake_run)
+    arm = prep_arms.prep_arm("bare", fake_repo, tmp_path / "arms", FLOOR, sync=True)
+    manifest = _manifest(arm)
+    assert "analytics/uv.lock" in manifest["files"]
+    assert manifest["files"]["analytics/uv.lock"]["layer"] == "substrate"

--- a/analytics/tests/test_quality_bench_prep.py
+++ b/analytics/tests/test_quality_bench_prep.py
@@ -11,23 +11,31 @@ FLOOR = "# floor\nlib at {{LIB_PATH}} project {{UV_PROJECT}}\n"
 
 @pytest.fixture
 def fake_repo(tmp_path: Path) -> Path:
+    """Mirror of the real layout: treatment skills/agents/libs, plus content
+    that must NEVER reach an arm (quality_bench keys, data-matching skill,
+    code-critic agent, dbt models)."""
     repo = tmp_path / "repo"
-    (repo / ".claude" / "skills" / "analytics-process").mkdir(parents=True)
-    (repo / ".claude" / "skills" / "win-analytics-knowledge").mkdir(parents=True)
-    (repo / ".claude" / "skills" / "serve-analytics-knowledge").mkdir(parents=True)
-    (repo / ".claude" / "agents").mkdir(parents=True)
-    (repo / "analytics" / "diagnostics" / "quality_bench" / "keys").mkdir(parents=True)
-    (repo / "analytics" / "lib").mkdir(parents=True)
-    for f in [
-        ".claude/skills/analytics-process/SKILL.md",
-        ".claude/skills/win-analytics-knowledge/SKILL.md",
-        ".claude/skills/serve-analytics-knowledge/SKILL.md",
-        ".claude/agents/reviewer.md",
-        "analytics/diagnostics/quality_bench/keys/q01_key.yaml",
-        "analytics/lib/databricks_conn.py",
-        "CLAUDE.md",
-    ]:
-        (repo / f).write_text("x")
+    files = {
+        ".claude/skills/analytics-process/SKILL.md": "process prose [p](references/pipeline.md)",
+        ".claude/skills/analytics-process/references/pipeline.md": "pipeline",
+        ".claude/skills/win-analytics-knowledge/SKILL.md": "win prose [g](references/gotchas.md)",
+        ".claude/skills/win-analytics-knowledge/references/gotchas.md": "win gotchas",
+        ".claude/skills/serve-analytics-knowledge/SKILL.md": "serve prose",
+        ".claude/skills/data-matching/SKILL.md": "matching prose",
+        ".claude/agents/product-data-scientist.md": "pds prose",
+        ".claude/agents/product-manager.md": "pm prose",
+        ".claude/agents/code-critic.md": "critic prose",
+        "analytics/lib/databricks_conn.py": "# conn",
+        "analytics/lib/win_analysis.py": "# win helpers",
+        "analytics/lib/serve_analysis.py": "# serve helpers",
+        "analytics/diagnostics/quality_bench/keys/q01_key.yaml": "answer: 42",
+        "dbt/project/models/marts/some_model.sql": "select 1",
+        "CLAUDE.md": "repo claude md",
+    }
+    for rel, content in files.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
     subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
     subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
     subprocess.run(
@@ -36,59 +44,127 @@ def fake_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_full_arm_excludes_quality_bench_keeps_skills(fake_repo, tmp_path):
-    arm = prep_arms.prep_arm("full", fake_repo, tmp_path / "arms", FLOOR, sync=False)
-    assert not (arm / "analytics" / "diagnostics" / "quality_bench").exists()
-    # git-archive export, not a worktree: no .git, so the deleted keys are not
-    # recoverable from history.
-    assert not (arm / ".git").exists()
-    assert (arm / ".claude" / "skills" / "analytics-process").exists()
-    assert "{{LIB_PATH}}" not in (arm / "CLAUDE.md").read_text()
-    assert "analytics/lib" in (arm / "CLAUDE.md").read_text()
-    settings = json.loads((arm / ".claude" / "settings.local.json").read_text())
-    assert settings["permissions"]["allow"]
+def _prep(arm, fake_repo, tmp_path):
+    return prep_arms.prep_arm(arm, fake_repo, tmp_path / "arms", FLOOR, sync=False)
 
 
-def test_knowledge_arm_prunes_process_skill_and_agents(fake_repo, tmp_path):
-    arm = prep_arms.prep_arm("knowledge", fake_repo, tmp_path / "arms", FLOOR, sync=False)
-    assert not (arm / ".claude" / "skills" / "analytics-process").exists()
-    assert not (arm / ".claude" / "agents").exists()
-    assert (arm / ".claude" / "skills" / "win-analytics-knowledge").exists()
-    assert (arm / ".claude" / "skills" / "serve-analytics-knowledge").exists()
-    settings = json.loads((arm / ".claude" / "settings.local.json").read_text())
-    assert settings["permissions"]["allow"]
+def _manifest(arm_dir: Path) -> dict:
+    return json.loads((arm_dir / "manifest.json").read_text())
 
 
-def test_bare_arm_is_scratch_with_floor_and_env(fake_repo, tmp_path):
-    arm = prep_arms.prep_arm("bare", fake_repo, tmp_path / "arms", FLOOR, sync=False)
-    assert not (arm / ".git").exists()
+def test_bare_is_substrate_only(fake_repo, tmp_path):
+    arm = _prep("bare", fake_repo, tmp_path)
+    assert (arm / "analytics" / "lib" / "databricks_conn.py").exists()
+    assert (arm / "analytics" / "pyproject.toml").exists()
     assert not (arm / ".claude" / "skills").exists()
+    assert not (arm / ".git").exists()
     claude_md = (arm / "CLAUDE.md").read_text()
     assert claude_md.startswith("# floor")
-    assert "env" in claude_md
-    assert (arm / "env" / "databricks_conn.py").exists()
-    assert (arm / "env" / "pyproject.toml").exists()
+    assert "analytics/lib" in claude_md and "{{LIB_PATH}}" not in claude_md
     settings = json.loads((arm / ".claude" / "settings.local.json").read_text())
     assert settings["permissions"]["allow"]
+
+
+def test_all_arms_share_identical_substrate(fake_repo, tmp_path):
+    dirs = {a: _prep(a, fake_repo, tmp_path) for a in ("bare", "knowledge", "full")}
+    texts = {a: (d / "CLAUDE.md").read_text() for a, d in dirs.items()}
+    assert texts["bare"] == texts["knowledge"] == texts["full"]
+    for d in dirs.values():
+        assert (d / "analytics" / "lib" / "databricks_conn.py").exists()
+        assert (d / "analytics" / "pyproject.toml").exists()
+
+
+def test_knowledge_arm_adds_only_knowledge_layer(fake_repo, tmp_path):
+    arm = _prep("knowledge", fake_repo, tmp_path)
+    assert (arm / ".claude" / "skills" / "win-analytics-knowledge" / "SKILL.md").exists()
+    assert (arm / ".claude" / "skills" / "serve-analytics-knowledge").exists()
+    assert (arm / "analytics" / "lib" / "win_analysis.py").exists()
+    assert (arm / "analytics" / "lib" / "serve_analysis.py").exists()
+    assert not (arm / ".claude" / "skills" / "analytics-process").exists()
+    assert not (arm / ".claude" / "skills" / "data-matching").exists()
+    assert not (arm / ".claude" / "agents").exists()
+
+
+def test_full_arm_adds_process_layer_and_claimed_reviewers_only(fake_repo, tmp_path):
+    arm = _prep("full", fake_repo, tmp_path)
+    assert (arm / ".claude" / "skills" / "analytics-process" / "SKILL.md").exists()
+    assert (arm / ".claude" / "skills" / "win-analytics-knowledge").exists()
+    assert (arm / ".claude" / "agents" / "product-data-scientist.md").exists()
+    assert (arm / ".claude" / "agents" / "product-manager.md").exists()
+    # Explicitly excluded treatments: not claimed by the pre-registered treatment.
+    assert not (arm / ".claude" / "agents" / "code-critic.md").exists()
+    assert not (arm / ".claude" / "skills" / "data-matching").exists()
+
+
+def test_no_arm_contains_quality_bench_or_repo_extras(fake_repo, tmp_path):
+    """Additive means absence by construction: keys, dbt models, and the repo
+    CLAUDE.md content simply are not in any layer."""
+    for arm_name in ("bare", "knowledge", "full"):
+        arm = _prep(arm_name, fake_repo, tmp_path)
+        assert not (arm / "analytics" / "diagnostics").exists()
+        assert not (arm / "dbt").exists()
+        assert not (arm / ".git").exists()
+        assert "repo claude md" not in (arm / "CLAUDE.md").read_text()
+
+
+def test_manifest_covers_every_file_with_layer_attribution(fake_repo, tmp_path):
+    arm = _prep("full", fake_repo, tmp_path)
+    manifest = _manifest(arm)
+    assert manifest["arm"] == "full" and manifest["ref"] == "main"
+    on_disk = {str(p.relative_to(arm)) for p in arm.rglob("*") if p.is_file() and p.name != "manifest.json"}
+    assert set(manifest["files"]) == on_disk
+    layers = {f["layer"] for f in manifest["files"].values()}
+    assert layers == {"substrate", "knowledge", "process"}
+    assert manifest["files"][".claude/skills/analytics-process/SKILL.md"]["layer"] == "process"
+    assert manifest["files"]["analytics/lib/win_analysis.py"]["layer"] == "knowledge"
+    assert manifest["files"]["analytics/lib/databricks_conn.py"]["layer"] == "substrate"
+    assert all(len(f["sha256"]) == 64 for f in manifest["files"].values())
+
+
+def test_manifest_is_deterministic(fake_repo, tmp_path):
+    m1 = _manifest(_prep("knowledge", fake_repo, tmp_path))
+    arm2 = prep_arms.prep_arm("knowledge", fake_repo, tmp_path / "arms2", FLOOR, sync=False)
+    assert m1 == _manifest(arm2)
 
 
 def test_unknown_arm_raises(fake_repo, tmp_path):
     with pytest.raises(ValueError):
-        prep_arms.prep_arm("mystery", fake_repo, tmp_path / "arms", FLOOR, sync=False)
+        _prep("mystery", fake_repo, tmp_path)
 
 
-def test_full_arm_survives_leftover_non_worktree_dir(fake_repo, tmp_path):
+def test_prep_survives_leftover_dir(fake_repo, tmp_path):
     arms_root = tmp_path / "arms"
     dest = arms_root / "full"
     dest.mkdir(parents=True)
     (dest / "leftover.txt").write_text("stale content from a crashed prior run")
-
     arm = prep_arms.prep_arm("full", fake_repo, arms_root, FLOOR, sync=False)
-
     assert arm == dest
     assert not (dest / "leftover.txt").exists()
-    assert not (arm / "analytics" / "diagnostics" / "quality_bench").exists()
-    assert (arm / ".claude" / "skills" / "analytics-process").exists()
+
+
+def test_missing_layer_path_at_ref_raises(fake_repo, tmp_path):
+    """A renamed skill must fail prep loudly, not silently build a thinner arm."""
+    subprocess.run(
+        ["git", "-C", str(fake_repo), "mv", ".claude/skills/analytics-process", ".claude/skills/renamed"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "-C",
+            str(fake_repo),
+            "commit",
+            "-qam",
+            "rename",
+        ],
+        check=True,
+    )
+    with pytest.raises(RuntimeError):
+        prep_arms.prep_arm("full", fake_repo, tmp_path / "arms", FLOOR, sync=False)
 
 
 def test_cli_help_works_under_bare_python():

--- a/analytics/tests/test_quality_bench_run_matrix.py
+++ b/analytics/tests/test_quality_bench_run_matrix.py
@@ -309,6 +309,21 @@ def test_bench_fingerprint_tracks_arm_manifests(tmp_path: Path):
     assert "arms_sha256" in run_matrix.bench_fingerprint(tmp_path, "m")
 
 
+def test_resume_guard_refuses_legacy_batch_without_arms_hash():
+    """A batch created before this change stored a fingerprint with no
+    arms_sha256 key at all. Resuming it under the new code (which always
+    emits arms_sha256, "{}" when there are no arm_dirs) must still refuse:
+    absent-vs-present is itself a change in what was gated, not a no-op. This
+    pins that refusal so a future revert to fingerprint[k] (which would raise
+    KeyError instead) or a gating regression (dropping arms_sha256 from the
+    tuple, or comparing .get(k) to .get(k) with a default that treats absent
+    as equal to "{}") gets caught here."""
+    state: dict = {"fingerprint": {"inputs_sha256": "aaa", "model": "m", "harness_git_sha": "sha1"}}
+    new_fp = {"inputs_sha256": "aaa", "model": "m", "arms_sha256": "{}", "harness_git_sha": "sha1"}
+    with pytest.raises(SystemExit):
+        run_matrix.resume_guard(state, new_fp)
+
+
 def test_resume_guard_blocks_changed_arms(tmp_path: Path):
     fp = {"inputs_sha256": "aaa", "model": "m", "arms_sha256": "x", "harness_git_sha": "sha1"}
     state: dict = {}

--- a/analytics/tests/test_quality_bench_run_matrix.py
+++ b/analytics/tests/test_quality_bench_run_matrix.py
@@ -293,3 +293,25 @@ def test_launch_run_success_no_transcript(tmp_path: Path):
     assert out["session_id"] == "sess1"
     assert (tmp_path / "batch" / "q01__bare__r1.answer.md").exists()
     assert out["transcript_file"] is None
+
+
+def test_bench_fingerprint_tracks_arm_manifests(tmp_path: Path):
+    (tmp_path / "questions").mkdir()
+    (tmp_path / "floor.md").write_text("floor")
+    arm = tmp_path / "arms" / "bare"
+    arm.mkdir(parents=True)
+    (arm / "manifest.json").write_text('{"files": {"a": 1}}')
+    a = run_matrix.bench_fingerprint(tmp_path, "m", {"bare": arm})
+    (arm / "manifest.json").write_text('{"files": {"a": 2}}')
+    b = run_matrix.bench_fingerprint(tmp_path, "m", {"bare": arm})
+    assert a["arms_sha256"] != b["arms_sha256"]
+    # no arm_dirs -> still produces the key (empty), keeping old call sites valid
+    assert "arms_sha256" in run_matrix.bench_fingerprint(tmp_path, "m")
+
+
+def test_resume_guard_blocks_changed_arms(tmp_path: Path):
+    fp = {"inputs_sha256": "aaa", "model": "m", "arms_sha256": "x", "harness_git_sha": "sha1"}
+    state: dict = {}
+    run_matrix.resume_guard(state, fp)
+    with pytest.raises(SystemExit):
+        run_matrix.resume_guard(state, {**fp, "arms_sha256": "y"})

--- a/analytics/tests/test_skill_doc_links.py
+++ b/analytics/tests/test_skill_doc_links.py
@@ -54,3 +54,23 @@ def test_relative_markdown_links_resolve():
             if not resolved.is_file():
                 broken.append(f"{doc.relative_to(REPO_ROOT)} -> {target}")
     assert not broken, "broken relative links:\n" + "\n".join(broken)
+
+
+KNOWLEDGE_SKILL_DIRS = [
+    REPO_ROOT / ".claude" / "skills" / "win-analytics-knowledge",
+    REPO_ROOT / ".claude" / "skills" / "serve-analytics-knowledge",
+]
+
+
+def test_knowledge_skills_are_self_contained():
+    """DATA-2164: the knowledge skills ship into bench arms without the
+    process or data-matching skills present, so their relative links must not
+    escape their own skill directory. Cross-skill pointers are plain text."""
+    escapes = []
+    for skill_dir in KNOWLEDGE_SKILL_DIRS:
+        for md in sorted(skill_dir.rglob("*.md")):
+            for target in _relative_md_targets(md.read_text()):
+                resolved = (md.parent / target).resolve()
+                if not resolved.is_relative_to(skill_dir.resolve()):
+                    escapes.append(f"{md.relative_to(REPO_ROOT)} -> {target}")
+    assert not escapes, "cross-skill links break arm self-containment:\n" + "\n".join(escapes)

--- a/analytics/tests/test_skill_doc_links.py
+++ b/analytics/tests/test_skill_doc_links.py
@@ -7,8 +7,9 @@ every markdown file in the analytics process/knowledge skills plus the reviewer
 agents and asserts each relative markdown link resolves to an existing file.
 """
 
-import re
 from pathlib import Path
+
+from quality_bench.integrity import relative_md_targets as _relative_md_targets
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -18,24 +19,12 @@ DOC_GLOBS = [
     ".claude/agents/product-*.md",
 ]
 
-LINK_RE = re.compile(r"\]\(([^)]+)\)")
-
 
 def _doc_files() -> list[Path]:
     files: list[Path] = []
     for pattern in DOC_GLOBS:
         files.extend(REPO_ROOT.glob(pattern))
     return sorted(files)
-
-
-def _relative_md_targets(text: str):
-    """Yield relative .md link targets, skipping external URLs and pure fragments."""
-    for match in LINK_RE.finditer(text):
-        target = match.group(1).split("#", 1)[0].strip()
-        if not target or target.startswith(("http://", "https://", "mailto:", "/")):
-            continue
-        if target.endswith(".md"):
-            yield target
 
 
 def test_doc_files_found():


### PR DESCRIPTION
Treatment-integrity rework of the quality_bench 3-arm benchmark, from sanjayr1's PR #636 review (treatment-integrity blocker). Workstreams 1+2 of DATA-2164; workstream 3 (intent-card multi-turn driver) is deferred to a follow-up ticket (86ajnt215).

## Pre-registration amendment (Tristan sign-off 2026-07-21)

The full arm is redefined from "repo as deployed" (git-archive export of main) to a curated bundle. The claim under test is now "the skills as a treatment," not "the repo as deployed." Recorded in the README's "Arm construction (amended 2026-07-22, DATA-2164)" section. The pre-registered Verdict rules are untouched.

## What changed

- **Additive one-factor arms** (`prep_arms.py` rewrite): every arm = identical substrate + declarative treatment layers exported per-path via `git archive <ref>`. bare = substrate; knowledge = + the two product-knowledge skills + `win/serve_analysis.py`; full = + analytics-process skill + its two claimed reviewer agents. Answer keys and `.git` are absent from every arm by construction (nothing is built by deletion). Per-arm `manifest.json` records sha256 + contributing layer for every file; a test pins byte-identical substrate across arms and knowledge files identical into full.
- **Integrity gates** (new `integrity.py` + `canaries.yaml`): prep fails loudly on relative md links that don't resolve inside the arm, on stale canaries, or on any canary phrase from a layer the arm doesn't include (layer-aware leakage scan; venv artifacts skipped). 9 verbatim treatment phrases, grader-side, with a freshness test against the repo.
- **Knowledge skills made self-contained upstream**: the 8 relative links into analytics-process/data-matching become plain-text pointers ("in the analytics-process skill, when installed"); no other wording changed; guarded permanently by `test_knowledge_skills_are_self_contained`.
- **Neutral floor** (`floor_gen.py` + `floor_static.md`): inventory is now name/type/column-count only — no warehouse comments (curated dbt descriptions were leaking into the bare arm). Shared operational facts live in an explicit reviewed allowlist section. `floor.md` regenerated live (877 rows).
- **Resume provenance** (`run_matrix.py`): batch resume now also gates on per-arm manifest hashes (`arms_sha256`), including refusal for pre-change batches.

## Verification

- 215 tests green after rebase onto main; pre-commit clean.
- Live: three arms prepped with "integrity ok" (bare 4 / knowledge 22 / full 31 manifest files); smoke batch (bare+full, sonnet) passed with `arms_sha256` recorded in state.json; full-arm skill-engagement probe fired the Skill tool (analytics-process + win-analytics-knowledge) with zero permission denials.
- Still open as pre-first-batch gates (not merge gates, per README): judge-path probe; Task/reviewer-dispatch headless probe.

Follow-up material noted on the ticket: ref-accurate canary staleness (verify phrases via `git show <ref>:` rather than the working tree); README note that adding an arm to an existing batch now refuses resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark methodology and prep/resume behavior (arms must be re-prepped; old batches may refuse resume) but does not alter production analytics pipelines—risk is mainly to experiment validity and local harness workflows.
> 
> **Overview**
> Reworks the **quality_bench** three-arm experiment so contrasts are **additive one-factor treatments** instead of subtractive git-archive exports with pruning.
> 
> **Arm construction** (`prep_arms.py`): every arm shares the same substrate (floor `CLAUDE.md`, `databricks_conn`, settings, `analytics/pyproject.toml`); **knowledge** adds Win/Serve knowledge skills plus `win_analysis.py` / `serve_analysis.py`; **full** adds **analytics-process** and the two reviewer agents. Layers are exported with per-path `git archive`, each arm gets a **`manifest.json`** (sha256 + layer per file), and prep aborts on failed integrity checks. The README records the pre-registration amendment and marks the old “non–one-factor arms” gate as closed.
> 
> **Integrity** (new `integrity.py`, `canaries.yaml`): dead relative markdown links inside an arm, stale canary phrases, and **layer-aware leakage** (treatment phrases must not appear in bare/floor or arms missing that layer). Batch **resume** in `run_matrix.py` now also requires unchanged **`arms_sha256`** from manifests.
> 
> **Floor leakage fix** (`floor_gen.py`, `floor_static.md`, regenerated `floor.md`): table inventory is **name / type / column count only**—no warehouse/dbt comments—and shared dbt naming facts move to an explicit allowlist section.
> 
> **Knowledge skills**: cross-skill relative links to analytics-process / data-matching become plain-text “when installed” pointers so knowledge arms stay self-contained without those skills present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b9fe733970d02eefe7cf1f66a3f79d05df6953. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->