### PR TITLE
[DATA-2144] quality_bench: gold-run answer keys q05/q07/q08 (Serve)

### DIFF
--- a/analytics/diagnostics/quality_bench/keys/q01_win_metric_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q01_win_metric_key.yaml
@@ -75,12 +75,19 @@ severity1_patterns:
   - '(?i)where\s+(not\s+)?(is_onboarded|has_completed_onboarding_flow)'
   - 'users_win_base\.user_created_at'
 
+# Names must exactly match required_resolutions keys: check_assumptions and
+# check_resolutions read the same answer-ledger fork names (grading.py).
+# Renamed 2026-07-23 (PR #671): account_created_definition -> account_created,
+# *_exclusion -> internal_accounts / demo_accounts, boundary_semantics ->
+# month_bucketing (q01's boundary fork IS the half-open month rule),
+# win_user_current_state_flag -> population (the flag choice is the
+# population resolution).
 required_assumptions:
-  - account_created_definition
-  - internal_accounts_exclusion
-  - demo_accounts_exclusion
-  - boundary_semantics
-  - win_user_current_state_flag
+  - account_created
+  - internal_accounts
+  - demo_accounts
+  - month_bucketing
+  - population
 
 intent_card: |
   Purpose: calibration-split census metric — any competent full-context run

--- a/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
@@ -124,6 +124,8 @@ severity1_patterns:
 required_assumptions:
   - completion_metric
   - onboarding_event_eras
+  - account_created
+  - population
   - internal_accounts
   - demo_accounts
   - completion_window

--- a/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q02_win_provenance_key.yaml
@@ -117,12 +117,17 @@ mandatory_sources:
 severity1_patterns:
   - '(?i)where\s+(not\s+)?(is_onboarded|has_completed_onboarding_flow)'
 
+# Names must exactly match required_resolutions keys: check_assumptions and
+# check_resolutions read the same answer-ledger fork names (grading.py).
+# Renamed 2026-07-23 (PR #671); boundary_semantics split into its two actual
+# boundary forks, completion_window (14d half-open) and month_bucketing.
 required_assumptions:
-  - completion_metric_definition
-  - onboarding_event_era_resolution
-  - internal_accounts_exclusion
-  - demo_accounts_exclusion
-  - boundary_semantics
+  - completion_metric
+  - onboarding_event_eras
+  - internal_accounts
+  - demo_accounts
+  - completion_window
+  - month_bucketing
 
 intent_card: |
   Purpose: provenance trap — "completed onboarding" spans three instrumented

--- a/analytics/diagnostics/quality_bench/keys/q05_serve_metric_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q05_serve_metric_key.yaml
@@ -84,10 +84,12 @@ mandatory_sources:
 severity1_patterns:
   - '(?i)where\s+(is_serve_user\s+and\s+)?has_completed_serve_onboarding'
 
+# Names must exactly match required_resolutions keys: check_assumptions and
+# check_resolutions read the same answer-ledger fork names (grading.py).
 required_assumptions:
-  - population_asof_reconstruction
-  - internal_accounts_exclusion
-  - onboarded_strict_subset
+  - population
+  - internal_accounts
+  - onboarded_definition
   - boundary_semantics
 
 intent_card: |

