### PR TITLE
Read raw L2 source as strings; match prod values for the L2 code columns

### DIFF
--- a/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_haystaq_s3_to_databricks.py
@@ -123,10 +123,14 @@ def model(dbt, session: SparkSession) -> DataFrame:
             table_name = _extract_table_name(source_file_type, state_id)
 
             s3_path = f"s3a://{s3_bucket}/{file.s3_state_prefix}{source_file_name}"
+            # Read every column as string (inferSchema=False), matching the main L2 loader. LALVOTERID
+            # is the join key to the uniform table in int__l2_nationwide_uniform_w_haystaq; if this
+            # side inferred it as a number and dropped a leading zero, the join would silently miss
+            # any zero-padded id. Keeping both sides string keeps the keys identical.
             data_df = session.read.options(delimiter="\t").csv(
                 path=s3_path,
                 header=True,
-                inferSchema=True,
+                inferSchema=False,
             )
             data_df = data_df.withColumn("loaded_at", current_timestamp())
 

--- a/dbt/project/models/load/load__l2_s3_to_databricks.py
+++ b/dbt/project/models/load/load__l2_s3_to_databricks.py
@@ -180,10 +180,15 @@ def model(dbt, session: SparkSession) -> DataFrame:
             # set up reader and add loaded_at column
             delimiter = "\t" if source_file_name.endswith(".tab") else ","
             s3_path = f"s3a://{s3_bucket}/{file.s3_state_prefix}{source_file_name}"
+            # Read every column as string (inferSchema=False). The raw L2 files carry zero-padded
+            # codes (ZIPs, ZipPlus4, DPBC, sequence codes) that Spark's type inference silently
+            # coerces to int, dropping leading zeros (e.g. 01854 -> 1854) before any model can see
+            # them. Keeping the source faithful preserves the original strings; downstream models
+            # cast the columns that need a non-string type.
             data_df = session.read.options(delimiter=delimiter).csv(
                 path=s3_path,
                 header=True,
-                inferSchema=True,
+                inferSchema=False,
             )
             data_df = data_df.withColumn("loaded_at", current_timestamp())
 

--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -78,8 +78,9 @@ with
             `Mailing_Families_FamilyID`,
             -- `Mailing_HHGender_Description`,
             `ConsumerData_Marital_Status` as `Marital_Status`,
