### PR TITLE
[DATA-2130] Add + ratify win_activated_users metric (Activated Candidates OKR)

### DIFF
--- a/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
@@ -38,5 +38,6 @@ a domain doc.
 |---|---|---|---|---|
 | **GoodParty Cumulative Wins** | Running total of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. Accumulates all time, so each period shows the cumulative win count to date. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
 | **GoodParty Win Rate** | Count of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
+| **Win Activated Users** | Count of Win-product users who have activated: sent at least one voter outreach campaign (first_campaign_sent_at is not null). The activated slice of win_users; the Activated Candidates OKR. | ref('users_win_base') | [engagement.md](engagement.md) | 2026-07-28 |
 | **Win Users** | Count of Win-product users. Slice or filter by the engagement dimensions (has_viewed_dashboard, is_active_candidate_30d, etc.) at query time. | ref('users_win_base') | [engagement.md](engagement.md) | pending |
 <!-- semantic-catalog:end -->

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -66,7 +66,12 @@ def test_records_by_target_routes_each_metric_to_its_skill():
     win_names = {r.name for r in grouped[cli.MD_TARGET_BY_SKILL["win-analytics-knowledge"]]}
     serve_names = {r.name for r in grouped[cli.MD_TARGET_BY_SKILL["serve-analytics-knowledge"]]}
 
-    assert win_names == {"win_users", "goodparty_win_rate", "goodparty_cumulative_wins"}
+    assert win_names == {
+        "win_users",
+        "win_activated_users",
+        "goodparty_win_rate",
+        "goodparty_cumulative_wins",
+    }
     assert serve_names == {"active_serve_users"}
     assert "active_serve_users" not in win_names
 

--- a/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
@@ -55,3 +55,19 @@ metrics:
       meta:
         owner: semantic-layer-data
         detail_doc: engagement.md
+
+  - name: win_activated_users
+    label: Win Activated Users
+    description: >
+      Count of Win-product users who have activated: sent at least one voter
+      outreach campaign (first_campaign_sent_at is not null). The activated
+      slice of win_users; the Activated Candidates OKR.
+    type: simple
+    type_params:
+      measure: win_user_count
+    filter: "{{ Dimension('user__is_activated') }}"
+    config:
+      meta:
+        owner: semantic-layer-business
+        detail_doc: engagement.md
+        ratified: 2026-07-28


### PR DESCRIPTION
Adds a new semantic-layer metric `win_activated_users` and ratifies it.

**Definition:** count of Win-product users who have activated — sent at least one voter outreach campaign (`first_campaign_sent_at is not null`). The activated slice of `win_users`; the Activated Candidates OKR.

**How:** a MetricFlow `simple` metric reusing the existing `win_user_count` measure with `filter: {{ Dimension('user__is_activated') }}`. No model or table change — pure semantic definition over `users_win_base`.

**Validation:** `dbt parse` builds the semantic manifest + OSI cleanly (only the two pre-existing OSI warnings). Parity check on `users_win_base`: 1,248 activated of 62,604 Win users (~2%), confirming the filter selects the intended subset.

**config.meta:** owner `semantic-layer-business` (OKR = business KPI), detail_doc `engagement.md`, `ratified: 2026-07-28`.

**Ratification:** per the SOP, a **business-group** approval on this PR is the sign-off. CODEOWNERS auto-requests both groups; the Win catalog projection is regenerated in-diff (catalog-freshness).

Part of the DATA-2126 semantic-layer epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Semantic-layer and documentation-only changes over existing `users_win_base.is_activated`; no pipeline or auth changes.
> 
> **Overview**
> Introduces the governed semantic metric **`win_activated_users`** for the Activated Candidates OKR: Win users who have sent at least one voter outreach campaign, implemented as a MetricFlow simple metric on existing `win_user_count` with `user__is_activated` — no mart or table changes.
> 
> **Ratification and catalog:** `config.meta` sets business owner, `engagement.md` detail, and ratification date; the Win **`canonical_metrics.md`** semantic-catalog block gains a **Win Activated Users** row marked ratified **2026-07-28**. The semantic-catalog CLI test now expects **`win_activated_users`** in the Win skill projection alongside the other Win metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca308377a48f5a2812e3be63071733dfd3ef7d82. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->