### PR TITLE
[DATA-2184] Semantic-layer governance: generator + soft-gate wiring (PR 1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Governed semantic-layer definitions. Both groups are auto-requested as
+# reviewers on any change to a sem_*.yml. This is advisory (a soft gate): it
+# requests review, it does not block merge. See the semantic-layer SOP.
+/dbt/project/models/**/sem_*.yml  @thegoodparty/semantic-layer-data @thegoodparty/semantic-layer-business

--- a/.github/workflows/semantic-layer-composition-check.yml
+++ b/.github/workflows/semantic-layer-composition-check.yml
@@ -30,11 +30,39 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Count only each reviewer's LATEST review, so a superseded or
+          # dismissed approval no longer counts as current coverage.
           APPROVERS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            --jq '[.[] | select(.state=="APPROVED") | .user.login] | unique | join(",")')
+            --jq 'group_by(.user.login) | map(max_by(.submitted_at)) | map(select(.state=="APPROVED").user.login) | join(",")')
           DATA=$(gh api "orgs/thegoodparty/teams/semantic-layer-data/members" --jq '[.[].login] | join(",")')
           BIZ=$(gh api "orgs/thegoodparty/teams/semantic-layer-business/members" --jq '[.[].login] | join(",")')
           COV=$(cd analytics && APPROVERS="$APPROVERS" DATA="$DATA" BIZ="$BIZ" PYTHONPATH="diagnostics" \
             uv run python -m semantic_catalog.composition)
           echo "coverage=$COV" >> "$GITHUB_OUTPUT"
           echo "Approval coverage: $COV"
+
+  catalog-freshness:
+    runs-on: ubuntu-latest
+    # Blocking gate: the generated canonical_metrics.md region must be
+    # regenerated and committed in the SAME PR that changes a sem_*.yml, so the
+    # projection is reviewed in the diff (and main never needs a bot push). A
+    # stale region fails the PR. This is a data-consistency check, separate from
+    # the soft human-approval signal above.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: analytics/uv.lock
+      - name: Install analytics env
+        working-directory: analytics
+        run: uv sync --frozen
+      - name: Check canonical_metrics.md is regenerated
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+        run: |
+          if ! uv run python -m semantic_catalog.cli --check; then
+            echo "::error::canonical_metrics.md is out of date. From analytics/, run 'uv run python -m semantic_catalog.cli --write' and commit the result in this PR." >&2
+            exit 1
+          fi

--- a/.github/workflows/semantic-layer-composition-check.yml
+++ b/.github/workflows/semantic-layer-composition-check.yml
@@ -1,0 +1,40 @@
+name: semantic-layer-composition-check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths: ['dbt/project/models/**/sem_*.yml']
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  composition:
+    runs-on: ubuntu-latest
+    # Soft gate: report, never block. The job always succeeds.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: analytics/uv.lock
+      - name: Install analytics env
+        working-directory: analytics
+        run: uv sync --frozen
+      - name: Evaluate approval composition
+        id: eval
+        env:
+          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          APPROVERS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '[.[] | select(.state=="APPROVED") | .user.login] | unique | join(",")')
+          DATA=$(gh api "orgs/thegoodparty/teams/semantic-layer-data/members" --jq '[.[].login] | join(",")')
+          BIZ=$(gh api "orgs/thegoodparty/teams/semantic-layer-business/members" --jq '[.[].login] | join(",")')
+          COV=$(cd analytics && APPROVERS="$APPROVERS" DATA="$DATA" BIZ="$BIZ" PYTHONPATH="diagnostics" \
+            uv run python -m semantic_catalog.composition)
+          echo "coverage=$COV" >> "$GITHUB_OUTPUT"
+          echo "Approval coverage: $COV"

--- a/.github/workflows/semantic-layer-composition-check.yml
+++ b/.github/workflows/semantic-layer-composition-check.yml
@@ -30,6 +30,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Until ORG_READ_TOKEN is provisioned, GH_TOKEN is empty and gh would
+          # exit non-zero under set -e. Report conservative coverage and skip,
+          # same as the publish workflow's coverage step.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "ORG_READ_TOKEN not provisioned; skipping composition check."
+            echo 'coverage={"data":false,"business":false}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Count only each reviewer's LATEST review, so a superseded or
           # dismissed approval no longer counts as current coverage.
           APPROVERS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -46,26 +46,35 @@ jobs:
             BIZ=$(gh api "orgs/thegoodparty/teams/semantic-layer-business/members" --jq '[.[].login] | join(",")')
             COV=$(cd analytics && APPROVERS="$APPROVERS" DATA="$DATA" BIZ="$BIZ" PYTHONPATH="diagnostics" \
               uv run python -m semantic_catalog.composition)
+            PR_URL="https://github.com/$REPO/pull/$PR"
           else
             # No PR found for this commit (e.g. a direct push to main): fall
             # back to the conservative "incomplete" default rather than
             # guessing at approval state.
             COV='{"data":false,"business":false}'
+            PR_URL="(direct push to main — no PR)"
           fi
           echo "COV=$COV" >> "$GITHUB_ENV"
-          echo "PR_URL=https://github.com/$REPO/pull/$PR" >> "$GITHUB_ENV"
+          echo "PR_URL=$PR_URL" >> "$GITHUB_ENV"
       - name: Build Slack change summary
         working-directory: analytics
         env:
           PYTHONPATH: diagnostics
         run: |
           set -euo pipefail
-          git worktree add --detach /tmp/base "${{ github.event.before }}"
-          uv run python -m semantic_catalog.cli \
-            --emit-slack /tmp/slack.txt \
-            --base-dir /tmp/base \
-            --pr-url "$PR_URL" \
-            --coverage "$COV"
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            # No prior commit to diff against — emit with an empty before-set.
+            uv run python -m semantic_catalog.cli --emit-slack /tmp/slack.txt --pr-url "$PR_URL" --coverage "$COV"
+          else
+            git worktree add --detach /tmp/base "$BEFORE"
+            uv run python -m semantic_catalog.cli \
+              --emit-slack /tmp/slack.txt \
+              --base-dir /tmp/base \
+              --pr-url "$PR_URL" \
+              --coverage "$COV"
+            git worktree remove --force /tmp/base
+          fi
       - name: Post Slack change summary
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -100,7 +109,7 @@ jobs:
           # The regenerated MD lives outside the sem_*.yml path filter above,
           # so this push does not re-trigger this workflow (no infinite loop).
           if ! git diff --quiet -- '.claude/skills/**/canonical_metrics.md'; then
-            git add .claude/skills/**/canonical_metrics.md
+            git add '.claude/skills/**/canonical_metrics.md'
             git commit -m "chore(semantic-layer): regenerate canonical_metrics.md"
             git push
           fi

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -5,7 +5,7 @@ on:
     paths: ['dbt/project/models/**/sem_*.yml']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish:
@@ -21,12 +21,17 @@ jobs:
       - name: Install analytics env
         working-directory: analytics
         run: uv sync --frozen
-      - name: Regenerate catalog artifacts
+      - name: Regenerate ClickUp page from merged state
         working-directory: analytics
         env:
           PYTHONPATH: diagnostics
         run: |
-          uv run python -m semantic_catalog.cli --write --emit-clickup /tmp/clickup_page.md
+          # canonical_metrics.md is regenerated and committed in the same PR
+          # that changes a sem_*.yml (enforced by the catalog-freshness PR
+          # check), so main is already in sync. We do NOT --write or push to
+          # main here (main is protected). Only build the ClickUp page for the
+          # upsert below.
+          uv run python -m semantic_catalog.cli --emit-clickup /tmp/clickup_page.md
       - name: Re-derive review coverage for the merged PR
         id: coverage
         env:
@@ -40,8 +45,10 @@ jobs:
           # against the PR that introduced this merge commit.
           PR=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // ""')
           if [ -n "$PR" ]; then
+            # Count only each reviewer's LATEST review, so a superseded or
+            # dismissed approval no longer counts as current coverage.
             APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" \
-              --jq '[.[] | select(.state=="APPROVED") | .user.login] | unique | join(",")')
+              --jq 'group_by(.user.login) | map(max_by(.submitted_at)) | map(select(.state=="APPROVED").user.login) | join(",")')
             DATA=$(gh api "orgs/thegoodparty/teams/semantic-layer-data/members" --jq '[.[].login] | join(",")')
             BIZ=$(gh api "orgs/thegoodparty/teams/semantic-layer-business/members" --jq '[.[].login] | join(",")')
             COV=$(cd analytics && APPROVERS="$APPROVERS" DATA="$DATA" BIZ="$BIZ" PYTHONPATH="diagnostics" \
@@ -81,12 +88,15 @@ jobs:
         run: |
           set -euo pipefail
           # LIVE-VERIFY SEAM: SLACK_BOT_TOKEN is not yet provisioned. Once it
-          # lands, confirm this chat.postMessage payload (channel id, scopes,
-          # response handling) against the live Slack API before relying on it.
-          curl -sf -X POST https://slack.com/api/chat.postMessage \
+          # lands, confirm this chat.postMessage payload (channel id, scopes)
+          # against the live Slack API before relying on it.
+          RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-type: application/json; charset=utf-8" \
-            --data "$(python3 -c 'import json;print(json.dumps({"channel":"C08K22X9ZNH","text":open("/tmp/slack.txt").read()}))')"
+            --data "$(python3 -c 'import json;print(json.dumps({"channel":"C08K22X9ZNH","text":open("/tmp/slack.txt").read()}))')")
+          # chat.postMessage returns HTTP 200 with {"ok":false} on errors (bad
+          # channel, missing scope, auth), so check the body, not just status.
+          echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); d.get("ok") or sys.exit("Slack API error: %s" % d.get("error","unknown"))'
       - name: Upsert ClickUp reference page
         env:
           CLICKUP_API_TOKEN: ${{ secrets.CLICKUP_API_TOKEN }}