--- a/analytics/diagnostics/quality_bench/keys/q05_serve_metric_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q05_serve_metric_key.yaml
@@ -1,0 +1,93 @@
+id: q05_serve_metric
+as_of: "2026-07-22"
+
+# Gold run 2026-07-22 (supervised). Source: mart_analytics.users_serve_base
+# (user grain, verified 1876 rows = 1876 distinct user_ids at pin time).
+# As-of reconstruction from timestamps, NOT current-state flags:
+#   serve_users_total     = is_serve_user population, email NOT ILIKE
+#                           '%@goodparty.org', eo_activated_at < TIMESTAMP
+#                           '2026-07-01 00:00:00' (all of June 30 included,
+#                           column stored representation, TIMESTAMP_NTZ)
+#   serve_users_onboarded = strict subset of total AND first_sms_poll_sent_at
+#                           < TIMESTAMP '2026-07-01 00:00:00' (TIMESTAMP/UTC);
+#                           no poll>=activation ordering requirement
+# Definition provenance: canonical_metrics.md rows "Serve user / EO activated"
+# and "Onboarding completed (Serve)", DATA-2115 lineage, status pending
+# ratification at pin time. If ratification amends either definition (e.g.
+# adds impersonation hygiene to the poll milestone), re-baseline this key
+# rather than failing runs. Known caveat, accepted: first_sms_poll_sent_at is
+# an Amplitude-milestone column upstream of impersonation hygiene, so a
+# staff-impersonated poll send would count — matching the governed flag is
+# the intended gold behavior.
+#
+# Wrong-fork ladder at pin time (what tolerances must exclude):
+#   1845  current-flag external total today (+0.38%)  <- binding constraint
+#   1867  as-of total without internal exclusion (+1.58%)
+#   1876  current-flag total incl. internal (+2.07%)
+#   1039  onboarded without strict-subset rule, 1028 + 11 non-Serve
+#         poll-senders (+1.07%)
+# Current-flag onboarded = 1028 today, numerically identical to gold (no poll
+# milestones exist after 2026-06-26), so the flag-vs-timestamp fork on
+# onboarded is guarded by required_resolutions/severity1, not by the number.
+#
+# Tolerances are a drift budget, not measurement uncertainty (replication is
+# exact from one deterministic query). As-of counts are frozen by
+# construction — new activity cannot move them; drift channels are mart
+# restatement only (Amplitude user-merge/reprocessing shifting
+# first_sms_poll_sent_at; product-DB corrections to pre-cutoff
+# eo_activated_at). Boundary exposure measured at pin: 0 external activations
+# dated 2026-06-30, 1 dated 2026-07-01, 0 polls near the boundary (max
+# ±1 user ≈ 0.05%). Total gets 0.3% (~5 users), below the 0.38% current-flag
+# fork; onboarded gets 0.5% (~5 users), below the 1.07% non-subset fork.
+# Restatement drift beyond these bands means re-baseline, not wider bands.
+numbers:
+  - name: serve_users_total
+    value: 1838
+    tolerance_pct: 0.3
+  - name: serve_users_onboarded
+    value: 1028
+    tolerance_pct: 0.5
+
+required_resolutions:
+  population: asof_timestamp_reconstruction (eo_activated_at < 2026-07-01 on users_serve_base; NOT current-state is_serve_user alone)
+  internal_accounts: exclude_goodparty_org_email_domain
+  onboarded_definition: first_sms_poll_sent_at < 2026-07-01, strict subset of serve_users_total (no poll/activation ordering requirement)
+  boundary_semantics: all_of_june_30_included (cutoff strictly before 2026-07-01 00:00:00, per-column stored representation)
+
+mandatory_sources:
+  - id: serve_user_mart
+    pattern: 'users_serve_base'
+    description: consulted the governed Serve user mart rather than raw civics/Amplitude tables alone
+  - id: activation_anchor
+    pattern: 'eo_activated_at'
+    description: anchored the census on the EO activation timestamp, not the current-state flag alone
+  - id: poll_milestone
+    pattern: 'first_sms_poll_sent_at'
+    description: onboarding completion read from the first-SMS-poll milestone timestamp
+  - id: internal_exclusion
+    pattern: '(?i)goodparty\.org'
+    description: evidence the GoodParty-internal account exclusion was applied
+
+# Confidently-wrong moves identified/anticipated during the gold run:
+# counting 2026 "Onboarding V2" Amplitude events as Serve onboarding (they
+# are the Win onboarding redesign — documented trap in serve sources.md),
+# and gating the as-of counts on current-state booleans in a WHERE clause
+# (right-number-today on onboarded by coincidence, wrong by construction).
+severity1_patterns:
+  - '(?i)onboarding v2'
+  - '(?i)where\s+(is_serve_user\s+and\s+)?has_completed_serve_onboarding'
+
+required_assumptions:
+  - population_asof_reconstruction
+  - internal_accounts_exclusion
+  - onboarded_strict_subset
+  - boundary_semantics
+
+intent_card: |
+  Purpose: pin the Serve as-of census (activation + poll-onboarding) as a
+  graded gold answer; guard the current-flag-vs-as-of trap.
+  Audience: benchmark grader + future re-baseliners (DATA-2144 harness).
+  Fork answers (asker): internal @goodparty.org accounts excluded (hygiene
+  default); "as of June 30" = all of June 30 (< 2026-07-01, stored
+  representation); onboarded = strict subset of total, no poll/activation
+  ordering; reconstruct from timestamps, never current-state flags.

