### PR TITLE
Add a final database-wide ANALYZE step (fresh per-partition planner stats)

### DIFF
--- a/airflow/astro/dags/load_people_api.py
+++ b/airflow/astro/dags/load_people_api.py
@@ -119,6 +119,12 @@ def load_people_api():
     build_indexes = _step("build_indexes", "build-indexes")
     validate = _step("validate", "validate")
     resize = _step("resize", "resize")
+    # Final step: a database-wide ANALYZE. build_indexes' per-parent VACUUM (ANALYZE) sets the
+    # leaf partitions' visibility maps but leaves their per-partition planner stats empty
+    # (parent-level ANALYZE only does the parent's inheritance stats), so the planner serves
+    # partition scans on default stats. A bare ANALYZE covers every leaf partition; run last so
+    # it reflects the fully loaded + resized cluster.
+    analyze = _step("analyze", "analyze")
     # Cost guard: a failed/aborted run after provision strands whatever writer instance class was
     # in effect (up to db.r8g.48xlarge post build_indexes, the same box validate now runs its heavy
     # per-state counts against) because `resize` never runs. Fires (trigger_rule=one_failed) if any
@@ -137,7 +143,7 @@ def load_people_api():
     # across resize — so correctness is identical either order. resize is then the clean final step.
     inspect_prod >> dbt_test_voter_gate >> [unload, provision]
     [unload, provision] >> create_schema
-    create_schema >> copy >> build_indexes >> validate >> resize
+    create_schema >> copy >> build_indexes >> validate >> resize >> analyze
     # The guard's upstreams must include EVERY task after which a cluster can exist, including
     # `unload` (which runs parallel to provision) and `validate` (which now runs on the scaled-up
     # writer before resize — a validate failure must flip it to serverless, not strand it).
@@ -145,7 +151,16 @@ def load_people_api():
     # succeeds, the downstream tasks go UPSTREAM_FAILED (which does NOT satisfy one_failed), so
     # unload (and every other task below) must feed the guard directly or the stranded cluster is
     # missed.
-    [provision, unload, create_schema, copy, build_indexes, validate, resize] >> scale_down_on_failure
+    [
+        provision,
+        unload,
+        create_schema,
+        copy,
+        build_indexes,
+        validate,
+        resize,
+        analyze,
+    ] >> scale_down_on_failure
 
 
 load_people_api()

--- a/airflow/astro/tests/dags/test_dag_example.py
+++ b/airflow/astro/tests/dags/test_dag_example.py
@@ -125,5 +125,6 @@ def test_load_people_api_scale_down_on_failure():
         "build_indexes",
         "validate",
         "resize",
+        "analyze",
     }
     assert "scale_down_on_failure" not in {t.task_id for t in _LOADER_DAG.get_task("resize").upstream_list}

--- a/people-api-loader/src/loader/people_api/cli.py
+++ b/people-api-loader/src/loader/people_api/cli.py
@@ -266,6 +266,7 @@ def status(run_date: RunDateArg) -> None:
     cfg = _setup(run_date, verify_aws=False)
     from loader.core.manifest.io import read_manifest
     from loader.people_api.manifests import (
+        AnalyzeManifest,
         CopyManifest,
         IndexManifest,
         InspectManifest,
@@ -283,8 +284,9 @@ def status(run_date: RunDateArg) -> None:
         ("schema", SchemaManifest),
         ("copy", CopyManifest),
         ("indexes", IndexManifest),
-        ("resize", ResizeManifest),
         ("validate", ValidateManifest),
+        ("resize", ResizeManifest),
+        ("analyze", AnalyzeManifest),
     ]
     tbl = Table(title=f"Run {run_date} — step status")
     tbl.add_column("Step")

--- a/people-api-loader/src/loader/people_api/cli.py
+++ b/people-api-loader/src/loader/people_api/cli.py
@@ -178,6 +178,15 @@ def resize(run_date: RunDateArg) -> None:
     step.run(cfg, run_date)
 
 
+@app.command()
+def analyze(run_date: RunDateArg) -> None:
+    """Step 7 — database-wide ANALYZE so every leaf partition has fresh planner stats."""
+    from loader.people_api.steps import analyze as step
+
+    cfg = _setup(run_date)
+    step.run(cfg, run_date)
+
+
 @app.command(name="scale-down")
 def scale_down(run_date: RunDateArg) -> None:
     """Failure cost guard — flip the writer to db.serverless (keeps the cluster + data)."""

