### PR TITLE
Strip libpq-unsupported query params (e.g. ?schema=) from connection strings

### DIFF
--- a/people-api-loader/src/loader/people_api/db.py
+++ b/people-api-loader/src/loader/people_api/db.py
@@ -13,6 +13,7 @@ fetched and decrypted at connect time. Nothing connection-related lives in this 
 
 from __future__ import annotations
 
+import urllib.parse
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING
@@ -21,11 +22,45 @@ import psycopg
 from psycopg.conninfo import conninfo_to_dict, make_conninfo
 
 from loader.core.aws import get_ssm_parameter
+from loader.core.log import get_logger
 from loader.people_api.bastion import open_tunnel
 from loader.people_api.config import LoaderConfig
 
 if TYPE_CHECKING:
     from psycopg import Connection
+
+log = get_logger(__name__)
+
+# libpq has no `schema` connection parameter — the search_path form is
+# `options=-csearch_path=` — so a stray `?schema=` in an SSM connection string makes psycopg
+# raise an opaque "invalid URI query parameter" error. The loader's Present-cluster baseline
+# reads the default (public) schema, so such params are dropped rather than honored.
+_UNSUPPORTED_QUERY_KEYS = frozenset({"schema"})
+
+
+def _conn_str(cfg: LoaderConfig, param_name: str) -> str:
+    """Fetch an SSM connection string, dropping any libpq-unsupported query params.
+
+    Postgres URLs (`postgresql://…?schema=green`) are re-emitted without the unsupported keys;
+    keyword=value strings and URLs without those keys are returned unchanged.
+    """
+    conn_str = get_ssm_parameter(cfg, param_name)
+    parts = urllib.parse.urlsplit(conn_str)
+    if not parts.scheme.startswith("postgres") or not parts.query:
+        return conn_str
+    pairs = urllib.parse.parse_qsl(parts.query, keep_blank_values=True)
+    kept = [(k, v) for k, v in pairs if k not in _UNSUPPORTED_QUERY_KEYS]
+    if len(kept) == len(pairs):
+        return conn_str
+    log.warning(
+        "db.dropped_unsupported_conn_params",
+        param=param_name,
+        dropped=sorted({k for k, _ in pairs if k in _UNSUPPORTED_QUERY_KEYS}),
+    )
+    return urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urllib.parse.urlencode(kept), parts.fragment)
+    )
+
 
 # TCP keepalives so a dropped connection (e.g. a severed bastion tunnel) surfaces as an error
 # in ~1 min rather than hanging indefinitely on a response that never arrives. connect_timeout
@@ -65,7 +100,7 @@ def _connect(
     bastion would otherwise each open their own tunnel and flood sshd MaxStartups; sharing one
     forward multiplexes them as channels on a single SSH transport. Ignored when no bastion.
     """
-    conninfo = make_conninfo(get_ssm_parameter(cfg, param_name), **_KEEPALIVE_KW)
+    conninfo = make_conninfo(_conn_str(cfg, param_name), **_KEEPALIVE_KW)
     if not cfg.bastion_enabled:
         # Direct: the SSM connection string, plus the keepalive params baked in above.
         with psycopg.connect(conninfo, autocommit=autocommit, connect_timeout=30) as conn:
@@ -100,7 +135,7 @@ def open_new_tunnel(cfg: LoaderConfig, run_date: str) -> Iterator[tuple[str, int
     if not cfg.bastion_enabled:
         yield None
         return
-    parts = conninfo_to_dict(make_conninfo(get_ssm_parameter(cfg, cfg.new_conn_param(run_date))))
+    parts = conninfo_to_dict(make_conninfo(_conn_str(cfg, cfg.new_conn_param(run_date))))
     target_host = str(parts.get("host") or "")
     target_port = int(parts.get("port") or 5432)
     with open_tunnel(cfg, target_host, target_port) as fwd:

--- a/people-api-loader/tests/test_connections.py
+++ b/people-api-loader/tests/test_connections.py
@@ -149,3 +149,41 @@ def test_connect_new_defaults_to_autocommit() -> None:
     import inspect
 
     assert inspect.signature(db.connect_new).parameters["autocommit"].default is True
+
+
+def test_connect_prod_tolerates_unsupported_schema_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An SSM connection string with a stray `?schema=green` (libpq has no `schema` param)
+    # must not blow up connect_prod with an opaque "invalid URI query parameter" error.
+    captured: dict = {}
+
+    def _fake_ssm(cfg: object, name: str, **k: object) -> str:
+        return "postgresql://u:p@rds.internal:5432/d?schema=green&sslmode=require"
+
+    monkeypatch.setattr(db, "get_ssm_parameter", _fake_ssm)
+
+    @contextmanager
+    def _fake_connect(conninfo: str, **k: object):
+        captured["conninfo"] = conninfo
+        yield "CONN"
+
+    monkeypatch.setattr(db.psycopg, "connect", _fake_connect)
+    cfg = cast(
+        LoaderConfig,
+        SimpleNamespace(db_conn_param="p", bastion_enabled=False, db_statement_timeout_ms=0),
+    )
+    with db.connect_prod(cfg) as conn:
+        assert conn == "CONN"
+    parts = conninfo_to_dict(captured["conninfo"])
+    assert "schema" not in parts
+    assert parts["host"] == "rds.internal"
+    assert parts["dbname"] == "d"
+    assert parts["sslmode"] == "require"  # other query params are preserved
+
+
+def test_conn_str_passthrough_for_keyword_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    # keyword=value strings (no URI query) are returned unchanged.
+    monkeypatch.setattr(db, "get_ssm_parameter", lambda cfg, name, **k: "host=h dbname=d user=u port=5432")
+    cfg = cast(LoaderConfig, SimpleNamespace())
+    assert db._conn_str(cfg, "p") == "host=h dbname=d user=u port=5432"


### PR DESCRIPTION
## Why

A stray `?schema=green` in the `people-db-connection-string-prod` SSM value made `inspect_prod` fail with an opaque `ProgrammingError: invalid URI query parameter: "schema"` — libpq has no `schema` parameter (the search_path form is `options=-csearch_path=`). The same edit had previously broken the dev param.

Rather than depend on the SSM values being pristine, sanitize the connection string in `db.py`: drop libpq-unsupported query params (currently `schema`) from `postgresql://` URLs before handing them to psycopg, logging a warning. Keyword=value strings and URLs without those params are unchanged. The Present-cluster baseline reads the default (public) schema, so an errant `?schema=` is dropped, not honored.

Covered by a `connect_prod` test that reproduces the exact failure and a passthrough test.

Note: deploying this needs another `requirements.txt` cache-bust bump (loader source changed). For the immediate prod run, cleaning the SSM param value also unblocks it.