### PR TITLE
Loader: run validate before resize + env-configurable build_indexes parallelism

### DIFF
--- a/airflow/astro/dags/load_people_api.py
+++ b/airflow/astro/dags/load_people_api.py
@@ -117,27 +117,35 @@ def load_people_api():
     create_schema = _step("create_schema", "create-schema")
     copy = _step("copy", "copy", extra_args=f"--parallelism {_COPY_PARALLELISM}")
     build_indexes = _step("build_indexes", "build-indexes")
-    resize = _step("resize", "resize")
     validate = _step("validate", "validate")
+    resize = _step("resize", "resize")
     # Cost guard: a failed/aborted run after provision strands whatever writer instance class was
-    # in effect (up to db.r8g.48xlarge post build_indexes) because `resize` never runs. Fires
-    # (trigger_rule=one_failed) if any resource-creating task fails, flipping the stranded writer to
-    # db.serverless WITHOUT resize's serve lockdown (no param-group swap, backup retention,
-    # deletion protection, or reboot) so the cluster + loaded data stay around for a resumed retry
-    # or forensics. Skipped when the run succeeds (resize already made the writer serverless).
+    # in effect (up to db.r8g.48xlarge post build_indexes, the same box validate now runs its heavy
+    # per-state counts against) because `resize` never runs. Fires (trigger_rule=one_failed) if any
+    # resource-creating task fails — INCLUDING validate, now that it runs BEFORE resize on the
+    # scaled-up index instance — flipping the stranded writer to db.serverless WITHOUT resize's
+    # serve lockdown (no param-group swap, backup retention, deletion protection, or reboot) so the
+    # cluster + loaded data stay around for a resumed retry or forensics. Skipped when the run
+    # succeeds (resize already made the writer serverless).
     scale_down_on_failure = _step("scale_down_on_failure", "scale-down", trigger_rule="one_failed")
 
     # dbt gate must pass before unload; unload + provision then run in parallel and both feed
-    # create-schema; then the serial load chain.
+    # create-schema; then the serial load chain. validate runs BEFORE resize: it reuses the big
+    # r8g.48xlarge index instance build_indexes already scaled up (validate's per-state
+    # count/GROUP BY checks are heavy over ~227M rows and slow on the small post-resize serving
+    # box), and validate only checks row counts + schema/index structure — none of which change
+    # across resize — so correctness is identical either order. resize is then the clean final step.
     inspect_prod >> dbt_test_voter_gate >> [unload, provision]
     [unload, provision] >> create_schema
-    create_schema >> copy >> build_indexes >> resize >> validate
+    create_schema >> copy >> build_indexes >> validate >> resize
     # The guard's upstreams must include EVERY task after which a cluster can exist, including
-    # `unload` (which runs parallel to provision). one_failed fires only on a DIRECT upstream in
-    # FAILED state; if unload fails while provision succeeds, the downstream tasks go UPSTREAM_FAILED
-    # (which does NOT satisfy one_failed), so unload must feed the guard directly or the stranded
-    # cluster is missed.
-    [provision, unload, create_schema, copy, build_indexes, resize] >> scale_down_on_failure
+    # `unload` (which runs parallel to provision) and `validate` (which now runs on the scaled-up
+    # writer before resize — a validate failure must flip it to serverless, not strand it).
+    # one_failed fires only on a DIRECT upstream in FAILED state; if unload fails while provision
+    # succeeds, the downstream tasks go UPSTREAM_FAILED (which does NOT satisfy one_failed), so
+    # unload (and every other task below) must feed the guard directly or the stranded cluster is
+    # missed.
+    [provision, unload, create_schema, copy, build_indexes, validate, resize] >> scale_down_on_failure
 
 
 load_people_api()

--- a/airflow/astro/docs/people_api_loader.md
+++ b/airflow/astro/docs/people_api_loader.md
@@ -38,8 +38,14 @@ not part of this loader.
 
 ```
 inspect_prod -> dbt_test_voter_gate -> unload -> provision -> create_schema -> copy
-             -> build_indexes -> resize -> validate
+             -> build_indexes -> validate -> resize
 ```
+
+`validate` runs **before** `resize`: `resize` flips the writer down to the small serving instance
+class, and `validate`'s heavy per-state `count`/`GROUP BY` checks over ~227M rows are slow there.
+Running `validate` first reuses the big index instance `build_indexes` already scaled up, so it's
+fast; `resize` is then the clean final step. `validate` only checks row counts + schema/index
+structure — none of which change across `resize` — so correctness is identical either order.
 
 | Step | Purpose |
 |---|---|