@@ -101,15 +111,3 @@ jobs:
             -H "Authorization: $CLICKUP_API_TOKEN" \
             -H "Content-Type: application/json" \
             --data "$(python3 -c 'import json;print(json.dumps({"content":open("/tmp/clickup_page.md").read(),"content_format":"text/md"}))')"
-      - name: Commit regenerated canonical_metrics.md
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          # The regenerated MD lives outside the sem_*.yml path filter above,
-          # so this push does not re-trigger this workflow (no infinite loop).
-          if ! git diff --quiet -- '.claude/skills/**/canonical_metrics.md'; then
-            git add '.claude/skills/**/canonical_metrics.md'
-            git commit -m "chore(semantic-layer): regenerate canonical_metrics.md"
-            git push
-          fi

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -1,0 +1,106 @@
+name: semantic-layer-publish
+on:
+  push:
+    branches: [main]
+    paths: ['dbt/project/models/**/sem_*.yml']
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: analytics/uv.lock
+      - name: Install analytics env
+        working-directory: analytics
+        run: uv sync --frozen
+      - name: Regenerate catalog artifacts
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+        run: |
+          uv run python -m semantic_catalog.cli --write --emit-clickup /tmp/clickup_page.md
+      - name: Re-derive review coverage for the merged PR
+        id: coverage
+        env:
+          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Cross-run outputs from the composition-check workflow are not
+          # available here, so re-derive coverage from the live GitHub API
+          # against the PR that introduced this merge commit.
+          PR=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // ""')
+          if [ -n "$PR" ]; then
+            APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" \
+              --jq '[.[] | select(.state=="APPROVED") | .user.login] | unique | join(",")')
+            DATA=$(gh api "orgs/thegoodparty/teams/semantic-layer-data/members" --jq '[.[].login] | join(",")')
+            BIZ=$(gh api "orgs/thegoodparty/teams/semantic-layer-business/members" --jq '[.[].login] | join(",")')
+            COV=$(cd analytics && APPROVERS="$APPROVERS" DATA="$DATA" BIZ="$BIZ" PYTHONPATH="diagnostics" \
+              uv run python -m semantic_catalog.composition)
+          else
+            # No PR found for this commit (e.g. a direct push to main): fall
+            # back to the conservative "incomplete" default rather than
+            # guessing at approval state.
+            COV='{"data":false,"business":false}'
+          fi
+          echo "COV=$COV" >> "$GITHUB_ENV"
+          echo "PR_URL=https://github.com/$REPO/pull/$PR" >> "$GITHUB_ENV"
+      - name: Build Slack change summary
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+        run: |
+          set -euo pipefail
+          git worktree add --detach /tmp/base "${{ github.event.before }}"
+          uv run python -m semantic_catalog.cli \
+            --emit-slack /tmp/slack.txt \
+            --base-dir /tmp/base \
+            --pr-url "$PR_URL" \
+            --coverage "$COV"
+      - name: Post Slack change summary
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          # LIVE-VERIFY SEAM: SLACK_BOT_TOKEN is not yet provisioned. Once it
+          # lands, confirm this chat.postMessage payload (channel id, scopes,
+          # response handling) against the live Slack API before relying on it.
+          curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data "$(python3 -c 'import json;print(json.dumps({"channel":"C08K22X9ZNH","text":open("/tmp/slack.txt").read()}))')"
+      - name: Upsert ClickUp reference page
+        env:
+          CLICKUP_API_TOKEN: ${{ secrets.CLICKUP_API_TOKEN }}
+          PAGE_ID: ${{ secrets.SEMANTIC_LAYER_CLICKUP_PAGE_ID }}
+        run: |
+          set -euo pipefail
+          # LIVE-VERIFY SEAM: CLICKUP_API_TOKEN and SEMANTIC_LAYER_CLICKUP_PAGE_ID
+          # are not yet provisioned. Once they land, confirm the v3 page-update
+          # body shape (content/content_format, page vs subpage semantics)
+          # against the live ClickUp API before relying on it.
+          curl -sf -X PUT "https://api.clickup.com/api/v3/docs/pages/$PAGE_ID" \
+            -H "Authorization: $CLICKUP_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "$(python3 -c 'import json;print(json.dumps({"content":open("/tmp/clickup_page.md").read(),"content_format":"text/md"}))')"
+      - name: Commit regenerated canonical_metrics.md
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # The regenerated MD lives outside the sem_*.yml path filter above,
+          # so this push does not re-trigger this workflow (no infinite loop).
+          if ! git diff --quiet -- '.claude/skills/**/canonical_metrics.md'; then
+            git add .claude/skills/**/canonical_metrics.md
+            git commit -m "chore(semantic-layer): regenerate canonical_metrics.md"
+            git push
+          fi

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -89,7 +89,12 @@ jobs:
           set -euo pipefail
           # LIVE-VERIFY SEAM: SLACK_BOT_TOKEN is not yet provisioned. Once it
           # lands, confirm this chat.postMessage payload (channel id, scopes)
-          # against the live Slack API before relying on it.
+          # against the live Slack API before relying on it. Until then, skip
+          # cleanly so the first governed merge does not red-fail this job.
+          if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
+            echo "SLACK_BOT_TOKEN not provisioned; skipping Slack notification."
+            exit 0
+          fi
           RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-type: application/json; charset=utf-8" \
@@ -106,7 +111,12 @@ jobs:
           # LIVE-VERIFY SEAM: CLICKUP_API_TOKEN and SEMANTIC_LAYER_CLICKUP_PAGE_ID
           # are not yet provisioned. Once they land, confirm the v3 page-update
           # body shape (content/content_format, page vs subpage semantics)
-          # against the live ClickUp API before relying on it.
+          # against the live ClickUp API before relying on it. Until then, skip
+          # cleanly so the first governed merge does not red-fail this job.
+          if [ -z "${CLICKUP_API_TOKEN:-}" ] || [ -z "${PAGE_ID:-}" ]; then
+            echo "ClickUp secrets not provisioned; skipping ClickUp upsert."
+            exit 0
+          fi
           curl -sf -X PUT "https://api.clickup.com/api/v3/docs/pages/$PAGE_ID" \
             -H "Authorization: $CLICKUP_API_TOKEN" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -40,6 +40,17 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          # Until ORG_READ_TOKEN is provisioned, GH_TOKEN is empty and the gh
+          # calls below would fail the job. Record conservative coverage and
+          # skip cleanly instead of red-failing the first governed merge.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "ORG_READ_TOKEN not provisioned; recording conservative coverage."
+            {
+              echo 'COV={"data":false,"business":false}'
+              echo 'PR_URL=(coverage unavailable until ORG_READ_TOKEN is provisioned)'
+            } >> "$GITHUB_ENV"
+            exit 0
+          fi
           # Cross-run outputs from the composition-check workflow are not
           # available here, so re-derive coverage from the live GitHub API
           # against the PR that introduced this merge commit.

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -33,8 +33,6 @@ MD_TARGETS = [
     SKILLS_ROOT / "serve-analytics-knowledge" / "references" / "canonical_metrics.md",
 ]
 PKG = Path(__file__).parent
-OWNERS = yaml.safe_load((PKG / "config" / "owners.yml").read_text())
-SOP_MD = (PKG / "templates" / "sop.md").read_text()
 
 
 def region_is_current(target: Path, records: list[MetricRecord]) -> bool:
@@ -82,7 +80,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"wrote {t}")
 
     if args.emit_clickup:
-        page = render_page(records, _lifecycles(records), SOP_MD, OWNERS)
+        owners = yaml.safe_load((PKG / "config" / "owners.yml").read_text())
+        sop_md = (PKG / "templates" / "sop.md").read_text()
+        page = render_page(records, _lifecycles(records), sop_md, owners)
         args.emit_clickup.write_text(page)
         print(f"wrote {args.emit_clickup}")
 

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -38,7 +38,12 @@ PKG = Path(__file__).parent
 def region_is_current(target: Path, records: list[MetricRecord]) -> bool:
     if not target.exists():
         return False