--- a/analytics/diagnostics/quality_bench/keys/q05_serve_metric_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q05_serve_metric_key.yaml
@@ -69,12 +69,19 @@ mandatory_sources:
     description: evidence the GoodParty-internal account exclusion was applied
 
 # Confidently-wrong moves identified/anticipated during the gold run:
-# counting 2026 "Onboarding V2" Amplitude events as Serve onboarding (they
-# are the Win onboarding redesign — documented trap in serve sources.md),
-# and gating the as-of counts on current-state booleans in a WHERE clause
-# (right-number-today on onboarded by coincidence, wrong by construction).
+# 1. Counting 2026 "Onboarding V2" Amplitude events as Serve onboarding
+#    (they are the Win onboarding redesign — documented trap in serve
+#    sources.md). Deliberately NO tripwire (q02/q07 precedent, PR #671
+#    review): a correct answer must NAME the trap to reject it, and any
+#    bare-phrase regex is blind to that distinction; actual misuse is
+#    guarded by the tolerance bands and the judge's semantic
+#    confident-wrongness grading.
+# 2. Gating the as-of counts on current-state booleans in a WHERE clause
+#    (right-number-today on onboarded by coincidence, wrong by
+#    construction) — tripwired below: this fork is numerically invisible
+#    at pin time, so the SQL-shaped regex (which cannot appear in correct
+#    prose or correct SQL) is the only deterministic guard.
 severity1_patterns:
-  - '(?i)onboarding v2'
   - '(?i)where\s+(is_serve_user\s+and\s+)?has_completed_serve_onboarding'
 
 required_assumptions:

--- a/analytics/diagnostics/quality_bench/keys/q07_serve_denominator_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q07_serve_denominator_key.yaml
@@ -64,9 +64,12 @@ severity1_patterns:
   # and every defensible fork stays above 99). Matches 0.0-89.9, not 9x.x.
   - "pct_serve_pledged\\D{0,15}\\b[0-8]?\\d\\.\\d+\\b"
   # Claiming the pledge can be point-in-time reconstructed from a timestamped
-  # source (campaign pledge is untimestamped; elected_office.pledged_at only
-  # exists from 2026-06-23; Segment coverage is a 1-month sliver).
-  - "pledge[^.]{0,80}(timestamped|point.in.time|pledged_at)[^.]{0,80}(full|complete|entire|all users|reconstruct)"
+  # source is confidently wrong (campaign pledge is untimestamped;
+  # elected_office.pledged_at only exists from 2026-06-23; Segment coverage
+  # is a 1-month sliver) — but deliberately NO tripwire (PR #671 review):
+  # the REQUIRED correct caveat ("point-in-time pledge reconstruction is
+  # impossible") shares every token with the wrong claim, so any regex here
+  # is negation-blind. The judge grades the over-claim semantically.
 required_assumptions:
   - denominator
   - internal_accounts

