### PR TITLE
[DATA-2181] Retire the writer's Race slice

### DIFF
--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -445,121 +445,6 @@ PLACE_UPSERT_QUERY = """
         parent_id = EXCLUDED.parent_id
 """
 
-RACE_UPSERT_QUERY = """
-    INSERT INTO {db_schema}."Race" (
-        id,
-        created_at,
-        updated_at,
-        br_hash_id,
-        br_database_id,
-        election_date,
-        state,
-        position_geoid,
-        position_level,
-        normalized_position_name,
-        position_description,
-        filing_office_address,
-        filing_phone_number,
-        paperwork_instructions,
-        filing_requirements,
-        is_runoff,
-        is_primary,
-        partisan_type,
-        filing_date_start,
-        filing_date_end,
-        employment_type,
-        eligibility_requirements,
-        salary,
-        sub_area_name,
-        sub_area_value,
-        frequency,
-        place_id,
-        slug,
-        position_names,
-        position_id,
-        number_of_seats,
-        win_number,
-        is_partisan,
-        office_type,
-        official_office_name,
-        office_level
-    )
-    SELECT
-        id::uuid,
-        created_at,
-        updated_at,
-        br_hash_id,
-        br_database_id,
-        election_date,
-        state,
-        position_geoid::text,
-        position_level::\"PositionLevel\",
-        normalized_position_name,
-        position_description,
-        filing_office_address,
-        filing_phone_number,
-        paperwork_instructions,
-        filing_requirements,
-        is_runoff,
-        is_primary,
-        partisan_type,
-        filing_date_start,
-        filing_date_end,
-        employment_type,
-        eligibility_requirements,
-        salary,
-        sub_area_name,
-        sub_area_value,
-        frequency,
-        place_id::uuid,
-        slug,
-        position_names,
-        position_id::uuid,
-        number_of_seats,
-        win_number,
-        is_partisan,
-        office_type,
-        official_office_name,
-        office_level
-    FROM {staging_schema}."Race"
-    ON CONFLICT (id) DO UPDATE SET
-        created_at = EXCLUDED.created_at,
-        updated_at = EXCLUDED.updated_at,
-        br_hash_id = EXCLUDED.br_hash_id,
-        br_database_id = EXCLUDED.br_database_id,
-        election_date = EXCLUDED.election_date,
-        state = EXCLUDED.state,
-        position_geoid = EXCLUDED.position_geoid,
-        position_level = EXCLUDED.position_level,
-        normalized_position_name = EXCLUDED.normalized_position_name,
-        position_description = EXCLUDED.position_description,
-        filing_office_address = EXCLUDED.filing_office_address,
-        filing_phone_number = EXCLUDED.filing_phone_number,
-        paperwork_instructions = EXCLUDED.paperwork_instructions,
-        filing_requirements = EXCLUDED.filing_requirements,
-        is_runoff = EXCLUDED.is_runoff,
-        is_primary = EXCLUDED.is_primary,
-        partisan_type = EXCLUDED.partisan_type,
-        filing_date_start = EXCLUDED.filing_date_start,
-        filing_date_end = EXCLUDED.filing_date_end,
-        employment_type = EXCLUDED.employment_type,
-        eligibility_requirements = EXCLUDED.eligibility_requirements,
-        salary = EXCLUDED.salary,
-        sub_area_name = EXCLUDED.sub_area_name,
-        sub_area_value = EXCLUDED.sub_area_value,
-        frequency = EXCLUDED.frequency,
-        place_id = EXCLUDED.place_id,
-        slug = EXCLUDED.slug,
-        position_names = EXCLUDED.position_names,
-        position_id = EXCLUDED.position_id,
-        number_of_seats = EXCLUDED.number_of_seats,
-        win_number = EXCLUDED.win_number,
-        is_partisan = EXCLUDED.is_partisan,
-        office_type = EXCLUDED.office_type,
-        official_office_name = EXCLUDED.official_office_name,
-        office_level = EXCLUDED.office_level
-"""
-
 STANCE_UPSERT_QUERY = """
     INSERT INTO {db_schema}."Stance" (
         id,
@@ -738,7 +623,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
     candidacy_df: DataFrame = dbt.ref("m_election_api__candidacy")
     issue_df: DataFrame = dbt.ref("m_election_api__issue")
     place_df: DataFrame = dbt.ref("m_election_api__place")
-    race_df: DataFrame = dbt.ref("m_election_api__race")
     stance_df: DataFrame = dbt.ref("m_election_api__stance")
     district_df: DataFrame = dbt.ref("m_election_api__district")
     position_df: DataFrame = dbt.ref("m_election_api__position")
@@ -765,7 +649,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
                 "Candidacy",
                 "Issue",
                 "Place",
-                "Race",
                 "Stance",
                 "District",
             ],
@@ -773,7 +656,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
                 candidacy_df,
                 issue_df,
                 place_df,
-                race_df,
                 stance_df,
                 district_df,
             ],
@@ -805,7 +687,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
     #   District -> (none)
     #   Position -> District, Place
     #   Person -> (none)
-    #   Race -> Place, Position
+    #   Race: swap-delivered by the sync_election_api DAG (not written here)
     #   Candidacy -> Race, Person
     #   OfficeHolder -> Person, Position
     #   Issue (self-ref)
@@ -825,7 +707,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
             "District",
             "Position",
             "Person",
-            "Race",
             "Candidacy",
             "OfficeHolder",
             "Issue",
@@ -836,7 +717,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
             district_df,
             position_df,
             person_df,
-            race_df,
             candidacy_df,
             officeholder_df,
             issue_df,
@@ -847,7 +727,6 @@ def model(dbt, session: SparkSession) -> DataFrame:
             DISTRICT_UPSERT_QUERY,
             POSITION_UPSERT_QUERY,
             PERSON_UPSERT_QUERY,
-            RACE_UPSERT_QUERY,
             CANDIDACY_UPSERT_QUERY,
             OFFICEHOLDER_UPSERT_QUERY,
             ISSUE_UPSERT_QUERY,

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -629,8 +629,9 @@ def model(dbt, session: SparkSession) -> DataFrame:
     person_df: DataFrame = dbt.ref("m_election_api__person")
     officeholder_df: DataFrame = dbt.ref("m_election_api__office_holder")
 
-    # the election_date window is owned entirely by m_election_api__race; the
-    # writer loads whatever the mart emits
+    # Race is delivered by the sync_election_api swap, not this writer; the
+    # election_date window is still owned by m_election_api__race upstream of
+    # every mart loaded here.
 
     # Implement incremental logic if this is an incremental run
     if dbt.is_incremental:

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -15,14 +15,13 @@ from pathlib import Path
 WRITER_PATH = Path(__file__).parent.parent / "project" / "models" / "write" / "write__election_api_db.py"
 
 # The writer's full table set, in FK-dependency order (parents before
-# children); Projected_Turnout is intentionally absent — it is delivered by
-# the sync_election_api Airflow DAG's atomic table swap (DATA-2015).
+# children); Projected_Turnout and Race are intentionally absent — they are
+# delivered by the sync_election_api Airflow DAG's atomic table swap (DATA-2015).
 EXPECTED_LOAD_TABLES = [
     "Place",
     "District",
     "Position",
     "Person",
-    "Race",
     "Candidacy",
     "OfficeHolder",
     "Issue",
@@ -31,7 +30,7 @@ EXPECTED_LOAD_TABLES = [
 
 # The incremental max-updated_at filter covers every load table except
 # Position, Person, and OfficeHolder, which have no updated_at to filter on.
-EXPECTED_INCREMENTAL_TABLES = ["Candidacy", "Issue", "Place", "Race", "Stance", "District"]
+EXPECTED_INCREMENTAL_TABLES = ["Candidacy", "Issue", "Place", "Stance", "District"]
 EXPECTED_NON_INCREMENTAL_TABLES = {"Position", "Person", "OfficeHolder"}
 
 
@@ -156,3 +155,17 @@ def test_stance_upsert_guards_candidacy_existence():
     query = _string_constant(_writer_tree(), "STANCE_UPSERT_QUERY")
     assert "candidacy_id IS NULL" in query
     assert "EXISTS" in query and '"Candidacy"' in query.split("EXISTS", 1)[1]
+
+
+def test_race_is_absent():
+    """Race must never reappear in this writer: it is delivered by the
+    sync_election_api Airflow DAG's atomic table swap. The candidacy-orphan
+    cleanup still READS live Race; only delivery is out of scope here."""
+    tree = _writer_tree()
+    source = WRITER_PATH.read_text()
+    for call in _zip_calls(tree):
+        first = _literal_string_list(call.args[0]) if call.args else None
+        if first:
+            assert "Race" not in first
+    assert "RACE_UPSERT_QUERY" not in source
+    assert 'INSERT INTO {db_schema}."Race"' not in source

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -15,8 +15,8 @@ from pathlib import Path
 WRITER_PATH = Path(__file__).parent.parent / "project" / "models" / "write" / "write__election_api_db.py"
 
 # The writer's full table set, in FK-dependency order (parents before
-# children); Projected_Turnout and Race are intentionally absent — they are
-# delivered by the sync_election_api Airflow DAG's atomic table swap (DATA-2015).
+# children); Projected_Turnout and Race are intentionally absent, both
+# delivered by the sync_election_api Airflow DAG's atomic table swap.
 EXPECTED_LOAD_TABLES = [
     "Place",
     "District",

--- a/dbt/tests/test_write__election_api_db.py
+++ b/dbt/tests/test_write__election_api_db.py
@@ -86,7 +86,7 @@ def test_every_zip_is_strict():
 
 
 def test_load_loop_table_set_is_pinned():
-    """The load loop writes exactly the nine tables, in FK-dependency
+    """The load loop writes exactly the eight tables, in FK-dependency
     order, with each table's DataFrame and upsert query aligned by name."""
     call = _zip_by_first_list(_writer_tree(), EXPECTED_LOAD_TABLES)
     assert len(call.args) == 3, "load loop zips (tables, dataframes, upsert queries)"