-    return splice_region(target.read_text(), render_region(records)) == target.read_text()
+    try:
+        return splice_region(target.read_text(), render_region(records)) == target.read_text()
+    except ValueError:
+        # Half-marked/corrupt file (one marker present): report as not current
+        # so --check fails cleanly as stale, not with an uncaught traceback.
+        return False
 
 
 def write_region(target: Path, records: list[MetricRecord]) -> None:

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -1,0 +1,88 @@
+"""Generate the semantic-layer catalog artifacts from the dbt sem_*.yml files.
+
+--check  : fail if the generated canonical_metrics.md region is stale (CI guard).
+--write  : splice the region into both knowledge skills' canonical_metrics.md.
+--emit-clickup / --emit-slack : write the rendered artifacts for the publish job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from semantic_catalog import lifecycle as lc_mod
+from semantic_catalog.clickup_page import render_page
+from semantic_catalog.lifecycle import Lifecycle
+from semantic_catalog.md_catalog import render_region, splice_region
+from semantic_catalog.parser import parse_semantic_tree
+from semantic_catalog.records import MetricRecord
+
+# analytics/diagnostics/semantic_catalog/cli.py -> parents[0]=semantic_catalog,
+# [1]=diagnostics, [2]=analytics, [3]=repo root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DBT_MODELS = REPO_ROOT / "dbt" / "project" / "models" / "marts"
+SEM_ROOTS = [DBT_MODELS / "analytics", DBT_MODELS / "civics"]
+SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
+MD_TARGETS = [
+    SKILLS_ROOT / "win-analytics-knowledge" / "references" / "canonical_metrics.md",
+    SKILLS_ROOT / "serve-analytics-knowledge" / "references" / "canonical_metrics.md",
+]
+PKG = Path(__file__).parent
+OWNERS = yaml.safe_load((PKG / "config" / "owners.yml").read_text())
+SOP_MD = (PKG / "templates" / "sop.md").read_text()
+
+
+def region_is_current(target: Path, records: list[MetricRecord]) -> bool:
+    if not target.exists():
+        return False
+    return splice_region(target.read_text(), render_region(records)) == target.read_text()
+
+
+def write_region(target: Path, records: list[MetricRecord]) -> None:
+    existing = target.read_text() if target.exists() else ""
+    target.write_text(splice_region(existing, render_region(records)))
+
+
+def _lifecycles(records: list[MetricRecord]) -> dict[str, Lifecycle]:
+    files = {r.yaml_file for r in records}
+    return {f: lc_mod.derive(f) for f in files}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="semantic_catalog")
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--emit-clickup", type=Path)
+    parser.add_argument("--emit-slack-page", type=Path)  # placeholder for the publish job
+    args = parser.parse_args(argv)
+
+    records = parse_semantic_tree(SEM_ROOTS)
+
+    if args.check:
+        stale = [t for t in MD_TARGETS if not region_is_current(t, records)]
+        if stale:
+            print("stale canonical_metrics.md region in:", file=sys.stderr)
+            for t in stale:
+                print(f"  {t}", file=sys.stderr)
+            return 1
+        print("catalog region up to date")
+        return 0
+
+    if args.write:
+        for t in MD_TARGETS:
+            write_region(t, records)
+            print(f"wrote {t}")
+
+    if args.emit_clickup:
+        page = render_page(records, _lifecycles(records), SOP_MD, OWNERS)
+        args.emit_clickup.write_text(page)
+        print(f"wrote {args.emit_clickup}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from semantic_catalog.lifecycle import Lifecycle
 from semantic_catalog.md_catalog import render_region, splice_region
 from semantic_catalog.parser import parse_semantic_tree
 from semantic_catalog.records import MetricRecord
+from semantic_catalog.slack_diff import render_message
 
 # analytics/diagnostics/semantic_catalog/cli.py -> parents[0]=semantic_catalog,
 # [1]=diagnostics, [2]=analytics, [3]=repo root.
@@ -56,7 +58,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--write", action="store_true")
     parser.add_argument("--emit-clickup", type=Path)
-    parser.add_argument("--emit-slack-page", type=Path)  # placeholder for the publish job
+    parser.add_argument("--emit-slack", type=Path)
+    parser.add_argument("--base-dir", type=Path, default=None)
+    parser.add_argument("--pr-url", type=str, default="")
+    parser.add_argument("--coverage", type=str, default="")
     args = parser.parse_args(argv)
 
     records = parse_semantic_tree(SEM_ROOTS)
@@ -80,6 +85,23 @@ def main(argv: list[str] | None = None) -> int:
         page = render_page(records, _lifecycles(records), SOP_MD, OWNERS)
         args.emit_clickup.write_text(page)
         print(f"wrote {args.emit_clickup}")
+
+    if args.emit_slack:
+        after = records
+        before = (
+            parse_semantic_tree(
+                [
+                    args.base_dir / "dbt/project/models/marts/analytics",
+                    args.base_dir / "dbt/project/models/marts/civics",
+                ]
+            )
+            if args.base_dir
+            else []
+        )
+        coverage = json.loads(args.coverage) if args.coverage else {"data": False, "business": False}
+        msg = render_message(before, after, args.pr_url, coverage)
+        args.emit_slack.write_text(msg)
+        print(f"wrote {args.emit_slack}")
 
     return 0
 

--- a/analytics/diagnostics/semantic_catalog/clickup_page.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_page.py
@@ -1,0 +1,78 @@
+"""Render the three-part ClickUp reference page.
+
+Part 1 (static): the SOP walkthrough, passed in from the repo template.
+Part 2 (static): decision-makers. Team slugs from owners.yml; human names only
+if an untracked `people` map is supplied at publish time (repo rule: no names in
+tracked files).
+Part 3 (dynamic): the per-metric catalog, generated from records + git lifecycle,
+inside CATALOG_BEGIN/CATALOG_END so any out-of-band page context is preserved.
+"""
+
+from __future__ import annotations
+
+from semantic_catalog.lifecycle import Lifecycle
+from semantic_catalog.records import MetricRecord
+
+CATALOG_BEGIN = "<!-- catalog:begin -->"
+CATALOG_END = "<!-- catalog:end -->"
+
+
+def _decision_makers(owners: dict, people: dict | None) -> str:
+    lines = ["## Decision-makers (data side)", ""]
+    for key, team in owners.get("teams", {}).items():
+        slug = team["slug"]
+        role = team.get("role", "")
+        if people and people.get(slug):
+            who = ", ".join(people[slug])
+            lines.append(f"- **{key.title()} group** ({slug}): {who}. {role}")
+        else:
+            lines.append(f"- **{key.title()} group** ({slug}). {role}")
+    return "\n".join(lines)
+
+
+def _lifecycle_cell(lc: Lifecycle | None) -> str:
+    if lc is None:
+        return " | "
+    created = f"{lc.created or ''}" + (f" (#{lc.created_pr})" if lc.created_pr else "")
+    updated = f"{lc.last_updated or ''}" + (f" (#{lc.last_updated_pr})" if lc.last_updated_pr else "")
+    return f"{created} | {updated}"
+
+
+def _catalog(records: list[MetricRecord], lifecycles: dict[str, Lifecycle]) -> str:
+    header = (
+        "| Metric | Definition | Type | Source | Owner | Ratified | Created | Last updated | Detail |\n"
+        "|---|---|---|---|---|---|---|---|---|"
+    )
+    rows = [header]
+    for rec in records:
+        lc = lifecycles.get(rec.yaml_file)
+        detail = f"[{rec.detail_doc}]({rec.detail_doc})" if rec.detail_doc else ""
+        ratified = rec.ratified or "pending"
+        if rec.retired:
+            ratified = f"{ratified} (retired {rec.retired})"
+        rows.append(
+            f"| {rec.label} | {rec.definition} | {rec.metric_type} | {rec.source} "
+            f"| {rec.owner or ''} | {ratified} | {_lifecycle_cell(lc)} | {detail} |"
+        )
+    return f"{CATALOG_BEGIN}\n" + "\n".join(rows) + f"\n{CATALOG_END}"
+
+
+def render_page(
+    records: list[MetricRecord],
+    lifecycles: dict[str, Lifecycle],
+    sop_md: str,
+    owners: dict,
+    people: dict | None = None,
+) -> str:
+    parts = [
+        "# Semantic layer reference",
+        "",
+        sop_md,
+        "",
+        _decision_makers(owners, people),
+        "",
+        "## Metric catalog",
+        "",
+        _catalog(records, lifecycles),
+    ]
+    return "\n".join(parts) + "\n"

--- a/analytics/diagnostics/semantic_catalog/clickup_page.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_page.py
@@ -57,7 +57,7 @@ def _catalog(records: list[MetricRecord], lifecycles: dict[str, Lifecycle]) -> s
             ratified = f"{ratified} (retired {rec.retired})"
         rows.append(
             f"| {_cell(rec.label)} | {_cell(rec.definition)} | {rec.metric_type} | {_cell(rec.source)} "
-            f"| {_cell(rec.owner or '')} | {ratified} | {_lifecycle_cell(lc)} | {detail} |"
+            f"| {_cell(rec.owner or '')} | {_cell(ratified)} | {_lifecycle_cell(lc)} | {detail} |"
         )
     return f"{CATALOG_BEGIN}\n" + "\n".join(rows) + f"\n{CATALOG_END}"
 

--- a/analytics/diagnostics/semantic_catalog/clickup_page.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_page.py
@@ -17,8 +17,13 @@ CATALOG_BEGIN = "<!-- catalog:begin -->"
 CATALOG_END = "<!-- catalog:end -->"
 
 
+def _cell(text: str | None) -> str:
+    # Escape pipes so a filter/definition never breaks the table.
+    return (text or "").replace("|", "\\|")
+
+
 def _decision_makers(owners: dict, people: dict | None) -> str:
-    lines = ["## Decision-makers (data side)", ""]
+    lines = ["## Decision-makers", ""]
     for key, team in owners.get("teams", {}).items():
         slug = team["slug"]
         role = team.get("role", "")
@@ -46,13 +51,13 @@ def _catalog(records: list[MetricRecord], lifecycles: dict[str, Lifecycle]) -> s
     rows = [header]
     for rec in records:
         lc = lifecycles.get(rec.yaml_file)
-        detail = f"[{rec.detail_doc}]({rec.detail_doc})" if rec.detail_doc else ""
+        detail = f"[{_cell(rec.detail_doc)}]({_cell(rec.detail_doc)})" if rec.detail_doc else ""
         ratified = rec.ratified or "pending"
         if rec.retired:
             ratified = f"{ratified} (retired {rec.retired})"
         rows.append(
-            f"| {rec.label} | {rec.definition} | {rec.metric_type} | {rec.source} "
-            f"| {rec.owner or ''} | {ratified} | {_lifecycle_cell(lc)} | {detail} |"
+            f"| {_cell(rec.label)} | {_cell(rec.definition)} | {rec.metric_type} | {_cell(rec.source)} "
+            f"| {_cell(rec.owner or '')} | {ratified} | {_lifecycle_cell(lc)} | {detail} |"
         )
     return f"{CATALOG_BEGIN}\n" + "\n".join(rows) + f"\n{CATALOG_END}"
 

--- a/analytics/diagnostics/semantic_catalog/composition.py
+++ b/analytics/diagnostics/semantic_catalog/composition.py
@@ -1,0 +1,49 @@
+"""Evaluate whether a PR's approvals cover both review groups.
+
+Pure and side-effect free: the workflow supplies the approver logins and each
+team's membership (from the GitHub API). Result feeds the merge-time Slack post.
+The composition check is a signal, never a merge block (soft gate).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable
+
+
+def _lower(names: Iterable[str]) -> set[str]:
+    return {n.lower() for n in names}
+
+
+def evaluate(
+    approver_logins: Iterable[str],
+    data_members: Iterable[str],
+    business_members: Iterable[str],
+) -> dict[str, bool]:
+    approvers = _lower(approver_logins)
+    return {
+        "data": bool(approvers & _lower(data_members)),
+        "business": bool(approvers & _lower(business_members)),
+    }
+
+
+def _split_env(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [x for x in value.split(",") if x]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read APPROVERS/DATA/BIZ (comma-separated logins) from env and print coverage JSON."""
+    del argv  # no CLI args; env-var driven for simple invocation from the workflow
+    approvers = _split_env(os.environ.get("APPROVERS"))
+    data_members = _split_env(os.environ.get("DATA"))
+    business_members = _split_env(os.environ.get("BIZ"))
+    coverage = evaluate(approvers, data_members, business_members)
+    print(json.dumps(coverage))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analytics/diagnostics/semantic_catalog/config/owners.yml
+++ b/analytics/diagnostics/semantic_catalog/config/owners.yml
@@ -1,0 +1,10 @@
+# Team slugs and the metric -> owning-team map. NO person names (repo rule).
+# Human display names for the ClickUp decision-makers section come from an
+# untracked file at publish time, never from this file.
+teams:
+  data:
+    slug: semantic-layer-data
+    role: Technical review — builds, conventions, value-for-value parity.
+  business:
+    slug: semantic-layer-business
+    role: Ratification — confirms the definition itself is correct.

--- a/analytics/diagnostics/semantic_catalog/config/owners.yml
+++ b/analytics/diagnostics/semantic_catalog/config/owners.yml
@@ -1,4 +1,5 @@
-# Team slugs and the metric -> owning-team map. NO person names (repo rule).
+# Team slugs and roles for the two review groups. NO person names (repo rule).
+# Per-metric ownership lives in each metric's config.meta.owner, not here.
 # Human display names for the ClickUp decision-makers section come from an
 # untracked file at publish time, never from this file.
 teams:

--- a/analytics/diagnostics/semantic_catalog/lifecycle.py
+++ b/analytics/diagnostics/semantic_catalog/lifecycle.py
@@ -30,8 +30,10 @@ def _default_run_git(args: list[str]) -> str:
 
 
 def _pr(subject: str) -> str | None:
-    match = _PR_RE.search(subject)
-    return match.group(1) if match else None
+    # Take the LAST match: a squash title like "Feature (#609) (#720)" carries
+    # the PR number last, with earlier "(#N)" referencing linked issues.
+    matches = _PR_RE.findall(subject)
+    return matches[-1] if matches else None
 
 
 def derive(yaml_file: str, run_git=_default_run_git) -> Lifecycle:

--- a/analytics/diagnostics/semantic_catalog/lifecycle.py
+++ b/analytics/diagnostics/semantic_catalog/lifecycle.py
@@ -1,0 +1,49 @@
+"""Git-derived lifecycle dates for a semantic YAML file.
+
+created/last_updated (and their PR numbers) come from git history, so they can
+never fall out of date and are never hand-authored. Granularity is per-FILE, not
+per-metric: a sem_*.yml holds a small set of related metrics, and per-block
+line-range attribution is a later refinement. PR numbers are parsed from
+`Merge pull request #N` subjects; squash-merge repos can also match `(#N)`.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+
+_PR_RE = re.compile(r"(?:Merge pull request #|\(#)(\d+)")
+_SEP = "\x1f"
+
+
+@dataclass(frozen=True)
+class Lifecycle:
+    created: str | None
+    created_pr: str | None
+    last_updated: str | None
+    last_updated_pr: str | None
+
+
+def _default_run_git(args: list[str]) -> str:
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+
+def _pr(subject: str) -> str | None:
+    match = _PR_RE.search(subject)
+    return match.group(1) if match else None
+
+
+def derive(yaml_file: str, run_git=_default_run_git) -> Lifecycle:
+    out = run_git(["log", "--follow", f"--format=%ad{_SEP}%s", "--date=short", "--", yaml_file])
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    if not lines:
+        return Lifecycle(None, None, None, None)
+    newest_date, _, newest_subject = lines[0].partition(_SEP)
+    oldest_date, _, oldest_subject = lines[-1].partition(_SEP)
+    return Lifecycle(
+        created=oldest_date,
+        created_pr=_pr(oldest_subject),
+        last_updated=newest_date,
+        last_updated_pr=_pr(newest_subject),
+    )

--- a/analytics/diagnostics/semantic_catalog/lifecycle.py
+++ b/analytics/diagnostics/semantic_catalog/lifecycle.py
@@ -35,7 +35,13 @@ def _pr(subject: str) -> str | None:
 
 
 def derive(yaml_file: str, run_git=_default_run_git) -> Lifecycle:
-    out = run_git(["log", "--follow", f"--format=%ad{_SEP}%s", "--date=short", "--", yaml_file])
+    try:
+        out = run_git(["log", "--follow", f"--format=%ad{_SEP}%s", "--date=short", "--", yaml_file])
+    except (subprocess.SubprocessError, OSError):
+        # git missing, shallow clone where --follow is unavailable, corrupt
+        # repo, etc.: degrade to an empty lifecycle rather than crashing the
+        # generator (same graceful-degradation as the no-history case below).
+        return Lifecycle(None, None, None, None)
     lines = [ln for ln in out.splitlines() if ln.strip()]
     if not lines:
         return Lifecycle(None, None, None, None)

--- a/analytics/diagnostics/semantic_catalog/md_catalog.py
+++ b/analytics/diagnostics/semantic_catalog/md_catalog.py
@@ -24,7 +24,7 @@ def _cell(text: str | None) -> str:
 
 
 def _row(rec: MetricRecord) -> str:
-    detail = f"[{rec.detail_doc}]({rec.detail_doc})" if rec.detail_doc else ""
+    detail = f"[{_cell(rec.detail_doc)}]({_cell(rec.detail_doc)})" if rec.detail_doc else ""
     ratified = rec.ratified or "pending"
     if rec.retired:
         ratified = f"{ratified} (retired {rec.retired})"

--- a/analytics/diagnostics/semantic_catalog/md_catalog.py
+++ b/analytics/diagnostics/semantic_catalog/md_catalog.py
@@ -29,7 +29,7 @@ def _row(rec: MetricRecord) -> str:
     if rec.retired:
         ratified = f"{ratified} (retired {rec.retired})"
     concept = f"**{_cell(rec.label)}**"
-    return f"| {concept} | {_cell(rec.definition)} | {_cell(rec.source)} " f"| {detail} | {ratified} |"
+    return f"| {concept} | {_cell(rec.definition)} | {_cell(rec.source)} " f"| {detail} | {_cell(ratified)} |"
 
 
 def render_rows(records: list[MetricRecord]) -> str:

--- a/analytics/diagnostics/semantic_catalog/md_catalog.py
+++ b/analytics/diagnostics/semantic_catalog/md_catalog.py
@@ -1,0 +1,54 @@
+"""Render the thin canonical_metrics.md routing rows from metric records.
+
+The file keeps its "resolve a concept here first" contract: Concept, one-line
+definition, source, owns-detail link, ratified. Generated rows live inside the
+begin/end markers so hand-authored (not-yet-encoded) rows can coexist during the
+epic.
+"""
+
+from __future__ import annotations
+
+from semantic_catalog.records import MetricRecord
+
+BEGIN_MARK = "<!-- semantic-catalog:begin -->"
+END_MARK = "<!-- semantic-catalog:end -->"
+
+_HEADER = (
+    "| Concept | Governed definition (one line) | Source | Owns detail | Ratified |\n" "|---|---|---|---|---|"
+)
+
+
+def _cell(text: str | None) -> str:
+    # Escape pipes so a filter/definition never breaks the table.
+    return (text or "").replace("|", "\\|")
+
+
+def _row(rec: MetricRecord) -> str:
+    detail = f"[{rec.detail_doc}]({rec.detail_doc})" if rec.detail_doc else ""
+    ratified = rec.ratified or "pending"
+    if rec.retired:
+        ratified = f"{ratified} (retired {rec.retired})"
+    concept = f"**{_cell(rec.label)}**"
+    return f"| {concept} | {_cell(rec.definition)} | {_cell(rec.source)} " f"| {detail} | {ratified} |"
+
+
+def render_rows(records: list[MetricRecord]) -> str:
+    lines = [_HEADER]
+    lines.extend(_row(r) for r in records)
+    return "\n".join(lines)
+
+
+def render_region(records: list[MetricRecord]) -> str:
+    return f"{BEGIN_MARK}\n{render_rows(records)}\n{END_MARK}"
+
+
+def splice_region(existing: str, region: str) -> str:
+    has_begin = BEGIN_MARK in existing
+    has_end = END_MARK in existing
+    if has_begin != has_end:
+        raise ValueError("file has exactly one semantic-catalog marker; refusing to splice")
+    if not has_begin:
+        return existing.rstrip("\n") + "\n\n" + region + "\n"
+    pre = existing.split(BEGIN_MARK, 1)[0]
+    post = existing.split(END_MARK, 1)[1]
+    return pre + region + post

--- a/analytics/diagnostics/semantic_catalog/parser.py
+++ b/analytics/diagnostics/semantic_catalog/parser.py
@@ -1,0 +1,92 @@
+"""Parse sem_*.yml files into MetricRecord objects.
+
+Governance metadata is read from config.meta (never top-level config). Metrics
+without config.meta parse cleanly as ungoverned/pending. Exposures carry their
+definition in config.meta.definition and their source in `url`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from semantic_catalog.records import MetricRecord
+
+
+def _meta(block: dict) -> dict:
+    return (block.get("config") or {}).get("meta") or {}
+
+
+def _clean(text: str | None) -> str:
+    # yaml folded/blocked scalars arrive with newlines; collapse to one line.
+    return " ".join((text or "").split())
+
+
+def _dimensions_for(models: list[dict]) -> tuple[str, ...]:
+    dims: list[str] = []
+    for model in models:
+        for dim in model.get("dimensions") or []:
+            dims.append(dim["name"])
+    return tuple(dims)
+
+
+def parse_semantic_file(path: Path) -> list[MetricRecord]:
+    doc = yaml.safe_load(path.read_text()) or {}
+    models = doc.get("semantic_models") or []
+    # A sem_*.yml holds one primary source; use the first model's `model:` ref
+    # as the source for its metrics. Dimensions are the union across models.
+    default_source = models[0]["model"] if models else ""
+    dims = _dimensions_for(models)
+
+    records: list[MetricRecord] = []
+
+    for metric in doc.get("metrics") or []:
+        meta = _meta(metric)
+        records.append(
+            MetricRecord(
+                name=metric["name"],
+                label=metric.get("label", metric["name"]),
+                definition=_clean(metric.get("description")),
+                metric_type=metric.get("type", "simple"),
+                source=default_source,
+                dimensions=dims,
+                filter=_clean(metric["filter"]) if metric.get("filter") else None,
+                owner=meta.get("owner"),
+                ratified=str(meta["ratified"]) if meta.get("ratified") else None,
+                detail_doc=meta.get("detail_doc"),
+                retired=str(meta["retired"]) if meta.get("retired") else None,
+                yaml_file=str(path),
+                kind="metric",
+            )
+        )
+
+    for exposure in doc.get("exposures") or []:
+        meta = _meta(exposure)
+        records.append(
+            MetricRecord(
+                name=exposure["name"],
+                label=exposure.get("label", exposure["name"]),
+                definition=_clean(meta.get("definition") or exposure.get("description")),
+                metric_type="exposure",
+                source=exposure.get("url", ""),
+                dimensions=(),
+                filter=None,
+                owner=meta.get("owner"),
+                ratified=str(meta["ratified"]) if meta.get("ratified") else None,
+                detail_doc=meta.get("detail_doc"),
+                retired=str(meta["retired"]) if meta.get("retired") else None,
+                yaml_file=str(path),
+                kind="exposure",
+            )
+        )
+
+    return records
+
+
+def parse_semantic_tree(roots: list[Path]) -> list[MetricRecord]:
+    records: list[MetricRecord] = []
+    for root in roots:
+        for path in sorted(root.rglob("sem_*.yml")):
+            records.extend(parse_semantic_file(path))
+    return sorted(records, key=lambda r: r.name)

--- a/analytics/diagnostics/semantic_catalog/parser.py
+++ b/analytics/diagnostics/semantic_catalog/parser.py
@@ -36,7 +36,7 @@ def parse_semantic_file(path: Path) -> list[MetricRecord]:
     models = doc.get("semantic_models") or []
     # A sem_*.yml holds one primary source; use the first model's `model:` ref
     # as the source for its metrics. Dimensions are the union across models.
-    default_source = models[0]["model"] if models else ""
+    default_source = models[0].get("model", "") if models else ""
     dims = _dimensions_for(models)
 
     records: list[MetricRecord] = []

--- a/analytics/diagnostics/semantic_catalog/records.py
+++ b/analytics/diagnostics/semantic_catalog/records.py
@@ -1,0 +1,26 @@
+"""Immutable record types for the semantic-layer catalog generator.
+
+One MetricRecord per governed concept — a dbt metric or an exposure. The
+generator's renderers consume these; nothing downstream re-reads YAML.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MetricRecord:
+    name: str
+    label: str
+    definition: str
+    metric_type: str
+    source: str
+    dimensions: tuple[str, ...]
+    filter: str | None
+    owner: str | None
+    ratified: str | None
+    detail_doc: str | None
+    retired: str | None
+    yaml_file: str
+    kind: str  # "metric" | "exposure"

--- a/analytics/diagnostics/semantic_catalog/slack_diff.py
+++ b/analytics/diagnostics/semantic_catalog/slack_diff.py
@@ -1,0 +1,48 @@
+"""Compose the Slack change summary for a governed-definition merge.
+
+Diffs the before/after record sets and states, loudly, whether each review
+group approved. The soft gate relies on this: a merge without both approvals is
+announced as incomplete, never hidden.
+"""
+
+from __future__ import annotations
+
+from semantic_catalog.records import MetricRecord
+
+
+def _by_name(records: list[MetricRecord]) -> dict[str, MetricRecord]:
+    return {r.name: r for r in records}
+
+
+def diff_records(before: list[MetricRecord], after: list[MetricRecord]) -> list[str]:
+    a, b = _by_name(before), _by_name(after)
+    lines: list[str] = []
+    for name in sorted(b.keys() - a.keys()):
+        lines.append(f"• added: {name} — {b[name].definition}")
+    for name in sorted(a.keys() - b.keys()):
+        lines.append(f"• removed: {name} — {a[name].definition}")
+    for name in sorted(a.keys() & b.keys()):
+        old, new = a[name], b[name]
+        if old.definition != new.definition:
+            lines.append(f"• changed: {name}\n    before: {old.definition}\n    after:  {new.definition}")
+        if old.ratified != new.ratified:
+            lines.append(f"• ratified: {name} — {old.ratified or 'pending'} → {new.ratified or 'pending'}")
+    return lines
+
+
+def render_message(
+    before: list[MetricRecord],
+    after: list[MetricRecord],
+    pr_url: str,
+    coverage: dict,
+) -> str:
+    body = ["*Semantic layer updated*", f"PR: {pr_url}", ""]
+    changes = diff_records(before, after)
+    body.extend(changes if changes else ["(no metric-level changes detected)"])
+    body.append("")
+    missing = [g for g in ("data", "business") if not coverage.get(g)]
+    if missing:
+        body.append(f":warning: review incomplete — missing approval from: {', '.join(missing)} group")
+    else:
+        body.append(":white_check_mark: review complete — both groups approved")
+    return "\n".join(body)

--- a/analytics/diagnostics/semantic_catalog/slack_diff.py
+++ b/analytics/diagnostics/semantic_catalog/slack_diff.py
@@ -27,6 +27,10 @@ def diff_records(before: list[MetricRecord], after: list[MetricRecord]) -> list[
             lines.append(f"• changed: {name}\n    before: {old.definition}\n    after:  {new.definition}")
         if old.ratified != new.ratified:
             lines.append(f"• ratified: {name} — {old.ratified or 'pending'} → {new.ratified or 'pending'}")
+        if old.retired != new.retired:
+            lines.append(f"• retired: {name} — {old.retired or 'active'} → {new.retired or 'active'}")
+        if old.owner != new.owner:
+            lines.append(f"• owner: {name} — {old.owner or '(none)'} → {new.owner or '(none)'}")
     return lines
 
 

--- a/analytics/diagnostics/semantic_catalog/slack_diff.py
+++ b/analytics/diagnostics/semantic_catalog/slack_diff.py
@@ -42,7 +42,8 @@ def render_message(
     body.append("")
     missing = [g for g in ("data", "business") if not coverage.get(g)]
     if missing:
-        body.append(f":warning: review incomplete — missing approval from: {', '.join(missing)} group")
+        noun = "group" if len(missing) == 1 else "groups"
+        body.append(f":warning: review incomplete — missing approval from: {', '.join(missing)} {noun}")
     else:
         body.append(":white_check_mark: review complete — both groups approved")
     return "\n".join(body)

--- a/analytics/diagnostics/semantic_catalog/templates/sop.md
+++ b/analytics/diagnostics/semantic_catalog/templates/sop.md
@@ -1,0 +1,22 @@
+## How the semantic layer is updated
+
+Governed metric definitions are authored in one place: the dbt semantic YAML
+(`dbt/project/models/**/sem_*.yml`). Nothing on this page is edited by hand; it
+is regenerated from that YAML on every merge.
+
+To change a definition:
+
+1. Edit the metric in its `sem_*.yml`, including its `config.meta` governance
+   block (`owner`, `ratified`, `detail_doc`, and `retired` if deprecating).
+2. Open a pull request. CODEOWNERS automatically requests a reviewer from the
+   data group and the business group.
+3. A data-group reviewer confirms the build, conventions, and value-for-value
+   parity with the prior definition.
+4. A business-group reviewer confirms the definition is correct. That approval
+   is the ratification; the same change sets the `ratified` date.
+5. On merge, CI regenerates the catalog and posts a change summary to the
+   notification channel, including whether both groups approved.
+
+The review gate is a soft gate. An absent approver never blocks an urgent fix.
+Accountability comes from the change being visible: a merge without both
+approvals is announced as exactly that, never silently.

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
 dev = [
     "pytest>=9.1.1",
     "mypy>=2.3.0",
-    "ruff>=0.6.0",
 ]
 
 [tool.uv]

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 dev = [
     "pytest>=9.1.1",
     "mypy>=2.3.0",
+    "ruff>=0.6.0",
 ]
 
 [tool.uv]

--- a/analytics/tests/fixtures/semantic_catalog/sem_fixture__users_demo.yml
+++ b/analytics/tests/fixtures/semantic_catalog/sem_fixture__users_demo.yml
@@ -1,0 +1,58 @@
+semantic_models:
+  - name: users_demo
+    description: Fixture semantic model for parser tests.
+    model: ref('users_demo_base')
+    defaults:
+      agg_time_dimension: registered_at
+    entities:
+      - name: user
+        type: primary
+        expr: user_id
+    dimensions:
+      - name: registered_at
+        type: time
+        type_params:
+          time_granularity: day
+      - name: is_activated
+        description: Has sent at least one outreach campaign.
+        type: categorical
+    measures:
+      - name: demo_user_count
+        agg: sum
+        expr: "1"
+
+metrics:
+  - name: activated_users
+    label: Activated Users
+    description: Count of users who have sent at least one outreach campaign.
+    type: simple
+    type_params:
+      measure: demo_user_count
+    filter: "{{ Dimension('user__is_activated') }}"
+    config:
+      meta:
+        owner: semantic-layer-business
+        ratified: '2026-07-24'
+        detail_doc: engagement.md
+  - name: demo_users
+    label: Demo Users
+    description: Count of demo users.
+    type: simple
+    type_params:
+      measure: demo_user_count
+
+exposures:
+  - name: demo_external_retention
+    label: Demo External Retention
+    type: analysis
+    description: Externally-defined retention rate.
+    url: https://example.amplitude.com/chart/abc123
+    owner:
+      name: analytics-team
+      email: analytics@example.org
+    config:
+      meta:
+        owner: semantic-layer-business
+        ratified: '2026-07-20'
+        detail_doc: engagement.md
+        definition: Share of activated users returning in week one.

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -26,3 +26,22 @@ def test_write_then_check_is_idempotent(tmp_path):
     records = parse_semantic_tree(cli.SEM_ROOTS)
     cli.write_region(target, records)
     assert cli.region_is_current(target, records) is True
+
+
+def test_emit_slack_writes_rendered_message(tmp_path):
+    out = tmp_path / "slack.txt"
+    rc = cli.main(
+        [
+            "--emit-slack",
+            str(out),
+            "--pr-url",
+            "http://pr/1",
+            "--coverage",
+            '{"data": true, "business": false}',
+        ]
+    )
+    assert rc == 0
+    text = out.read_text()
+    assert "http://pr/1" in text
+    assert "incomplete" in text.lower()
+    assert "business" in text.lower()

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -45,3 +45,14 @@ def test_emit_slack_writes_rendered_message(tmp_path):
     assert "http://pr/1" in text
     assert "incomplete" in text.lower()
     assert "business" in text.lower()
+
+
+def test_region_is_current_false_on_half_marked_file(tmp_path):
+    # One marker present (corrupt/merge-conflict): --check should treat the
+    # file as stale (return False), not crash with an uncaught ValueError.
+    from semantic_catalog.md_catalog import BEGIN_MARK
+
+    target = tmp_path / "canonical_metrics.md"
+    target.write_text(f"# Canonical metrics\n\n{BEGIN_MARK}\nrows but no end marker\n")
+    records = parse_semantic_tree(cli.SEM_ROOTS)
+    assert cli.region_is_current(target, records) is False

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from semantic_catalog import cli
+from semantic_catalog.parser import parse_semantic_tree
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sem_roots_exist():
+    assert cli.SEM_ROOTS, "no semantic-model roots configured"
+    for root in cli.SEM_ROOTS:
+        assert root.is_dir(), f"missing {root}"
+
+
+def test_real_repo_parses_without_error():
+    records = parse_semantic_tree(cli.SEM_ROOTS)
+    names = {r.name for r in records}
+    # The four metrics that exist today must all parse.
+    assert {"win_users", "active_serve_users", "goodparty_win_rate", "goodparty_cumulative_wins"} <= names
+
+
+def test_write_then_check_is_idempotent(tmp_path):
+    # Copy a target file into a tmp location, write, then check == clean.
+    target = tmp_path / "canonical_metrics.md"
+    target.write_text("# Canonical metrics\n\nintro\n")
+    records = parse_semantic_tree(cli.SEM_ROOTS)
+    cli.write_region(target, records)
+    assert cli.region_is_current(target, records) is True

--- a/analytics/tests/test_semantic_catalog_clickup.py
+++ b/analytics/tests/test_semantic_catalog_clickup.py
@@ -1,0 +1,59 @@
+from semantic_catalog.clickup_page import CATALOG_BEGIN, CATALOG_END, render_page
+from semantic_catalog.lifecycle import Lifecycle
+from semantic_catalog.records import MetricRecord
+
+OWNERS = {
+    "teams": {
+        "data": {"slug": "semantic-layer-data", "role": "Technical review."},
+        "business": {"slug": "semantic-layer-business", "role": "Ratification."},
+    },
+}
+
+
+def _rec():
+    return MetricRecord(
+        name="activated_users",
+        label="Activated Candidates",
+        definition="Has sent at least one voter outreach campaign.",
+        metric_type="simple",
+        source="ref('users_win_base')",
+        dimensions=("is_activated",),
+        filter=None,
+        owner="semantic-layer-business",
+        ratified="2026-07-24",
+        detail_doc="engagement.md",
+        retired=None,
+        yaml_file="sem_analytics__users_win.yml",
+        kind="metric",
+    )
+
+
+def _lifecycles():
+    return {"sem_analytics__users_win.yml": Lifecycle("2026-06-01", "610", "2026-07-24", "720")}
+
+
+def test_page_has_three_parts():
+    page = render_page([_rec()], _lifecycles(), "## How the semantic layer is updated\nSOP.", OWNERS)
+    assert "How the semantic layer is updated" in page  # static part 1
+    assert "Decision-makers" in page  # static part 2
+    assert CATALOG_BEGIN in page and CATALOG_END in page  # dynamic part 3
+
+
+def test_catalog_row_has_lifecycle_and_governance():
+    page = render_page([_rec()], _lifecycles(), "SOP", OWNERS)
+    assert "Activated Candidates" in page
+    assert "2026-06-01" in page and "#610" in page  # created + PR
+    assert "2026-07-24" in page and "#720" in page  # last updated + PR
+    assert "engagement.md" in page
+
+
+def test_decision_makers_render_slugs_without_people():
+    page = render_page([_rec()], _lifecycles(), "SOP", OWNERS, people=None)
+    assert "semantic-layer-data" in page
+    assert "semantic-layer-business" in page
+
+
+def test_decision_makers_use_people_when_present():
+    people = {"semantic-layer-data": ["Alice", "Bob"], "semantic-layer-business": ["Charlie"]}
+    page = render_page([_rec()], _lifecycles(), "SOP", OWNERS, people=people)
+    assert "Alice" in page and "Charlie" in page

--- a/analytics/tests/test_semantic_catalog_clickup.py
+++ b/analytics/tests/test_semantic_catalog_clickup.py
@@ -57,3 +57,28 @@ def test_decision_makers_use_people_when_present():
     people = {"semantic-layer-data": ["Alice", "Bob"], "semantic-layer-business": ["Charlie"]}
     page = render_page([_rec()], _lifecycles(), "SOP", OWNERS, people=people)
     assert "Alice" in page and "Charlie" in page
+
+
+def test_catalog_escapes_pipes_in_cells():
+    """Verify that pipe characters in metric metadata are escaped to prevent table corruption."""
+    rec_with_pipe = MetricRecord(
+        name="test_metric",
+        label="Test Metric | With Pipe",
+        definition="count where is_winner | has_source",
+        metric_type="simple",
+        source="ref('test_table') | filter",
+        dimensions=("dim1",),
+        filter=None,
+        owner="semantic-layer-data | backup",
+        ratified="2026-07-24",
+        detail_doc="test.md | backup.md",
+        retired=None,
+        yaml_file="test.yml",
+        kind="metric",
+    )
+    page = render_page([rec_with_pipe], {}, "SOP", OWNERS)
+    # Verify escaped pipes appear in output (raw unescaped pipes should not break table)
+    assert "is_winner \\| has_source" in page
+    assert "With Pipe" in page  # label should still be readable (escaped internally)
+    # Ensure catalog markers are present (table not corrupted)
+    assert CATALOG_BEGIN in page and CATALOG_END in page

--- a/analytics/tests/test_semantic_catalog_composition.py
+++ b/analytics/tests/test_semantic_catalog_composition.py
@@ -1,0 +1,42 @@
+import json
+
+from semantic_catalog.composition import evaluate, main
+
+
+def test_both_groups_covered():
+    cov = evaluate({"alice", "charlie"}, {"alice", "bob"}, {"charlie"})
+    assert cov == {"data": True, "business": True}
+
+
+def test_missing_business():
+    cov = evaluate({"alice"}, {"alice", "bob"}, {"charlie"})
+    assert cov == {"data": True, "business": False}
+
+
+def test_case_insensitive_logins():
+    cov = evaluate({"Alice"}, {"alice"}, {"charlie"})
+    assert cov["data"] is True
+
+
+def test_main_prints_coverage_json(capsys, monkeypatch):
+    monkeypatch.setenv("APPROVERS", "Alice,charlie")
+    monkeypatch.setenv("DATA", "alice,bob")
+    monkeypatch.setenv("BIZ", "charlie")
+
+    exit_code = main()
+
+    assert exit_code == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == {"data": True, "business": True}
+
+
+def test_main_empty_env_vars_treated_as_no_members(capsys, monkeypatch):
+    monkeypatch.delenv("APPROVERS", raising=False)
+    monkeypatch.delenv("DATA", raising=False)
+    monkeypatch.delenv("BIZ", raising=False)
+
+    exit_code = main()
+
+    assert exit_code == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == {"data": False, "business": False}

--- a/analytics/tests/test_semantic_catalog_lifecycle.py
+++ b/analytics/tests/test_semantic_catalog_lifecycle.py
@@ -50,3 +50,11 @@ def test_derive_degrades_on_git_error():
         raise subprocess.CalledProcessError(128, ["git", "log"])
 
     assert derive("x.yml", run_git=run_git) == Lifecycle(None, None, None, None)
+
+
+def test_derive_takes_last_pr_number_in_title():
+    # A squash title with a linked issue then the PR: last "(#N)" is the PR.
+    run_git = _fake_git([("2026-07-24", "Feature (#609) (#720)")])
+    lc = derive("x.yml", run_git=run_git)
+    assert lc.created_pr == "720"
+    assert lc.last_updated_pr == "720"

--- a/analytics/tests/test_semantic_catalog_lifecycle.py
+++ b/analytics/tests/test_semantic_catalog_lifecycle.py
@@ -1,4 +1,6 @@
-from semantic_catalog.lifecycle import derive
+import subprocess
+
+from semantic_catalog.lifecycle import Lifecycle, derive
 
 
 def _fake_git(commits):
@@ -39,3 +41,12 @@ def test_derive_handles_untracked_file():
     lc = derive("never_committed.yml", run_git=run_git)
     assert lc.created is None
     assert lc.last_updated is None
+
+
+def test_derive_degrades_on_git_error():
+    # git missing / shallow clone / corrupt repo: return an empty lifecycle
+    # rather than propagating the exception and crashing the generator.
+    def run_git(args):
+        raise subprocess.CalledProcessError(128, ["git", "log"])
+
+    assert derive("x.yml", run_git=run_git) == Lifecycle(None, None, None, None)

--- a/analytics/tests/test_semantic_catalog_lifecycle.py
+++ b/analytics/tests/test_semantic_catalog_lifecycle.py
@@ -1,0 +1,41 @@
+from semantic_catalog.lifecycle import derive
+
+
+def _fake_git(commits):
+    # commits: list of (iso_date, subject) newest-first, as `git log` would print.
+    log = "\n".join(f"{d}\x1f{s}" for d, s in commits)
+
+    def run_git(args):
+        return log
+
+    return run_git
+
+
+def test_derive_first_and_last():
+    run_git = _fake_git(
+        [
+            ("2026-07-24", "Merge pull request #720 from data-2184/x"),
+            ("2026-06-01", "Merge pull request #610 from data-2109/y"),
+        ]
+    )
+    lc = derive("sem_analytics__users_win.yml", run_git=run_git)
+    assert lc.last_updated == "2026-07-24"
+    assert lc.last_updated_pr == "720"
+    assert lc.created == "2026-06-01"
+    assert lc.created_pr == "610"
+
+
+def test_derive_handles_no_pr_in_subject():
+    run_git = _fake_git([("2026-07-24", "direct commit no pr")])
+    lc = derive("x.yml", run_git=run_git)
+    assert lc.created == "2026-07-24"
+    assert lc.created_pr is None
+
+
+def test_derive_handles_untracked_file():
+    def run_git(args):
+        return ""
+
+    lc = derive("never_committed.yml", run_git=run_git)
+    assert lc.created is None
+    assert lc.last_updated is None

--- a/analytics/tests/test_semantic_catalog_md.py
+++ b/analytics/tests/test_semantic_catalog_md.py
@@ -1,0 +1,71 @@
+from semantic_catalog.md_catalog import (
+    BEGIN_MARK,
+    END_MARK,
+    render_region,
+    render_rows,
+    splice_region,
+)
+from semantic_catalog.records import MetricRecord
+
+
+def _rec(**kw):
+    base = dict(
+        name="activated_users",
+        label="Activated Candidates",
+        definition="Has sent at least one voter outreach campaign.",
+        metric_type="simple",
+        source="ref('users_win_base')",
+        dimensions=("is_activated",),
+        filter=None,
+        owner="semantic-layer-business",
+        ratified="2026-07-24",
+        detail_doc="engagement.md",
+        retired=None,
+        yaml_file="sem_analytics__users_win.yml",
+        kind="metric",
+    )
+    base.update(kw)
+    return MetricRecord(**base)
+
+
+def test_render_rows_has_header_and_row():
+    out = render_rows([_rec()])
+    assert "| Concept |" in out
+    assert "Activated Candidates" in out
+    assert "engagement.md" in out
+    assert "2026-07-24" in out
+
+
+def test_pending_renders_pending():
+    out = render_rows([_rec(ratified=None, owner=None)])
+    assert "pending" in out
+
+
+def test_render_region_wraps_in_markers():
+    out = render_region([_rec()])
+    assert out.startswith(BEGIN_MARK)
+    assert out.rstrip().endswith(END_MARK)
+
+
+def test_splice_replaces_existing_region():
+    existing = f"# Title\n\nintro\n\n{BEGIN_MARK}\nOLD\n{END_MARK}\n\nfooter\n"
+    region = render_region([_rec()])
+    out = splice_region(existing, region)
+    assert "OLD" not in out
+    assert "Activated Candidates" in out
+    assert out.startswith("# Title")
+    assert out.rstrip().endswith("footer")
+
+
+def test_splice_appends_when_no_markers():
+    existing = "# Title\n\nbody\n"
+    out = splice_region(existing, render_region([_rec()]))
+    assert out.startswith("# Title")
+    assert BEGIN_MARK in out
+
+
+def test_splice_rejects_half_marked_file():
+    import pytest
+
+    with pytest.raises(ValueError):
+        splice_region(f"x {BEGIN_MARK} y", render_region([_rec()]))

--- a/analytics/tests/test_semantic_catalog_parser.py
+++ b/analytics/tests/test_semantic_catalog_parser.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from semantic_catalog.parser import parse_semantic_file
+
+FIXTURE = Path(__file__).parent / "fixtures" / "semantic_catalog" / "sem_fixture__users_demo.yml"
+
+
+def _by_name(records):
+    return {r.name: r for r in records}
+
+
+def test_parses_metric_with_governance_meta():
+    recs = _by_name(parse_semantic_file(FIXTURE))
+    m = recs["activated_users"]
+    assert m.kind == "metric"
+    assert m.label == "Activated Users"
+    assert m.definition.startswith("Count of users who have sent")
+    assert m.metric_type == "simple"
+    assert m.source == "ref('users_demo_base')"
+    assert m.owner == "semantic-layer-business"
+    assert m.ratified == "2026-07-24"
+    assert m.detail_doc == "engagement.md"
+    assert m.retired is None
+    assert m.filter is not None
+    assert "is_activated" in m.dimensions
+
+
+def test_pending_metric_has_no_ratified():
+    recs = _by_name(parse_semantic_file(FIXTURE))
+    m = recs["demo_users"]
+    assert m.owner is None
+    assert m.ratified is None
+    assert m.detail_doc is None
+
+
+def test_parses_exposure_as_record():
+    recs = _by_name(parse_semantic_file(FIXTURE))
+    e = recs["demo_external_retention"]
+    assert e.kind == "exposure"
+    assert e.source == "https://example.amplitude.com/chart/abc123"
+    assert e.definition == "Share of activated users returning in week one."
+    assert e.ratified == "2026-07-20"

--- a/analytics/tests/test_semantic_catalog_slack.py
+++ b/analytics/tests/test_semantic_catalog_slack.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from semantic_catalog.records import MetricRecord
 from semantic_catalog.slack_diff import diff_records, render_message
 
@@ -53,3 +55,11 @@ def test_message_flags_incomplete_review_both_groups_pluralizes():
 def test_message_confirms_complete_review():
     msg = render_message([], [_rec("a", "d")], "http://pr/1", {"data": True, "business": True})
     assert "both groups" in msg.lower() or "complete" in msg.lower()
+
+
+def test_diff_detects_retired_and_owner_changes():
+    base = _rec("a", "d")
+    after = dataclasses.replace(base, retired="2026-07-01", owner="semantic-layer-data")
+    lines = "\n".join(diff_records([base], [after]))
+    assert "retired: a" in lines and "2026-07-01" in lines
+    assert "owner: a" in lines and "semantic-layer-data" in lines

--- a/analytics/tests/test_semantic_catalog_slack.py
+++ b/analytics/tests/test_semantic_catalog_slack.py
@@ -41,6 +41,13 @@ def test_message_flags_incomplete_review():
     assert "http://pr/1" in msg
     assert "incomplete" in msg.lower() or "missing" in msg.lower()
     assert "business" in msg.lower()
+    assert "business group" in msg.lower()
+    assert "business groups" not in msg.lower()
+
+
+def test_message_flags_incomplete_review_both_groups_pluralizes():
+    msg = render_message([], [_rec("a", "d")], "http://pr/1", {"data": False, "business": False})
+    assert "data, business groups" in msg.lower()
 
 
 def test_message_confirms_complete_review():

--- a/analytics/tests/test_semantic_catalog_slack.py
+++ b/analytics/tests/test_semantic_catalog_slack.py
@@ -1,0 +1,48 @@
+from semantic_catalog.records import MetricRecord
+from semantic_catalog.slack_diff import diff_records, render_message
+
+
+def _rec(name, definition, ratified=None):
+    return MetricRecord(
+        name=name,
+        label=name.title(),
+        definition=definition,
+        metric_type="simple",
+        source="ref('m')",
+        dimensions=(),
+        filter=None,
+        owner="semantic-layer-business",
+        ratified=ratified,
+        detail_doc="engagement.md",
+        retired=None,
+        yaml_file="sem.yml",
+        kind="metric",
+    )
+
+
+def test_diff_detects_added_removed_changed():
+    before = [_rec("a", "old def"), _rec("gone", "x")]
+    after = [_rec("a", "new def"), _rec("b", "brand new")]
+    lines = "\n".join(diff_records(before, after))
+    assert "b" in lines and "added" in lines.lower()
+    assert "gone" in lines and "removed" in lines.lower()
+    assert "a" in lines and "old def" in lines and "new def" in lines
+
+
+def test_diff_detects_ratification():
+    before = [_rec("a", "d", ratified=None)]
+    after = [_rec("a", "d", ratified="2026-07-24")]
+    lines = "\n".join(diff_records(before, after))
+    assert "ratified" in lines.lower() and "2026-07-24" in lines
+
+
+def test_message_flags_incomplete_review():
+    msg = render_message([], [_rec("a", "d")], "http://pr/1", {"data": True, "business": False})
+    assert "http://pr/1" in msg
+    assert "incomplete" in msg.lower() or "missing" in msg.lower()
+    assert "business" in msg.lower()
+
+
+def test_message_confirms_complete_review():
+    msg = render_message([], [_rec("a", "d")], "http://pr/1", {"data": True, "business": True})
+    assert "both groups" in msg.lower() or "complete" in msg.lower()

--- a/analytics/uv.lock
+++ b/analytics/uv.lock
@@ -21,6 +21,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -35,6 +36,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.6.0" },
 ]
 
 [[package]]
@@ -659,6 +661,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]

--- a/analytics/uv.lock
+++ b/analytics/uv.lock
@@ -21,7 +21,6 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
-    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -36,7 +35,6 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
-    { name = "ruff", specifier = ">=0.6.0" },
 ]
 
 [[package]]
