### PR TITLE
[DATA-2173] Repair Active Candidates OKR flags (dead dashboard event)

### DIFF
--- a/dbt/project/macros/amplitude_event_taxonomy.sql
+++ b/dbt/project/macros/amplitude_event_taxonomy.sql
@@ -189,7 +189,9 @@
         both dashboard events. TRUE for a user's first dashboard view and for any
         view whose gap from the prior dashboard event exceeds gap_seconds; co-fired
         pairs collapse to one, genuine re-visits still count. Apply only to rows
-        already filtered to is_dashboard_view_event, then count_if the result.
+        already filtered to is_dashboard_view_event, materialize the result as a
+        boolean column in a CTE/subquery, then count_if that column in an outer
+        query (a window function cannot be nested directly inside count_if).
 
         Args:
             event_time_col: SQL expression for the event timestamp.

--- a/dbt/project/macros/amplitude_event_taxonomy.sql
+++ b/dbt/project/macros/amplitude_event_taxonomy.sql
@@ -145,7 +145,8 @@
         (int__amplitude_win_activity and its weekly variant). Extend this list
         when a genuinely recurrent activity event is added to those rollups.
 
-        The dashboard view is now a 3-event allowlist entry, not 2: the legacy
+        The allowlist now carries 3 events total (1 campaign-outreach event
+        plus 2 dashboard-view events): the legacy
         'Dashboard - Candidate Dashboard Viewed' and its live replacement
         'Dashboard - Campaign Plan Viewed' co-fired Apr-Jun 2026 during the
         dashboard-surface migration (see is_dashboard_view_event /

--- a/dbt/project/macros/amplitude_event_taxonomy.sql
+++ b/dbt/project/macros/amplitude_event_taxonomy.sql
@@ -145,12 +145,68 @@
         (int__amplitude_win_activity and its weekly variant). Extend this list
         when a genuinely recurrent activity event is added to those rollups.
 
+        The dashboard view is now a 3-event allowlist entry, not 2: the legacy
+        'Dashboard - Candidate Dashboard Viewed' and its live replacement
+        'Dashboard - Campaign Plan Viewed' co-fired Apr-Jun 2026 during the
+        dashboard-surface migration (see is_dashboard_view_event /
+        dashboard_view_is_new for the union and co-fire dedup).
+
         Args:
             event_type_col: SQL expression producing the event_type string.
 
         Usage:
             {{ amplitude_event_is_recurrent('event_type') }} as is_recurrent
     #}
+    {{ event_type_col }} in (
+        'Voter Outreach - Campaign Completed',
+        'Dashboard - Candidate Dashboard Viewed',
+        'Dashboard - Campaign Plan Viewed'
+    )
+{% endmacro %}
+
+{% macro is_dashboard_view_event(event_type_col) %}
+    {#
+        Membership test for a candidate-dashboard view, spanning the 2026-05/06
+        dashboard-surface migration. The legacy event
+        'Dashboard - Candidate Dashboard Viewed' died in-data 2026-06-13 when the
+        rebuild replaced the surface with the Campaign Plan view, which fires
+        'Dashboard - Campaign Plan Viewed' (live 2026-04-09). The two co-fired
+        2026-04-09 -> 2026-06-13, so raw counts over this union double-count that
+        window (use dashboard_view_is_new for counts); MIN/MAX/EXISTS and
+        COUNT(DISTINCT date) over the union are co-fire-safe.
+
+        Args:
+            event_type_col: SQL expression producing the event_type string.
+    #}
     {{ event_type_col }}
-    in ('Voter Outreach - Campaign Completed', 'Dashboard - Candidate Dashboard Viewed')
+    in ('Dashboard - Candidate Dashboard Viewed', 'Dashboard - Campaign Plan Viewed')
+{% endmacro %}
+
+{% macro dashboard_view_is_new(event_time_col, partition_col, gap_seconds=30) %}
+    {#
+        Time-gap sessionization for de-duplicating dashboard-view counts across
+        the 2026-04-09 -> 2026-06-13 co-fire window, where a single visit fired
+        both dashboard events. TRUE for a user's first dashboard view and for any
+        view whose gap from the prior dashboard event exceeds gap_seconds; co-fired
+        pairs collapse to one, genuine re-visits still count. Apply only to rows
+        already filtered to is_dashboard_view_event, then count_if the result.
+
+        Args:
+            event_time_col: SQL expression for the event timestamp.
+            partition_col: SQL expression for the per-user partition key.
+            gap_seconds: collapse window in seconds (co-fire threshold).
+    #}
+    case
+        when
+            lag({{ event_time_col }}) over (
+                partition by {{ partition_col }} order by {{ event_time_col }}
+            )
+            is null
+            or {{ event_time_col }} > lag({{ event_time_col }}) over (
+                partition by {{ partition_col }} order by {{ event_time_col }}
+            )
+            + interval {{ gap_seconds }} seconds
+        then true
+        else false
+    end
 {% endmacro %}

--- a/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
@@ -123,6 +123,15 @@ models:
             expression: "first_dashboard_viewed_at <= last_dashboard_viewed_at"
           config:
             where: "first_dashboard_viewed_at is not null and last_dashboard_viewed_at is not null"
+      # At user grain the earliest dashboard event always has lag = null, so it
+      # always counts as a new view. Any user with a dashboard view must have
+      # dashboard_view_count >= 1; a value of 0 here would mean the co-fire
+      # dedup logic zeroed out a real view.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "dashboard_view_count >= 1"
+          config:
+            where: "last_dashboard_viewed_at is not null"
 
   - name: int__amplitude_serve_activity
     description: >

--- a/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
@@ -192,7 +192,7 @@ models:
     description: >
       User x month intermediate aggregating Win product engagement from Amplitude.
       Captures campaign sends (Voter Outreach - Campaign Completed), and dashboard views
-      (Dashboard - Candidate Dashboard Viewed).
+      (unioning the legacy and current dashboard-view event names, deduped).
 
       Grain: One row per user_id x activity_month_year.
 
@@ -238,8 +238,9 @@ models:
 
       - name: dashboard_views
         description: >
-          Count of 'Dashboard - Candidate Dashboard Viewed' events in this month.
-          Zero if user had only campaign events this month.
+          Deduped count of dashboard-view events (legacy + live event names)
+          in this month. Co-fires of both event names for the same view are
+          collapsed to one. Zero if user had only campaign events this month.
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
@@ -255,7 +256,10 @@ models:
                 min_value: 0
 
       - name: total_events
-        description: Total Win engagement events (campaigns + dashboard views) in this month.
+        description: >
+          Total raw Win engagement events (campaigns + dashboard views) in
+          this month, undeduped; can exceed campaigns_sent + dashboard_views
+          when a dashboard view co-fired both event names.
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
@@ -306,7 +310,9 @@ models:
             where: "first_dashboard_viewed_at is not null and last_dashboard_viewed_at is not null"
       - dbt_utils.expression_is_true:
           arguments:
-            expression: "campaigns_sent + dashboard_views = total_events"
+            # dashboard_views is deduped; total_events is raw, so equality
+            # only holds outside co-fire windows where both event names fired.
+            expression: "campaigns_sent + dashboard_views <= total_events"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "dashboard_view_days <= activity_days"

--- a/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude.yaml
@@ -398,8 +398,9 @@ models:
 
       - name: dashboard_views
         description: >
-          Count of 'Dashboard - Candidate Dashboard Viewed' events in this week.
-          Zero if user had only campaign events this week.
+          Deduped count of dashboard-view events (legacy + live event names)
+          in this week. Co-fires of both event names for the same view are
+          collapsed to one. Zero if user had only campaign events this week.
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
@@ -415,7 +416,10 @@ models:
                 min_value: 0
 
       - name: total_events
-        description: Total Win engagement events (campaigns + dashboard views) in this week.
+        description: >
+          Total raw Win engagement events (campaigns + dashboard views) in
+          this week, undeduped; can exceed campaigns_sent + dashboard_views
+          when a dashboard view co-fired both event names.
         data_tests:
           - not_null
           - dbt_utils.accepted_range:
@@ -470,7 +474,9 @@ models:
             where: "first_dashboard_viewed_at is not null and last_dashboard_viewed_at is not null"
       - dbt_utils.expression_is_true:
           arguments:
-            expression: "campaigns_sent + dashboard_views = total_events"
+            # dashboard_views is deduped; total_events is raw, so equality
+            # only holds outside co-fire windows where both event names fired.
+            expression: "campaigns_sent + dashboard_views <= total_events"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "dashboard_view_days <= activity_days"

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_user_milestones.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_user_milestones.sql
@@ -37,6 +37,7 @@ with
                 'pro_upgrade_complete',
                 'Voter Outreach - Campaign Completed',
                 'Dashboard - Candidate Dashboard Viewed',
+                'Dashboard - Campaign Plan Viewed',
                 'Serve Onboarding - Getting Started Viewed',
                 'Serve Onboarding - Constituency Profile Viewed',
                 'Serve Onboarding - Poll Value Props Viewed',
@@ -47,9 +48,22 @@ with
             )
     ),
 
+    dashboard_views_dedup as (
+        select user_id, count_if(is_new_view) as dashboard_view_count
+        from
+            (
+                select
+                    user_id,
+                    {{ dashboard_view_is_new("event_time", "user_id") }} as is_new_view
+                from milestone_events
+                where {{ is_dashboard_view_event("event_type") }}
+            )
+        group by 1
+    ),
+
     final as (
         select
-            user_id,
+            me.user_id,
 
             -- Onboarding CVR
             min(
@@ -60,8 +74,7 @@ with
             ) as amplitude_registration_completed_at,
             min(
                 case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
-                    then event_time
+                    when {{ is_dashboard_view_event("event_type") }} then event_time
                 end
             ) as first_dashboard_viewed_at,
             min_by(
@@ -97,15 +110,10 @@ with
             -- Active Candidates
             max(
                 case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
-                    then event_time
+                    when {{ is_dashboard_view_event("event_type") }} then event_time
                 end
             ) as last_dashboard_viewed_at,
-            count(
-                case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed' then 1
-                end
-            ) as dashboard_view_count,
+            coalesce(max(dv.dashboard_view_count), 0) as dashboard_view_count,
 
             -- Supplemental
             min(
@@ -154,8 +162,9 @@ with
                     then event_time
                 end
             ) as serve_poll_preview_at
-        from milestone_events
-        group by 1
+        from milestone_events me
+        left join dashboard_views_dedup dv on me.user_id = dv.user_id
+        group by me.user_id
     )
 
 select *

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_user_milestones.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_user_milestones.sql
@@ -48,16 +48,16 @@ with
             )
     ),
 