### PR DESCRIPTION
> **DO NOT MERGE until cutover day.** This PR is the third leg of the race
> delivery migration and merges only on the day the swap is enabled, right
> after the first supervised swap passes parity, so the Race table has
> exactly one deliverer at every moment. Runbook in #677's description.
> Draft status is the merge guard; mark ready-for-review on cutover day.

## Summary
- Deletes the writer's Race slice: the upsert constant, the mart ref, and
  the entries in the incremental-filter and load-loop zip lists. The
  post-load age-out DELETE was already removed with the window change; the
  swap's whole-table replace is the age-out from cutover onward.
- Pins the retirement with a source-contract test (test_race_is_absent),
  the same pattern that pins Projected_Turnout's absence.
- Keeps the candidacy-orphan cleanup untouched: it reads live Race and ages
  candidacies out identically under swap delivery.

Depends on #677 (its branch is this branch's base). Rebase onto main and
re-run the writer test suite on cutover day before marking ready.

## Verification
- Writer source-contract suite green (8 tests including both existence
  guards and the new absence pin).
- Remote dbt parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cutover timing matters: Candidacy still depends on swap-delivered Race rows, so merging before the swap is live could leave a delivery gap; the change is otherwise a focused removal with guards and tests intact.
> 
> **Overview**
> **Race** is no longer written by `write__election_api_db`; the `sync_election_api` Airflow DAG’s atomic table swap is the sole deliverer, matching **Projected_Turnout**.
> 
> The change drops `RACE_UPSERT_QUERY`, the `m_election_api__race` ref, and **Race** from the incremental-filter and load-loop zip lists (eight tables remain). Comments document that swap delivery and that the election-date window still lives upstream in `m_election_api__race`.
> 
> **Candidacy** upsert guards, orphan cleanup that **reads** live `Race`, and stance/candidacy FK guards are unchanged.
> 
> Tests pin the new contract: expected load/incremental lists no longer include **Race**, and `test_race_is_absent` blocks reintroducing Race upserts or zip entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1867a12070b65ac012fff9f4716560231a6ae72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->