-            cast(
-                to_date(`Voters_MovedFrom_Date`, 'MM/dd/yyyy') as date
+            coalesce(
+                try_to_date(`Voters_MovedFrom_Date`, 'yyyy-MM-dd'),
+                try_to_date(`Voters_MovedFrom_Date`, 'MM/dd/yyyy')
             ) as `MovedFrom_Date`,
             `Voters_MovedFrom_Party_Description` as `MovedFrom_Party_Description`,
             `Voters_MovedFrom_State` as `MovedFrom_State`,

--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -31,7 +31,7 @@ with
 
             -- Demographics
             `ConsumerData_Business_Owner` as `Business_Owner`,
-            `Voters_CalculatedRegDate` as `CalculatedRegDate`,
+            cast(`Voters_CalculatedRegDate` as date) as `CalculatedRegDate`,
             `CountyEthnic_Description`,
             `CountyEthnic_LALEthnicCode`,
             `Voters_CountyVoterID` as `CountyVoterID`,
@@ -265,7 +265,7 @@ with
             `EXT_District`,
             `Exempted_Village_School_District`,
             `Facilities_Improvement_District`,
-            `Voters_FIPS` as `FIPS`,
+            cast(`Voters_FIPS` as int) as `FIPS`,
             `Fire_District`,
             `Fire_Maintenance_District`,
             `Fire_Protection_District`,

--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -31,7 +31,14 @@ with
 
             -- Demographics
             `ConsumerData_Business_Owner` as `Business_Owner`,
-            cast(`Voters_CalculatedRegDate` as date) as `CalculatedRegDate`,
+            -- The data is ISO (yyyy-MM-dd) across all states, but the L2 spec
+            -- documents MM/dd/yyyy,
+            -- so parse both and keep whichever succeeds (try_to_date returns null,
+            -- never errors).
+            coalesce(
+                try_to_date(`Voters_CalculatedRegDate`, 'yyyy-MM-dd'),
+                try_to_date(`Voters_CalculatedRegDate`, 'MM/dd/yyyy')
+            ) as `CalculatedRegDate`,
             `CountyEthnic_Description`,
             `CountyEthnic_LALEthnicCode`,
             `Voters_CountyVoterID` as `CountyVoterID`,

--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -173,13 +173,24 @@ with
             `Primary_2022`,
             `Primary_2024`,
             `Primary_2026`,
-            `Voters_VotingPerformanceEvenYearGeneral`
-            as `VotingPerformanceEvenYearGeneral`,
-            `Voters_VotingPerformanceEvenYearGeneralAndPrimary`
-            as `VotingPerformanceEvenYearGeneralAndPrimary`,
-            `Voters_VotingPerformanceEvenYearPrimary`
-            as `VotingPerformanceEvenYearPrimary`,
-            `Voters_VotingPerformanceMinorElection` as `VotingPerformanceMinorElection`,
+            -- The int model casts these to double for its other consumers, but prod
+            -- stores them as
+            -- integer text ('42', not '42.0'); round-trip through int so the serving
+            -- text matches.
+            cast(
+                cast(`Voters_VotingPerformanceEvenYearGeneral` as int) as string
+            ) as `VotingPerformanceEvenYearGeneral`,
+            cast(
+                cast(
+                    `Voters_VotingPerformanceEvenYearGeneralAndPrimary` as int
+                ) as string
+            ) as `VotingPerformanceEvenYearGeneralAndPrimary`,
+            cast(
+                cast(`Voters_VotingPerformanceEvenYearPrimary` as int) as string
+            ) as `VotingPerformanceEvenYearPrimary`,
+            cast(
+                cast(`Voters_VotingPerformanceMinorElection` as int) as string
+            ) as `VotingPerformanceMinorElection`,
 
             -- Districts
             `AddressDistricts_Change_Changed_CD`,

--- a/dbt/project/models/write/write__l2_databricks_to_gp_api.py
+++ b/dbt/project/models/write/write__l2_databricks_to_gp_api.py
@@ -1058,6 +1058,15 @@ def model(dbt, session: SparkSession) -> DataFrame:
         for column in INTEGER_COLUMNS:
             df = df.withColumn(column, col(column).try_cast("int"))
 
+        # The source is now all-string (inferSchema=False upstream). This legacy write path has
+        # numeric target columns that an implicit text->numeric insert would reject on an empty
+        # geocoding/age value. try_cast reproduces the double/int values this path already wrote
+        # (empty -> null), so its output is unchanged. Fidelity for the new serving cluster comes
+        # from the loader path, not here.
+        for column in ["Residence_Addresses_Latitude", "Residence_Addresses_Longitude"]:
+            df = df.withColumn(column, col(column).try_cast("double"))
+        df = df.withColumn("Voters_Age", col("Voters_Age").try_cast("int"))
+
         num_rows_loaded = _load_data_to_postgres(
             df=df,
             state_id=state_id,


### PR DESCRIPTION
## The bug

Zero-padded codes lose their leading zeros. An MA ZIP `01854` is stored as `1854`, in both the new cluster **and current prod** (prod green.Voter returns `2191` for a voter that should be `02191`).

## Root cause

`load__l2_s3_to_databricks.py` reads every L2 file with `inferSchema=True`. Spark infers a type per column, so any numeric-looking column is parsed as int/double at ingestion and the leading zero is gone the moment the file is read (confirmed: `dbt_source.l2_s3_ma_uniform.Residence_Addresses_Zip` is `int 1854`). The staging passthrough and the int model's string-cast can't recover a zero that never landed.

## Fix

Read the raw files as all-string (`inferSchema=False`) so the source keeps the exact vendor text, and cast downstream only where a non-string type is needed. This also matches the repo convention that casting belongs downstream, not at the raw read.

## How this maps to the full mismatch list

This PR is the **value-fidelity** half; the loader PR (#707) is the **type** half. Together they cover the full list:

| Group | Type fixed by | Value fixed by |
|---|---|---|
| 8 integer codes (ZIP / ZipPlus4 / DPBC / ethnic / sequence) | #707 → text | **this PR** (flip → string passthrough, leading zeros preserved) |
| lat/long (2) | #707 → text | **this PR** (flip → exact source string, no float reformatting) |
| voting-performance (4) | #707 → text | **this PR** (mart int→string cast → `42`, not `42.0`) |
| election flags (26) | #707 → text | already correct — the int model casts to boolean, which unloads as `true`/`false`, exactly what prod stores |
| District `state`→enum, `created_at`/`updated_at`→timestamp; DistrictStats `district_id`→uuid, `updated_at`→timestamp | #707 | n/a (not value bugs) |

Two Voter columns (`FIPS`, `CalculatedRegDate`) were relying on inference as a passthrough and would regress to text under the flip; this PR casts them explicitly in the mart so they stay int/date. Every other non-text Voter column was already explicitly cast or generated.

## Blast radius — read before merge

- **This re-types the entire L2 source to string**, affecting every L2 consumer, not just people-api. The Voter contract is handled here; the District family is covered by #707's `schema_types_match` guardrail. **All other L2 consumers (haystaq, turnout inference, zip-to-district, deid_voters, the write paths) must be validated with a full `dbt build` before merge** — anything doing numeric ops on a now-string column needs its own cast.
- **Takes effect only after a full L2 re-ingest + mart rebuild + a loader run.** The zeros come back on a fresh read of the `.tab` files, so the existing prod-20260728 cluster needs a rebuild (an in-place ALTER cannot recover them).

No ticket linked yet — please attach the ClickUp ticket.
