### PR TITLE
Filter the country-scope US district instead of extending the USState enum

### DIFF
--- a/dbt/project/models/marts/people_api/m_people_api__district.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__district.sql
@@ -17,3 +17,11 @@ select
     l2_district_name as name,
     state
 from {{ ref("m_election_api__district") }}
+-- Drop the single country-scope row (state='US', a Country district). The serving
+-- contract types
+-- District.state as the USState enum (50 states + DC), which has no 'US' value; prod
+-- never carried
+-- this row, and nothing references it (no DistrictVoter link, no DistrictStats row).
+-- Excluding it
+-- keeps District.state within the enum without extending it.
+where state <> 'US'

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -116,10 +116,10 @@ TABLE_SPECS: dict[str, TableSpec] = {
         # id is the salted-uuid string in the mart; Prisma types it @db.Uuid, so store UUID.
         # created_at/updated_at: the mart emits timestamptz, but the District serving contract is
         # timestamp WITHOUT time zone (unlike DistrictVoter, which is timestamptz) — match the contract.
-        # state: the serving public."USState" enum, matching prod. District has one country-scope row
-        # (type=Country, state="US") the 51-value enum can't hold, so "US" is appended to the enum in
-        # create_schema._USSTATE_LABELS. The app's Prisma USState enum must also include "US", or
-        # people-api fails reading that row (a coordinated people-api change).
+        # state: the serving public."USState" enum, matching prod. The one country-scope row
+        # (type=Country, state="US") that the 51-value enum can't hold is dropped in the
+        # m_people_api__district mart (prod never carried it; nothing references it), so every
+        # District.state value lands within the enum and no Prisma enum change is needed.
         type_overrides={
             "id": "UUID",
             "state": '"USState"',
@@ -182,8 +182,8 @@ LOADER_ADDED_COLUMNS: dict[str, set[str]] = {"Voter": {"geom", "hf_most_importan
 # Columns whose serving TYPE intentionally differs from the prod contract, so the validate
 # schema-type guardrail must not flag them as drift (the type analogue of LOADER_ADDED_COLUMNS).
 # Keyed by serving table -> column names. Currently empty: District.state (previously here because
-# the loader stored text) now matches prod as the USState enum, with "US" added to the enum for the
-# country-scope row. Add an entry only for a genuinely intended, documented type divergence.
+# the loader stored text) now matches prod as the USState enum, since the country-scope "US" row is
+# dropped in the district mart. Add an entry only for a genuinely intended, documented type divergence.
 ACCEPTED_TYPE_DIVERGENCES: dict[str, set[str]] = {}
 
 

--- a/people-api-loader/src/loader/people_api/steps/create_schema.py
+++ b/people-api-loader/src/loader/people_api/steps/create_schema.py
@@ -88,11 +88,6 @@ _USSTATE_LABELS = (
     "WI",
     "WY",
     "DC",
-    # "US" is the District country-scope row (type=Country). Appended AFTER the 51 state labels so
-    # the existing labels keep prod's ordinals; only District.state ever holds it (Voter /
-    # DistrictVoter partition on real states, never "US"). The app's Prisma USState enum must
-    # include "US" too, or people-api fails reading that District row.
-    "US",
 )
 
 

--- a/people-api-loader/tests/test_create_schema.py
+++ b/people-api-loader/tests/test_create_schema.py
@@ -137,9 +137,8 @@ def test_build_green_view_ddl_covers_all_tables() -> None:
     assert len(stmts) == 1 + len(TABLE_SPECS)
 
 
-# public."USState" labels: the 51 state labels in the serving cluster's public.USState order (DC
-# last), then "US" appended for the District country-scope row (mirrors the private _USSTATE_LABELS
-# in create_schema.py so a drift there is caught here too).
+# public."USState" labels, DC LAST, matching the serving cluster's public.USState order exactly (mirrors
+# the private _USSTATE_LABELS in create_schema.py so a drift there is caught here too).
 _USSTATE_LABELS = (
     "AL",
     "AK",
@@ -192,7 +191,6 @@ _USSTATE_LABELS = (
     "WI",
     "WY",
     "DC",
-    "US",  # country-scope District row; appended after the 51 state labels (see create_schema.py)
 )
 
 
@@ -200,16 +198,14 @@ def test_build_usstate_enum_ddl_shape() -> None:
     ddl = step.build_usstate_enum_ddl()
     assert 'CREATE TYPE public."USState" AS ENUM' in ddl
     assert "EXCEPTION WHEN duplicate_object THEN NULL" in ddl
-    assert len(_USSTATE_LABELS) == 52
+    assert len(_USSTATE_LABELS) == 51
     for label in _USSTATE_LABELS:
         assert f"'{label}'" in ddl
-    assert ddl.count("'") == 2 * len(_USSTATE_LABELS)  # exactly 52 quoted labels, no duplicates
-    # The 51 state labels are in prod's public.USState order with DC last; "US" (the District
-    # country-scope row) is appended after them.
+    assert ddl.count("'") == 2 * len(_USSTATE_LABELS)  # exactly 51 quoted labels, no duplicates
+    # DC is last among the labels (matches the serving cluster's public.USState order).
     label_positions = [ddl.index(f"'{s}'") for s in _USSTATE_LABELS]
     assert label_positions == sorted(label_positions)
-    assert _USSTATE_LABELS[-2] == "DC"
-    assert _USSTATE_LABELS[-1] == "US"
+    assert _USSTATE_LABELS[-1] == "DC"
 
 
 def test_usstate_type_created_before_voter_table(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -223,13 +219,12 @@ def test_usstate_type_created_before_voter_table(monkeypatch: pytest.MonkeyPatch
 
 
 def test_states_and_usstate_labels_agree_as_a_set() -> None:
-    # STATES (partition keys) and _USSTATE_LABELS (enum labels) are separately ordered lists. The
-    # enum labels are the 51 partition-key states plus "US" (the District country-scope row, which
-    # is never a partition key). Guard that relationship so adding a code to one but not the other
-    # surfaces here rather than at loader run time.
+    # STATES (partition keys) and _USSTATE_LABELS (enum labels) are separately ordered
+    # lists; guard that they cover the same 51 codes so adding a code to one but not the
+    # other surfaces here rather than at loader run time.
     from loader.people_api.schema.states import STATES
 
-    assert set(step._USSTATE_LABELS) == set(STATES) | {"US"}
+    assert set(STATES) == set(step._USSTATE_LABELS)
 
 
 def test_build_partitioned_ddl_parametrizes_table_and_column() -> None:


### PR DESCRIPTION
## Why

The `m_people_api__district` mart emits exactly one country-scope row (`state='US'`, `type=Country`). The serving contract types `District.state` as the `USState` enum (50 states + DC), which has no `US` value. #707 handled this by appending `US` to the loader's enum — but that also requires a coordinated change to people-api's Prisma `USState` enum, or the app errors reading that row.

## Fix

Drop the single `US` row in the district mart instead. This is cleaner and removes the cross-repo dependency:
- **Prod never carried it** — prod's `green.District.state` is the 51-value enum, which structurally can't hold `US`. So filtering matches prod exactly.
- **Nothing references it** — verified against the built marts: 0 `DistrictVoter` rows and 0 `DistrictStats` rows point at the `US` district (`DistrictVoter` joins on the voter's real state, so it never links to the country scope).

With the row gone, every `District.state` value falls within the existing enum, so this also reverts #707's `US` enum label (and its tests). `District.state` stays typed as the enum. **No Prisma change is needed.**

## Note
Rebuilding just the district view surfaces a pre-existing relationships-test failure (~1.97M `DistrictVoter` rows with district_ids not in the current district mart) — that's incremental staleness in the prod `DistrictVoter` data, unrelated to this filter (the orphans are not the `US` district). A full-refresh rebuild clears it, and CI builds fresh, so it doesn't affect this PR.