### PR TITLE
[DATA-2144] quality_bench: gold-run answer key q03_win_pit (Win Active Candidates PIT)

### DIFF
--- a/analytics/diagnostics/quality_bench/keys/q03_win_pit_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q03_win_pit_key.yaml
@@ -1,0 +1,104 @@
+id: q03_win_pit
+as_of: "2026-07-23"
+numbers:
+  # Active Candidates (OKR), recomputed point-in-time: distinct Win users
+  # (users_win_candidacy, is_latest_version AND NOT is_demo) with >=1
+  # dashboard-view union event in the trailing 30 days of each as-of date.
+  #
+  # Three dates escalate across the dashboard-view event lifecycle:
+  #   Mar-31 — legacy era (successor absent before 2026-04-09); tests PIT anchoring.
+  #   May-31 — union load-bearing mid-migration (legacy-only undercounts -13.5%).
+  #   Jul-15 — window [2026-06-15, 2026-07-16) FULLY post the 2026-06-13 legacy
+  #            death; the union is the ONLY source. Legacy-only, the dead
+  #            is_active_candidate_30d flag, and the milestone
+  #            last_dashboard_viewed_at (caps 2026-06-13) all collapse to 0.
+  #
+  # Tolerance (re-baseline convention): 1% across all three. Mar/May sit fully
+  # inside live event coverage, so re-run drift is limited to late mart edits to
+  # the registry (user deletion, demo/latest-version reclassification) —
+  # historically <1% on closed periods. 1% ADMITS the users_win_base anchor
+  # (Mar 1016 / May 648 / Jul 536, the governed flag's home table, +0-0.3%)
+  # while FAILING every wrong fork: the un-anchored any-uid read
+  # (1062 = +4.7% Mar, 655 = +1.4% May; the May value caps tolerance below 2%),
+  # the legacy-only / milestone read (May 559 = -13.5%; Jul 0), and the dead
+  # stored flag (0 at all three). Jul-15 is a recent window (closed 2026-07-16,
+  # 7d before the pin), but Amplitude events settle within days so 1% (+-5)
+  # absorbs residual backfill; the discriminating trap there is 0, which fails
+  # by 100%. Population fork settled to candidacy-hygiene in the gold run
+  # (see required_resolutions.population).
+  - name: active_candidates_2026_03_31
+    value: 1014
+    tolerance_pct: 1.0
+  - name: active_candidates_2026_05_31
+    value: 646
+    tolerance_pct: 1.0
+  - name: active_candidates_2026_07_15
+    value: 536
+    tolerance_pct: 1.0
+required_resolutions:
+  # Do NOT read users_win_base.is_active_candidate_30d — it reads FALSE for all
+  # users (dead legacy anchor event, capped 2026-06-13; DATA-2173). Recompute.
+  metric_recompute: recompute_from_raw_not_stored_is_active_candidate_30d
+  # 2-event dashboard union, per-user EXISTS (co-fire-safe). Legacy-only
+  # undercounts May (surface migration); March is legacy-only by code truth
+  # (successor instrumented 2026-04-01, absent before the March window closes).
+  dashboard_event: union_candidate_dashboard_viewed_and_campaign_plan_viewed
+  # Distinct users, hygiene-anchored to the candidacy registry.
+  population: users_win_candidacy_latest_version_non_demo_distinct_user
+  # Trailing 30d matching the OKR flag arithmetic (>= as_of - 30 days), applied
+  # as event_time >= date_sub(as_of,30) AND event_time < date_add(as_of,1):
+  # 31 calendar days, as-of day fully included. Calendar-month alignment here is
+  # a coincidence of two 31-day months, not the definition.
+  trailing_window: trailing_30d_okr_arithmetic_half_open_asof_day_inclusive
+  # Anchored to the as-of date, not current_date (the point-in-time discipline).
+  pit_anchor: anchored_to_as_of_date_not_current_date
+mandatory_sources:
+  - id: population_table
+    pattern: "users_win_candidacy"
+    description: Population must be the candidacy registry (latest-version,
+      non-demo), distinct users — not users_win_base's stored active flag and
+      not un-anchored Amplitude user_ids.
+  - id: raw_event_stream
+    pattern: "stg_airbyte_source__amplitude_api_events"
+    description: The metric must be recomputed from the raw event stream — the
+      stored is_active_candidate_30d flag is dead (reads FALSE for all users).
+  - id: dashboard_union
+    pattern: "Dashboard - Campaign Plan Viewed"
+    description: Evidence the run used the 2-event dashboard union — the legacy
+      event alone undercounts the May window by 13.5% (surface migration).
+severity1_patterns:
+  # Legacy-only (or milestone last_dashboard_viewed_at) read of the May window
+  # stated as the answer: 559 vs true 646 (-13.5%). This is the point-in-time /
+  # dashboard-union trap the question exists to catch; the milestone recompute
+  # anchored to as_of lands exactly here.
+  - "active_candidates_2026_05_31\\D{0,15}\\b559\\b"
+  # Post-death collapse: reporting 0 for the Jul-15 window, where the entire
+  # trailing-30d window is after the 2026-06-13 legacy death. Legacy-only, the
+  # dead is_active_candidate_30d flag, and the milestone last_dashboard_viewed_at
+  # all read 0 here; the union reads 536. This is the headline dead-legacy trap.
+  - "active_candidates_2026_07_15[\"'\\s:=]{1,6}0\\b"
+  # Dead stored-flag read at the March/May dates: reporting 0 active candidates
+  # (is_active_candidate_30d reads FALSE for all users). Assignment-form only,
+  # so a correct run mentioning "the flag reads 0" in prose does not trip it.
+  - "active_candidates_2026_0[35]_31[\"'\\s:=]{1,6}0\\b"
+required_assumptions:
+  - metric_recompute
+  - dashboard_event
+  - population
+  - trailing_window
+  - pit_anchor
+intent_card: |
+  Purpose: tests point-in-time discipline for the Active Candidates OKR —
+  recomputing anchored to a past date (not current_date), avoiding the dead
+  is_active_candidate_30d flag (DATA-2173), and using the version-safe 2-event
+  dashboard union across the 2026-05/06 surface migration and the 2026-06-13
+  legacy-event death. The three dates escalate: Mar-31 (legacy era, tests PIT
+  anchoring), May-31 (union load-bearing mid-migration), Jul-15 (window fully
+  post-death — union is the only source; legacy/dead-flag/milestone all read 0).
+  Audience: data team / OKR reporting; a leadership-facing headline, so
+  demo/internal hygiene is required and the count is distinct users.
+  Forks (asker's answers): metric = recompute from raw, never the stored flag;
+  dashboard = candidate-dashboard OR campaign-plan view union; population =
+  candidacy registry (latest-version, non-demo), distinct users — not
+  users_win_base, not un-anchored user_ids; window = trailing-30d OKR arithmetic,
+  as-of day inclusive; anchor = the as-of date, not current_date.

--- a/analytics/diagnostics/quality_bench/questions/q03_win_pit.md
+++ b/analytics/diagnostics/quality_bench/questions/q03_win_pit.md
@@ -1,5 +1,7 @@
 As of March 31, 2026: how many Win users were active candidates, meaning they
-had viewed their candidate dashboard at least once in the preceding 30 days?
+had viewed their candidate dashboard at least once in the trailing 30 days (on
+or after the date 30 days before the as-of date, counting the as-of date itself;
+for March 31, an event on or after 2026-03-01 through the end of 2026-03-31)?
 
 Report that count as `active_candidates_2026_03_31`. Then report the same
 measure as of May 31, 2026 as `active_candidates_2026_05_31`, and again as of

--- a/analytics/diagnostics/quality_bench/questions/q03_win_pit.md
+++ b/analytics/diagnostics/quality_bench/questions/q03_win_pit.md
@@ -2,4 +2,5 @@ As of March 31, 2026: how many Win users were active candidates, meaning they
 had viewed their candidate dashboard at least once in the preceding 30 days?
 
 Report that count as `active_candidates_2026_03_31`. Then report the same
-measure as of May 31, 2026 as `active_candidates_2026_05_31`.
+measure as of May 31, 2026 as `active_candidates_2026_05_31`, and again as of
+July 15, 2026 as `active_candidates_2026_07_15`.


### PR DESCRIPTION
## What
Gold-run answer key for `q03_win_pit` (holdout split), the Win point-in-time trap
question, plus the widened prompt (added a third as-of date).

## Numbers (Active Candidates OKR, recomputed point-in-time)
- `active_candidates_2026_03_31` = 1014
- `active_candidates_2026_05_31` = 646
- `active_candidates_2026_07_15` = 536

All +/- 1.0% tolerance: admits the `users_win_base` anchor; fails the
un-anchored, legacy-only, and dead-flag reads.

## Method
2-event dashboard union (`Dashboard - Candidate Dashboard Viewed` OR
`Dashboard - Campaign Plan Viewed`), per-user EXISTS (co-fire-safe); distinct Win
users from `users_win_candidacy` (latest-version, non-demo); trailing-30d
matching the OKR flag arithmetic, anchored to each as-of date, not
`current_date`. Does not read the dead `users_win_base.is_active_candidate_30d`
flag (DATA-2173).

## Why three dates
March (legacy era) tests point-in-time anchoring; May (mid-migration) makes the
union load-bearing (legacy-only reads -13.5%); July 15 places the whole
trailing-30d window after the 2026-06-13 legacy-event death, where legacy-only,
the dead flag, and the milestone all collapse to 0 vs union 536 (the binary
dead-legacy test). Both original dates sat inside live legacy coverage and were
survivable; the post-death date makes the trap fail hard.

## Verification
Events cross-checked against the omni git provenance CSV (code-truth
instrumented/retired dates), not just data-observed min/max. Two reviewers
(product-data-scientist, product-manager) returned no blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to quality-bench YAML and question text; no runtime analytics, auth, or production data paths are modified.
> 
> **Overview**
> Adds the **gold-run answer key** for holdout bench question `q03_win_pit`, encoding expected Active Candidates counts for three as-of dates (Mar 31 / May 31 / Jul 15 2026 at **1014 / 646 / 536**, each ±1%) plus the resolution contract: recompute from raw Amplitude events, **2-event dashboard union**, `users_win_candidacy` population hygiene, trailing-30d OKR window, and **PIT anchored to as-of** (not `current_date` or dead `is_active_candidate_30d`).
> 
> The key also wires **severity-1 regex traps** for common wrong forks (e.g. legacy-only May **559**, Jul **0**, dead-flag zeros) and documents mandatory source patterns in the intent card.
> 
> The **prompt** in `q03_win_pit.md` is extended to require reporting `active_candidates_2026_07_15`, so the Jul post–legacy-event-death case is explicitly scored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe1870d40bfc185aa00fbabf6337d60999707a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->