@@ -661,31 +659,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "ruff"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
-    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
-    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First PR of DATA-2184 (semantic-layer change SOP and governance). It makes the dbt semantic layer the single authored home for governed KPI definitions, with a generator that projects the catalog and a soft two-group review gate.

This PR contains the tooling and the gate wiring only. It touches no governed `sem_*.yml` file, so there are no metric-definition changes here.

## What is included

Generator (`analytics/diagnostics/semantic_catalog/`, all test-driven):
- `parser` builds `MetricRecord` from `sem_*.yml` plus `config.meta` (pending-safe when governance metadata is absent)
- `md_catalog` renders the thin `canonical_metrics.md` routing table inside a delimited region so hand-authored rows can coexist during the epic
- `lifecycle` derives created and last-updated dates plus PR numbers from git history
- `clickup_page` renders the three-part reference page
- `slack_diff` renders the change diff and states review coverage loudly
- `cli` orchestrates: `--check` (drift guard), `--write`, `--emit-clickup`, `--emit-slack`

Governance wiring:
- `.github/CODEOWNERS` auto-requests two teams on any `sem_*.yml` change (advisory, does not block merge)
- `semantic-layer-composition-check.yml`: a non-blocking check that reports whether both review groups approved
- `semantic-layer-publish.yml`: on merge to main, regenerates the catalog and posts to Slack and ClickUp