@@ -49,10 +55,10 @@ inspect_prod -> dbt_test_voter_gate -> unload -> provision -> create_schema -> c
 | `provision` | Create a fresh Aurora cluster + writer on the **copy-phase** instance class, empty cluster parameter groups, connection string to SSM. Reuses the shared S3 gateway VPC endpoint. |
 | `create_schema` | Apply CREATE TABLE statements from the committed snapshot for all four tables: `Voter` and `DistrictVoter` (partitioned by State with per-state LIST children) and `District` and `DistrictStats` (flat). |
 | `copy` | Parallel server-side `aws_s3.table_import_from_s3`: for partitioned tables (Voter, DistrictVoter), per-state per-file copy with rows routed to partitions by `"State"`; for flat tables (District, DistrictStats), whole-table copy. Idempotent per state/table (count / DELETE + reload). |
-| `build_indexes` | Scale the writer up to the **index-phase** class, then add primary keys and indexes for all four tables: for partitioned tables (Voter, DistrictVoter) build per-partition indexes and attach to parent; for flat tables (District, DistrictStats) build parent-level indexes. Then `ANALYZE` all tables. See below. |
-| `resize` | Flip the writer down to the serving instance class (`serve_instance_class`, prod default `db.r6g.4xlarge`; dev sets `LOADER_SERVE_INSTANCE_CLASS=db.t4g.medium`), swap in the serve parameter group, bump backup retention, enable deletion protection. |
-| `validate` | Row counts vs the `inspect_prod` baseline (per-state for partitioned tables within +/-10%, whole-table for flat tables), plus per-table schema/index structural checks (with `:<table>` suffix in check names). Failure halts the DAG. |
-| `scale_down_on_failure` | Not in the happy path — a `trigger_rule=one_failed` branch off `provision`→`resize`. On any post-provision failure it runs `loader scale-down`, flipping the writer to `db.serverless` to stop provisioned-instance cost. Skipped on a successful run. See "Failure cost guard" below. |
+| `build_indexes` | Scale the writer up to the **index-phase** class, then add primary keys and indexes for all four tables: for partitioned tables (Voter, DistrictVoter) build per-partition indexes and attach to parent; for flat tables (District, DistrictStats) build parent-level indexes. Then `ANALYZE` all tables. Concurrent-builder count defaults to `LOADER_INDEX_PARALLELISM` (else 128). See below. |
+| `validate` | Row counts vs the `inspect_prod` baseline (per-state for partitioned tables within +/-10%, whole-table for flat tables), plus per-table schema/index structural checks (with `:<table>` suffix in check names). Runs on the still-scaled-up index instance (before `resize`). Failure halts the DAG. |
+| `resize` | Flip the writer down to the serving instance class (`serve_instance_class`, prod default `db.r6g.4xlarge`; dev sets `LOADER_SERVE_INSTANCE_CLASS=db.t4g.medium`), swap in the serve parameter group, bump backup retention, enable deletion protection. Finishes with a lightweight post-resize smoke check (`SELECT 1` against the resized cluster) confirming it's reachable. |
+| `scale_down_on_failure` | Not in the happy path — a `trigger_rule=one_failed` branch off `provision`→`validate`→`resize`. On any post-provision failure (including a `validate` failure, which now runs on the scaled-up writer before `resize`) it runs `loader scale-down`, flipping the writer to `db.serverless` to stop provisioned-instance cost. Skipped on a successful run. See "Failure cost guard" below. |
 
 ## Connectivity: bastion
 
@@ -120,26 +126,29 @@ v2 flip. Airflow retries also cover a mid-build drop since every step is idempot
 
 ## Failure cost guard
 