+    dashboard_view_flags as (
+        select
+            user_id, {{ dashboard_view_is_new("event_time", "user_id") }} as is_new_view
+        from milestone_events
+        where {{ is_dashboard_view_event("event_type") }}
+    ),
+
     dashboard_views_dedup as (
         select user_id, count_if(is_new_view) as dashboard_view_count
-        from
-            (
-                select
-                    user_id,
-                    {{ dashboard_view_is_new("event_time", "user_id") }} as is_new_view
-                from milestone_events
-                where {{ is_dashboard_view_event("event_type") }}
-            )
+        from dashboard_view_flags
         group by 1
     ),
 

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity.sql
@@ -24,9 +24,10 @@ with
             user_id is not null
             and try_cast(user_id as bigint) is not null
             -- Recurrent-activity events come from the single-source taxonomy
-            -- instead of a hardcoded list. Resolves to the same 2
-            -- events: 'Voter Outreach - Campaign Completed',
-            -- 'Dashboard - Candidate Dashboard Viewed'.
+            -- instead of a hardcoded list. Resolves to 3 events:
+            -- 'Voter Outreach - Campaign Completed', plus both the legacy
+            -- and live dashboard-view events (unioned below via
+            -- is_dashboard_view_event).
             and event_type in (
                 select event_type
                 from {{ ref("int__amplitude_event_catalog") }}
@@ -34,10 +35,28 @@ with
             )
     ),
 
