### PR TITLE
docs(analytics-process): render the senior-analyst loop as a TodoWrite tree

### DIFF
--- a/.claude/skills/analytics-process/SKILL.md
+++ b/.claude/skills/analytics-process/SKILL.md
@@ -15,11 +15,11 @@ work*, not *what is true about the data*.
 An index, not the specification: each step's operational detail lives in its reference doc,
 and the stage/actor/gate topology lives in [`references/pipeline.md`](references/pipeline.md),
 the single description of the pipeline flow. Three legibility conventions are always on —
-seed a `TodoWrite` list at the start of a run with these items in order — **frame**, **approve
-framing** (hard gate), **find sources**, **brief**, **execute**, **results checkpoint** (hard
-gate), **review**, **close the loop** — and flip each to `in_progress`/`completed` as you
-advance (the pinned tree is the at-a-glance progress view, and the two hard gates are items so
-they can't be skipped);
+seed a `TodoWrite` list at the start of a run with the staged to-do items the runbook names —
+**frame**, **approve framing** (hard gate), **execute**, **results checkpoint** (hard gate),
+**review**, **calibrate** — and flip each to `in_progress`/`completed` as you advance (the
+pinned tree is the at-a-glance progress view, and the two hard gates are items so they can't be
+skipped);
 announce each step transition with a one-line stage banner; and mark each cleared checkpoint
 with a gate receipt. Banner/receipt formats and stock why-clauses live in `pipeline.md`
 ("Legibility").

--- a/.claude/skills/analytics-process/SKILL.md
+++ b/.claude/skills/analytics-process/SKILL.md
@@ -14,9 +14,12 @@ work*, not *what is true about the data*.
 
 An index, not the specification: each step's operational detail lives in its reference doc,
 and the stage/actor/gate topology lives in [`references/pipeline.md`](references/pipeline.md),
-the single description of the pipeline flow. Two legibility conventions are always on —
-announce each step transition with a one-line stage banner, and each cleared checkpoint with a
-gate receipt; formats and stock why-clauses live in `pipeline.md` ("Legibility").
+the single description of the pipeline flow. Three legibility conventions are always on —
+seed a `TodoWrite` list with one item per loop step below at the start of a run and flip each
+to `in_progress`/`completed` as you advance (the pinned tree is the at-a-glance progress view);
+announce each step transition with a one-line stage banner; and mark each cleared checkpoint
+with a gate receipt. Banner/receipt formats and stock why-clauses live in `pipeline.md`
+("Legibility").
 
 1. **Clarify and scope (framing).** Run the framing routine ([`references/framing.md`](references/framing.md)) in your own context — it converses with the user. No execution code until the human approves the framing.
 2. **Find sources.** Resolve every concept through the knowledge skill, and verify named tables/columns/events against the live catalog — docs drift.

--- a/.claude/skills/analytics-process/SKILL.md
+++ b/.claude/skills/analytics-process/SKILL.md
@@ -15,8 +15,11 @@ work*, not *what is true about the data*.
 An index, not the specification: each step's operational detail lives in its reference doc,
 and the stage/actor/gate topology lives in [`references/pipeline.md`](references/pipeline.md),
 the single description of the pipeline flow. Three legibility conventions are always on —
-seed a `TodoWrite` list with one item per loop step below at the start of a run and flip each
-to `in_progress`/`completed` as you advance (the pinned tree is the at-a-glance progress view);
+seed a `TodoWrite` list at the start of a run with these items in order — **frame**, **approve
+framing** (hard gate), **find sources**, **brief**, **execute**, **results checkpoint** (hard
+gate), **review**, **close the loop** — and flip each to `in_progress`/`completed` as you
+advance (the pinned tree is the at-a-glance progress view, and the two hard gates are items so
+they can't be skipped);
 announce each step transition with a one-line stage banner; and mark each cleared checkpoint
 with a gate receipt. Banner/receipt formats and stock why-clauses live in `pipeline.md`
 ("Legibility").

--- a/.claude/skills/analytics-process/references/pipeline.md
+++ b/.claude/skills/analytics-process/references/pipeline.md
@@ -21,11 +21,16 @@ doc documents the flow; a human (or the process skill stepping through it) drive
 | 3 | **Review (methodology + interpretation)** | `product-data-scientist` | the executed notebook, read against the brief | a methodology review + an interpretation of results | Read-only and advisory. Surfaces leakage / survivorship / calibration concerns and interprets effect sizes. Does not edit code or open PRs. |
 | + | **Review (usefulness)** | `product-manager` | the plan or the deliverable | a framing / actionability review | Read-only and advisory. Asks whether this answers the team's real question and whether names/segments/thresholds match how consumers think. Invoked proactively at plan checkpoints and pre-PR — a checkpoint, not a strict sequence position. |
 
-## Legibility: stage banners and gate receipts
+## Legibility: stage banners, gate receipts, and the TodoWrite tree
 
 The pipeline's robustness is invisible unless narrated: from the user's seat, unannounced
-stages read as delay. Two always-on conventions keep the chat transcript legible; each is one
+stages read as delay. Three always-on conventions keep the chat transcript legible; each is one
 line, near-zero cost.
+
+**TodoWrite tree.** At the start of a run, seed a `TodoWrite` list with one item per step of the
+senior-analyst loop plus the two hard gates (approve framing, results checkpoint), and flip each
+to `in_progress`/`completed` as you advance. The harness pins and re-renders the active list, so
+it reads as a live progress tree — the at-a-glance complement to the per-transition banners below.
 
 **Stage banner.** At every transition into a step of the senior-analyst loop (the skill's
 6-step numbering), open with one line:

--- a/.claude/skills/analytics-process/references/pipeline.md
+++ b/.claude/skills/analytics-process/references/pipeline.md
@@ -27,10 +27,11 @@ The pipeline's robustness is invisible unless narrated: from the user's seat, un
 stages read as delay. Three always-on conventions keep the chat transcript legible; each is one
 line, near-zero cost.
 
-**TodoWrite tree.** At the start of a run, seed a `TodoWrite` list with one item per step of the
-senior-analyst loop plus the two hard gates (approve framing, results checkpoint), and flip each
-to `in_progress`/`completed` as you advance. The harness pins and re-renders the active list, so
-it reads as a live progress tree — the at-a-glance complement to the per-transition banners below.
+**TodoWrite tree.** At the start of a run, seed a `TodoWrite` list with the staged to-do items
+the runbook names (frame → approve framing → execute → results checkpoint → review → calibrate),
+and flip each to `in_progress`/`completed` as you advance. The harness pins and re-renders the
+active list, so it reads as a live progress tree — the at-a-glance complement to the
+per-transition banners below.
 
 **Stage banner.** At every transition into a step of the senior-analyst loop (the skill's
 6-step numbering), open with one line:


### PR DESCRIPTION
The analytics-process skill's only progress signals were scrolling stage banners and gate receipts. Those work as a narrative log but give no at-a-glance view of where a run is in the six-step senior-analyst loop, and they scroll out of view as the run proceeds.

This adds a third always-on legibility convention: seed a TodoWrite list with one item per loop step and advance it as you go. The harness already pins and re-renders the active todo list, so the six steps show up as a live progress tree without any new tooling — matching the display other skills already get from the same mechanism.

The banner/receipt conventions are unchanged (they stay as the narrative log), and the reviewer-gate topology is deliberately untouched — the todo list is pure display and does not affect when reviewers are dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to skill guidance; no runtime code, gates, or reviewer dispatch behavior.
> 
> **Overview**
> The **analytics-process** skill’s senior-analyst loop section now requires **three** always-on legibility conventions instead of two.
> 
> Agents must **seed a `TodoWrite` list** with one item per loop step at run start and move items through `in_progress` / `completed` as they advance, using the harness-pinned tree as the at-a-glance progress view. **Stage banners** and **gate receipts** are unchanged; banner/receipt formats still point to `pipeline.md` (“Legibility”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7340351544a766f75cb2435c86861fcd0420b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->