-`resize` (which flips the writer down to the serving instance class) is downstream of
-`build_indexes`, so a run that fails or is aborted mid-build never reaches it and would otherwise
-strand its scaled-up writer at full index-class cost. The `scale_down_on_failure` task
+`resize` (which flips the writer down to the serving instance class) is now downstream of both
+`build_indexes` and `validate`, so a run that fails or is aborted mid-build **or during validate**
+never reaches `resize` and would otherwise strand its scaled-up writer at full index-class cost —
+`validate` runs on that same scaled-up writer (before `resize`), so its failure carries exactly the
+same stranding risk `build_indexes`'s failure always has. The `scale_down_on_failure` task
 (`trigger_rule=one_failed`, upstreams
-`provision`/`create_schema`/`copy`/`build_indexes`/`resize`) runs `loader scale-down`, which flips
-the writer to `db.serverless` to stop that cost — Serverless v2 (min ACU) is the cheapest holding
-state for a cluster kept only for resume/forensics, distinct from the provisioned class the healthy
-path serves from. It deliberately skips the serve lockdown that `resize` applies (no serve parameter
-group, backup-retention bump, deletion protection, or reboot), so the failed run's cluster and
-loaded data survive for resume/forensics and stay easy to `teardown`. It is skipped on a fully
-successful run (where `resize` already sized the writer to the serving class). Limit: it fires on an
-organic failure or a task marked failed, but not if the whole DAG
+`provision`/`create_schema`/`copy`/`build_indexes`/`validate`/`resize`) runs `loader scale-down`,
+which flips the writer to `db.serverless` to stop that cost — Serverless v2 (min ACU) is the
+cheapest holding state for a cluster kept only for resume/forensics, distinct from the provisioned
+class the healthy path serves from. It deliberately skips the serve lockdown that `resize` applies
+(no serve parameter group, backup-retention bump, deletion protection, or reboot), so the failed
+run's cluster and loaded data survive for resume/forensics and stay easy to `teardown`. It is
+skipped on a fully successful run (where `resize` already sized the writer to the serving class).
+Limit: it fires on an organic failure or a task marked failed, but not if the whole DAG
 run is hard-deleted — that still needs a manual `loader teardown`/`scale-down`.
 
 ## Validation
 
-The `validate` step runs a battery of gates against the freshly loaded cluster and fails the step —
-blocking cutover — if any gate fails (each check is a named `ValidationCheck` with a `passed` flag
-and details, persisted in the step manifest). Gates run per table (`Voter`, `DistrictVoter`,
-`District`, `DistrictStats`) except where noted:
+The `validate` step runs **before** `resize` (see "Step sequence" above) so its checks execute on
+the big index instance rather than the small serving box. It runs a battery of gates against the
+freshly loaded cluster and fails the step — blocking `resize` — if any gate fails (each check is a
+named `ValidationCheck` with a `passed` flag and details, persisted in the step manifest). Gates run
+per table (`Voter`, `DistrictVoter`, `District`, `DistrictStats`) except where noted:
 
 - **`row_counts_match_databricks:<table>`** — new-cluster row count matches the Databricks mart
   source (per state for the partitioned tables).
@@ -171,6 +180,10 @@ from `os.environ`; BashOperators forward them with `append_env=True`):
 - `LOADER_VPC_ID`, `LOADER_DB_SUBNET_GROUP`, `LOADER_SECURITY_GROUP_ID`, `LOADER_KMS_KEY_ARN`
 - `LOADER_DATABRICKS_WAREHOUSE_ID` (unload only)
 - Optional sizing overrides: `LOADER_LOAD_INSTANCE_CLASS`, `LOADER_INDEX_INSTANCE_CLASS`
+- `LOADER_INDEX_PARALLELISM` — optional override for `build_indexes`'s concurrent-builder count
+  (default 128, tuned for the 192-vCPU `db.r8g.48xlarge` index instance). All builders share one
+  bastion tunnel, so this is the knob to back off with if the bastion sshd's session limits get
+  tight; the CLI's `--parallelism` flag still overrides this when passed explicitly.
 
 **Airflow Variables** (need a per-deployment override; an unset override resolves to empty at
 runtime, it does not fall back to the workspace value):

--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # post-merge. (During review this tracked the DATA-2100 feature branch so astro-dev ran the PR's loader;
 # repinned to @main for merge — it resolves to this PR's loader once merged.) See PR #607.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-22.3
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-23.1
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This

--- a/airflow/astro/tests/dags/test_dag_example.py
+++ b/airflow/astro/tests/dags/test_dag_example.py
@@ -91,24 +91,39 @@ def test_dag_retries(dag_id, dag, fileloc):
 
 
 def test_load_people_api_sequence():
-    """The loader DAG gates unload/provision on the dbt test and ends resize -> validate."""
+    """The loader DAG gates unload/provision on the dbt test and ends build_indexes -> validate ->
+    resize: validate runs BEFORE resize so its heavy per-state counts run on the big index instance,
+    not the small post-resize serving box.
+    """
     assert _LOADER_DAG is not None, f"load_people_api failed to load from {_LOADER_DAG_FILE}"
     assert "dbt_test_voter_gate" in {t.task_id for t in _LOADER_DAG.get_task("unload").upstream_list}
     assert "dbt_test_voter_gate" in {t.task_id for t in _LOADER_DAG.get_task("provision").upstream_list}