-    final as (
+    dashboard_view_flags as (
         select
             user_id,
-            activity_month_year,
+            event_time,
+            {{ dashboard_view_is_new("event_time", "user_id") }} as is_new_view
+        from win_events
+        where {{ is_dashboard_view_event("event_type") }}
+    ),
+
+    dashboard_views_dedup as (
+        select
+            user_id,
+            date_trunc('month', event_time) as activity_month_year,
+            count_if(is_new_view) as dashboard_views
+        from dashboard_view_flags
+        group by 1, 2
+    ),
+
+    final as (
+        select
+            we.user_id,
+            we.activity_month_year,
 
             count(
                 case when event_type = 'Voter Outreach - Campaign Completed' then 1 end
@@ -61,27 +80,21 @@ with
                 end
             ) as last_campaign_sent_at,
 
-            count(
-                case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed' then 1
-                end
-            ) as dashboard_views,
+            coalesce(max(dv.dashboard_views), 0) as dashboard_views,
             count(
                 distinct case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
+                    when {{ is_dashboard_view_event("event_type") }}
                     then date(event_time)
                 end
             ) as dashboard_view_days,
             min(
                 case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
-                    then event_time
+                    when {{ is_dashboard_view_event("event_type") }} then event_time
                 end
             ) as first_dashboard_viewed_at,
             max(
                 case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
-                    then event_time
+                    when {{ is_dashboard_view_event("event_type") }} then event_time
                 end
             ) as last_dashboard_viewed_at,
 
@@ -89,8 +102,12 @@ with
             count(distinct date(event_time)) as activity_days,
             min(event_time) as first_activity_at,
             max(event_time) as last_activity_at
-        from win_events
-        group by 1, 2
+        from win_events we
+        left join
+            dashboard_views_dedup dv
+            on we.user_id = dv.user_id
+            and we.activity_month_year = dv.activity_month_year
+        group by we.user_id, we.activity_month_year
     )
 
 select *

--- a/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity_weekly.sql
+++ b/dbt/project/models/intermediate/amplitude/int__amplitude_win_activity_weekly.sql
@@ -24,9 +24,10 @@ with
             user_id is not null
             and try_cast(user_id as bigint) is not null
             -- Recurrent-activity events come from the single-source catalog
-            -- instead of a hardcoded list. Resolves to the same 2 events:
-            -- 'Voter Outreach - Campaign Completed',
-            -- 'Dashboard - Candidate Dashboard Viewed'.
+            -- instead of a hardcoded list. Resolves to 3 events:
+            -- 'Voter Outreach - Campaign Completed', plus both the legacy
+            -- and live dashboard-view events (unioned below via
+            -- is_dashboard_view_event).
             and event_type in (
                 select event_type
                 from {{ ref("int__amplitude_event_catalog") }}
@@ -34,11 +35,29 @@ with
             )
     ),
 
