### PR TITLE
Loader: VACUUM (ANALYZE) after build_indexes instead of plain ANALYZE

### DIFF
--- a/airflow/astro/docs/people_api_loader.md
+++ b/airflow/astro/docs/people_api_loader.md
@@ -55,7 +55,7 @@ structure — none of which change across `resize` — so correctness is identic
 | `provision` | Create a fresh Aurora cluster + writer on the **copy-phase** instance class, empty cluster parameter groups, connection string to SSM. Reuses the shared S3 gateway VPC endpoint. |
 | `create_schema` | Apply CREATE TABLE statements from the committed snapshot for all four tables: `Voter` and `DistrictVoter` (partitioned by State with per-state LIST children) and `District` and `DistrictStats` (flat). |
 | `copy` | Parallel server-side `aws_s3.table_import_from_s3`: for partitioned tables (Voter, DistrictVoter), per-state per-file copy with rows routed to partitions by `"State"`; for flat tables (District, DistrictStats), whole-table copy. Idempotent per state/table (count / DELETE + reload). |
-| `build_indexes` | Scale the writer up to the **index-phase** class, then add primary keys and indexes for all four tables: for partitioned tables (Voter, DistrictVoter) build per-partition indexes and attach to parent; for flat tables (District, DistrictStats) build parent-level indexes. Then `ANALYZE` all tables. Concurrent-builder count defaults to `LOADER_INDEX_PARALLELISM` (else 128). See below. |
+| `build_indexes` | Scale the writer up to the **index-phase** class, then add primary keys and indexes for all four tables: for partitioned tables (Voter, DistrictVoter) build per-partition indexes and attach to parent; for flat tables (District, DistrictStats) build parent-level indexes. Then `VACUUM (ANALYZE)` all tables — a freshly bulk-loaded table has an empty visibility map, so this sets it (enabling index-only scans and letting serving-side `count(*)` avoid a full heap scan) in the same pass that refreshes planner stats. Concurrent-builder count defaults to `LOADER_INDEX_PARALLELISM` (else 128). See below. |
 | `validate` | Row counts vs the `inspect_prod` baseline (per-state for partitioned tables within +/-10%, whole-table for flat tables), plus per-table schema/index structural checks (with `:<table>` suffix in check names). Runs on the still-scaled-up index instance (before `resize`). Failure halts the DAG. |
 | `resize` | Flip the writer down to the serving instance class (`serve_instance_class`, prod default `db.r6g.4xlarge`; dev sets `LOADER_SERVE_INSTANCE_CLASS=db.t4g.medium`), swap in the serve parameter group, bump backup retention, enable deletion protection. Finishes with a lightweight post-resize smoke check (`SELECT 1` against the resized cluster) confirming it's reachable. |
 | `scale_down_on_failure` | Not in the happy path — a `trigger_rule=one_failed` branch off `provision`→`validate`→`resize`. On any post-provision failure (including a `validate` failure, which now runs on the scaled-up writer before `resize`) it runs `loader scale-down`, flipping the writer to `db.serverless` to stop provisioned-instance cost. Skipped on a successful run. See "Failure cost guard" below. |
@@ -86,8 +86,8 @@ Overridable via `LOADER_LOAD_INSTANCE_CLASS` / `LOADER_INDEX_INSTANCE_CLASS` /
 
 **Cost logic.** Index building is CPU-bound and embarrassingly parallel, so its cost in
 instance-hours is roughly flat across instance sizes for the parallel bulk (a smaller box just takes
-proportionally longer at a proportionally lower rate). The serial tail (PK add, ANALYZE, the few
-giant-partition builds) has a fixed wall-time and makes a bigger box strictly more expensive, since
+proportionally longer at a proportionally lower rate). The serial tail (PK add, VACUUM (ANALYZE), the
+few giant-partition builds) has a fixed wall-time and makes a bigger box strictly more expensive, since
 you pay for idle cores during it. So the cost-minimizing index box is the smallest one whose
 wall-clock you can tolerate; do not upsize past what actually fills. Storage is `aurora-iopt1`
 (I/O-Optimized), which is correct for the write-heavy load and build.

--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # post-merge. (During review this tracked the DATA-2100 feature branch so astro-dev ran the PR's loader;
 # repinned to @main for merge — it resolves to this PR's loader once merged.) See PR #607.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-23.1
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-23.2
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -107,10 +107,12 @@ TABLE_SPECS: dict[str, TableSpec] = {
 }
 
 