-    assert "resize" in {t.task_id for t in _LOADER_DAG.get_task("validate").upstream_list}
+    assert "build_indexes" in {t.task_id for t in _LOADER_DAG.get_task("validate").upstream_list}
+    assert "validate" in {t.task_id for t in _LOADER_DAG.get_task("resize").upstream_list}
+    # resize must not be upstream of validate anymore (the old order is fully gone).
+    assert "resize" not in {t.task_id for t in _LOADER_DAG.get_task("validate").upstream_list}
 
 
 def test_load_people_api_scale_down_on_failure():
     """scale_down_on_failure is the on-failure cost guard: downstream of every task after which a
-    cluster can exist (provision, unload, and the serial load chain), firing via
-    trigger_rule=one_failed if any of them fails, but NOT upstream of validate (a successful run
-    skips it since resize already made the writer serverless). `unload` must be a direct upstream:
-    one_failed fires only on a FAILED direct upstream, and an unload failure with provision success
-    leaves the rest UPSTREAM_FAILED, which does not satisfy one_failed.
+    cluster can exist (provision, unload, the serial load chain, AND validate — which now runs on
+    the scaled-up writer before resize, so a validate failure must flip it to serverless too),
+    firing via trigger_rule=one_failed if any of them fails, but NOT upstream of resize (a
+    successful run skips it since resize already made the writer serverless). `unload` must be a
+    direct upstream: one_failed fires only on a FAILED direct upstream, and an unload failure with
+    provision success leaves the rest UPSTREAM_FAILED, which does not satisfy one_failed.
     """
     assert _LOADER_DAG is not None, f"load_people_api failed to load from {_LOADER_DAG_FILE}"
     scale_down_task = _LOADER_DAG.get_task("scale_down_on_failure")
     assert scale_down_task.trigger_rule == "one_failed"
     upstream_ids = {t.task_id for t in scale_down_task.upstream_list}
-    assert upstream_ids == {"provision", "unload", "create_schema", "copy", "build_indexes", "resize"}
-    assert "scale_down_on_failure" not in {t.task_id for t in _LOADER_DAG.get_task("validate").upstream_list}
+    assert upstream_ids == {
+        "provision",
+        "unload",
+        "create_schema",
+        "copy",
+        "build_indexes",
+        "validate",
+        "resize",
+    }
+    assert "scale_down_on_failure" not in {t.task_id for t in _LOADER_DAG.get_task("resize").upstream_list}

--- a/people-api-loader/src/loader/people_api/cli.py
+++ b/people-api-loader/src/loader/people_api/cli.py
@@ -17,7 +17,6 @@ from rich.table import Table
 from loader.core.cli import RunDateArg, setup_environment
 from loader.core.log import get_logger
 from loader.people_api.config import LoaderConfig, require_run_date