--- a/analytics/diagnostics/quality_bench/keys/q07_serve_denominator_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q07_serve_denominator_key.yaml
@@ -1,0 +1,84 @@
+id: q07_serve_denominator
+as_of: "2026-07-23"
+numbers:
+  # Tolerance rationale (re-baseline convention): the discriminating number is
+  # the count. Near-miss ladder (verified 2026-07-23): skip the pledge filter
+  # entirely = 1838 (+0.38%); skip the internal-email filter = 1856 (+1.37%);
+  # skip the as-of activation cut = ~1865 (+1.9%); all-product pledge base =
+  # ~39k. 0.2% (+-3 users) fails every rung. The legitimate
+  # censoring-band floor (subtracting the 6-user contamination bound, 1825,
+  # -0.33%) ALSO fails numerically by design — keep-current-state is the
+  # required resolution; a run that subtracts is caught here and graded on
+  # scoping via resolutions/judge, not passed silently.
+  # DECAY NOTE: has_pledged is current-state and only accretes, so a correct
+  # later re-run drifts UP toward the 1838 no-filter value (7 users of
+  # headroom). Denominator is fully as-of-bounded and stable at 1838.
+  # RE-BASELINE TRIGGER: when a correct current-state re-run reads within
+  # tolerance of 1838, the count no longer discriminates the pledge-filter
+  # fork — re-pin the key or move that guard entirely to resolutions/judge.
+  - name: serve_pledged_users
+    value: 1831
+    tolerance_pct: 0.2
+  # pct cannot discriminate the internal-filter (99.4) or as-of (99.4) forks
+  # at one decimal — the count guards those. 0.3% spans the legitimate
+  # censoring band (true as-of pct in [99.3, 99.6]) while failing the
+  # no-pledge-filter read (100.0) and the all-product-base read (~4.7).
+  - name: pct_serve_pledged
+    value: 99.6
+    tolerance_pct: 0.3
+required_resolutions:
+  denominator: canonical_serve_population_eo_activated_asof_june30
+  internal_accounts: excluded_via_goodparty_org_email_proxy
+  pledge_definition: campaign_pledge_or_elected_office_pledge_union
+  pledge_asof: current_state_flag_kept_with_documented_bound
+  boundary_semantics: half_open_before_july1_on_timestamp_columns
+  activation_floor: none_oct_2025_launch_wave_included
+mandatory_sources:
+  - id: population_table
+    pattern: "users_serve_base"
+    description: Population anchor and pledge flag must come from the canonical
+      Serve mart (is_serve_user + eo_activated_at), not from the all-product
+      campaign pledge base or an activity table.
+  - id: asof_anchor
+    pattern: "eo_activated_at"
+    description: Evidence the run reconstructed the June 30 population from the
+      activation timestamp — is_serve_user alone is current-state and includes
+      July activations.
+  # LIMITATION (verified 2026-07-23): the union arm is numerically invisible
+  # in-window — all 3 elected_office-pledge-only users resolved by acquiring
+  # pledged campaigns or being internal, so campaign has_pledged alone
+  # reproduces 1831 exactly. This check is string-presence evidence the run
+  # CONSULTED the new EO-pledge field (live 2026-06-23), not proof it used
+  # the union, and a disclaimer mention passes it. Deliberately NO severity1
+  # tripwire on correct prose saying "the EO-pledge arm adds nothing
+  # in-window" (q02/q04 precedent: tripwires must not fire on correct prose).
+  - id: eo_pledge_arm
+    pattern: "pledged_at|elected_office"
+    description: Evidence the run consulted the elected_office EO-pledge field
+      (consultation check only — see limitation comment above).
+severity1_patterns:
+  # All-product pledge base as the numerator (true value 1831; the documented
+  # gotcha reads ~39k — any 5+ digit count is confidently wrong).
+  - "serve_pledged_users\\D{0,15}\\b\\d{5,}\\b"
+  # A pct below ~90 (all-product-base denominator reads ~4.7; true value 99.6
+  # and every defensible fork stays above 99). Matches 0.0-89.9, not 9x.x.
+  - "pct_serve_pledged\\D{0,15}\\b[0-8]?\\d\\.\\d+\\b"
+  # Claiming the pledge can be point-in-time reconstructed from a timestamped
+  # source (campaign pledge is untimestamped; elected_office.pledged_at only
+  # exists from 2026-06-23; Segment coverage is a 1-month sliver).
+  - "pledge[^.]{0,80}(timestamped|point.in.time|pledged_at)[^.]{0,80}(full|complete|entire|all users|reconstruct)"
+required_assumptions:
+  - denominator
+  - internal_accounts
+  - pledge_definition
+  - pledge_asof
+intent_card: |
+  Purpose: test whether a run picks the right denominator — the ~1.8k
+  canonical Serve population, not the 39k all-product pledge base.
+  Audience: benchmark harness / future graded runs.
+  Forks: Serve user = EO-activated as of June 30 (no activation-date floor —
+  the late-Oct 2025 wave is the real launch); internal @goodparty.org
+  excluded; pledge = campaign pledge or the new EO pledge; the untimestamped
+  pledge flag is used current-state with a documented <=6-user bound.
+  Note: ~99.6% is the expected shape, not an error — don't reward hedging
+  away from it.