-# Loader-added Postgres columns absent from the prod serving schema — an intended divergence, like
-# the partition column. build_indexes creates them post-load (it owns the DDL); validate's
-# schema-diff allows them so the extra column doesn't read as drift. Keyed by serving table.
-LOADER_ADDED_COLUMNS: dict[str, set[str]] = {"Voter": {"geom"}}
+# Serving-cluster columns absent from the current prod (swain) baseline — intended divergences that
+# validate's schema-diff must not read as drift, like the partition column. Two kinds land here:
+# loader-created-post-load columns whose DDL build_indexes owns ("geom"), and newly-projected mart
+# columns the serving schema gained while the prod baseline still predates them
+# ("hf_most_important_policy_item"). Keyed by serving table.
+LOADER_ADDED_COLUMNS: dict[str, set[str]] = {"Voter": {"geom", "hf_most_important_policy_item"}}
 
 
 def is_partitioned(table: str) -> bool:

--- a/people-api-loader/src/loader/people_api/steps/build_indexes.py
+++ b/people-api-loader/src/loader/people_api/steps/build_indexes.py
@@ -1,4 +1,4 @@
-"""Step 5 — build the PK + indexes on the unified Voter table, then ANALYZE (DATA-1853).
+"""Step 5 — build the PK + indexes on the unified Voter table, then VACUUM (ANALYZE).
 
 Reads the PK, the LALVOTERID unique, and the plain indexes from `schema_spec`
 (the pg_catalog-sourced `_serving_seed`) and applies them to the LIST-partitioned
