### PR TITLE
[DATA-2188] Semantic layer: config.meta backfill + per-skill catalog projection

### DIFF
--- a/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
@@ -32,3 +32,9 @@ explicitly in the analysis and flag it as a candidate registry row in the calibr
 **Outcome note (from the DATA-2115 decisions):** People Served is the decision-level outcome;
 **retention on broad engagement** is the per-user analysis outcome. Re-election / continuation
 in office is parked until officeholder data lands in civics.
+
+<!-- semantic-catalog:begin -->
+| Concept | Governed definition (one line) | Source | Owns detail | Ratified |
+|---|---|---|---|---|
+| **Active Serve Users** | Count of active serve users: completed Serve onboarding by sending an SMS poll AND pledged. Definition owned by int__serve_active_user, surfaced through users_serve_base; the gold membership view users_serve_active exposes the same population for direct dashboard reads. Time series bucket by onboarding-completion date (the metric's aggregation time is first_sms_poll_sent_at), not by pledge or account registration date. | ref('users_serve_base') | [sources.md](sources.md) | pending |
+<!-- semantic-catalog:end -->

--- a/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
@@ -32,3 +32,11 @@ When a question names a concept not in this table, fall through to the per-domai
 table in the knowledge skill's `SKILL.md`. When you define a genuinely new canonical metric,
 add a row here (and have the owner ratify it) rather than letting the definition live only in
 a domain doc.
+
+<!-- semantic-catalog:begin -->
+| Concept | Governed definition (one line) | Source | Owns detail | Ratified |
+|---|---|---|---|---|
+| **GoodParty Cumulative Wins** | Running total of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. Accumulates all time, so each period shows the cumulative win count to date. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
+| **GoodParty Win Rate** | Count of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
+| **Win Users** | Count of Win-product users. Slice or filter by the engagement dimensions (has_viewed_dashboard, is_active_candidate_30d, etc.) at query time. | ref('users_win_base') | [engagement.md](engagement.md) | pending |
+<!-- semantic-catalog:end -->

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -28,10 +28,31 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 DBT_MODELS = REPO_ROOT / "dbt" / "project" / "models" / "marts"
 SEM_ROOTS = [DBT_MODELS / "analytics", DBT_MODELS / "civics"]
 SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
-MD_TARGETS = [
-    SKILLS_ROOT / "win-analytics-knowledge" / "references" / "canonical_metrics.md",
-    SKILLS_ROOT / "serve-analytics-knowledge" / "references" / "canonical_metrics.md",
-]
+
+# Each skill owns one canonical_metrics.md. The generated region is projected
+# PER SKILL so a product's cheat sheet lists only its own metrics, and each
+# row's detail_doc link resolves inside that skill's own references/ dir.
+MD_TARGET_BY_SKILL = {
+    "win-analytics-knowledge": SKILLS_ROOT
+    / "win-analytics-knowledge"
+    / "references"
+    / "canonical_metrics.md",
+    "serve-analytics-knowledge": SKILLS_ROOT
+    / "serve-analytics-knowledge"
+    / "references"
+    / "canonical_metrics.md",
+}
+
+# Which skill each governed sem_*.yml routes its metrics to. Civics outcome
+# metrics are documented in the Win skill (outcomes.md lives there), so they
+# route to win rather than to a civics-specific sheet. A sem file absent from
+# this map is a hard error (see records_by_target) so a new metric can never
+# silently land in the wrong sheet, or none at all.
+SKILL_BY_SEM_FILE = {
+    "sem_analytics__users_win.yml": "win-analytics-knowledge",
+    "sem_analytics__users_serve.yml": "serve-analytics-knowledge",
+    "sem_civics__candidacy_stage.yml": "win-analytics-knowledge",
+}
 PKG = Path(__file__).parent
 
 
@@ -49,6 +70,27 @@ def region_is_current(target: Path, records: list[MetricRecord]) -> bool:
 def write_region(target: Path, records: list[MetricRecord]) -> None:
     existing = target.read_text() if target.exists() else ""
     target.write_text(splice_region(existing, render_region(records)))
+
+
+def records_by_target(records: list[MetricRecord]) -> dict[Path, list[MetricRecord]]:
+    """Group records by the canonical_metrics.md they should render into.
+
+    Routes each record via its source sem file (SKILL_BY_SEM_FILE). Raises on an
+    unmapped sem file so a newly-added metric fails loudly rather than being
+    dropped from every sheet. Every known target appears in the result, with an
+    empty list when a skill currently has no metrics.
+    """
+    grouped: dict[Path, list[MetricRecord]] = {t: [] for t in MD_TARGET_BY_SKILL.values()}
+    for rec in records:
+        sem_file = Path(rec.yaml_file).name
+        skill = SKILL_BY_SEM_FILE.get(sem_file)
+        if skill is None:
+            raise ValueError(
+                f"{sem_file} has no route in SKILL_BY_SEM_FILE; add a mapping so its "
+                "metrics land in a canonical_metrics.md."
+            )
+        grouped[MD_TARGET_BY_SKILL[skill]].append(rec)
+    return grouped
 
 
 def _lifecycles(records: list[MetricRecord]) -> dict[str, Lifecycle]:
@@ -70,7 +112,8 @@ def main(argv: list[str] | None = None) -> int:
     records = parse_semantic_tree(SEM_ROOTS)
 
     if args.check:
-        stale = [t for t in MD_TARGETS if not region_is_current(t, records)]
+        grouped = records_by_target(records)
+        stale = [t for t, recs in grouped.items() if not region_is_current(t, recs)]
         if stale:
             print("stale canonical_metrics.md region in:", file=sys.stderr)
             for t in stale:
@@ -80,8 +123,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.write:
-        for t in MD_TARGETS:
-            write_region(t, records)
+        for t, recs in records_by_target(records).items():
+            write_region(t, recs)
             print(f"wrote {t}")
 
     if args.emit_clickup:

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -56,3 +56,39 @@ def test_region_is_current_false_on_half_marked_file(tmp_path):
     target.write_text(f"# Canonical metrics\n\n{BEGIN_MARK}\nrows but no end marker\n")
     records = parse_semantic_tree(cli.SEM_ROOTS)
     assert cli.region_is_current(target, records) is False
+
+
+def test_records_by_target_routes_each_metric_to_its_skill():
+    # Per-skill projection: each product's cheat sheet gets only its own
+    # metrics. Civics outcome metrics route to Win (outcomes.md lives there).
+    records = parse_semantic_tree(cli.SEM_ROOTS)
+    grouped = cli.records_by_target(records)
+    win_names = {r.name for r in grouped[cli.MD_TARGET_BY_SKILL["win-analytics-knowledge"]]}
+    serve_names = {r.name for r in grouped[cli.MD_TARGET_BY_SKILL["serve-analytics-knowledge"]]}
+
+    assert win_names == {"win_users", "goodparty_win_rate", "goodparty_cumulative_wins"}
+    assert serve_names == {"active_serve_users"}
+    assert "active_serve_users" not in win_names
+
+
+def test_records_by_target_raises_on_unmapped_sem_file():
+    import pytest
+    from semantic_catalog.records import MetricRecord
+
+    stray = MetricRecord(
+        name="stray",
+        label="Stray",
+        definition="x",
+        metric_type="simple",
+        source="ref('m')",
+        dimensions=(),
+        filter=None,
+        owner=None,
+        ratified=None,
+        detail_doc=None,
+        retired=None,
+        yaml_file="sem_unmapped__thing.yml",
+        kind="metric",
+    )
+    with pytest.raises(ValueError):
+        cli.records_by_target([stray])

--- a/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
@@ -63,3 +63,7 @@ metrics:
     type: simple
     type_params:
       measure: active_serve_user_count
+    config:
+      meta:
+        owner: semantic-layer-business
+        detail_doc: sources.md

--- a/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
@@ -51,3 +51,7 @@ metrics:
     type: simple
     type_params:
       measure: win_user_count
+    config:
+      meta:
+        owner: semantic-layer-data
+        detail_doc: engagement.md

--- a/dbt/project/models/marts/civics/sem_civics__candidacy_stage.yml
+++ b/dbt/project/models/marts/civics/sem_civics__candidacy_stage.yml
@@ -47,6 +47,10 @@ metrics:
       and {{ TimeDimension('candidacy_stage__election_stage_date', 'day') }} >= '2026-01-01'
       and {{ TimeDimension('candidacy_stage__election_stage_date', 'day') }} < '2027-01-01'
       and {{ TimeDimension('candidacy_stage__election_stage_date', 'day') }} < current_date()
+    config:
+      meta:
+        owner: semantic-layer-business
+        detail_doc: outcomes.md
 
   - name: goodparty_cumulative_wins
     label: GoodParty Cumulative Wins
@@ -63,3 +67,7 @@ metrics:
       and {{ TimeDimension('candidacy_stage__election_stage_date', 'day') }} >= '2026-01-01'
       and {{ TimeDimension('candidacy_stage__election_stage_date', 'day') }} < '2027-01-01'
       and {{ TimeDimension('candidacy_stage__election_stage_date', 'day') }} < current_date()
+    config:
+      meta:
+        owner: semantic-layer-business
+        detail_doc: outcomes.md


### PR DESCRIPTION
## Why

The governance machinery from #694 (DATA-2184) is in place, but no governed metric carried its `config.meta` yet. This wires the four existing semantic-layer metrics into that machinery so ownership, the generated catalog, and the review gate have something to act on. It is the first PR to touch a governed `sem_*.yml`, so it is the first to exercise the blocking catalog-freshness gate.

Two things are bundled because the gate forces them into one diff:

**1. Governance metadata.** `owner` (team) and `detail_doc` on `win_users`, `active_serve_users`, `goodparty_win_rate`, and `goodparty_cumulative_wins`. Every row stays `pending`; ratification is a business sign-off that rides the per-metric subtasks, not this PR. `active_serve_users` points at `sources.md` rather than an `engagement.md` that does not exist in the Serve skill, matching that skill's existing routing for the concept.

**2. Per-skill catalog projection.** The generator previously wrote the same all-metrics region into both product cheat sheets, which would have put broken `detail_doc` links into the Serve file (no `engagement.md`/`outcomes.md` there) and cross-domain rows into each. It now routes each metric to its own skill's `canonical_metrics.md`; civics outcome metrics route to the Win skill, where `outcomes.md` lives. An unmapped `sem_*.yml` is a hard error so a new metric can never silently land in the wrong sheet, or none at all. The regenerated regions are committed so catalog-freshness passes in the same PR.

## Follow-up

Whether to collapse the two per-skill catalogs into one shared governed catalog is noted on the epic; it sits near the epic's MD-to-generated cutover and likely folds into that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and catalog tooling plus dbt metric metadata only; no runtime query or data pipeline behavior changes.
> 
> **Overview**
> Wires the four existing governed semantic-layer metrics into **DATA-2184** governance by adding `config.meta` (`owner`, `detail_doc`) on `win_users`, `active_serve_users`, `goodparty_win_rate`, and `goodparty_cumulative_wins` in the `sem_*.yml` files. Ratification stays **pending**; this PR is what makes the catalog freshness gate and ownership routing real on the first touched metrics.
> 
> The semantic catalog CLI no longer splices the **same** metric table into both Win and Serve `canonical_metrics.md` files. It **projects per skill** via `SKILL_BY_SEM_FILE` / `records_by_target`, so each cheat sheet only lists that product’s metrics and `detail_doc` links resolve under that skill’s `references/` (civics outcome metrics route to Win where `outcomes.md` lives). An unmapped `sem_*.yml` **raises** instead of silently omitting metrics. `--check` and `--write` use the grouped targets; tests cover routing and the unmapped-file error.
> 
> Regenerated `<!-- semantic-catalog:begin -->` regions are committed in both skills’ `canonical_metrics.md` so CI catalog-freshness passes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cad8b34a4529725ac1053404640c6e6f1029d54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->