### PR TITLE
Bump loader cache-bust to reinstall the ENVIRONMENT loader

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -11,11 +11,10 @@ sshtunnel>=0.4.0,<1.0.0
 
 # People-API loader CLI — installed from this monorepo's subdirectory so the
 # `loader` console script is on PATH for the load_people_api DAG's BashOperators.
-# Pinned to @main so the loader co-versions with the DAG on main and survives feature-branch deletion
-# post-merge. (During review this tracked the DATA-2100 feature branch so astro-dev ran the PR's loader;
-# repinned to @main for merge — it resolves to this PR's loader once merged.) See PR #607.
+# Pinned to @main so the loader co-versions with the DAG on main and survives feature-branch
+# deletion post-merge.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-23.2
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-27.1
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This


### PR DESCRIPTION
Follow-up to #698. The astro image installs the loader from `@main` and caches that pip layer on `requirements.txt`, so the ENVIRONMENT change on main won't reach the image until this file changes. Bump the `bust=` token (and drop the stale review-time note on the pin).