### PR TITLE
docs(semantic-layer): self-contained ClickUp reference page (intro + diagram + explainer)

### DIFF
--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -130,7 +130,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.emit_clickup:
         owners = yaml.safe_load((PKG / "config" / "owners.yml").read_text())
         sop_md = (PKG / "templates" / "sop.md").read_text()
-        page = render_page(records, _lifecycles(records), sop_md, owners)
+        footer_md = (PKG / "templates" / "footer.md").read_text()
+        page = render_page(records, _lifecycles(records), sop_md, owners, footer_md=footer_md)
         args.emit_clickup.write_text(page)
         print(f"wrote {args.emit_clickup}")
 

--- a/analytics/diagnostics/semantic_catalog/clickup_page.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_page.py
@@ -6,6 +6,8 @@ if an untracked `people` map is supplied at publish time (repo rule: no names in
 tracked files).
 Part 3 (dynamic): the per-metric catalog, generated from records + git lifecycle,
 inside CATALOG_BEGIN/CATALOG_END so any out-of-band page context is preserved.
+Part 4 (static, optional): a footer rendered after the catalog (governance
+diagram + reader explainer), passed in from the repo template.
 """
 
 from __future__ import annotations
@@ -68,6 +70,7 @@ def render_page(
     sop_md: str,
     owners: dict,
     people: dict | None = None,
+    footer_md: str = "",
 ) -> str:
     parts = [
         "# Semantic layer reference",
@@ -80,4 +83,6 @@ def render_page(
         "",
         _catalog(records, lifecycles),
     ]
+    if footer_md:
+        parts += ["", footer_md]
     return "\n".join(parts) + "\n"

--- a/analytics/diagnostics/semantic_catalog/templates/footer.md
+++ b/analytics/diagnostics/semantic_catalog/templates/footer.md
@@ -1,0 +1,32 @@
+## How governance works
+
+```
+   AUTHOR                  REVIEW  (auto-requested by CODEOWNERS)        PUBLISH
+   ------                  -----------------------------------          -------
+
+  edit the metric    open    +--------------------------------+  merge   catalog
+  in its dbt YAML  ->  PR -> | data group:                    | ------>  updates
+  (sem_*.yml +               | builds + value-for-value parity|          +
+  config.meta)               +--------------------------------+          change summary
+                             | business group:                |          posts to
+                             | confirms the definition        |          #data-alignment
+                             | = RATIFIES (sets ratified date)|
+                             +--------------------------------+
+
+  Soft gate: both groups are auto-requested on every change. A merge without
+  both approvals still goes through, but it is announced in #data-alignment as
+  exactly that. Accountability by visibility, not by blocking.
+```
+
+## What this means for you
+
+- **Using a metric?** Build on the **ratified** ones. A business owner has
+  signed off that the definition is correct. **Pending** means encoded but not
+  yet signed off, so use with care.
+- **Need a new metric, or a change to one?** Open a pull request editing the
+  metric's `sem_*.yml`. Both review groups are auto-requested, so you do not
+  have to chase anyone down. A business owner's approval is what ratifies it.
+- **You're a reviewer?** Data group: confirm it builds and matches the prior
+  definition value-for-value. Business group: confirm the definition is what
+  the business actually means. Your approval is the ratification.
+- **Questions?** Post in #data-alignment.

--- a/analytics/diagnostics/semantic_catalog/templates/sop.md
+++ b/analytics/diagnostics/semantic_catalog/templates/sop.md
@@ -1,3 +1,12 @@
+This page is the single source of truth for GoodParty's governed business
+metrics, the numbers we hold ourselves to (Win and Serve activation, win rate,
+cumulative wins, and more). Each metric is defined once in code, reviewed by
+both a data owner and a business owner, and published here automatically. A
+metric marked **ratified** has an agreed definition that is safe to build
+dashboards, reports, and AI answers on. **Pending** means the definition exists
+but has not been signed off yet. Nothing here is hand-edited; it regenerates
+from the code definitions on every change.
+
 ## How the semantic layer is updated
 
 Governed metric definitions are authored in one place: the dbt semantic YAML

--- a/analytics/tests/test_semantic_catalog_clickup.py
+++ b/analytics/tests/test_semantic_catalog_clickup.py
@@ -39,6 +39,24 @@ def test_page_has_three_parts():
     assert CATALOG_BEGIN in page and CATALOG_END in page  # dynamic part 3
 
 
+def test_footer_renders_after_catalog():
+    page = render_page(
+        [_rec()],
+        _lifecycles(),
+        "SOP",
+        OWNERS,
+        footer_md="## How governance works\n## What this means for you\nBROADCAST",
+    )
+    assert "What this means for you" in page
+    # Footer must come after the catalog block, not before it.
+    assert page.index(CATALOG_END) < page.index("What this means for you")
+
+
+def test_footer_omitted_when_empty():
+    page = render_page([_rec()], _lifecycles(), "SOP", OWNERS)
+    assert "What this means for you" not in page
+
+
 def test_catalog_row_has_lifecycle_and_governance():
     page = render_page([_rec()], _lifecycles(), "SOP", OWNERS)
     assert "Activated Candidates" in page


### PR DESCRIPTION
Makes the generated semantic-layer reference page broadcastable as a standalone explainer.

**Adds:**
- An intro paragraph at the top (what the page is, ratified vs pending), in `templates/sop.md`.
- A footer rendered **after** the catalog table (`templates/footer.md`): a plain-ASCII governance-flow diagram (author → review by both groups → publish) and a 'what this means for you' section for consumers, proposers, and reviewers.

**Mechanism:** `render_page` gains an optional `footer_md` arg (backward-compatible); `cli --emit-clickup` reads `footer.md` and passes it. Both additions are static template content, so they survive catalog regenerations. 2 new tests cover footer-after-catalog ordering and the empty-footer default.

Generator-only change (no governed `sem_*.yml` touched), so this goes through normal review, not the CODEOWNERS gate. Part of the DATA-2126 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and catalog rendering only; no metric definitions, auth, or runtime data paths change.
> 
> **Overview**
> Makes the generated **semantic layer reference** page usable as a standalone explainer without extra context.
> 
> **Intro:** `templates/sop.md` now opens with what the page is, **ratified** vs **pending**, and that content is regenerated from `sem_*.yml` on every change.
> 
> **Footer after the catalog:** New `templates/footer.md` adds a governance flow diagram (author → data/business review → publish) and a **What this means for you** section for consumers, proposers, and reviewers. `render_page` accepts optional `footer_md` (default empty, backward-compatible) and appends it **after** the `CATALOG_END` block. `--emit-clickup` loads `footer.md` and passes it through.
> 
> Tests assert footer ordering relative to the catalog and that an empty footer is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfac738c9c60706c46f0ac25354fa1d3e0669654. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->