--- a/analytics/diagnostics/quality_bench/keys/q08_serve_provenance_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q08_serve_provenance_key.yaml
@@ -1,0 +1,130 @@
+id: q08_serve_provenance
+as_of: "2026-07-23"
+
+# Gold run 2026-07-23 (supervised). Metric: broad Serve engagement MAU (the
+# analysis default, serve methodology_defaults.md; predicate committed in
+# analytics/lib/serve_analysis.py). Per month = COUNT(DISTINCT user_id) among
+# is_serve_user (users_serve_base, grain verified 69,893 = 69,893 distinct at
+# pin) with >= 1 qualifying event that calendar month (UTC, half-open
+# date_trunc buckets): family = 'serve' in int__amplitude_event_catalog OR a
+# Viewed on a Serve-surface path; event_time >= eo_activated_at (product-DB
+# derived, NOT an Amplitude event); in-session only (session_id != -1);
+# event-level email not @goodparty.org; impersonation-tainted
+# (user_id, session_id) excluded. Execution record with exact SQL:
+# analytics/ad_hoc/2026-07-23_q08_serve_mau_results.md (gitignored, local).
+#
+# The provenance trap does NOT discriminate numerically: in-window
+# instrumentation changes create no seam. eo_activated_at is derived in dbt
+# from durable product-DB tables (min completed-poll created_at via
+# elected_offices, least-ed with first serve-org created_at; definition
+# broadened 2026-03-31 but recomputed retroactively, so one definition covers
+# all five months). The one in-window supersession (Briefings-% retired
+# 2026-05-28, replaced same day by Briefing Assistant-%) involves Win-named
+# events that were never family='serve'; both eras are covered by the
+# /dashboard/briefings% path-Viewed backstop. So a provenance-naive run can
+# land on correct numbers by luck: the trap is guarded by mandatory_sources
+# (provenance-asset consult) and required_resolutions, not by the numbers.
+#
+# Wrong-fork ladder at pin time (per-month distinct users, gold in [] ):
+#   month    [gold] poll_anch  family_only  no_activation  no_hygiene  incl_server
+#   2026-02  [346]  363        338          439            351         366
+#   2026-03  [294]  257        268          353            302         337
+#   2026-04  [61]   27         36           78             71          65
+#   2026-05  [48]   17         24           51             58          327
+#   2026-06  [60]   16         55           61             91          327
+# At tolerance_pct 2 (integer granularity makes Apr-Jun effectively exact or
+# +-1), no single month excludes every fork (Feb no_hygiene 351 and Jun
+# no_activation 61 each sit inside their month's band) but EVERY fork fails
+# >= 3 of the 5 graded months, so the five-number contract jointly rejects
+# all five. Poll-anchored is ABOVE gold in Feb (+4.9%); the "undercounts
+# 2-3x" heuristic holds only from April on.
+#
+# Tolerances are a drift budget, not measurement uncertainty: replication is
+# exact (0.00% drift vs the 2026-07-14 reference series in all months, and an
+# independently-structured query reproduces gold exactly). Drift channels:
+# Amplitude user-merge/reprocessing; product-DB corrections backdating
+# eo_activated_at or poll/org rows (the retroactive derivation restates all
+# months if the definition changes again); and, distinctively,
+# reclassification of int__amplitude_event_catalog. Catalog pin at as_of:
+# 81 family='serve' event types, md5(newline-joined sorted list) =
+# 010fe390668d1c535613e818e51ddb05. Re-baseline this key (not widen bands)
+# if the pin changes, if the users.sql serve derivation changes, or when the
+# broad-engagement registry row (pending ratification) is ratified with an
+# amended definition.
+#
+# June caveat carried on the number: taint bite is 15/75 raw (vs 1-3 in other
+# months); the excluded 15 were wholly impersonation-driven, and 18 of the 60
+# clean users also carried tainted sessions. 60 stands as the governed clean
+# count, but May->Jun (48->60) is not evidence of organic recovery, and the
+# taint filter is a known lower bound.
+numbers:
+  - name: serve_active_users_2026_02
+    value: 346
+    tolerance_pct: 2
+  - name: serve_active_users_2026_03
+    value: 294
+    tolerance_pct: 2
+  - name: serve_active_users_2026_04
+    value: 61
+    tolerance_pct: 2
+  - name: serve_active_users_2026_05
+    value: 48
+    tolerance_pct: 2
+  - name: serve_active_users_2026_06
+    value: 60
+    tolerance_pct: 2
+
+required_resolutions:
+  metric: broad_serve_engagement (family='serve' catalog membership OR Viewed on Serve-surface path, per analytics/lib/serve_analysis.py; NOT poll-anchored users_serve_activity)
+  activation_scope: events at/after eo_activated_at (product-DB derived column; pre-activation activity is Win campaigning)
+  server_emitted_events: excluded via session_id != -1 (Briefing Assistant dispatch events are not user engagement)
+  hygiene: exclude @goodparty.org event-level emails AND impersonation-tainted (user_id, session_id) sessions
+  month_bucketing: calendar months on event_time (UTC), half-open [month start, next month start); months independent
+
+mandatory_sources:
+  - id: serve_engagement_definition
+    pattern: '(?i)(serve_analysis|serve_engagement_predicate|broad.{0,3}serve.{0,3}engagement|broad.{0,3}engagement)'
+    description: resolved "actively used" to the broad-engagement analysis default, not an improvised or poll-anchored metric
+  - id: event_taxonomy
+    pattern: "int__amplitude_event_catalog|family\\s*=\\s*'serve'"
+    description: serve-surface membership sourced from the governed event catalog
+  - id: activation_anchor
+    pattern: 'eo_activated_at'
+    description: engagement time-scoped to the EO activation anchor
+  - id: provenance_assets
+    pattern: '(?i)(amplitude_event_provenance|event-lifecycle-assets|instrumented_date|retired_date)'
+    description: version-continuity across the 2026-05/06 Serve event generation checked against the omni event-lifecycle assets (the q08 trap)
+  - id: server_emitted_exclusion
+    pattern: 'session_id\s*(!=|<>)\s*-1'
+    description: evidence the in-session condition excluded server-emitted dispatch events
+  - id: impersonation_hygiene
+    pattern: '(?i)impersonat'
+    description: evidence the staff-impersonation taint exclusion was considered and applied
+
+# Confidently-wrong moves identified/anticipated during the gold run:
+# counting "Onboarding V2" events as Serve (they are the Win onboarding
+# redesign; documented trap in serve sources.md); asserting a settled cause
+# for the April 2026 cliff (open question per methodology_defaults.md); and
+# reading the May->June uptick as engagement recovery (the June number is the
+# month most inflated by staff impersonation pre-filter, and the filter is a
+# lower bound).
+severity1_patterns:
+  - '(?i)onboarding v2'
+  - '(?i)(april|2026-04).{0,100}(cliff|drop|decline|fell).{0,100}(because|due to|caused by|explained by)'
+  - '(?i)june.{0,80}(shows|indicates|suggests|demonstrates)\s+(a\s+|an\s+)?(recovery|rebound|re-engagement)'
+
+required_assumptions:
+  - metric_broad_engagement
+  - activation_time_scope
+  - server_emitted_exclusion
+  - impersonation_hygiene
+  - month_boundary_semantics
+
+intent_card: |
+  Purpose: gold key for q08 (provenance trap): monthly distinct active Serve
+  users, Feb-Jun 2026.
+  Audience: benchmark grader scoring future agent runs on trust and bloat.
+  Fork answers (asker): broad-engagement MAU per the committed lib predicate
+  (poll-anchored rejected); events scoped to at/after product-DB
+  eo_activated_at; calendar months UTC; current is_serve_user flag; clean
+  (impersonation-excluded) counts are the answer.

