### PR TITLE
Make election_api Person slug globally unique

### DIFF
--- a/dbt/project/macros/slugify.sql
+++ b/dbt/project/macros/slugify.sql
@@ -1,113 +1,35 @@
-{% macro slugify(column_name, keep_hyphens=true) %}
+{% macro slugify(column_name) %}
     {#-
-        Matches npm (slugify package)[https://www.npmjs.com/package/slugify] behavior with lower=true and defaults:
-        - replacement: '-'
-        - lower: true
-        - strict: false
-        - trim: true
-
-        Args:
-            column_name: The column or string expression to slugify
-            keep_hyphens: Boolean to keep existing hyphens (default: true)
+        Slugify one or more column/string expressions into a single lowercase,
+        hyphen-joined slug. Extra positional args are joined with '-'; empty or
+        null fields drop out, so there are no leading, trailing, or doubled
+        hyphens. Matches npm (slugify)[https://www.npmjs.com/package/slugify]
+        with lower=true, replacement='-', strict=false, trim=true.
 
         Example:
             {{ slugify('title') }}
-            {{ slugify('title', keep_hyphens=false) }}
+            {{ slugify('first_name', 'last_name', "left(id, 8)") }}
     -#}
-    {% if keep_hyphens %}
-        trim(
-            both '-/'
-            from  -- trim leading/trailing hyphens and forward slashes
+    {%- set cols = [column_name] + (varargs | list) -%}
+    trim(
+        both '-/'
+        from  -- trim leading/trailing hyphens and forward slashes
+            regexp_replace(
                 regexp_replace(
                     regexp_replace(
                         regexp_replace(
-                            regexp_replace(
-                                lower(trim({{ column_name }})), '[^a-z0-9\\s-/]', ''  -- remove special chars except hyphens and forward slashes
-                            ),
-                            '\\s+',
-                            '-'  -- replace spaces with single hyphen
+                            lower(trim(concat_ws('-', {{ cols | join(", ") }}))),
+                            '[^a-z0-9\\s-/]',
+                            ''  -- remove special chars except hyphens and forward slashes
                         ),
-                        '-{2,}',
-                        '-'  -- collapse multiple hyphens
+                        '\\s+',
+                        '-'  -- replace spaces with single hyphen
                     ),
-                    '/{2,}',
-                    '-'  -- collapse multiple forward slashes (can use '/' instead)
-                )
-        )
-    {% else %}
-        trim(
-            both '-/'
-            from  -- trim leading/trailing hyphens and forward slashes
-                regexp_replace(
-                    regexp_replace(
-                        regexp_replace(
-                            regexp_replace(
-                                lower(trim({{ column_name }})), '[^a-z0-9\\s-/]', ''  -- remove special chars except hyphens and forward slashes
-                            ),
-                            '\\s+',
-                            '-'  -- replace spaces with single hyphen
-                        ),
-                        '-{2,}',
-                        '-'  -- collapse multiple hyphens
-                    ),
-                    '/{2,}',
-                    '-'  -- collapse multiple forward slashes (can use '/' instead)
-                )
-        )
-    {% endif %}
-{% endmacro %}
-
-{% macro generate_candidate_slug(first_name_col, last_name_col, office_name_col=none) %}
-    {#-
-        Generates a candidate slug from first name, last name, and optional office name.
-        This macro creates slugified identifiers for candidates that can be used across models.
-
-        Args:
-            first_name_col: The first name column or expression
-            last_name_col: The last name column or expression
-            office_name_col: Optional office name column for additional context
-
-        Example:
-            {{ generate_candidate_slug('first_name', 'last_name') }}
-            {{ generate_candidate_slug('first_name', 'last_name', 'official_office_name') }}
-    -#}
-    {% if office_name_col %}
-        case
-            when {{ office_name_col }} is not null and {{ office_name_col }} != ''
-            then
-                concat(
-                    {{
-                        slugify(
-                            "concat(coalesce("
-                            + first_name_col
-                            + ", ''), '-', coalesce("
-                            + last_name_col
-                            + ", ''))"
-                        )
-                    }},
-                    '/',
-                    {{ slugify(office_name_col) }}
-                )
-            else
-                {{
-                    slugify(
-                        "concat(coalesce("
-                        + first_name_col
-                        + ", ''), '-', coalesce("
-                        + last_name_col
-                        + ", ''))"
-                    )
-                }}
-        end
-    {% else %}
-        {{
-            slugify(
-                "concat(coalesce("
-                + first_name_col
-                + ", ''), '-', coalesce("
-                + last_name_col
-                + ", ''))"
+                    '-{2,}',
+                    '-'  -- collapse multiple hyphens
+                ),
+                '/{2,}',
+                '-'  -- collapse multiple forward slashes
             )
-        }}
-    {% endif %}
+    )
 {% endmacro %}

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -767,10 +767,12 @@ models:
           - is_uuid
       - name: slug
         description: >
-          slugify(first_name-last_name). Cosmetic URL prefix; NOT NULL but not
-          unique in the API (the trailing UUID disambiguates).
+          slugify(first_name-last_name) with an 8-hex suffix from the person id.
+          The /people/<slug> URL resolves on slug alone, so it is globally
+          unique. If uniqueness ever fails, widen the suffix beyond 8 hex.
         tests:
           - not_null
+          - unique
       - name: br_person_id
         description: "BallotReady person databaseId; null for GP-native people."
 

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -97,7 +97,18 @@ with
 select
     people.gp_person_id as id,
     people.br_person_id_int as br_person_id,
-    {{ slugify("concat_ws('-', people.first_name, people.last_name)") }} as slug,
+    -- Globally unique: the /people/<slug> URL resolves on slug alone (no
+    -- trailing UUID), so every slug carries an 8-hex suffix from the person id.
+    -- Leading trim drops the separator when the name slugifies to empty.
+    trim(
+        leading '-'
+        from
+            concat(
+                {{ slugify("concat_ws('-', people.first_name, people.last_name)") }},
+                '-',
+                left(people.gp_person_id, 8)
+            )
+    ) as slug,
     people.first_name,
     coalesce(br_person.middle_name, office_holder.middle_name) as middle_name,
     people.last_name,

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -99,16 +99,11 @@ select
     people.br_person_id_int as br_person_id,
     -- Globally unique: the /people/<slug> URL resolves on slug alone (no
     -- trailing UUID), so every slug carries an 8-hex suffix from the person id.
-    -- Leading trim drops the separator when the name slugifies to empty.
-    trim(
-        leading '-'
-        from
-            concat(
-                {{ slugify("concat_ws('-', people.first_name, people.last_name)") }},
-                '-',
-                left(people.gp_person_id, 8)
-            )
-    ) as slug,
+    {{
+        slugify(
+            "people.first_name", "people.last_name", "left(people.gp_person_id, 8)"
+        )
+    }} as slug,
     people.first_name,
     coalesce(br_person.middle_name, office_holder.middle_name) as middle_name,
     people.last_name,


### PR DESCRIPTION
## Summary

The public person profile URL is moving to `/people/<slug>` with no trailing UUID (see the paired election-api change adding a unique index on `Person.slug`). That makes the slug the authoritative lookup key, so it must be globally unique. Today the mart emits bare `first-last`, which collides heavily (e.g. one name maps to 82 people), so the unique-index migration cannot apply.

This makes every person slug carry an 8-hex suffix from the person id, enforces uniqueness with a dbt test, and generalizes the `slugify` macro so the whole slug is built in one call.

## Changes

- `m_election_api__person.slug` is now `slugify(first_name, last_name, left(gp_person_id, 8))` — an 8-hex suffix on every row (not only on collision), so a slug only changes if the person's id re-mints, never because a later same-name person appears. Added a `unique` test on `slug`.
- `slugify` is now variadic: it joins any number of column/string expressions with `-` and runs the existing cleaning pipeline, which drops empty/null fields and trims stray hyphens. This removes the need for the manual leading-hyphen trim (the 13 of 507k rows whose names slugify to empty now fall back cleanly to just the hex).
- Dropped `keep_hyphens` (its two branches were identical, so it was a no-op) and the orphaned `generate_candidate_slug` macro (no callers).

## Notes

- The suffix rides `gp_person_id`, minted by the earliest-member rule, so slugs are stable across ETL runs and safe under full refresh. The `unique` test is the real guarantee; if 8 hex ever collides, widen the suffix.
- Unblocks the election-api unique-index migration, which needs Person re-materialized on dev first.

## Testing

`dbt build` passes for all five `slugify`-consuming models (`m_election_api__person`, `m_election_api__candidacy`, `m_election_api__race`, `int__enhanced_place`, `int__geo_id_attributes`), including `unique_m_election_api__person_slug` against ~507k rows.