### PR TITLE
Disable the retired legacy L2 write path

### DIFF
--- a/dbt/project/models/write/write.yaml
+++ b/dbt/project/models/write/write.yaml
@@ -33,6 +33,10 @@ models:
     description: >
       This model writes data from Databricks to the voter db in gp-api.
     config:
+      # Legacy path to the gp-api voter DB, being retired in favor of the people-api loader. It is
+      # incompatible with the all-string L2 source (its numeric target columns reject text), so
+      # disable it rather than leave it failing every on-merge/CI build.
+      enabled: false
       meta:
         dbt_environment: "{{ env_var('DBT_ENVIRONMENT') }}"
         staging_schema: "{{ env_var('DBT_STAGING_SCHEMA') }}"


### PR DESCRIPTION
## Why

`write__l2_databricks_to_gp_api` writes L2 data to the legacy `gp-api` voter DB, which is being **retired** in favor of the people-api loader. After the L2 ingestion moved to all-string (`inferSchema=False`), this path fails with `DatatypeMismatch` — its target columns are numeric (e.g. `VoterTelephones_LandlineConfidenceCode` is `integer`) and it now sends text, and its cast list only covers 6 columns.

The recurring 12-hour `dbt build` job already excludes this model, so the team already treats it as semi-deprecated. But the **on-merge** job runs it via `state:modified+`, so it's the lone failure on every merge build after the ingestion change.

## Fix

Disable the model (`config: enabled: false`), so it drops out of every build — on-merge, CI, and scheduled — rather than staying permanently red. It's a terminal write with no dbt dependents, so nothing else is affected, and its tests disable with it.

This does not affect the people-api migration, which succeeded independently.