### PR TITLE
[DATA-2145] Grader fork-matching fix, internal-fork doc alignment, ablation arms

### DIFF
--- a/.claude/skills/serve-analytics-knowledge/references/methodology_defaults.md
+++ b/.claude/skills/serve-analytics-knowledge/references/methodology_defaults.md
@@ -13,7 +13,8 @@ These apply by default to Serve-product analyses. Document deviations in your pr
 | Decision | Default |
 |---|---|
 | Unit of analysis | User (`user_id`); Serve has no candidacy-version grain |
-| Canonical population | `users_serve_base` filtered `is_serve_user` (1,869 as of 2026-07; currently 1:1 with `eo_activated_at IS NOT NULL`) |
+| Canonical population | `users_serve_base` filtered `is_serve_user` (1,869 as of 2026-07, a figure that still includes internal accounts; currently 1:1 with `eo_activated_at IS NOT NULL`) |
+| Population counts | Any reported count of Serve users excludes `@goodparty.org` accounts (staff/test), same convention as Win. `is_serve_user` alone retains them — apply the email exclusion on top. |
 | Engagement definition | **Broad Serve engagement** (below) is the analysis default; poll-anchored series (`users_serve_activity` MAU, `is_active_eo`) are continuity-only |
 | Outcome | People Served (decision level); retention on broad engagement (per user); re-election parked until officeholder data lands |
 | Engagement time-scope | Events at `event_time >= eo_activated_at` — pre-activation activity is campaigning (Win), not serving; ~all Serve users are also Win candidates |

--- a/analytics/diagnostics/quality_bench/README.md
+++ b/analytics/diagnostics/quality_bench/README.md
@@ -96,6 +96,32 @@ lag the layers under test:
 After the branch merges, the default (`main`) is correct and the flag can be
 dropped.
 
+## Ablation arms (post-hoc, 2026-07-25 — exploratory, not pre-registered)
+
+The 2026-07-25 batch showed the process layer went un-invoked in 20/24 full
+runs (skill loaded 4/24, reviewer agents dispatched 1/72), so full-vs-knowledge
+measured routing, not efficacy. Three additional arms force engagement via an
+arm-root `PROCESS_MANDATE.md` (written by prep_arms, layer `mandate`; the floor
+carries an inert pointer to it):
+
+- `forced_full` — knowledge + process docs + reviewer agents + mandate to use all of it
+- `knowledge_docs` — knowledge + process docs only (mandate: follow stages, no reviewers)
+- `knowledge_reviewers` — knowledge + reviewer agents only (mandate: dispatch both on the draft)
+
+Cancellation logic: if any process component helps and another cancels it, at
+least one component arm must deviate from both knowledge and forced_full —
+split a component further only when that pattern shows up. Build and run them
+explicitly (they are never built or run by default):
+
+    uv run python diagnostics/quality_bench/prep_arms.py --arms forced_full knowledge_docs knowledge_reviewers
+    uv run python diagnostics/quality_bench/run_matrix.py --batch <date>-ablation \
+        --arms forced_full knowledge_docs knowledge_reviewers \
+        --questions q03_win_pit q04_win_denominator q05_serve_metric q06_serve_overlap q07_serve_denominator \
+        --reps 6
+
+Report ablation results as exploratory alongside (never inside) the
+pre-registered three-arm verdict.
+
 ## Invocation
 
 Three CLIs in this directory (`prep_arms.py`, `run_matrix.py`, `grade.py`)

--- a/analytics/diagnostics/quality_bench/canaries.yaml
+++ b/analytics/diagnostics/quality_bench/canaries.yaml
@@ -17,13 +17,13 @@ canaries:
   - layer: knowledge
     source: analytics/lib/serve_analysis.py
     phrase: "Implements the **broad Serve engagement** definition"
-  - layer: process
+  - layer: process-docs
     source: .claude/skills/analytics-process/SKILL.md
     phrase: "route the executed analysis through the two adversarial reviewer agents"
-  - layer: process
+  - layer: reviewers
     source: .claude/agents/product-data-scientist.md
     phrase: "from a methodological-rigor perspective"
-  - layer: process
+  - layer: reviewers
     source: .claude/agents/product-manager.md
     phrase: "from a usefulness and clarity perspective"
   - layer: knowledge

--- a/analytics/diagnostics/quality_bench/floor.md
+++ b/analytics/diagnostics/quality_bench/floor.md
@@ -5,6 +5,9 @@ warehouse. Everything you need to connect is below. Answer the question you are
 given; do not ask clarifying questions (no user is present) — resolve ambiguity
 yourself and state every resolution in the assumptions ledger.
 
+If a `PROCESS_MANDATE.md` exists at the repo root, read it before anything else
+and follow it; its instructions are mandatory.
+
 ## Databricks access
 
 Auth is already configured on this machine (Databricks CLI profile). Run SQL

--- a/analytics/diagnostics/quality_bench/floor_static.md
+++ b/analytics/diagnostics/quality_bench/floor_static.md
@@ -5,6 +5,9 @@ warehouse. Everything you need to connect is below. Answer the question you are
 given; do not ask clarifying questions (no user is present) — resolve ambiguity
 yourself and state every resolution in the assumptions ledger.
 
+If a `PROCESS_MANDATE.md` exists at the repo root, read it before anything else
+and follow it; its instructions are mandatory.
+
 ## Databricks access
 
 Auth is already configured on this machine (Databricks CLI profile). Run SQL