@@ -297,10 +297,20 @@ def _order_children_largest_first(
     return sorted(units, key=lambda u: partition_bytes.get(u[1], 0), reverse=True)
 
 
-def _analyze(cfg: LoaderConfig, run_date: str, table: str, *, forward: tuple[str, int] | None = None) -> None:
+def _vacuum_analyze(
+    cfg: LoaderConfig, run_date: str, table: str, *, forward: tuple[str, int] | None = None
+) -> None:
+    """VACUUM (ANALYZE) `table`, subsuming a plain ANALYZE.
+
+    A freshly bulk-loaded table has an empty visibility map, so `count(*)` and index-only scans fall
+    back to full heap scans. `VACUUM` sets the visibility map (enabling index-only scans); `ANALYZE`
+    refreshes planner stats. `VACUUM` requires autocommit (it cannot run inside a transaction block);
+    `connect_new` defaults to `autocommit=True`, which this relies on — do not pass `autocommit=False`
+    here.
+    """
     with connect_new(cfg, run_date, forward=forward) as conn, conn.cursor() as cur:
-        cur.execute(f'ANALYZE public."{table}"')  # ty: ignore[no-matching-overload]
-        log.info("indexes.analyzed", table=table)
+        cur.execute(f'VACUUM (ANALYZE) public."{table}"')  # ty: ignore[no-matching-overload]
+        log.info("indexes.vacuum_analyzed", table=table)
 
 
 def _l2type_coverage(
@@ -525,8 +535,11 @@ def run(cfg: LoaderConfig, run_date: str, *, parallelism: int = _DEFAULT_BUILDER
                 # 2. Flat table: plain indexes build directly on the table (no partitions to walk).
                 _build_in_parallel(_create_plain_flat, plain_idxs)
 
-            # 3. ANALYZE this table.
-            _analyze(cfg, run_date, table, forward=fwd)
+            # 3. VACUUM (ANALYZE) this table: sets the visibility map (so serving-side count(*) and
+            #    index-only scans skip the full heap scan a freshly bulk-loaded table would otherwise
+            #    force) and refreshes planner stats in the same pass. On a partitioned parent (Voter)
+            #    this recurses to every partition automatically.
+            _vacuum_analyze(cfg, run_date, table, forward=fwd)
 
             analyzed_tables.append(table)
             constraints_added.extend(p.constraint for p in pks)

--- a/people-api-loader/tests/test_build_indexes.py
+++ b/people-api-loader/tests/test_build_indexes.py
@@ -1,4 +1,4 @@
-"""build-indexes: applies PK + indexes (with State partition key) to public."Voter", then ANALYZE."""
+"""build-indexes: applies PK + indexes (with State partition key) to public."Voter", then VACUUM (ANALYZE)."""
 
 from __future__ import annotations
 
@@ -370,11 +370,11 @@ def test_partition_sizes_uses_table_prefix(monkeypatch: pytest.MonkeyPatch) -> N
     assert any(r"LIKE 'DistrictVoter\_%'" in s for s in executed_sql(conn))
 
 
-def test_analyze_parametrizes_table(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_vacuum_analyze_parametrizes_table(monkeypatch: pytest.MonkeyPatch) -> None:
     conn = FakeConn()
     monkeypatch.setattr(step, "connect_new", fake_connect(conn))
-    step._analyze(_CFG, "20260709", "District", forward=None)
-    assert any('ANALYZE public."District"' in s for s in executed_sql(conn))
+    step._vacuum_analyze(_CFG, "20260709", "District", forward=None)
+    assert any('VACUUM (ANALYZE) public."District"' in s for s in executed_sql(conn))
 
 
 def test_create_index_flat_no_state() -> None:
@@ -470,7 +470,7 @@ def test_run_builds_pk_indexes_and_analyzes(monkeypatch: pytest.MonkeyPatch) -> 
     )
     # ...and NOT built directly on the parent (that's the slow serial-per-partition path we removed).
     assert not any('"Voter_Active_idx" ON public."Voter" USING' in s for s in sql)
-    assert any('ANALYZE public."Voter"' in s for s in sql)
+    assert any('VACUUM (ANALYZE) public."Voter"' in s for s in sql)
     assert manifest.status == "complete"
     assert manifest.analyzed_tables == ["Voter"]
     assert "Voter_pkey" in manifest.constraints_added
@@ -504,7 +504,7 @@ def test_run_adds_postgis_and_geometry_column(monkeypatch: pytest.MonkeyPatch) -
 def test_run_builds_all_tables(monkeypatch: pytest.MonkeyPatch) -> None:
     # The full loop over TABLE_SPECS: partitioned tables (Voter, DistrictVoter) get State appended
     # to PK/unique and the parent-only+child+attach machinery; flat tables (District, DistrictStats)
-    # get a State-free PK and plain indexes built directly on the table. ANALYZE every table.
+    # get a State-free PK and plain indexes built directly on the table. VACUUM (ANALYZE) every table.
     captured: dict = {}
     conn = FakeConn()
     monkeypatch.setattr(step, "connect_new", fake_connect(conn))
@@ -563,7 +563,7 @@ def test_run_builds_all_tables(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not any("District_name_idx" in s and "ON ONLY" in s for s in sql)
     assert not any("District_name_idx_CA" in s for s in sql)
 
-    # ANALYZE every table, in TABLE_SPECS order (Voter first).
+    # VACUUM (ANALYZE) every table, in TABLE_SPECS order (Voter first).
     assert manifest.analyzed_tables == ["Voter", "District", "DistrictStats", "DistrictVoter"]
     assert set(manifest.constraints_added) == {
         "Voter_pkey",
@@ -598,7 +598,7 @@ def _pool_test_setup(monkeypatch: pytest.MonkeyPatch, connect: object) -> None:
     """Shared `run()` scaffolding for the worker-pool resilience tests below.
 
     `indexes_for` returns no indexes, so only the PK stage (a single item) does real building
-    work through `_build_in_parallel`; `_partition_sizes`/`_analyze` still run (unconditional in
+    work through `_build_in_parallel`; `_partition_sizes`/`_vacuum_analyze` still run (unconditional in
     `run()`) and each make exactly one `connect_new` call, which the tests account for.
     """
     monkeypatch.setattr(step, "connect_new", connect)
@@ -610,7 +610,7 @@ def _pool_test_setup(monkeypatch: pytest.MonkeyPatch, connect: object) -> None:
     monkeypatch.setattr(step, "write_manifest", lambda cfg, m: "uri")
     monkeypatch.setattr(step, "rds", lambda cfg: _FakeRds(current_class=cfg.index_instance_class))
     # Restrict the per-table loop to Voter so the connect-count/pk-call assertions below (which
-    # account for exactly the Voter PK + _partition_sizes + _analyze connects) stay exact.
+    # account for exactly the Voter PK + _partition_sizes + _vacuum_analyze connects) stay exact.
     monkeypatch.setattr(step, "TABLE_SPECS", {"Voter": step.TABLE_SPECS["Voter"]})
 
 
@@ -634,7 +634,7 @@ def test_run_absorbs_transient_connection_drop(monkeypatch: pytest.MonkeyPatch) 
     assert manifest.status == "complete"
     assert pk_calls["n"] == 2  # failed once, requeued, retried, and succeeded
     # pg_trgm install (1) + PK stage reconnecting once (2) + unconditional
-    # _partition_sizes (1) + _analyze (1).
+    # _partition_sizes (1) + _vacuum_analyze (1).
     assert connect_calls["n"] == 5
 
 

--- a/people-api-loader/tests/test_connections.py
+++ b/people-api-loader/tests/test_connections.py
@@ -140,3 +140,12 @@ def test_statement_timeout_skipped_when_zero(monkeypatch: pytest.MonkeyPatch) ->
     with db.connect_prod(cfg):
         pass
     assert conn.executed == []  # 0 disables the timeout (no SET issued)
+
+
+def test_connect_new_defaults_to_autocommit() -> None:
+    # build_indexes._vacuum_analyze relies on this default: VACUUM cannot run inside a transaction
+    # block, and _vacuum_analyze never passes autocommit explicitly. If this default ever flips to
+    # False, VACUUM would fail in prod — so pin the contract here.
+    import inspect
+
+    assert inspect.signature(db.connect_new).parameters["autocommit"].default is True

--- a/people-api-loader/tests/test_integration_pg.py
+++ b/people-api-loader/tests/test_integration_pg.py
@@ -417,6 +417,7 @@ def test_vacuum_analyze_runs_under_autocommit(
     that default. Also asserts the ANALYZE side effect (planner stats populated) landed.
     """
     with pg_conn.cursor() as cur:
+        _exec(cur, 'DROP TABLE IF EXISTS public."VacTgt" CASCADE')
         _exec(cur, 'CREATE TABLE public."VacTgt" (k int)')
         _exec(cur, 'INSERT INTO public."VacTgt" (k) VALUES (1), (2), (3)')
 

--- a/people-api-loader/tests/test_integration_pg.py
+++ b/people-api-loader/tests/test_integration_pg.py
@@ -24,6 +24,7 @@ import subprocess
 import tempfile
 import uuid
 from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from types import SimpleNamespace
 from typing import cast
@@ -421,9 +422,22 @@ def test_vacuum_analyze_runs_under_autocommit(
         _exec(cur, 'CREATE TABLE public."VacTgt" (k int)')
         _exec(cur, 'INSERT INTO public."VacTgt" (k) VALUES (1), (2), (3)')
 
-    monkeypatch.setattr(build_indexes, "connect_new", fake_connect(pg_conn))
-    # Would raise "VACUUM cannot run inside a transaction block" if the connection weren't autocommit.
+    # Spy on connect_new so we also enforce that _vacuum_analyze does NOT override the autocommit
+    # default to False — otherwise VACUUM would raise "cannot run inside a transaction block" in
+    # prod, and yielding the (always-autocommit) pg_conn would hide that.
+    captured_kwargs: list[dict[str, object]] = []
+
+    @contextmanager
+    def spy_connect_new(*args: object, **kwargs: object) -> Iterator[psycopg.Connection]:
+        captured_kwargs.append(dict(kwargs))
+        yield pg_conn
+
+    monkeypatch.setattr(build_indexes, "connect_new", spy_connect_new)
     build_indexes._vacuum_analyze(_CFG, "20260609", "VacTgt")
+
+    # _vacuum_analyze must rely on connect_new's autocommit default, never force autocommit=False.
+    assert captured_kwargs, "connect_new was not called"
+    assert all(kw.get("autocommit", True) is True for kw in captured_kwargs), captured_kwargs
 
     # VACUUM sets reltuples to the exact live-tuple count; ANALYZE alone only estimates.
     with pg_conn.cursor() as cur:

--- a/people-api-loader/tests/test_integration_pg.py
+++ b/people-api-loader/tests/test_integration_pg.py
@@ -405,3 +405,25 @@ def test_state_column_is_a_real_usstate_enum(pg_conn: psycopg.Connection) -> Non
     # the enum), not merely by the partition's implicit CHECK.
     with pg_conn.cursor() as cur, pytest.raises(psycopg.errors.InvalidTextRepresentation):
         _exec(cur, insert, (str(uuid.uuid4()), "ZZ"))
+
+
+def test_vacuum_analyze_runs_under_autocommit(
+    pg_conn: psycopg.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`build_indexes._vacuum_analyze` must execute `VACUUM (ANALYZE)` against a real connection.
+
+    VACUUM has a hard requirement — it cannot run inside a transaction block — so this guards the
+    reliance on `connect_new` defaulting to autocommit. `pg_conn` is autocommit=True, mirroring
+    that default. Also asserts the ANALYZE side effect (planner stats populated) landed.
+    """
+    with pg_conn.cursor() as cur:
+        _exec(cur, 'CREATE TABLE public."VacTgt" (k int)')
+        _exec(cur, 'INSERT INTO public."VacTgt" (k) VALUES (1), (2), (3)')
+
+    monkeypatch.setattr(build_indexes, "connect_new", fake_connect(pg_conn))
+    # Would raise "VACUUM cannot run inside a transaction block" if the connection weren't autocommit.
+    build_indexes._vacuum_analyze(_CFG, "20260609", "VacTgt")
+
+    # VACUUM sets reltuples to the exact live-tuple count; ANALYZE alone only estimates.
+    with pg_conn.cursor() as cur:
+        assert _scalar(cur, "SELECT reltuples FROM pg_class WHERE relname='VacTgt'") == 3

--- a/people-api-loader/tests/test_validate.py
+++ b/people-api-loader/tests/test_validate.py
@@ -398,6 +398,20 @@ def test_check_schema_diff_loader_added_geom_allowed(monkeypatch: pytest.MonkeyP
     assert "geom" in check.details["allowed_extra"]
 
 
+def test_check_schema_diff_hf_policy_column_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # hf_most_important_policy_item is a mart column the serving schema gained while the prod
+    # baseline still predates it — an intended divergence registered in LOADER_ADDED_COLUMNS,
+    # so it must NOT read as drift (this is what made validate's schema-diff fail on the first
+    # refresh that added it).
+    prod = [("col_a",), ("col_b",)]
+    new = [*prod, ("hf_most_important_policy_item",)]
+    monkeypatch.setattr(step, "connect_prod", fake_connect(FakeConn().queue_result(prod)))
+    monkeypatch.setattr(step, "connect_new", fake_connect(FakeConn().queue_result(new)))
+    check = step._check_schema_diff(_CFG, "20260609", "Voter")
+    assert check.passed is True
+    assert "hf_most_important_policy_item" in check.details["allowed_extra"]
+
+
 def test_check_schema_diff_non_partition_extra_still_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     # Only the partition column is a free pass; any other extra column still fails.
     prod = [("district_id",), ("voter_id",), ("created_at",), ("updated_at",)]


### PR DESCRIPTION
## Why
`build_indexes` runs a plain `ANALYZE public."<table>"` per table. On a freshly bulk-loaded table the **visibility map** is empty, so `count(*)` and index-only scans fall back to full heap scans — which is why `validate` crawls on the small serving instance and why serving-side broad-filter counts are slow.

`ANALYZE` only refreshes planner stats; **`VACUUM` sets the visibility map** (enabling index-only scans). `VACUUM (ANALYZE)` does both in one pass, so it fully subsumes the current `ANALYZE`.

## What
- `build_indexes`: `_analyze` → `_vacuum_analyze`, running `VACUUM (ANALYZE) public."<table>"` per table, in the same spot (after that table's indexes, on the `r8g.48xlarge` index instance, before `resize`) so the one-time full scan is paid on the fast box.
- `VACUUM` requires autocommit (can't run in a transaction block); `connect_new` defaults `autocommit=True`, which this relies on — documented in the helper's docstring and now **DB-verified** by an integration test that drives `_vacuum_analyze` against real Postgres under autocommit.
- Docs (`people_api_loader.md`) updated; cache-bust bump.

## Tradeoff
`VACUUM (ANALYZE)` full-scans each table (vs `ANALYZE`'s sample), adding wall-clock to `build_indexes` — a one-time build cost on the big instance instead of paying full heap scans on every serving-side count forever.

## Tests
people-api-loader: 318 passed / 5 skipped + integration 5 passed (incl. the new `VACUUM (ANALYZE)`-against-real-PG test); ruff/format/ty clean.