-from loader.people_api.steps.build_indexes import _DEFAULT_BUILDERS
 
 app = typer.Typer(
     help="GoodParty voter-DB refresh pipeline.",
@@ -152,15 +151,22 @@ def copy(
 def build_indexes(
     run_date: RunDateArg,
     parallelism: Annotated[
-        int,
-        typer.Option("--parallelism", help="Concurrent CREATE INDEX builds (peak memory scales with this)."),
-    ] = _DEFAULT_BUILDERS,
+        int | None,
+        typer.Option(
+            "--parallelism",
+            help=(
+                "Concurrent CREATE INDEX builds (peak memory scales with this). Defaults to "
+                "cfg.index_parallelism (LOADER_INDEX_PARALLELISM, else the loader default) "
+                "when omitted; passing this flag always overrides that."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Step 5 — PKs, non-unique indexes, FKs, ANALYZE."""
     from loader.people_api.steps import build_indexes as step
 
     cfg = _setup(run_date)
-    step.run(cfg, run_date, parallelism=parallelism)
+    step.run(cfg, run_date, parallelism=parallelism if parallelism is not None else cfg.index_parallelism)
 
 
 @app.command()

--- a/people-api-loader/src/loader/people_api/config.py
+++ b/people-api-loader/src/loader/people_api/config.py
@@ -84,6 +84,14 @@ DEFAULT_SCALE_DOWN_MIN_ACU = 0.5
 DEFAULT_SCALE_DOWN_MAX_ACU = 128.0
 DEFAULT_ENGINE_VERSION = "16.8"
 
+# build_indexes's concurrent-builder count, overridable via LOADER_INDEX_PARALLELISM so an
+# operator can back off from the loader default (e.g. against a bastion sshd MaxStartups limit)
+# without a code change. Must match steps/build_indexes.py's `_DEFAULT_BUILDERS` (128, sized for
+# the ~192-vCPU db.r8g.48xlarge index instance) — kept as a separate constant here (not imported
+# from build_indexes) to avoid a config <-> steps import cycle; update both if the index box
+# changes.
+DEFAULT_INDEX_PARALLELISM = 128
+
 # Env-var name reserved for the master password. MUST NEVER be set — included
 # only so we can detect and refuse it. See `LoaderConfig.from_env()`.
 _FORBIDDEN_ENV_VAR = "VOTER_DB_MASTER_PASSWORD"
@@ -150,6 +158,9 @@ class LoaderConfig(BaseLoaderConfig):
     # Failure-cost guard only (steps/scale_down.py) — NOT the serving class, see comment above.
     scale_down_min_acu: float
     scale_down_max_acu: float
+    # build_indexes's default concurrent-builder count (see DEFAULT_INDEX_PARALLELISM above);
+    # the CLI's --parallelism flag still overrides this when passed explicitly.
+    index_parallelism: int
 
     # PG table name -> Databricks mart FQN (column/type source for emit-ddl).
     mart_fqns: dict[str, str]
@@ -229,6 +240,7 @@ class LoaderConfig(BaseLoaderConfig):
             serve_instance_class=_env("LOADER_SERVE_INSTANCE_CLASS", DEFAULT_SERVE_INSTANCE_CLASS),
             scale_down_min_acu=float(os.environ.get("LOADER_SCALE_DOWN_MIN_ACU", DEFAULT_SCALE_DOWN_MIN_ACU)),
             scale_down_max_acu=float(os.environ.get("LOADER_SCALE_DOWN_MAX_ACU", DEFAULT_SCALE_DOWN_MAX_ACU)),
+            index_parallelism=int(os.environ.get("LOADER_INDEX_PARALLELISM", DEFAULT_INDEX_PARALLELISM)),
             mart_fqns=mart_fqns,
             _tags=tags,
         )

--- a/people-api-loader/src/loader/people_api/config.py
+++ b/people-api-loader/src/loader/people_api/config.py
@@ -240,7 +240,9 @@ class LoaderConfig(BaseLoaderConfig):
             serve_instance_class=_env("LOADER_SERVE_INSTANCE_CLASS", DEFAULT_SERVE_INSTANCE_CLASS),
             scale_down_min_acu=float(os.environ.get("LOADER_SCALE_DOWN_MIN_ACU", DEFAULT_SCALE_DOWN_MIN_ACU)),
             scale_down_max_acu=float(os.environ.get("LOADER_SCALE_DOWN_MAX_ACU", DEFAULT_SCALE_DOWN_MAX_ACU)),
-            index_parallelism=int(os.environ.get("LOADER_INDEX_PARALLELISM", DEFAULT_INDEX_PARALLELISM)),
+            index_parallelism=max(
+                1, int(os.environ.get("LOADER_INDEX_PARALLELISM", DEFAULT_INDEX_PARALLELISM))
+            ),
             mart_fqns=mart_fqns,
             _tags=tags,
         )

--- a/people-api-loader/src/loader/people_api/steps/build_indexes.py
+++ b/people-api-loader/src/loader/people_api/steps/build_indexes.py
@@ -373,6 +373,12 @@ def _ensure_instance_class(cfg: LoaderConfig, run_date: str) -> None:
 
 def run(cfg: LoaderConfig, run_date: str, *, parallelism: int = _DEFAULT_BUILDERS) -> IndexManifest:
     bind(run_date=run_date, step="indexes")
+    # Guard: parallelism < 1 (a bad LOADER_INDEX_PARALLELISM or an explicit --parallelism 0) would
+    # spawn zero builder threads via `range(min(parallelism, len(items)))`, silently skip every
+    # index, and still write a "complete" manifest (specs come from the catalog read, not build
+    # results) — leaving an index-less cluster that a re-run then short-circuits past. Clamp to at
+    # least one worker so a misconfig can never produce that.
+    parallelism = max(1, parallelism)
     existing = read_manifest(cfg, run_date, "indexes", IndexManifest)
     if existing and existing.status == "complete":
         log.info(

--- a/people-api-loader/src/loader/people_api/steps/resize.py
+++ b/people-api-loader/src/loader/people_api/steps/resize.py
@@ -6,6 +6,12 @@ parameter group for the serve group (reboot applies it), bump backup retention t
 days, and enable deletion protection. The rds-s3-import role is intentionally left attached
 (future incremental loads reuse it).
 
+resize is now the pipeline's LAST step (validate runs before it — see steps/validate.py), so
+after the reboot settles we run one trivial `SELECT 1` against the resized cluster and log a
+confirmation. This is a connectivity smoke check only (is the freshly-resized writer actually
+reachable and serving), not a data check — that's validate's job, run earlier while the writer
+was still on the large index instance.
+
 Idempotent: a completed manifest short-circuits.
 """
 
@@ -16,6 +22,7 @@ from datetime import UTC, datetime
 from loader.core.aws import flip_writer_to_provisioned, rds, retry_after_settle
 from loader.core.log import bind, get_logger
 from loader.people_api.config import LoaderConfig
+from loader.people_api.db import connect_new
 from loader.people_api.manifests import (
     ResizeManifest,
     manifest_uri,
@@ -86,6 +93,17 @@ def run(cfg: LoaderConfig, run_date: str) -> ResizeManifest:
     rds_client.reboot_db_instance(DBInstanceIdentifier=instance_id)
     _wait()
     log.info("resize.applied", instance_class=cfg.serve_instance_class)
+
+    # Lightweight post-resize smoke check: the resized/rebooted writer actually accepts a
+    # connection and serves a trivial query. NOT a data check (row counts/schema/indexes were
+    # already validated pre-resize); this only guards against the resize itself leaving the
+    # cluster unreachable (e.g. a security-group or param-group misstep, or a reboot that didn't
+    # fully clear). A failure here raises and no "complete" manifest is written, same as any other
+    # resize failure.
+    with connect_new(cfg, run_date) as conn, conn.cursor() as cur:
+        cur.execute("SELECT 1")
+        cur.fetchone()
+    log.info("resize.smoke_check_ok")
 
     manifest = ResizeManifest(
         run_date=run_date,

--- a/people-api-loader/tests/test_cli_smoke.py
+++ b/people-api-loader/tests/test_cli_smoke.py
@@ -7,7 +7,9 @@ wired up and every documented subcommand is registered.
 from __future__ import annotations
 
 import re
+from types import SimpleNamespace
 
+import pytest
 from typer.testing import CliRunner
 
 from loader.people_api.cli import app
@@ -51,11 +53,39 @@ def test_status_help_renders() -> None:
     assert "--date" in _plain(result.output)
 
 
-def test_build_indexes_parallelism_defaults_to_module_constant() -> None:
-    # The CLI default must track build_indexes._DEFAULT_BUILDERS (128, tuned for the index box)
-    # rather than a stale hardcoded literal — see the 32-vs-128 under-parallelization finding.
-    from loader.people_api.steps.build_indexes import _DEFAULT_BUILDERS
+def test_build_indexes_omitted_flag_uses_config_parallelism(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With --parallelism omitted, the CLI must resolve the concurrency from
+    # cfg.index_parallelism (LOADER_INDEX_PARALLELISM, else the loader default of 128) at RUNTIME,
+    # not from a value baked in at Typer-decoration time (which can't see env/cfg).
+    from loader.people_api import cli
+    from loader.people_api.steps import build_indexes as step
 
-    result = runner.invoke(app, ["build-indexes", "--help"])
+    captured: dict = {}
+    fake_cfg = SimpleNamespace(index_parallelism=42)
+    monkeypatch.setattr(cli, "_setup", lambda run_date: fake_cfg)
+    monkeypatch.setattr(
+        step, "run", lambda cfg, run_date, *, parallelism: captured.update(parallelism=parallelism)
+    )
+
+    result = runner.invoke(app, ["build-indexes", "--date", "20260709"])
+
     assert result.exit_code == 0, result.output
-    assert f"[default: {_DEFAULT_BUILDERS}]" in _plain(result.output)
+    assert captured["parallelism"] == 42
+
+
+def test_build_indexes_explicit_flag_overrides_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An explicit --parallelism must win over cfg.index_parallelism, not just supply a fallback.
+    from loader.people_api import cli
+    from loader.people_api.steps import build_indexes as step
+
+    captured: dict = {}
+    fake_cfg = SimpleNamespace(index_parallelism=42)
+    monkeypatch.setattr(cli, "_setup", lambda run_date: fake_cfg)
+    monkeypatch.setattr(
+        step, "run", lambda cfg, run_date, *, parallelism: captured.update(parallelism=parallelism)
+    )
+
+    result = runner.invoke(app, ["build-indexes", "--date", "20260709", "--parallelism", "7"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["parallelism"] == 7

--- a/people-api-loader/tests/test_cluster_lifecycle_moto.py
+++ b/people-api-loader/tests/test_cluster_lifecycle_moto.py
@@ -105,6 +105,8 @@ def test_resize_applies_lockdown(monkeypatch: pytest.MonkeyPatch) -> None:
     rds = boto3.client("rds", region_name=_REGION)
     monkeypatch.setattr(resize_step, "read_manifest", lambda *a: None)
     monkeypatch.setattr(resize_step, "write_manifest", lambda cfg, m: "uri")
+    # No real DB behind moto's RDS: fake the post-resize smoke check's connection too.
+    monkeypatch.setattr(resize_step, "connect_new", fake_connect(FakeConn().queue_result((1,))))
 
     manifest = resize_step.run(cfg, _DATE)
 

--- a/people-api-loader/tests/test_config.py
+++ b/people-api-loader/tests/test_config.py
@@ -154,3 +154,16 @@ def test_from_env_instance_classes_override(monkeypatch: pytest.MonkeyPatch) -> 
     cfg = LoaderConfig.from_env()
     assert cfg.load_instance_class == "db.r8g.8xlarge"
     assert cfg.index_instance_class == "db.r8g.24xlarge"
+
+
+def test_from_env_index_parallelism_defaults_to_loader_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Unset = today's behavior exactly: build_indexes._DEFAULT_BUILDERS (128).
+    from loader.people_api.steps.build_indexes import _DEFAULT_BUILDERS
+
+    monkeypatch.delenv("LOADER_INDEX_PARALLELISM", raising=False)
+    assert LoaderConfig.from_env().index_parallelism == _DEFAULT_BUILDERS == 128
+
+
+def test_from_env_index_parallelism_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOADER_INDEX_PARALLELISM", "16")
+    assert LoaderConfig.from_env().index_parallelism == 16

--- a/people-api-loader/tests/test_config.py
+++ b/people-api-loader/tests/test_config.py
@@ -167,3 +167,13 @@ def test_from_env_index_parallelism_defaults_to_loader_default(monkeypatch: pyte
 def test_from_env_index_parallelism_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LOADER_INDEX_PARALLELISM", "16")
     assert LoaderConfig.from_env().index_parallelism == 16
+
+
+@pytest.mark.parametrize("bad", ["0", "-4"])
+def test_from_env_index_parallelism_clamped_to_at_least_one(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    # A 0/negative value would spawn zero builder threads and silently skip every index while
+    # still writing a "complete" manifest; clamp to at least one worker.
+    monkeypatch.setenv("LOADER_INDEX_PARALLELISM", bad)
+    assert LoaderConfig.from_env().index_parallelism == 1

--- a/people-api-loader/tests/test_resize.py
+++ b/people-api-loader/tests/test_resize.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ClientError
 from loader.core import aws
 from loader.people_api.config import LoaderConfig
 from loader.people_api.steps import resize as step
+from tests._fakes import FakeConn, executed_sql, fake_connect
 
 # Deliberately distinct from both DEFAULT_SERVE_INSTANCE_CLASS ("db.r6g.4xlarge") and the dev
 # override ("db.t4g.medium") so these tests catch resize reading a hardcoded default instead of
@@ -87,9 +88,11 @@ class FakeRds:
 def test_resize_applies_provisioned_class_and_writes_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
     rds_client = FakeRds()
     captured: dict = {}
+    conn = FakeConn().queue_result((1,))
     monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
     monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
     monkeypatch.setattr(step, "write_manifest", lambda cfg, m: captured.setdefault("m", m) or "uri")
+    monkeypatch.setattr(step, "connect_new", fake_connect(conn))
 
     manifest = step.run(_CFG, "20260616")
 
@@ -111,6 +114,31 @@ def test_resize_applies_provisioned_class_and_writes_manifest(monkeypatch: pytes
     by = dict(rds_client.calls)
     assert by["modify_instance"]["DBInstanceClass"] == _TEST_SERVE_CLASS
     assert by["modify_instance"]["ApplyImmediately"] is True
+    # Post-resize smoke check: a trivial SELECT 1 against the resized cluster, run after the
+    # reboot settles and before the manifest is written.
+    assert executed_sql(conn) == ["SELECT 1"]
+
+
+def test_resize_smoke_check_failure_propagates_and_blocks_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If the post-resize connectivity smoke check fails (the resized writer is unreachable), that
+    # must surface as a resize failure — not a silently "complete" manifest over a cluster the
+    # loader can't actually reach.
+    rds_client = FakeRds()
+    wrote: dict = {}
+
+    def _boom(*a: object, **k: object):
+        raise RuntimeError("could not connect to resized writer")
+
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
+    monkeypatch.setattr(step, "write_manifest", lambda cfg, m: wrote.setdefault("m", m) or "uri")
+    monkeypatch.setattr(step, "connect_new", _boom)
+
+    with pytest.raises(RuntimeError, match="could not connect"):
+        step.run(_CFG, "20260616")
+    assert "m" not in wrote  # no complete manifest written over an unreachable resize
 
 
 def test_resize_retries_in_progress_modify(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -125,6 +153,7 @@ def test_resize_retries_in_progress_modify(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
     monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
     monkeypatch.setattr(step, "write_manifest", lambda cfg, m: "uri")
+    monkeypatch.setattr(step, "connect_new", fake_connect(FakeConn().queue_result((1,))))
 
     manifest = step.run(_CFG, "20260616")  # must not raise; modifies retried after settle
 
@@ -171,6 +200,7 @@ def test_resize_reboot_waits_for_class_applied_not_just_available(monkeypatch: p
     monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
     monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
     monkeypatch.setattr(step, "write_manifest", lambda cfg, m: "uri")
+    monkeypatch.setattr(step, "connect_new", fake_connect(FakeConn().queue_result((1,))))
 
     manifest = step.run(_CFG, "20260616")
 
@@ -221,6 +251,7 @@ def test_resize_waits_for_cluster_settle_before_instance_class_modify(
     monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
     monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
     monkeypatch.setattr(step, "write_manifest", lambda cfg, m: "uri")
+    monkeypatch.setattr(step, "connect_new", fake_connect(FakeConn().queue_result((1,))))
 
     manifest = step.run(_CFG, "20260616")
 


### PR DESCRIPTION
Two bundled loader improvements (both future-build; no effect until deployed).

## 1. Run `validate` before `resize`
`resize` flips the writer down to the small serving instance (dev `db.t4g.medium`), and `validate` then runs heavy per-state `count`/`GROUP BY` over ~227M rows on 2 vCPU — very slow (observed ~60 min, I/O-bound, no post-load VACUUM so no index-only scans). Reordering to `build_indexes >> validate >> resize` runs validate on the `r8g.48xlarge` index instance that's already scaled up — fast, parallel — then `resize` is the clean final step.

`validate` only checks row counts + schema/index structure, none of which change across `resize`, so correctness is identical either order.

**Safety fix:** `scale_down_on_failure` (trigger_rule=one_failed) now includes **`validate`** in its upstreams. With validate running before resize on the big `r8g.48xlarge` instance, a validate failure must flip the writer to `db.serverless` — otherwise it strands the expensive instance (exactly the cost bleed we hit manually).

## 2. `LOADER_INDEX_PARALLELISM` env knob
`build_indexes` runs 128 concurrent builders over one shared bastion tunnel (128 channels), which is fragile against the bastion sshd's session limits. This adds a `LOADER_INDEX_PARALLELISM` env override (default **128 = current behavior when unset**); the CLI `--parallelism` flag still overrides. Lets us dial concurrency down per-deployment (e.g., dev) without a code change if the bastion is constrained.

## 3. Minor
- Light post-resize `SELECT 1` connectivity smoke check (resize is now the final step) — confirms the resized/rebooted writer is queryable; not the heavy counts.
- Docs (`people_api_loader.md`): step order, scale_down note, `LOADER_INDEX_PARALLELISM`.
- Cache-bust bump.

## Tests
people-api-loader: 316 passed / 4 skipped + integration 4 passed; ruff/format/ty clean. airflow: 82 passed / 2 skipped — updated the pre-existing DAG-order tests (`test_load_people_api_sequence`, `test_load_people_api_scale_down_on_failure`) to the new graph, asserting validate-before-resize and validate in the scale_down upstreams.