Tests: the full analytics suite is green (249 tests, 31 for this package). Lint is ruff 0.7.4 via pre-commit.

## Scope and sequencing

- Tasks 8 to 10 (CODEOWNERS and the two workflows) are inert until the provisioning below is done. This is by design.
- The `config.meta` backfill on the real metric files is deliberately held for a follow-up PR, so the first change through the gate is a clean definition-only diff.

## Provisioning needed to activate the gate (after merge)

1. Create two GitHub teams and add members. The slugs must match these names, since they are referenced in CODEOWNERS and both workflows:
   - `semantic-layer-data` (technical reviewers)
   - `semantic-layer-business` (business ratifiers)
2. Add repo secrets: `SLACK_BOT_TOKEN`, `CLICKUP_API_TOKEN`, `SEMANTIC_LAYER_CLICKUP_PAGE_ID`, `ORG_READ_TOKEN`.

## Known follow-ups (not blocking)

- `cli --check` is not wired into CI yet. It returns non-zero until the follow-up PR first writes the catalog region, so it should be added to CI after that lands.
- The new package is mypy-clean on its own but is not type-checked in CI, because adding it to the analytics mypy target pulls the sibling `quality_bench` package's pre-existing type errors into the check.
- The Slack and ClickUp request bodies in the publish workflow, and an actionlint pass on both workflows, should be confirmed on the first live run once the secrets exist.

