### PR TITLE
[DATA-2134] Ratify active_serve_users metric

### DIFF
--- a/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
@@ -36,5 +36,5 @@ in office is parked until officeholder data lands in civics.
 <!-- semantic-catalog:begin -->
 | Concept | Governed definition (one line) | Source | Owns detail | Ratified |
 |---|---|---|---|---|
-| **Active Serve Users** | Count of active serve users: completed Serve onboarding by sending an SMS poll AND pledged. Definition owned by int__serve_active_user, surfaced through users_serve_base; the gold membership view users_serve_active exposes the same population for direct dashboard reads. Time series bucket by onboarding-completion date (the metric's aggregation time is first_sms_poll_sent_at), not by pledge or account registration date. | ref('users_serve_base') | [sources.md](sources.md) | pending |
+| **Active Serve Users** | Count of active serve users: completed Serve onboarding by sending an SMS poll AND pledged. Definition owned by int__serve_active_user, surfaced through users_serve_base; the gold membership view users_serve_active exposes the same population for direct dashboard reads. Time series bucket by onboarding-completion date (the metric's aggregation time is first_sms_poll_sent_at), not by pledge or account registration date. | ref('users_serve_base') | [sources.md](sources.md) | 2026-07-28 |
 <!-- semantic-catalog:end -->

--- a/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
@@ -67,3 +67,4 @@ metrics:
       meta:
         owner: semantic-layer-business
         detail_doc: sources.md
+        ratified: 2026-07-28


### PR DESCRIPTION
Ratifies the `active_serve_users` semantic-layer metric (first of the four encoded metrics).

**Change:** adds `ratified: 2026-07-28` to `config.meta` on `active_serve_users` in `sem_analytics__users_serve.yml`, and regenerates the Serve `canonical_metrics.md` catalog region (blocking catalog-freshness check).

**Definition (unchanged):** count of active Serve users — completed Serve onboarding by sending an SMS poll AND pledged.

**Ratification:** per the semantic-layer SOP, a **business-group** (`semantic-layer-business`) approval on this PR is the sign-off that consummates the ratification. A data-group approval covers the technical/build side. CODEOWNERS has auto-requested both.

Part of the DATA-2126 semantic-layer epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only governance update; no changes to metric logic, SQL, or dashboards.
> 
> **Overview**
> **Ratifies** the governed semantic-layer metric **`active_serve_users`** by setting **`ratified: 2026-07-28`** on `config.meta` in `sem_analytics__users_serve.yml`. The metric definition and aggregation behavior are unchanged.
> 
> The Serve **`canonical_metrics.md`** auto-generated catalog block is updated so **Active Serve Users** moves from **`pending`** to **`2026-07-28`**, keeping the docs in sync with the YAML source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c235e6fb93d1f8ab0a8b0bade9c8ef352f4691. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->