### PR TITLE
[DATA-2117] Source-stable race updated_at + win_number doc truth-ups

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -384,11 +384,12 @@ models:
                 inclusive: true
       - name: win_number
         description: >
-          BallotReady viability_score.win_number passed through from
-          mart_civics.candidacy. Sparse in practice; null for nearly all
-          small non-partisan local races. The consuming app computes a
-          fallback estimate from projected_turnout / number_of_seats; do not
-          coalesce here.
+          Path-to-victory vote target. No live source supplies it: BallotReady
+          carries no win number, and the only values that ever existed come
+          from 2023-2025 HubSpot-archive candidacies. Their races fall inside
+          the six-year window, but archive candidacies rarely resolve to a
+          BallotReady race id, so in practice the column remains null across
+          the mart and consumers fall back to a computed estimate.
         tests:
           - dbt_utils.accepted_range:
               arguments:

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -39,17 +39,18 @@ with
     -- One row per gp_election_id with the race-level civics attributes
     -- (is_partisan, office_type, official_office_name, office_level), which are
     -- position-grain and in practice invariant across candidacies within an
-    -- election cycle. win_number is carried here too but has no live source:
-    -- BallotReady supplies no win number, and the only values that exist come
-    -- from the 2023-2025 HubSpot archive (int__civics_candidacy_2025), whose
-    -- past elections fall well outside this mart's date window (a 2-month
-    -- grace period at the oldest), so win_number is null for every row this
-    -- mart emits, and consumers fall back
-    -- to a computed estimate. Aggregate with any valid value; downstream Race
-    -- rows that share a gp_election_id (i.e. multiple BR race stages for the
-    -- same election cycle) will all carry the same values. Drop non-positive
-    -- win_number sentinels (e.g. -1) an archive candidacy can attach to an
-    -- in-window race after id re-keying; a sub-1 "votes to win" is never real.
+    -- election cycle.
+    -- win_number is carried here but has no live source: BallotReady
+    -- supplies none, and the only values that ever existed come from
+    -- 2023-2025 HubSpot-archive candidacies. Their races now fall inside
+    -- the six-year window, but archive candidacies rarely resolve to a
+    -- BallotReady race id, so in practice the column is null across the
+    -- mart and consumers fall back to a computed estimate.
+    -- Aggregate with any valid value; downstream Race rows that share a
+    -- gp_election_id (i.e. multiple BR race stages for the same election
+    -- cycle) will all carry the same values. Drop non-positive win_number
+    -- sentinels (e.g. -1) an archive candidacy can attach to an in-window
+    -- race after id re-keying; a sub-1 "votes to win" is never real.
     civics_race_attrs as (
         select
             gp_election_id,
@@ -66,19 +67,15 @@ with
 select
     tbl_race.id,
     tbl_race.created_at,
-    -- Bump updated_at when a filing-address override applies (BallotReady's
-    -- own updated_at does not change), and otherwise ride the place row's
-    -- updated_at: the place mart bumps it whenever a slug changes
-    -- (disambiguation in either direction), so every dependent race clears
-    -- the election-api write model's incremental gate (updated_at greater
-    -- than the postgres max) in the same run and republishes its rebuilt
-    -- slug and place_id. Comparing slugs instead would miss a place moving
-    -- back from a suffixed slug to a clean one.
-    case
-        when filing_overrides.br_database_id is not null
-        then current_timestamp()
-        else greatest(tbl_race.updated_at, tbl_place.updated_at)
-    end as updated_at,
+    -- Ride the greater of the race's own BR timestamp and the place row's
+    -- updated_at (the place mart bumps it whenever a slug changes, so a
+    -- dependent race republishes its rebuilt slug and place_id in the same
+    -- build). Deliberately source-stable: a filing-address override changes
+    -- row content without bumping updated_at, and civics-joined columns can
+    -- also change without a bump. A bump implies the row changed; the
+    -- reverse does not hold, and nothing downstream consumes this column as
+    -- a change signal.
+    greatest(tbl_race.updated_at, tbl_place.updated_at) as updated_at,
     tbl_race.br_hash_id,
     tbl_race.br_database_id,
     tbl_race.election_date,

--- a/dbt/project/tests/mart_election_api_race_win_number_estimate_coverage_warn.sql
+++ b/dbt/project/tests/mart_election_api_race_win_number_estimate_coverage_warn.sql
@@ -6,10 +6,11 @@
     )
 }}
 
--- win_number is structurally null on the election_api race mart: BallotReady
+-- win_number is null in practice on the election_api race mart: BallotReady
 -- supplies no win number, and the only values that ever existed are HubSpot
--- archive rows for 2023-2025 elections, which the mart's date window
--- excludes. So the win_number_effective the campaign-strategy-context
+-- archive rows for 2023-2025 elections, which rarely resolve to a
+-- BallotReady race id even now that the six-year window makes their races
+-- eligible. So the win_number_effective the campaign-strategy-context
 -- endpoint serves is always win_number_estimate, and that estimate is null
 -- whenever a race has no positive Projected_Turnout for its election year.
 --


### PR DESCRIPTION
## Summary
- updated_at on the race mart becomes source-stable unconditionally:
  greatest(race, place) with the filing-override build-time bump removed. The
  bump existed to clear the writer's incremental gate, which is dead code
  (the filtered dataframes are discarded), so nothing consumes the column as
  a change signal. Under whole-table swap delivery a byte-stable row is the
  property that matters. The single live override row's updated_at moves
  backward to its source-derived value.
- win_number docs catch up with the six-year window that landed separately
  (#675): archive races are now in-window, but archive candidacies rarely
  resolve to a BallotReady race id, so the column is null in practice
  (measured 0 of 1,012,125 rows on the widened build). Mart comment, yaml
  description, and the coverage warn test's header now state that instead of
  the stale structural-null claim.

This PR originally carried the window widening itself; #675 landed that as a
short-term unblock, so this is the delivery-migration residue. The swap
migration (rehearsal-gated race group + inbound-FK-safe swap transaction)
follows in a separate PR.

## Verification
- Remote build green (15/15) at the six-year window: 1,012,125 rows,
  election_date 2020-08-01..2028-07-18, updated_at 100% populated.
- win_number coverage measured on the widened build (0 populated), matching
  the new doc text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)