Ticket: DATA-2184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CI can push bot commits to main and call external APIs once secrets exist; workflows use `contents: write` and org tokens, but metric definitions are untouched in this PR.
> 
> **Overview**
> Adds **semantic-layer governance tooling** without changing any governed `sem_*.yml` files. A new `analytics/diagnostics/semantic_catalog` package parses dbt `sem_*.yml` (including `config.meta`), derives per-file lifecycle from git, and renders **canonical_metrics.md** regions (both knowledge skills), a **ClickUp** reference page, and **Slack** merge summaries with metric diffs and review coverage.
> 
> **GitHub wiring:** CODEOWNERS requests `semantic-layer-data` and `semantic-layer-business` on `sem_*.yml` changes (advisory). A PR workflow reports whether both groups approved (`continue-on-error`, non-blocking). On merge to `main`, a publish workflow regenerates artifacts, posts to Slack/ClickUp (secrets not yet provisioned), and commits updated `canonical_metrics.md` without re-triggering the workflow.
> 
> The CLI supports `--check` (drift guard), `--write`, `--emit-clickup`, and `--emit-slack`; coverage is computed by `composition.evaluate` from approvers vs team membership. **31 tests** cover parser, markdown splice, lifecycle, ClickUp/Slack output, composition, and CLI integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec239a2d4ea2dce3488dd5f98627a33f6bd3da6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->