--- a/analytics/diagnostics/quality_bench/grading.py
+++ b/analytics/diagnostics/quality_bench/grading.py
@@ -5,6 +5,7 @@ owns the judged layer)."""
 from __future__ import annotations
 
 import contextlib
+import itertools
 import re
 from dataclasses import dataclass
 
@@ -79,39 +80,112 @@ def check_severity1(answer_text: str, key: Key) -> list[CheckResult]:
     return out
 
 
-def check_assumptions(block: dict | None, key: Key) -> list[CheckResult]:
-    """Each required_assumptions fork must be surfaced in the answer's assumptions
-    ledger with a non-empty resolution: a bare fork entry says nothing about how
-    the fork was actually resolved."""
-    ledger = _resolutions(block) if block else {}
-    out = []
-    for fork in key.required_assumptions:
-        resolution = ledger.get(fork, "").strip()
-        detail = f"resolved as {resolution!r}" if resolution else "fork missing or resolution empty"
-        out.append(CheckResult(fork, "assumption", bool(resolution), detail))
-    return out
-
-
 def _norm(s: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", s.lower()).strip()
 
 
+# Tokens too generic to indicate two fork names/resolutions are about the same
+# thing (every ledger entry has a "definition" or touches "users").
+_GENERIC_TOKENS = {
+    "a",
+    "an",
+    "and",
+    "as",
+    "at",
+    "by",
+    "de",
+    "definition",
+    "for",
+    "handling",
+    "in",
+    "is",
+    "no",
+    "not",
+    "of",
+    "on",
+    "or",
+    "per",
+    "the",
+    "to",
+    "via",
+    "with",
+}
+
+
+def _tokens(s: str) -> set[str]:
+    return {t for t in _norm(s).split() if t not in _GENERIC_TOKENS}
+
+
+def _tokens_match(a: str, b: str) -> bool:
+    # Same word, or same 4-char prefix (registered/registration, created/creation,
+    # user/users) — cheap inflection tolerance without a stemmer.
+    return a == b or (len(a) >= 4 and len(b) >= 4 and a[:4] == b[:4])
+
+
+def _token_overlap(a: set[str], b: set[str]) -> int:
+    return sum(1 for x in a if any(_tokens_match(x, y) for y in b))
+
+
+def _find_fork(key_fork: str, ledger: dict[str, str]) -> str | None:
+    """Best ledger fork name for a key fork. Answers invent their own fork slugs
+    (the floor deliberately does not leak the key's names), so exact lookup is
+    the fast path and token overlap the real one: `account_created` should find
+    `account_creation_timestamp`, not miss."""
+    if key_fork in ledger:
+        return key_fork
+    want = _tokens(key_fork)
+    best, best_score = None, 0
+    for name in ledger:
+        score = _token_overlap(want, _tokens(name))
+        if score > best_score:
+            best, best_score = name, score
+    return best
+
+
+def check_assumptions(block: dict | None, key: Key) -> list[CheckResult]:
+    """Each required_assumptions fork must be surfaced in the answer's assumptions
+    ledger with a non-empty resolution: a bare fork entry says nothing about how
+    the fork was actually resolved. Fork names are matched by token overlap, not
+    exact string (see _find_fork)."""
+    ledger = _resolutions(block) if block else {}
+    out = []
+    for fork in key.required_assumptions:
+        name = _find_fork(fork, ledger)
+        resolution = ledger.get(name, "").strip() if name else ""
+        detail = f"as {name!r}: {resolution!r}" if resolution else "fork missing or resolution empty"
+        out.append(CheckResult(fork, "assumption", bool(resolution), detail))
+    return out
+
+
+def _content_match(got: str, want: str) -> bool:
+    g, w = _norm(got), _norm(want)
+    if bool(g) and (w in g or g in w):
+        return True
+    # Free-phrased resolutions rarely containment-match a key slug; two
+    # non-generic token hits is the lenient reported-only fallback.
+    return _token_overlap(_tokens(got), _tokens(want)) >= 2
+
+
 def check_resolutions(block: dict | None, key: Key) -> list[CheckResult]:
     """Compare each resolved fork against the key's expected value (normalized
-    containment either way — models phrase resolutions freely). Reported as the
-    resolutions_match column, NOT gated into the verdict rules: cross-rep
+    containment or token overlap — models phrase resolutions freely). Reported as
+    the resolutions_match column, NOT gated into the verdict rules: cross-rep
     agreement (cell_consistency) is deliberately correctness-blind, and the
     deterministic instrument for a wrong resolution is the numbers themselves —
     key tolerances must be tight enough that the wrong fork's number fails."""
     ledger = _resolutions(block) if block else {}
     out = []
     for fork, expected in key.required_resolutions.items():