--- a/analytics/diagnostics/quality_bench/keys/q08_serve_provenance_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q08_serve_provenance_key.yaml
@@ -108,10 +108,14 @@ mandatory_sources:
 # reading the May->June uptick as engagement recovery (the June number is the
 # month most inflated by staff impersonation pre-filter, and the filter is a
 # lower bound).
-severity1_patterns:
-  - '(?i)onboarding v2'
-  - '(?i)(april|2026-04).{0,100}(cliff|drop|decline|fell).{0,100}(because|due to|caused by|explained by)'
-  - '(?i)june.{0,80}(shows|indicates|suggests|demonstrates)\s+(a\s+|an\s+)?(recovery|rebound|re-engagement)'
+# Deliberately NO tripwires for any of these (PR #671 review; q02/q07
+# precedent that patterns must not fire on correct prose): a correct answer
+# must NAME Onboarding V2 to reject it, and the REQUIRED cliff/recovery
+# caveats ("the cliff is not explained by...", "nothing in June suggests a
+# recovery") share their tokens with the wrong claims, so every candidate
+# regex is negation-blind. All three traps are graded semantically by the
+# judge's confident-wrongness rubric.
+severity1_patterns: []
 
 required_assumptions:
   - metric_broad_engagement

--- a/analytics/diagnostics/quality_bench/keys/q08_serve_provenance_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q08_serve_provenance_key.yaml
@@ -117,12 +117,14 @@ mandatory_sources:
 # judge's confident-wrongness rubric.
 severity1_patterns: []
 
