### PR TITLE
Harden the semantic-layer governance gate: naming guard + token-health heartbeat

### DIFF
--- a/.github/workflows/semantic-layer-file-placement.yml
+++ b/.github/workflows/semantic-layer-file-placement.yml
@@ -1,0 +1,36 @@
+name: semantic-layer-file-placement
+# Blocking gate: a semantic_models:/metrics: block outside a governed sem_*.yml
+# would bypass CODEOWNERS, the composition check, catalog-freshness, and the
+# catalog itself all at once. This job fails the PR so the sem_*.yml naming
+# convention is an enforced invariant, not just a convention.
+#
+# The path filter is deliberately BROAD (every .yml/.yaml under models), not the
+# sem_*.yml filter the sibling workflows use: the violation is a file that is NOT
+# named sem_*.yml, so a narrow filter would never trigger on the PR that adds one.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'dbt/project/models/**/*.yml'
+      - 'dbt/project/models/**/*.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  file-placement:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: analytics/uv.lock
+      - name: Install analytics env
+        working-directory: analytics
+        run: uv sync --frozen
+      - name: Check semantic definitions live in sem_*.yml
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+        run: uv run python -m semantic_catalog.naming_guard

--- a/.github/workflows/semantic-layer-token-health.yml
+++ b/.github/workflows/semantic-layer-token-health.yml
@@ -1,0 +1,109 @@
+name: semantic-layer-token-health
+# The governance gate's accountability rests on two secrets: ORG_READ_TOKEN (the
+# composition check reads team membership with it) and SLACK_APP_BOT_TOKEN (the
+# publish job announces every governed merge to #data-alignment). Both workflows
+# skip cleanly when their token is missing, so a revoked or expired token, or a
+# bot removed from the channel, would silently disable the gate's visibility with
+# no error anywhere. This heartbeat exercises both tokens on a schedule and shouts
+# if either is unhealthy or nearing expiry, so a dead integration cannot rot
+# unnoticed. It fails the run on a hard problem (so GitHub notifies watchers even
+# when Slack itself is the dead integration and cannot self-report).
+on:
+  schedule:
+    - cron: '0 15 * * 1'   # Mondays 15:00 UTC (~7-8am PT)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  SLACK_CHANNEL: C08K22X9ZNH   # #data-alignment
+  EXPIRY_WARN_DAYS: '7'        # warn when a token expires within this many days
+
+jobs:
+  token-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Exercise governance tokens
+        env:
+          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          SLACK_APP_BOT_TOKEN: ${{ secrets.SLACK_APP_BOT_TOKEN }}
+        run: |
+          # No `set -e`: collect every problem in one run rather than exit on the
+          # first. pipefail still surfaces failures inside pipes.
+          set -o pipefail
+          problems=()
+          warnings=()
+
+          # --- ORG_READ_TOKEN: make the exact team-membership call the gate uses ---
+          if [ -z "${GH_TOKEN:-}" ]; then
+            problems+=("ORG_READ_TOKEN is not set. The composition check cannot read team membership, so approval coverage is always reported as incomplete.")
+          else
+            hdrs="$(mktemp)"
+            if gh api -i "orgs/thegoodparty/teams/semantic-layer-data/members" >"$hdrs" 2>/dev/null; then
+              # Fine-grained / expiring PATs return this header; a classic
+              # never-expiring token omits it, in which case there is nothing to
+              # warn about.
+              exp="$(grep -i '^github-authentication-token-expiration:' "$hdrs" | sed -E 's/^[^:]+:[[:space:]]*//' | tr -d '\r')"
+              if [ -n "$exp" ]; then
+                # GNU date on the ubuntu runner parses the header timestamp
+                # ("YYYY-MM-DD HH:MM:SS UTC" or "... +0000") directly.
+                exp_epoch="$(date -d "$exp" +%s 2>/dev/null || true)"
+                if [ -n "$exp_epoch" ]; then
+                  days=$(( (exp_epoch - $(date -u +%s)) / 86400 ))
+                  if [ "$days" -le "${EXPIRY_WARN_DAYS}" ]; then
+                    warnings+=("ORG_READ_TOKEN expires in ${days} day(s) (on ${exp}). Rotate it before it lapses or the composition check goes dark.")
+                  fi
+                fi
+              fi
+            else
+              problems+=("ORG_READ_TOKEN cannot read team membership (revoked, expired, or missing the org read scope).")
+            fi
+            rm -f "$hdrs"
+          fi
+
+          # --- SLACK_APP_BOT_TOKEN: validate the token, then confirm the bot is
+          # still in the announcement channel (a valid token alone does not prove
+          # it can post there). ---
+          if [ -z "${SLACK_APP_BOT_TOKEN:-}" ]; then
+            problems+=("SLACK_APP_BOT_TOKEN is not set. Governed merges cannot be announced in #data-alignment, which is the gate's only enforcement.")
+          else
+            auth="$(curl -sS -X POST https://slack.com/api/auth.test -H "Authorization: Bearer $SLACK_APP_BOT_TOKEN")"
+            if ! echo "$auth" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("ok") else 1)'; then
+              err="$(echo "$auth" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("error","unknown"))')"
+              problems+=("SLACK_APP_BOT_TOKEN failed auth.test (error: ${err}). Merge announcements will not post.")
+            else
+              info="$(curl -sS "https://slack.com/api/conversations.info?channel=${SLACK_CHANNEL}" -H "Authorization: Bearer $SLACK_APP_BOT_TOKEN")"
+              member="$(echo "$info" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("yes" if d.get("ok") and d.get("channel",{}).get("is_member") else "no")')"
+              if [ "$member" != "yes" ]; then
+                problems+=("The Slack bot is not a member of #data-alignment (${SLACK_CHANNEL}). Re-invite it or announcements will silently fail.")
+              fi
+            fi
+          fi
+
+          # --- report ---
+          if [ ${#problems[@]} -eq 0 ] && [ ${#warnings[@]} -eq 0 ]; then
+            echo "Governance tokens healthy."
+            exit 0
+          fi
+
+          msg="Semantic-layer governance token health check found issues:"
+          for p in "${problems[@]}"; do msg="${msg}"$'\n'"- [PROBLEM] ${p}"; done
+          for w in "${warnings[@]}"; do msg="${msg}"$'\n'"- [WARNING] ${w}"; done
+          echo "$msg"
+
+          # Best-effort Slack alert. Only lands if the Slack token itself is
+          # healthy; when Slack is the broken integration, the job failure below
+          # is the signal instead.
+          if [ -n "${SLACK_APP_BOT_TOKEN:-}" ]; then
+            curl -sS -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer $SLACK_APP_BOT_TOKEN" \
+              -H "Content-type: application/json; charset=utf-8" \
+              --data "$(MSG="$msg" CH="$SLACK_CHANNEL" python3 -c 'import json,os; print(json.dumps({"channel": os.environ["CH"], "text": os.environ["MSG"]}))')" \
+              >/dev/null || true
+          fi
+
+          # Hard problems fail the run so GitHub notifies watchers regardless of
+          # Slack. Warnings-only (e.g. impending expiry) surface without failing.
+          [ ${#problems[@]} -gt 0 ] && exit 1
+          exit 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,3 +99,15 @@ repos:
         files: ^apps/genie-slack-bot/
         pass_filenames: false
         stages: [pre-push]
+    # Governance guard: semantic_models:/metrics: content must live in a
+    # sem_*.yml so it cannot bypass the review gate and catalog. Broad `files:`
+    # (any yml under models) so it fires on a mis-named file, which is the
+    # violation. CI enforcement is semantic-layer-file-placement.yml; this is the
+    # local pre-push copy. Runs in the analytics env like the pytest hooks above.
+    -   id: semantic-file-placement
+        name: semantic definitions must live in sem_*.yml (pre-push)
+        entry: bash -c 'cd analytics && PYTHONPATH=diagnostics uv run python -m semantic_catalog.naming_guard'
+        language: system
+        files: ^dbt/project/models/.*\.ya?ml$
+        pass_filenames: false
+        stages: [pre-push]

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -25,8 +25,13 @@ from semantic_catalog.slack_diff import render_message
 # analytics/diagnostics/semantic_catalog/cli.py -> parents[0]=semantic_catalog,
 # [1]=diagnostics, [2]=analytics, [3]=repo root.
 REPO_ROOT = Path(__file__).resolve().parents[3]
-DBT_MODELS = REPO_ROOT / "dbt" / "project" / "models" / "marts"
-SEM_ROOTS = [DBT_MODELS / "analytics", DBT_MODELS / "civics"]
+# Parse EVERY sem_*.yml under models, not an allow-list of subdirs, so the
+# parser's coverage matches the CODEOWNERS glob (/dbt/project/models/**/sem_*.yml)
+# exactly. A governed file added under any subdir is auto-catalogued; the naming
+# guard (semantic_catalog.naming_guard) enforces that all semantic content lives
+# in a sem_*.yml so nothing can escape this scope.
+DBT_MODELS = REPO_ROOT / "dbt" / "project" / "models"
+SEM_ROOTS = [DBT_MODELS]
 SKILLS_ROOT = REPO_ROOT / ".claude" / "skills"
 
 # Each skill owns one canonical_metrics.md. The generated region is projected
@@ -137,16 +142,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.emit_slack:
         after = records
-        before = (
-            parse_semantic_tree(
-                [
-                    args.base_dir / "dbt/project/models/marts/analytics",
-                    args.base_dir / "dbt/project/models/marts/civics",
-                ]
-            )
-            if args.base_dir
-            else []
-        )
+        before = parse_semantic_tree([args.base_dir / "dbt/project/models"]) if args.base_dir else []
         coverage = json.loads(args.coverage) if args.coverage else {"data": False, "business": False}
         msg = render_message(before, after, args.pr_url, coverage)
         args.emit_slack.write_text(msg)

--- a/analytics/diagnostics/semantic_catalog/naming_guard.py
+++ b/analytics/diagnostics/semantic_catalog/naming_guard.py
@@ -1,0 +1,75 @@
+"""Guard: every semantic definition must live in a governed sem_*.yml file.
+
+The whole governance gate keys off one filename convention: sem_*.yml under
+dbt/project/models. CODEOWNERS auto-requests the reviewer groups on it, the
+composition and catalog-freshness checks trigger on it, and the catalog parser
+reads it. A semantic_models:/metrics: block in a differently-named file, or in a
+sem_*.yaml (wrong extension), would slip past every one of those at once:
+reviewers never requested, never catalogued, never announced on merge.
+
+This check fails when it finds such a file, turning the naming convention into
+an enforced invariant so a governed metric can never escape coverage.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+# analytics/diagnostics/semantic_catalog/naming_guard.py -> parents[3] = repo root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODELS_ROOT = REPO_ROOT / "dbt" / "project" / "models"
+
+
+def _defines_semantics(path: Path) -> bool:
+    """True if the YAML has a top-level semantic_models: or metrics: block."""
+    try:
+        doc = yaml.safe_load(path.read_text())
+    except yaml.YAMLError:
+        # Malformed YAML is check-yaml's job, not ours; do not crash here.
+        return False
+    return isinstance(doc, dict) and bool(doc.get("semantic_models") or doc.get("metrics"))
+
+
+def _is_governed_name(path: Path) -> bool:
+    """The exact pattern the CODEOWNERS filter and the parser both key on."""
+    return path.name.startswith("sem_") and path.suffix == ".yml"
+
+
+def find_misplaced(models_root: Path = MODELS_ROOT) -> list[Path]:
+    """Semantic files that escape the sem_*.yml convention, sorted by path."""
+    misplaced: list[Path] = []
+    for path in sorted(models_root.rglob("*")):
+        if path.is_dir() or path.suffix not in (".yml", ".yaml"):
+            continue
+        if _is_governed_name(path):
+            continue
+        if _defines_semantics(path):
+            misplaced.append(path)
+    return misplaced
+
+
+def main() -> int:
+    misplaced = find_misplaced()
+    if misplaced:
+        print(
+            "Semantic definitions (semantic_models:/metrics:) must live in a governed "
+            "sem_*.yml file so the review gate and catalog cover them. These files "
+            "escape the convention and would bypass governance entirely:",
+            file=sys.stderr,
+        )
+        for path in misplaced:
+            print(f"  {path.relative_to(REPO_ROOT)}", file=sys.stderr)
+        print(
+            "Rename each to sem_<name>.yml (prefix sem_, extension .yml).",
+            file=sys.stderr,
+        )
+        return 1
+    print("all semantic definitions live in governed sem_*.yml files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analytics/tests/test_semantic_catalog_naming_guard.py
+++ b/analytics/tests/test_semantic_catalog_naming_guard.py
@@ -1,0 +1,45 @@
+from semantic_catalog import naming_guard
+
+
+def test_real_repo_has_no_misplaced_semantic_files():
+    # Every governed metric today lives in a sem_*.yml; the guard must pass clean
+    # on the real tree, or CI would be red on an untouched repo.
+    assert naming_guard.find_misplaced() == []
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_flags_semantic_block_in_non_sem_file(tmp_path):
+    # A metrics: block in a differently-named file bypasses the path filter.
+    _write(tmp_path / "marts" / "schema.yml", "metrics:\n  - name: sneaky\n")
+    assert naming_guard.find_misplaced(tmp_path) == [tmp_path / "marts" / "schema.yml"]
+
+
+def test_flags_wrong_extension(tmp_path):
+    # sem_ prefix but .yaml: the *.yml path filter and the parser both miss it.
+    _write(tmp_path / "sem_thing.yaml", "semantic_models:\n  - name: m\n")
+    assert naming_guard.find_misplaced(tmp_path) == [tmp_path / "sem_thing.yaml"]
+
+
+def test_ignores_governed_sem_file(tmp_path):
+    _write(tmp_path / "marts" / "sem_users.yml", "metrics:\n  - name: ok\n")
+    assert naming_guard.find_misplaced(tmp_path) == []
+
+
+def test_ignores_ordinary_yaml_without_semantics(tmp_path):
+    # A normal dbt schema/model-properties file (no semantic block) is fine.
+    _write(tmp_path / "marts" / "schema.yml", "models:\n  - name: some_model\n")
+    assert naming_guard.find_misplaced(tmp_path) == []
+
+
+def test_malformed_yaml_does_not_crash(tmp_path):
+    # check-yaml owns syntax errors; the guard must not raise on them.
+    _write(tmp_path / "broken.yml", "metrics: [unclosed\n")
+    assert naming_guard.find_misplaced(tmp_path) == []
+
+
+def test_main_returns_zero_on_clean_repo():
+    assert naming_guard.main() == 0


### PR DESCRIPTION
Closes two gaps found while auditing the governance gate. Both make the existing gate harder to bypass silently; neither changes the metric definitions themselves.

## 1. Enforce the `sem_*.yml` naming convention

The whole gate keys off one filename pattern (`dbt/project/models/**/sem_*.yml`): CODEOWNERS auto-requests the reviewer groups on it, the composition and catalog-freshness checks trigger on it, and the catalog parser reads it. A `semantic_models:`/`metrics:` block in a differently-named file, or a `sem_*.yaml` with the wrong extension, would slip past all of them at once. Reviewers never requested, never catalogued, never announced. There was no backstop, because the parser used the same convention.

- `naming_guard.py` fails when any `.yml`/`.yaml` under `dbt/project/models` defines semantic content but isn't named `sem_*.yml`, turning the convention into an enforced invariant.
- `semantic-layer-file-placement.yml` runs it as a blocking CI job with a **broad** path filter. The violation is a file that is NOT named `sem_*.yml`, so a narrow `sem_*.yml` filter would never fire on the PR that introduces one.
- A pre-push hook mirrors the check locally, following the existing per-directory hook pattern.
- The parser roots are broadened from two hardcoded subdirs to all of `dbt/project/models`, so catalog coverage matches the CODEOWNERS glob exactly. Catalog output is unchanged (freshness check still passes).

## 2. Weekly token-health heartbeat

The gate's accountability rests on two secrets, and both workflows skip cleanly when their token is missing. So a revoked/expired token, or a bot removed from #data-alignment, would silently disable the gate's visibility with no error anywhere.

`semantic-layer-token-health.yml` (weekly + manual dispatch):
- Exercises `ORG_READ_TOKEN` with the exact team-membership call the gate uses; warns when it is within `EXPIRY_WARN_DAYS` (7) of expiring.
- Validates `SLACK_APP_BOT_TOKEN` via `auth.test` and confirms the bot is still a member of #data-alignment.
- On a hard problem, fails the run so GitHub notifies watchers even when Slack itself is the dead integration; also posts a best-effort Slack alert when Slack is healthy.

## Testing

- 304 analytics tests pass; 7 new tests cover the naming guard (real tree, non-`sem_` files, wrong extension, ordinary schema files, malformed YAML).
- Live negative test: a mis-named semantic file fails the guard with a clear rename message.
- Catalog freshness verified byte-identical after the parser broadening.
- Heartbeat: check-yaml passes, `bash -n` clean, expiry date-math and report/exit-code logic verified offline. Its first live run is post-merge (scheduled/dispatch workflows only run from the default branch) - worth a manual `workflow_dispatch` right after merge to confirm both tokens report healthy.

## Follow-up (not in this PR)

Confirm whether `catalog-freshness` and the new `file-placement` job are marked as **required** status checks in branch protection. A failing CI job only blocks merge if it is required; otherwise every gate here, including the ones labeled blocking, is soft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes add CI/guardrails and operational monitoring around existing governance; no metric definitions or runtime data paths are modified.
> 
> **Overview**
> Hardens the semantic-layer governance gate so metrics cannot bypass review/catalog silently, and adds monitoring for the secrets the gate depends on.
> 
> **`sem_*.yml` enforcement:** New `semantic_catalog.naming_guard` fails when any YAML under `dbt/project/models` contains top-level `semantic_models:` or `metrics:` but is not named `sem_*.yml` (including `sem_*.yaml`). It runs in blocking PR CI (`semantic-layer-file-placement.yml` with a broad models YAML path filter) and as a pre-push hook. The catalog CLI now parses all of `dbt/project/models` (not only `marts/analytics` and `marts/civics`) so parser scope matches CODEOWNERS; Slack diff base parsing uses the same root.
> 
> **Token heartbeat:** New weekly (and manual) `semantic-layer-token-health` workflow probes `ORG_READ_TOKEN` via the same GitHub team-membership API the gate uses (with expiry warnings) and validates `SLACK_APP_BOT_TOKEN` plus bot membership in #data-alignment; hard failures fail the job and optionally post to Slack.
> 
> **Tests:** Seven unit tests cover the naming guard edge cases on the real repo tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc206fc191e1f94a7a53aaf569cd49801a8a8375. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->