### PR TITLE
Cast mailing ZIP and ZIP+4 identifier columns to string

### DIFF
--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
@@ -91,6 +91,9 @@ PERFORMANCE_PERCENTAGE_COLUMNS = [
 # leading zeros are preserved (e.g. a New Jersey ZIP 08731 is not stored as 8731).
 IDENTIFIER_STRING_COLUMNS = [
     "Residence_Addresses_Zip",
+    "Residence_Addresses_ZipPlus4",
+    "Mailing_Addresses_Zip",
+    "Mailing_Addresses_ZipPlus4",
     "Precinct",
     "State_House_District",
     "State_Legislative_District",


### PR DESCRIPTION
## Why

`int__l2_nationwide_uniform` pins identifier/code columns to STRING before the 51-state union so leading zeros survive (e.g. a ZIP `08731` isn't coerced to `8731`). `Residence_Addresses_Zip` was in that list, but three sibling columns of the same class were not:

- `Residence_Addresses_ZipPlus4`
- `Mailing_Addresses_Zip`
- `Mailing_Addresses_ZipPlus4`

They currently surface in `m_people_api__voter` as INT with stripped leading zeros. These are codes, not quantities, so this adds them to `IDENTIFIER_STRING_COLUMNS` for consistent, deterministic string typing.

## Note on rollout

This cast only takes effect once the L2 `stg_dbt_source__l2_s3_*_uniform` views are recreated (they are Databricks schema-bound to the old INT types and sit outside `state:modified+`, so they were never rebound after the `inferSchema=False` source fix) and int → snapshot → marts are full-refreshed from that corrected staging. The recreate-staging + downstream full-refresh is run as a separate prod operation alongside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