-    final as (
+    dashboard_view_flags as (
         select
             user_id,
-            week_start_date,
-            date_add(week_start_date, 6) as week_end_date,
+            event_time,
+            {{ dashboard_view_is_new("event_time", "user_id") }} as is_new_view
+        from win_events
+        where {{ is_dashboard_view_event("event_type") }}
+    ),
+
+    dashboard_views_dedup as (
+        select
+            user_id,
+            cast(date_trunc('week', event_time) as date) as week_start_date,
+            count_if(is_new_view) as dashboard_views
+        from dashboard_view_flags
+        group by 1, 2
+    ),
+
+    final as (
+        select
+            we.user_id,
+            we.week_start_date,
+            date_add(we.week_start_date, 6) as week_end_date,
 
             -- Campaign activity
             count(
@@ -64,27 +83,21 @@ with
             ) as last_campaign_sent_at,
 
             -- Dashboard activity
-            count(
-                case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed' then 1
-                end
-            ) as dashboard_views,
+            coalesce(max(dv.dashboard_views), 0) as dashboard_views,
             count(
                 distinct case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
+                    when {{ is_dashboard_view_event("event_type") }}
                     then date(event_time)
                 end
             ) as dashboard_view_days,
             min(
                 case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
-                    then event_time
+                    when {{ is_dashboard_view_event("event_type") }} then event_time
                 end
             ) as first_dashboard_viewed_at,
             max(
                 case
-                    when event_type = 'Dashboard - Candidate Dashboard Viewed'
-                    then event_time
+                    when {{ is_dashboard_view_event("event_type") }} then event_time
                 end
             ) as last_dashboard_viewed_at,
 
@@ -93,8 +106,12 @@ with
             count(distinct date(event_time)) as activity_days,
             min(event_time) as first_activity_at,
             max(event_time) as last_activity_at
-        from win_events
-        group by 1, 2
+        from win_events we
+        left join
+            dashboard_views_dedup dv
+            on we.user_id = dv.user_id
+            and we.week_start_date = dv.week_start_date
+        group by we.user_id, we.week_start_date
     )
 
 select *

--- a/dbt/project/tests/assert_milestone_events_classified.sql
+++ b/dbt/project/tests/assert_milestone_events_classified.sql
@@ -15,6 +15,7 @@ with
             ('pro_upgrade_complete'),
             ('Voter Outreach - Campaign Completed'),
             ('Dashboard - Candidate Dashboard Viewed'),
+            ('Dashboard - Campaign Plan Viewed'),
             ('Serve Onboarding - Getting Started Viewed'),
             ('Serve Onboarding - Constituency Profile Viewed'),
             ('Serve Onboarding - Poll Value Props Viewed'),

--- a/dbt/project/tests/assert_recurrent_events_are_win.sql
+++ b/dbt/project/tests/assert_recurrent_events_are_win.sql
@@ -12,7 +12,8 @@ with
     recurrent_events(event_type) as (
         values
             ('Voter Outreach - Campaign Completed'),
-            ('Dashboard - Candidate Dashboard Viewed')
+            ('Dashboard - Candidate Dashboard Viewed'),
+            ('Dashboard - Campaign Plan Viewed')
     )
 
 select event_type, {{ amplitude_event_family("event_type") }} as family


### PR DESCRIPTION
## Problem

`mart_analytics.users_win_base.is_active_candidate_30d` — the canonical Active Candidates OKR flag — read FALSE for all ~62.5k users. The anchor Amplitude event `Dashboard - Candidate Dashboard Viewed` stopped firing in production on 2026-06-13, when the dashboard rebuild replaced the candidate-dashboard surface with the Campaign Plan view. Users still view the dashboard (the new surface fires `Dashboard - Campaign Plan Viewed`, live since 2026-04-09), but the models only counted the dead event, so `last_dashboard_viewed_at` was capped at 2026-06-13 while `current_date` marched on. `_7d` was already dead; `_30d` fully dead since ~2026-07-13; `_90d` decaying to zero by mid-September. The same dead event sat in the recurrent-activity allowlist, zeroing dashboard engagement in the Win activity intermediates after 2026-06-13.

## Fix

Replace the single dead event with the 2-event union (`Dashboard - Candidate Dashboard Viewed` ∪ `Dashboard - Campaign Plan Viewed`) everywhere a dashboard view is identified, via two new macros in `amplitude_event_taxonomy.sql`:

- `is_dashboard_view_event(col)` — membership over the union (single source of truth).
- `dashboard_view_is_new(event_time, partition)` — per-user time-gap sessionization for de-duplicating raw view *counts*.

The two events co-fired 2026-04-09 → 2026-06-13 (one visit fired both), so naive counts would double-count that window. MIN/MAX timestamps and distinct-date counts are inherently co-fire-safe; only the raw counts (`dashboard_view_count`, `dashboard_views`) are deduped. The 30s sessionization threshold was calibrated empirically — co-fire deltas cluster at p90 = 13s with a large gap to the ~31-min separate-visit tail (9,863 pairs sampled).

**Touched:** `int__amplitude_user_milestones`, `int__amplitude_win_activity`, `int__amplitude_win_activity_weekly` (+ the macro file, `amplitude_event_is_recurrent` widened, and the drift guards `assert_recurrent_events_are_win` / `assert_milestone_events_classified` synced). `users_win_base` needs no change — the OKR flags derive downstream of milestones. The recurrent-count row invariant on the two activity models was relaxed from `=` to `<=` (`dashboard_views` is now deduped, `total_events` is raw), with a new user-grain floor guard on milestones (`dashboard_view_count >= 1 where last_dashboard_viewed_at is not null`) to keep the dedup honest.

## Validation (dev build)

| Check | Before | After |
|---|---|---|
| `is_active_candidate_30d` | 0 (all ~62.5k users) | 551 |
| `max_last_dashboard_viewed_at` | capped 2026-06-13 | 2026-07-23 |
| May-2026 cohort 14-day dashboard views | 157 (legacy only) | 245 (union) |
| Plan-only viewers by cohort, Jan→May 2026 | — | 0/0/3/0/76 |
| `dbt test` (6 objects) | — | 116 pass / 1 pre-existing WARN / 0 error |

Cohort counts run modestly above the ticket's 2026-07-22 estimates (~225, ~68) — two extra days of Amplitude data since then; direction and magnitude are consistent, not a logic change.

## Notes for reviewers

- `is_onboarded` uses `first_dashboard_viewed_at`, now a MIN over the union. Net effect is strongly positive; a tiny population whose Campaign Plan view predates their registration event could flip FALSE — immaterial in the data, flagging for awareness.
- The period (month/week) activity models intentionally have no per-period dedup lower-bound test (it would false-fail on sessions straddling a period boundary); the user-grain guard on milestones covers dedup correctness.
- Pre-existing unrelated WARN: `relationships_int__amplitude_user_milestones_user_id__...` (269 orphaned user_ids) — predates this branch (last touched by an earlier taxonomy change), configured warn-not-error.

Ticket: https://app.clickup.com/t/86ajnqr0k (DATA-2173)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OKR-facing milestone and activity rollups and count semantics during an event migration window; logic is macro-centralized and guarded by updated dbt tests, but downstream metrics will shift materially.
> 
> **Overview**
> Repairs **Active Candidates** and Win engagement metrics that went flat after the legacy Amplitude event **`Dashboard - Candidate Dashboard Viewed`** stopped firing (replaced by **`Dashboard - Campaign Plan Viewed`**).
> 
> Adds taxonomy macros **`is_dashboard_view_event`** (legacy + live union) and **`dashboard_view_is_new`** (30s per-user gap sessionization) so co-fired pairs in Apr–Jun 2026 do not double-count raw view totals. **`amplitude_event_is_recurrent`** now includes both dashboard event names.
> 
> **`int__amplitude_user_milestones`**, **`int__amplitude_win_activity`**, and **`int__amplitude_win_activity_weekly`** use the union for first/last dashboard timestamps and deduped **`dashboard_view_count`** / **`dashboard_views`**; **`total_events`** stays raw. dbt tests relax **`campaigns_sent + dashboard_views = total_events`** to **`<=`**, add **`dashboard_view_count >= 1`** when **`last_dashboard_viewed_at`** is set, and sync drift guards **`assert_milestone_events_classified`** / **`assert_recurrent_events_are_win`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df57dc67f52fc1d86b6a097b8e4033ec7698b9c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->