--- a/people-api-loader/src/loader/people_api/manifests.py
+++ b/people-api-loader/src/loader/people_api/manifests.py
@@ -28,6 +28,7 @@ from loader.core.manifest.io import (
 from loader.core.manifest.models import ManifestBase, Status
 
 __all__ = [
+    "AnalyzeManifest",
     "CopyManifest",
     "CopyTableResult",
     "IndexManifest",
@@ -151,6 +152,12 @@ class ResizeManifest(ManifestBase):
     final_instance_class: str
     backup_retention_days: int
     deletion_protection: bool
+
+
+class AnalyzeManifest(ManifestBase):
+    step: Literal["analyze"] = "analyze"
+    # public base tables + leaf partitions with fresh manual-ANALYZE stats after the run.
+    tables_analyzed: int
 
 
 class ValidationCheck(BaseModel):

--- a/people-api-loader/src/loader/people_api/steps/analyze.py
+++ b/people-api-loader/src/loader/people_api/steps/analyze.py
@@ -1,0 +1,71 @@
+"""Step 7 — ANALYZE the whole database as the final step.
+
+`build_indexes` runs `VACUUM (ANALYZE)` on each partitioned parent. The VACUUM recurses to the
+leaf partitions and sets their visibility maps, but the parent-level ANALYZE only refreshes the
+parent's inheritance statistics — it does NOT populate each leaf partition's own per-column
+stats (they stay `last_analyze IS NULL`), so the planner has no selectivity stats for the
+partitions it actually scans. A bare, database-wide `ANALYZE` processes every table AND every
+leaf partition the connecting role owns in one statement, giving the planner fresh per-partition
+stats. Runs last so it reflects the fully loaded + resized serving cluster.
+
+Idempotent: ANALYZE is safe to re-run, and a completed manifest short-circuits.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from loader.core.log import bind, get_logger
+from loader.people_api.config import LoaderConfig
+from loader.people_api.db import connect_new
+from loader.people_api.manifests import (
+    AnalyzeManifest,
+    manifest_uri,
+    read_manifest,
+    write_manifest,
+)
+
+log = get_logger(__name__)
+
+# Count the public base tables + leaf partitions that now carry fresh manual-ANALYZE stats, as an
+# observability signal in the manifest (a partitioned parent's ANALYZE previously left these NULL).
+_ANALYZED_COUNT_SQL = """
+SELECT count(*)
+FROM pg_stat_all_tables s
+JOIN pg_class c ON c.oid = s.relid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = 'public' AND c.relkind = 'r' AND s.last_analyze IS NOT NULL
+"""
+
+
+def run(cfg: LoaderConfig, run_date: str) -> AnalyzeManifest:
+    bind(run_date=run_date, step="analyze")
+    existing = read_manifest(cfg, run_date, "analyze", AnalyzeManifest)
+    if existing and existing.status == "complete":
+        log.info(
+            "analyze.skip", reason="manifest already complete", uri=manifest_uri(cfg, run_date, "analyze")
+        )
+        return existing
+
+    started = datetime.now(UTC)
+    log.info("analyze.start", cluster=cfg.new_cluster_id(run_date))
+
+    # A bare ANALYZE processes every table + leaf partition, which the per-parent ANALYZE in
+    # build_indexes does not reach. connect_new is autocommit by default.
+    with connect_new(cfg, run_date) as conn, conn.cursor() as cur:
+        cur.execute("ANALYZE")
+        cur.execute(_ANALYZED_COUNT_SQL)
+        row = cur.fetchone()
+        tables_analyzed = int(row[0]) if row else 0
+    log.info("analyze.done", tables_analyzed=tables_analyzed)
+
+    manifest = AnalyzeManifest(
+        run_date=run_date,
+        status="complete",
+        started_at=started,
+        finished_at=datetime.now(UTC),
+        tables_analyzed=tables_analyzed,
+    )
+    uri = write_manifest(cfg, manifest)
+    log.info("analyze.complete", uri=uri, tables_analyzed=tables_analyzed)
+    return manifest

--- a/people-api-loader/src/loader/people_api/steps/build_indexes.py
+++ b/people-api-loader/src/loader/people_api/steps/build_indexes.py
@@ -535,10 +535,12 @@ def run(cfg: LoaderConfig, run_date: str, *, parallelism: int = _DEFAULT_BUILDER
                 # 2. Flat table: plain indexes build directly on the table (no partitions to walk).
                 _build_in_parallel(_create_plain_flat, plain_idxs)
 
-            # 3. VACUUM (ANALYZE) this table: sets the visibility map (so serving-side count(*) and
-            #    index-only scans skip the full heap scan a freshly bulk-loaded table would otherwise
-            #    force) and refreshes planner stats in the same pass. On a partitioned parent (Voter)
-            #    this recurses to every partition automatically.
+            # 3. VACUUM (ANALYZE) this table: on a partitioned parent (Voter) the VACUUM recurses to
+            #    every leaf partition and sets its visibility map (so serving-side count(*) /
+            #    index-only scans skip the full heap scan a freshly bulk-loaded partition would
+            #    otherwise force). The parent-level ANALYZE refreshes only the parent's inheritance
+            #    stats, NOT each leaf partition's per-column stats — the final `analyze` step (a
+            #    database-wide ANALYZE) covers those.
             _vacuum_analyze(cfg, run_date, table, forward=fwd)
 
             analyzed_tables.append(table)

--- a/people-api-loader/tests/test_analyze.py
+++ b/people-api-loader/tests/test_analyze.py
@@ -1,0 +1,39 @@
+"""analyze: a bare database-wide ANALYZE (every leaf partition) as the final step + manifest."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from loader.people_api.config import LoaderConfig
+from loader.people_api.steps import analyze as step
+from tests._fakes import FakeConn, executed_sql, fake_connect
+
+_CFG = cast(LoaderConfig, SimpleNamespace(new_cluster_id=lambda rd: f"gp-people-db-{rd}"))
+
+
+def test_analyze_runs_bare_analyze_and_writes_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+    conn = FakeConn().queue_result((104,))  # the analyzed-relation count query
+    monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
+    monkeypatch.setattr(step, "write_manifest", lambda cfg, m: captured.setdefault("m", m) or "uri")
+    monkeypatch.setattr(step, "connect_new", fake_connect(conn))
+
+    manifest = step.run(_CFG, "20260728")
+
+    assert manifest.status == "complete"
+    assert manifest.tables_analyzed == 104
+    sqls = executed_sql(conn)
+    # A bare, whole-database ANALYZE — it reaches every leaf partition, unlike a per-parent
+    # `ANALYZE public."Voter"`, which only refreshes the parent's inheritance stats.
+    assert sqls[0] == "ANALYZE"
+    assert not any('ANALYZE public."' in s for s in sqls)
+
+
+def test_analyze_skips_completed_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    done = SimpleNamespace(status="complete")
+    monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: done)
+    monkeypatch.setattr(step, "manifest_uri", lambda cfg, rd, name: "uri")
+    assert step.run(_CFG, "20260728") is done


### PR DESCRIPTION
## Why

`build_indexes` runs `VACUUM (ANALYZE)` on each partitioned parent (`Voter`, `DistrictVoter`). The VACUUM recurses to the leaf partitions and sets their visibility maps (confirmed: partitions are 100% all-visible, index-only scans work), but the parent-level **ANALYZE only refreshes the parent's inheritance statistics** — it does not populate each leaf partition's own per-column stats. Verified on the freshly-built prod cluster: every `Voter_XX` / `DistrictVoter_XX` partition had `last_analyze IS NULL AND last_autoanalyze IS NULL` after a full successful run, so the planner was serving partition scans on default selectivity.

## What

- New final step `analyze` (CLI `loader analyze`) that runs a **bare, database-wide `ANALYZE`** — one statement that processes every table *and* every leaf partition the connecting role owns, which the per-parent ANALYZE never reached. Idempotent + manifest-guarded like the other steps.
- Wired as the last step: `… build_indexes >> validate >> resize >> analyze`, and added to the `scale_down_on_failure` cost-guard upstreams.
- Fixed the `build_indexes` comment that claimed the parent `VACUUM (ANALYZE)` "recurses to every partition automatically" — true for the VACUUM/visibility-map, false for the ANALYZE/stats.

Manually running `ANALYZE;` on the prod cluster dropped the large-district (Dallas, 676k rows) count to ~1.35s warm with a correct nested-loop/index plan and 0 heap fetches.