+# Names must exactly match required_resolutions keys: check_assumptions and
+# check_resolutions read the same answer-ledger fork names (grading.py).
 required_assumptions:
-  - metric_broad_engagement
-  - activation_time_scope
-  - server_emitted_exclusion
-  - impersonation_hygiene
-  - month_boundary_semantics
+  - metric
+  - activation_scope
+  - server_emitted_events
+  - hygiene
+  - month_bucketing
 
 intent_card: |
   Purpose: gold key for q08 (provenance trap): monthly distinct active Serve


### PR DESCRIPTION
## Summary

Answer keys for the three Serve gold runs (DATA-2144 question bank), each authored in a supervised full-pipeline session (framing gate, results checkpoint, two adversarial reviewers, calibration close) and approved by the benchmark owner:

- **q05_serve_metric_key** — as-of 2026-06-30 Serve census: `serve_users_total` 1838 (tol 0.3%), `serve_users_onboarded` 1028 (tol 0.5%). Tolerance ceiling set by the nearest wrong fork (current-flag total 1845, +0.38%); wrong-fork ladder, drift channels (mart restatement only), and definition provenance (DATA-2115 rows, pending ratification → re-baseline on definition change) documented in key comments. Settled forks: as-of timestamp reconstruction (not current-state flags), internal @goodparty.org exclusion, onboarded = strict subset, full-June-30 boundary.
- **q07_serve_denominator_key**, **q08_serve_provenance_key** — authored in their own gold-run sessions; staged alongside for a single bench batch.

Keys are grader-side only; prep_arms excludes quality_bench from every run worktree.

Companion calib PR (knowledge-doc spillover + ledger rows from the same runs) opened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only benchmark artifacts with no runtime, auth, or production data-path changes; risk is limited to mis-graded future bench runs if keys are wrong.
> 
> **Overview**
> Adds **three grader-only YAML answer keys** under `analytics/diagnostics/quality_bench/keys/` for the DATA-2144 Serve gold runs, following the existing `KEY_SCHEMA` (pinned numbers, tolerances, `required_resolutions`, `mandatory_sources`, `severity1_patterns`, `intent_card`).
> 
> **q05** pins the **as-of June 30 Serve census** (`serve_users_total` 1838, `serve_users_onboarded` 1028) with tight tolerances chosen to reject current-flag and wrong-subset forks; comments document wrong-fork ladders and re-baseline triggers on mart restatement.
> 
> **q07** grades **pledge rate on the canonical ~1.8k Serve denominator** (`serve_pledged_users` 1831, `pct_serve_pledged` 99.6), guarding the all-product pledge base and pledge-as-of semantics via resolutions and regex tripwires.
> 
> **q08** pins **monthly broad Serve engagement MAU** (Feb–Jun 2026, five counts at 2% tolerance) and forces provenance/consultation checks (`serve_analysis`, event catalog, lifecycle assets) because numerics alone cannot catch a lucky wrong definition.
> 
> No application or harness code changes in this diff—keys only, consumed by `grade.py` / `bank.py` and excluded from run worktrees by `prep_arms`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54aabe0a8e07c05445248dcb0b7bf14c571619b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->