-        got = _norm(ledger.get(fork, ""))
-        want = _norm(expected)
-        matched = bool(got) and (want in got or got in want)
-        out.append(
-            CheckResult(fork, "resolution", matched, f"resolved {ledger.get(fork, '')!r}, key {expected!r}")
+        name = _find_fork(fork, ledger)
+        got = ledger.get(name, "") if name else ""
+        # No name match anywhere: fall back to scanning every entry's content,
+        # so a fork filed under an unrecognizable slug still gets credit.
+        matched = (
+            _content_match(got, expected)
+            if got
+            else any(_content_match(r, expected) for r in ledger.values())
         )
+        out.append(CheckResult(fork, "resolution", matched, f"resolved {got!r}, key {expected!r}"))
     return out
 
 
@@ -141,11 +215,18 @@ def cell_consistency(blocks: list[dict | None], key: Key) -> dict:
             else:
                 # Zero mean: identical reps (all zero) are perfectly consistent.
                 spreads[name] = 0.0 if max(vals) == min(vals) else float("inf")
-    forks = set(key.required_resolutions)
+    # Resolution agreement is key-blind AND reported-only: reps invent their own
+    # fork names and phrase resolutions freely, so the comparable set is fork
+    # names two or more reps both surfaced, compared fuzzily. It never gates
+    # `consistent`: key tolerances are set so a divergent fork choice moves the
+    # number, making numeric spread the deterministic instrument (same argument
+    # as check_resolutions).
+    ledgers = [_resolutions(b) for b in parsed]
+    shared = {f for i, led in enumerate(ledgers) for f in led if any(f in o for o in ledgers[i + 1 :])}
     agreement = {}
-    for fork in forks:
-        seen = {_resolutions(b).get(fork) for b in parsed}
-        agreement[fork] = len(seen) == 1 and None not in seen
+    for fork in shared:
+        seen = [led[fork] for led in ledgers if fork in led]
+        agreement[fork] = all(_content_match(a, b) for a, b in itertools.pairwise(seen))
     numbers_ok = all(spreads.get(n, float("inf")) <= t for n, t in tol.items()) if parsed else False
     max_spread = max(spreads.get(n.name, float("inf")) for n in key.numbers) if parsed else float("inf")
     return {
@@ -154,5 +235,5 @@ def cell_consistency(blocks: list[dict | None], key: Key) -> dict:
         "number_spread_pct": spreads,
         "max_spread_pct": max_spread,
         "resolution_agreement": agreement,
-        "consistent": bool(parsed) and numbers_ok and all(agreement.values()),
+        "consistent": bool(parsed) and numbers_ok,
     }

--- a/analytics/diagnostics/quality_bench/grading.py
+++ b/analytics/diagnostics/quality_bench/grading.py
@@ -159,7 +159,11 @@ def check_assumptions(block: dict | None, key: Key) -> list[CheckResult]:
 
 def _content_match(got: str, want: str) -> bool:
     g, w = _norm(got), _norm(want)
-    if bool(g) and (w in g or g in w):
+    # Both sides must carry content: `"" in s` is vacuously True, so an empty
+    # resolution must never "match" a non-empty one (or vice versa).
+    if not g or not w:
+        return False
+    if w in g or g in w:
         return True
     # Free-phrased resolutions rarely containment-match a key slug; two
     # non-generic token hits is the lenient reported-only fallback.
@@ -177,14 +181,18 @@ def check_resolutions(block: dict | None, key: Key) -> list[CheckResult]:
     out = []
     for fork, expected in key.required_resolutions.items():
         name = _find_fork(fork, ledger)
-        got = ledger.get(name, "") if name else ""
-        # No name match anywhere: fall back to scanning every entry's content,
-        # so a fork filed under an unrecognizable slug still gets credit.
-        matched = (
-            _content_match(got, expected)
-            if got
-            else any(_content_match(r, expected) for r in ledger.values())
-        )
+        if name is not None:
+            # A matched fork with an empty resolution is unresolved — it must
+            # not fall through to the whole-ledger scan and pass on unrelated
+            # overlap.
+            got = ledger[name]
+            matched = _content_match(got, expected)
+        else:
+            # No name match anywhere: fall back to scanning every entry's
+            # content, so a fork filed under an unrecognizable slug still gets
+            # credit.
+            got = ""
+            matched = any(_content_match(r, expected) for r in ledger.values())
         out.append(CheckResult(fork, "resolution", matched, f"resolved {got!r}, key {expected!r}"))
     return out
 
@@ -216,17 +224,28 @@ def cell_consistency(blocks: list[dict | None], key: Key) -> dict:
                 # Zero mean: identical reps (all zero) are perfectly consistent.
                 spreads[name] = 0.0 if max(vals) == min(vals) else float("inf")
     # Resolution agreement is key-blind AND reported-only: reps invent their own
-    # fork names and phrase resolutions freely, so the comparable set is fork
-    # names two or more reps both surfaced, compared fuzzily. It never gates
-    # `consistent`: key tolerances are set so a divergent fork choice moves the
-    # number, making numeric spread the deterministic instrument (same argument
-    # as check_resolutions).
+    # fork names AND their own spellings of them, so forks are matched across
+    # ledgers fuzzily (_find_fork), not by exact name. Each fork concept anchors
+    # on its first appearance (ledger order); a concept surfaced by >=2 reps must
+    # be resolved compatibly in all of them. It never gates `consistent`: key
+    # tolerances are set so a divergent fork choice moves the number, making
+    # numeric spread the deterministic instrument (same argument as
+    # check_resolutions).
     ledgers = [_resolutions(b) for b in parsed]
-    shared = {f for i, led in enumerate(ledgers) for f in led if any(f in o for o in ledgers[i + 1 :])}
     agreement = {}
-    for fork in shared:
-        seen = [led[fork] for led in ledgers if fork in led]
-        agreement[fork] = all(_content_match(a, b) for a, b in itertools.pairwise(seen))
+    consumed: set[tuple[int, str]] = set()
+    for i, anchor in enumerate(ledgers):
+        for fork in anchor:
+            if (i, fork) in consumed:
+                continue
+            seen = [anchor[fork]]
+            for j in range(i + 1, len(ledgers)):
+                matched = _find_fork(fork, ledgers[j])
+                if matched is not None and (j, matched) not in consumed:
+                    consumed.add((j, matched))
+                    seen.append(ledgers[j][matched])
+            if len(seen) >= 2:
+                agreement[fork] = all(_content_match(a, b) for a, b in itertools.pairwise(seen))
     numbers_ok = all(spreads.get(n, float("inf")) <= t for n, t in tol.items()) if parsed else False
     max_spread = max(spreads.get(n.name, float("inf")) for n in key.numbers) if parsed else float("inf")
     return {

--- a/analytics/diagnostics/quality_bench/keys/q01_win_metric_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q01_win_metric_key.yaml
@@ -69,11 +69,14 @@ mandatory_sources:
 
 # Confidently-wrong claims observed/anticipated during the gold run:
 # gating the count on the stored onboarding flags, which are new-flow-blind
-# post-2026-05-07 (any such filter is wrong by construction), and reading a
-# creation timestamp column that does not exist on users_win_base.
+# post-2026-05-07 (any such filter is wrong by construction). A tripwire on
+# the nonexistent users_win_base.user_created_at column was DROPPED 2026-07-25
+# (#671 rule): correct answers quote the gotcha doc naming that column as
+# nonexistent, so the bare-name pattern is negation-blind — 2 false positives
+# on judge-clean runs in the 2026-07-25 batch, and a run actually using the
+# column cannot produce numbers at all.
 severity1_patterns:
   - '(?i)where\s+(not\s+)?(is_onboarded|has_completed_onboarding_flow)'
-  - 'users_win_base\.user_created_at'
 
 # Names must exactly match required_resolutions keys: check_assumptions and
 # check_resolutions read the same answer-ledger fork names (grading.py).

--- a/analytics/diagnostics/quality_bench/keys/q04_win_denominator_key.yaml
+++ b/analytics/diagnostics/quality_bench/keys/q04_win_denominator_key.yaml
@@ -133,8 +133,12 @@ severity1_patterns:
   # The known single-event near-miss for May dashboard views, stated as the
   # answer value.
   - "viewed_dashboard_2026_05\\D{0,15}\\b157\\b"
-  # Reading the fake completion collapse as a real product finding.
-  - "(onboarding|completion)[^.]{0,80}(collaps|dropped to (near[- ])?zero)"
+  # A prose-shaped pattern for "reading the fake completion collapse as a real
+  # product finding" was DROPPED 2026-07-25 (#671 rule: negation-blind): it
+  # fired on correct acquisition-mix prose ("paid share ... collapsed" near the
+  # word "onboarding") in 2 judge-clean runs and never on a true misread. The
+  # real dead-event trap stays guarded by the numeric onboarded_2026_05
+  # pattern above (true positive confirmed on bare r1, judge concurring).
 required_assumptions:
   - denominator
   - internal_accounts

--- a/analytics/diagnostics/quality_bench/prep_arms.py
+++ b/analytics/diagnostics/quality_bench/prep_arms.py
@@ -263,7 +263,12 @@ if __name__ == "__main__":
     failures += [f"floor: {f}" for f in integrity.check_text_leakage(floor_text, set(), canaries)]
     if failures:
         raise SystemExit("pre-prep integrity failed:\n" + "\n".join(failures))
-    for arm in args.arms or ARMS:
+    # nargs="*" makes a bare `--arms` an empty list; that's a user error, not a
+    # request for the defaults.
+    arms = args.arms if args.arms is not None else ARMS
+    if not arms:
+        parser.error("--arms requires at least one arm name; omit the flag to build the default arms")
+    for arm in arms:
         path = prep_arm(arm, repo_root, args.arms_root, floor_text, ref=args.ref, sync=not args.no_sync)
         arm_failures = integrity.check_links(path)
         arm_failures += integrity.check_arm_leakage(path, set(ARM_LAYERS[arm]), canaries)

--- a/analytics/diagnostics/quality_bench/prep_arms.py
+++ b/analytics/diagnostics/quality_bench/prep_arms.py
@@ -39,6 +39,8 @@ except ImportError:  # bare `python prep_arms.py`: diagnostics/ isn't on sys.pat
     from quality_bench.bank import ARMS
 
 # Treatment layers: repo-relative paths exported verbatim from --ref.
+# The original "process" layer split into process-docs + reviewers on
+# 2026-07-25 for the ablation arms; full = both, so its file set is unchanged.
 LAYERS: dict[str, list[str]] = {
     "knowledge": [
         ".claude/skills/win-analytics-knowledge",
@@ -46,18 +48,62 @@ LAYERS: dict[str, list[str]] = {
         "analytics/lib/win_analysis.py",
         "analytics/lib/serve_analysis.py",
     ],
-    "process": [
+    "process-docs": [
         ".claude/skills/analytics-process",
+    ],
+    "reviewers": [
         ".claude/agents/product-data-scientist.md",
         ".claude/agents/product-manager.md",
     ],
 }
 # code-critic (repo review) and data-matching are deliberately NOT layers:
 # they are not part of the pre-registered treatment.
+#
+# bare/knowledge/full are the pre-registered DATA-2164 arms. The remaining
+# arms are the post-hoc 2026-07-25 ablation (exploratory, label as such in
+# reporting): the first batch showed the process layer went un-invoked in
+# 20/24 full runs, so these arms carry a PROCESS_MANDATE.md (written below,
+# part of the treatment) that forces engagement, isolating docs vs reviewers.
 ARM_LAYERS: dict[str, list[str]] = {
     "bare": [],
     "knowledge": ["knowledge"],
-    "full": ["knowledge", "process"],
+    "full": ["knowledge", "process-docs", "reviewers"],
+    "forced_full": ["knowledge", "process-docs", "reviewers"],
+    "knowledge_docs": ["knowledge", "process-docs"],
+    "knowledge_reviewers": ["knowledge", "reviewers"],
+}
+
+_MANDATE_HEADER = """\
+# Process mandate (mandatory)
+
+These instructions apply to EVERY question in this environment, even ones that
+look like quick lookups. Do not skip a step because the question appears simple.
+"""
+MANDATES: dict[str, str] = {
+    "forced_full": _MANDATE_HEADER
+    + """
+1. Load the `analytics-process` skill BEFORE running any query, and follow its
+   stages: framing before querying, methodology defaults, execution.
+2. Before finalizing, dispatch BOTH reviewer agents — `product-data-scientist`
+   and `product-manager` — on your draft answer (numbers and method), and
+   address their feedback in the final answer (state what changed, or why not).
+""",
+    "knowledge_docs": _MANDATE_HEADER
+    + """
+1. Load the `analytics-process` skill BEFORE running any query, and follow its
+   stages: framing before querying, methodology defaults, execution.
+2. The reviewer agents are NOT available in this environment. Skip any reviewer
+   dispatch the skill calls for and note it as unavailable; run every other
+   stage yourself.
+""",
+    "knowledge_reviewers": _MANDATE_HEADER
+    + """
+1. Scope and execute the analysis with your own methodology (no process skill
+   ships in this environment).
+2. Before finalizing, dispatch BOTH reviewer agents — `product-data-scientist`
+   and `product-manager` — on your draft answer (numbers and method), and
+   address their feedback in the final answer (state what changed, or why not).
+""",
 }
 SUBSTRATE_EXPORTS = ["analytics/lib/databricks_conn.py"]
 
@@ -178,6 +224,9 @@ def prep_arm(
     for layer in ARM_LAYERS[arm]:
         for extracted in _export_paths(repo_root, dest, ref, LAYERS[layer]):
             layer_of[extracted] = layer
+    if arm in MANDATES:
+        (dest / "PROCESS_MANDATE.md").write_text(MANDATES[arm])
+        layer_of["PROCESS_MANDATE.md"] = "mandate"
     # Sync before the manifest so uv.lock (dependency resolution) is part of
     # run provenance: a re-prep that resolves different deps changes the
     # manifest, and run_matrix's arms_sha256 gate then refuses to mix it into
@@ -198,6 +247,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--no-sync", action="store_true", help="skip `uv sync` in each arm (tests/CI; runs need synced arms)"
     )
+    parser.add_argument(
+        "--arms",
+        nargs="*",
+        default=None,
+        choices=sorted(ARM_LAYERS),
+        help="arms to build (default: the pre-registered bare/knowledge/full; name the ablation arms explicitly)",
+    )
     args = parser.parse_args()
     here = Path(__file__).parent
     repo_root = here.parents[2]
@@ -207,7 +263,7 @@ if __name__ == "__main__":
     failures += [f"floor: {f}" for f in integrity.check_text_leakage(floor_text, set(), canaries)]
     if failures:
         raise SystemExit("pre-prep integrity failed:\n" + "\n".join(failures))
-    for arm in ARMS:
+    for arm in args.arms or ARMS:
         path = prep_arm(arm, repo_root, args.arms_root, floor_text, ref=args.ref, sync=not args.no_sync)
         arm_failures = integrity.check_links(path)
         arm_failures += integrity.check_arm_leakage(path, set(ARM_LAYERS[arm]), canaries)

--- a/analytics/tests/test_quality_bench_grading.py
+++ b/analytics/tests/test_quality_bench_grading.py
@@ -310,6 +310,57 @@ def test_cell_consistency_key_blind_fork_agreement():
     assert cell["resolution_agreement"] == {"my_own_slug": False}
 
 
+def test_cell_consistency_cross_rep_variant_fork_names():
+    """PR #688 delegate: reps spell the same fork concept differently, so
+    cross-rep matching must be fuzzy — variant slugs with divergent resolutions
+    are a reported disagreement, not silently absent."""
+    key = make_key()
+
+    def rep(fork: str, res: str) -> dict:
+        return {
+            "results": {
+                "numbers": {"total_users_jan": 9880},
+                "assumptions": [{"fork": fork, "resolution": res}],
+            }
+        }
+
+    cell = grading.cell_consistency(
+        [rep("account_creation_timestamp", "registered_at"), rep("account_created_at", "onboarded_at")], key
+    )
+    assert cell["resolution_agreement"] == {"account_creation_timestamp": False}
+    cell = grading.cell_consistency(
+        [rep("account_creation_timestamp", "registered_at"), rep("account_created_at", "registered_at")], key
+    )
+    assert cell["resolution_agreement"] == {"account_creation_timestamp": True}
+
+
+def test_content_match_rejects_empty_sides():
+    """PR #688 Bugbot: '' in s is vacuously True — an empty resolution must not
+    agree with a non-empty one in either direction, nor with another empty."""
+    assert grading._content_match("", "registered_at") is False
+    assert grading._content_match("registered_at", "") is False
+    assert grading._content_match("", "") is False
+
+
+def test_check_resolutions_matched_fork_with_empty_resolution_fails():
+    """PR #688 Bugbot: a name-matched fork with an empty resolution is
+    unresolved; it must not fall through to the whole-ledger content scan and
+    pass on an unrelated entry's overlap."""
+    key = make_key(required_resolutions={"denominator": "cumulative registered users"})
+    answer = """```yaml
+results:
+  numbers:
+    total_users_jan: 9885
+  assumptions:
+    - fork: denominator
+      resolution: null
+    - fork: unrelated_note
+      resolution: cumulative registered users mentioned in passing
+```"""
+    block = grading.parse_results_block(answer)
+    assert grading.check_resolutions(block, key)[0].passed is False
+
+
 def test_cell_consistency_sparse_number_reports_inf_spread():
     key = make_key(
         numbers=[NumberSpec("total_users_jan", 9880.0, 0.5), NumberSpec("activated_jan", 100.0, 0.5)]

--- a/analytics/tests/test_quality_bench_grading.py
+++ b/analytics/tests/test_quality_bench_grading.py
@@ -219,6 +219,97 @@ def test_cell_consistency_handles_unparsed_reps():
     assert cell["n_parsed"] == 2
 
 
+def test_check_assumptions_free_form_fork_names():
+    """2026-07-25 batch regression: answers invent their own fork slugs (the floor
+    never leaks the key's names), so matching is token-overlap, not exact. These
+    are the actual q01 key forks vs the fork names a full-arm run emitted."""
+    key = make_key(
+        required_assumptions=[
+            "account_created",
+            "internal_accounts",
+            "demo_accounts",
+            "month_bucketing",
+            "population",
+        ]
+    )
+    answer = """```yaml
+results:
+  numbers:
+    total_users_jan: 9885
+  assumptions:
+    - fork: win_user_population_table
+      resolution: mart_analytics.users_win_base (user grain)
+    - fork: account_creation_timestamp
+      resolution: registered_at
+    - fork: internal_account_definition
+      resolution: email ILIKE '%@goodparty.org' excluded
+    - fork: demo_account_handling
+      resolution: demo exclusion applied in cross-check
+    - fork: month_boundary_timezone
+      resolution: calendar month of stored timestamp
+```"""
+    block = grading.parse_results_block(answer)
+    by_fork = {c.check_id: c.passed for c in grading.check_assumptions(block, key)}
+    assert by_fork == {
+        "account_created": True,
+        "internal_accounts": True,
+        "demo_accounts": True,
+        "month_bucketing": True,
+        "population": True,
+    }
+
+
+def test_check_resolutions_free_form_fork_and_phrasing():
+    """Key slug and answer phrasing share no containment, only tokens; two
+    non-generic token hits count, zero must not."""
+    key = make_key(
+        required_resolutions={
+            "account_created": "db_registration (registered_at / gp_api user.created_at; NOT onboarding-gated)",
+            "internal_accounts": "exclude_goodparty_org_email_domain",
+        }
+    )
+    answer = """```yaml
+results:
+  numbers:
+    total_users_jan: 9885
+  assumptions:
+    - fork: account_creation_timestamp
+      resolution: registered_at from the users mart
+    - fork: internal_account_definition
+      resolution: dropped rows where email matches goodparty.org domain
+```"""
+    block = grading.parse_results_block(answer)
+    by_fork = {c.check_id: c.passed for c in grading.check_resolutions(block, key)}
+    assert by_fork == {"account_created": True, "internal_accounts": True}
+    # A resolution about something else entirely still fails.
+    wrong_key = make_key(required_resolutions={"account_created": "onboarding_completion_event"})
+    assert grading.check_resolutions(block, wrong_key)[0].passed is False
+
+
+def test_cell_consistency_key_blind_fork_agreement():
+    """Reps agreeing on their OWN fork names count as consistent even when those
+    names match nothing in the key; a fork surfaced by only one rep is not a
+    disagreement."""
+    key = make_key(required_resolutions={"denominator": "cumulative"})
+
+    def rep(res: str, extra: bool = False) -> dict:
+        assumptions = [{"fork": "my_own_slug", "resolution": res}]
+        if extra:
+            assumptions.append({"fork": "only_in_one_rep", "resolution": "whatever"})
+        return {"results": {"numbers": {"total_users_jan": 9880}, "assumptions": assumptions}}
+
+    cell = grading.cell_consistency(
+        [rep("cumulative"), rep("cumulative"), rep("cumulative", extra=True)], key
+    )
+    assert cell["consistent"] is True
+    assert cell["resolution_agreement"] == {"my_own_slug": True}
+    # Divergent resolution phrasing with agreeing numbers: numbers are the
+    # instrument, so the cell stays consistent; the disagreement is reported.
+    cell = grading.cell_consistency([rep("cumulative"), rep("monthly active")], key)
+    assert cell["consistent"] is True
+    assert cell["resolution_agreement"] == {"my_own_slug": False}
+
+
 def test_cell_consistency_sparse_number_reports_inf_spread():
     key = make_key(
         numbers=[NumberSpec("total_users_jan", 9880.0, 0.5), NumberSpec("activated_jan", 100.0, 0.5)]

--- a/analytics/tests/test_quality_bench_integrity.py
+++ b/analytics/tests/test_quality_bench_integrity.py
@@ -66,7 +66,7 @@ def test_real_canaries_are_fresh():
     # only checks entries that remain). Adding a canary means bumping this.
     assert len(canaries) == 9
     layers = {c.layer for c in canaries}
-    assert layers == {"knowledge", "process"}
+    assert layers == {"knowledge", "process-docs", "reviewers"}
     assert integrity.check_canary_staleness(canaries, REPO_ROOT) == []
 
 

--- a/analytics/tests/test_quality_bench_prep.py
+++ b/analytics/tests/test_quality_bench_prep.py
@@ -115,8 +115,9 @@ def test_manifest_covers_every_file_with_layer_attribution(fake_repo, tmp_path):
     on_disk = {str(p.relative_to(arm)) for p in arm.rglob("*") if p.is_file() and p.name != "manifest.json"}
     assert set(manifest["files"]) == on_disk
     layers = {f["layer"] for f in manifest["files"].values()}
-    assert layers == {"substrate", "knowledge", "process"}
-    assert manifest["files"][".claude/skills/analytics-process/SKILL.md"]["layer"] == "process"
+    assert layers == {"substrate", "knowledge", "process-docs", "reviewers"}
+    assert manifest["files"][".claude/skills/analytics-process/SKILL.md"]["layer"] == "process-docs"
+    assert manifest["files"][".claude/agents/product-manager.md"]["layer"] == "reviewers"
     assert manifest["files"]["analytics/lib/win_analysis.py"]["layer"] == "knowledge"
     assert manifest["files"]["analytics/lib/databricks_conn.py"]["layer"] == "substrate"
     assert all(len(f["sha256"]) == 64 for f in manifest["files"].values())
@@ -126,6 +127,37 @@ def test_manifest_is_deterministic(fake_repo, tmp_path):
     m1 = _manifest(_prep("knowledge", fake_repo, tmp_path))
     arm2 = prep_arms.prep_arm("knowledge", fake_repo, tmp_path / "arms2", FLOOR, sync=False)
     assert m1 == _manifest(arm2)
+
+
+def test_ablation_arms_layer_composition_and_mandate(fake_repo, tmp_path):
+    """The 2026-07-25 ablation arms: forced_full ships everything full does plus
+    a mandate; the two component arms ship exactly one process component each."""
+    forced = _prep("forced_full", fake_repo, tmp_path / "a")
+    docs = _prep("knowledge_docs", fake_repo, tmp_path / "b")
+    reviewers = _prep("knowledge_reviewers", fake_repo, tmp_path / "c")
+    for arm in (forced, docs, reviewers):
+        assert (arm / "PROCESS_MANDATE.md").exists()
+        assert _manifest(arm)["files"]["PROCESS_MANDATE.md"]["layer"] == "mandate"
+        assert (arm / ".claude" / "skills" / "win-analytics-knowledge").exists()
+    assert (forced / ".claude" / "skills" / "analytics-process").exists()
+    assert (forced / ".claude" / "agents" / "product-manager.md").exists()
+    assert (docs / ".claude" / "skills" / "analytics-process").exists()
+    assert not (docs / ".claude" / "agents").exists()
+    assert not (reviewers / ".claude" / "skills" / "analytics-process").exists()
+    assert (reviewers / ".claude" / "agents" / "product-data-scientist.md").exists()
+    # The pre-registered arms carry no mandate.
+    assert not (_prep("full", fake_repo, tmp_path / "d") / "PROCESS_MANDATE.md").exists()
+
+
+def test_forced_full_file_set_matches_full_except_mandate(fake_repo, tmp_path):
+    """forced_full is full + mandate and nothing else: the ablation must not
+    accidentally vary treatment content."""
+    full = _manifest(_prep("full", fake_repo, tmp_path / "a"))["files"]
+    forced = _manifest(_prep("forced_full", fake_repo, tmp_path / "b"))["files"]
+    assert set(forced) - set(full) == {"PROCESS_MANDATE.md"}
+    assert {k: v["sha256"] for k, v in full.items()} == {
+        k: v["sha256"] for k, v in forced.items() if k != "PROCESS_MANDATE.md"
+    }
 
 
 def test_unknown_arm_raises(fake_repo, tmp_path):
@@ -234,7 +266,7 @@ def _run_prep_cli(
 
 def test_cli_passes_integrity_on_clean_repo(fake_repo, tmp_path):
     canaries_yaml = (
-        'canaries:\n  - {layer: process, source: .claude/agents/product-manager.md, phrase: "pm prose"}\n'
+        'canaries:\n  - {layer: reviewers, source: .claude/agents/product-manager.md, phrase: "pm prose"}\n'
     )
     proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml)
     assert proc.returncode == 0, proc.stderr
@@ -247,7 +279,7 @@ def test_cli_fails_when_treatment_canary_leaks_into_floor(fake_repo, tmp_path):
     to confirm the pre-prep floor-leakage gate fires on its own, not just as
     a side effect of a fresh copy."""
     canaries_yaml = (
-        'canaries:\n  - {layer: process, source: .claude/agents/product-manager.md, phrase: "pm prose"}\n'
+        'canaries:\n  - {layer: reviewers, source: .claude/agents/product-manager.md, phrase: "pm prose"}\n'
     )
     proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml, arms_subdir="arms")
     assert proc.returncode == 0, proc.stderr
@@ -266,7 +298,7 @@ def test_cli_fails_when_treatment_canary_leaks_into_floor(fake_repo, tmp_path):
 
 def test_cli_fails_on_stale_canary(fake_repo, tmp_path):
     canaries_yaml = (
-        "canaries:\n  - {layer: process, source: .claude/agents/product-manager.md, "
+        "canaries:\n  - {layer: reviewers, source: .claude/agents/product-manager.md, "
         'phrase: "not actually in the file"}\n'
     )
     proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml)

--- a/analytics/tests/test_quality_bench_prep.py
+++ b/analytics/tests/test_quality_bench_prep.py
@@ -242,7 +242,11 @@ def test_cli_help_works_via_path_shim():
 
 
 def _run_prep_cli(
-    fake_repo: Path, tmp_path: Path, canaries_yaml: str, arms_subdir: str = "arms"
+    fake_repo: Path,
+    tmp_path: Path,
+    canaries_yaml: str,
+    arms_subdir: str = "arms",
+    extra_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run the prep CLI as a real subprocess against the fake repo, by copying
     the harness modules in. The CLI resolves repo_root from its own file
@@ -257,7 +261,14 @@ def _run_prep_cli(
     (dest / "floor.md").write_text("# floor\nlib {{LIB_PATH}} proj {{UV_PROJECT}}\n")
     (dest / "canaries.yaml").write_text(canaries_yaml)
     return subprocess.run(
-        [sys.executable, str(dest / "prep_arms.py"), "--arms-root", str(tmp_path / arms_subdir), "--no-sync"],
+        [
+            sys.executable,
+            str(dest / "prep_arms.py"),
+            "--arms-root",
+            str(tmp_path / arms_subdir),
+            "--no-sync",
+            *(extra_args or []),
+        ],
         capture_output=True,
         text=True,
         timeout=120,
@@ -271,6 +282,18 @@ def test_cli_passes_integrity_on_clean_repo(fake_repo, tmp_path):
     proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml)
     assert proc.returncode == 0, proc.stderr
     assert "integrity ok" in proc.stdout
+
+
+def test_cli_bare_arms_flag_is_an_error(fake_repo, tmp_path):
+    """PR #688 delegate: `--arms` with no values (nargs='*' -> []) must error,
+    not silently fall through to building the pre-registered default arms."""
+    canaries_yaml = (
+        'canaries:\n  - {layer: reviewers, source: .claude/agents/product-manager.md, phrase: "pm prose"}\n'
+    )
+    proc = _run_prep_cli(fake_repo, tmp_path, canaries_yaml, extra_args=["--arms"])
+    assert proc.returncode != 0
+    assert "requires at least one arm name" in proc.stderr
+    assert "prepped" not in proc.stdout
 
 
 def test_cli_fails_when_treatment_canary_leaks_into_floor(fake_repo, tmp_path):


### PR DESCRIPTION
## What happened

The 2026-07-25 verdict batch ran (72/72 ok, all three pre-registered arms). The arm ranking is unambiguous — knowledge >> bare on every axis, full best on trust (0 judge-confident-wrong in 24 runs) — but the report's rule-1 verdict was contaminated by two measurement artifacts, and the batch surfaced one governance finding and one design finding. This PR fixes all four. The corrected re-grade of the 2026-07-25 batch is exploratory; the confirmatory verdict comes from a fresh batch on a ref containing this PR.

## 1. Grader bug: key fork slugs can never match answer ledgers

`check_assumptions` / `check_resolutions` / `cell_consistency` matched the key's fork slugs exactly against answer ledgers — but the floor deliberately never leaks key fork names, so runs invent their own (`account_creation_timestamp` vs the key's `account_created`). Result: adherence 0/72 and all 24 cells `consistent=False` (even at 0.00% numeric spread, 3/3 parsed), which poisoned `cells_consistent` in rule 1.

Fix in `grading.py`:
- fork matching by token overlap (4-char-prefix inflection tolerance, generic-token stoplist) with a content-scan fallback
- cell `consistent` gates on numeric spread only — numbers are the deterministic instrument, per the rationale already written into `check_resolutions`
- rep-to-rep resolution agreement is key-blind and fuzzy, reported-only

Re-graded the batch with cached judges: cells are now informative (full inconsistent only on q03 at 4.6% spread, q06, q07 — real variance), and adherence differentiates (q01 full 3/3 across sources/assumptions/resolutions).

## 2. Internal-account fork: docs align to keys (governance finding)

q05/q06/q07 "failures" were not wrong answers and not key drift: runs computed the keys' exact values (1838/1028, 1833, 1831) as sensitivity checks, then reported include-internal headlines (1867/1040, 1858, 1856) — correctly citing serve `methodology_defaults.md`, whose canonical-population row omits the internal exclusion (the `@goodparty.org` exclusion appeared only in the event-hygiene bundle). Win docs already prescribe exclusion for counts. The benchmark caught a real doc/intent inconsistency.

Ruling (Tristan): docs align to keys. New "Population counts" default row + clarified canonical-population row. Keys and questions unchanged.

## 3. Ablation arms (post-hoc, exploratory)

The batch's biggest design finding: the process layer went un-invoked — analytics-process loaded in 4/24 full runs, reviewer agents dispatched once in 72 runs. full-vs-knowledge therefore measured skill routing, not process efficacy.

`prep_arms.py` grows three explicit ablation arms — `forced_full`, `knowledge_docs`, `knowledge_reviewers` — via a `PROCESS_MANDATE.md` written at prep (layer `mandate`) plus an inert floor pointer. The old `process` layer splits into `process-docs` + `reviewers` (full's file set unchanged; canaries retagged; `forced_full` is verified byte-identical to `full` except the mandate). Never built or run by default. README documents scope, run command, and the cancellation-detection logic; results are reported alongside, never inside, the pre-registered verdict.

## 4. Two severity-1 tripwires dropped (#671 negation-blindness rule)

- q01 `users_win_base\.user_created_at`: fired on answers correctly quoting the gotcha doc that the column does not exist (2 FPs, judge-clean)
- q04 `(onboarding|completion)...collaps`: fired on correct acquisition-mix prose (2 FPs, 0 TPs); the real dead-event trap stays guarded by the numeric `onboarded_2026_05` pattern (TP confirmed on bare r1, judge concurring)

## Verification

- 141 quality_bench tests green (new regression tests pin the real free-form fork names from the batch and the ablation arm composition/mandate invariants)
- ruff + ruff-format clean; pre-push analytics suite green
- all three ablation arms built against the real repo with integrity ok

## Operational note

Prep ablation arms only from a ref containing this PR — layers export via `git archive <ref>`, and the doc fix changes the knowledge layer's `arms_sha256`, so a fresh batch is required regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to analytics diagnostics, benchmark grading, and Serve methodology documentation—not production auth, data pipelines, or user-facing APIs.
> 
> **Overview**
> Fixes **quality_bench** measurement and governance issues surfaced by the 2026-07-25 verdict batch so pre-registered rule 1 and adherence metrics reflect real run quality, not grader or doc mismatches.
> 
> **Grading (`grading.py`):** Assumption and resolution checks now match answer ledger fork names via **token overlap** (not exact key slugs), with fuzzy resolution content matching and a ledger scan fallback. **`cell_consistency`** treats cells as consistent when numeric spread is within tolerance only—resolution agreement is reported but no longer gates `consistent`. Regression tests pin real batch fork names.
> 
> **Answer keys:** Two **severity-1** tripwires removed on q01 and q04 because negation-blind patterns fired on correct prose.
> 
> **Serve docs:** `methodology_defaults.md` adds an explicit **Population counts** row: reported Serve user counts exclude `@goodparty.org`, aligning docs with benchmark keys.
> 
> **Ablation harness:** The monolithic `process` layer splits into **`process-docs`** and **`reviewers`** (pre-registered `full` file set unchanged). Three optional arms—`forced_full`, `knowledge_docs`, `knowledge_reviewers`—ship **`PROCESS_MANDATE.md`** and are built only via `prep_arms.py --arms`; floor templates require following the mandate when present. README documents exploratory ablation runs separate from the three-arm verdict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2977e8008b203b26afe4d5b294efe9a77017f0e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->