### PR TITLE
[DATA-2197] Correct hubspot_contact_id for gp_api candidacies

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_gp_api.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_gp_api.sql
@@ -21,6 +21,13 @@ with
     -- exist in the users mart (matches candidate_gp_api's user filter).
     users as (select user_id from {{ ref("users") }}),
 
+    -- hubspotid lives in the user's meta_data JSON (a real HubSpot CONTACT id),
+    -- not on the users mart. Mirrors int__civics_candidate_gp_api.
+    user_hubspot as (
+        select id as user_id, meta_data:hubspotid::string as hubspot_contact_id
+        from {{ ref("stg_airbyte_source__gp_api_db_user") }}
+    ),
+
     person_ids as (
         select record_key, gp_person_id
         from {{ ref("int__civics_person_canonical_ids") }}
@@ -74,6 +81,7 @@ with
         select
             c.campaign_id,
             c.user_id,
+            uh.hubspot_contact_id,
             c.hubspot_id,
             c.is_verified,
             c.is_pledged,
@@ -100,6 +108,7 @@ with
         inner join users as u on c.user_id = u.user_id
         left join
             person_ids as p on 'gp_api|' || cast(c.user_id as string) = p.record_key
+        left join user_hubspot as uh on c.user_id = uh.user_id
     ),
 
     candidacies_with_ids as (
@@ -143,7 +152,7 @@ with
             ) as gp_election_id,
 
             campaign_id as product_campaign_id,
-            hubspot_id as hubspot_contact_id,
+            hubspot_contact_id,
             case
                 when hubspot_id is not null then to_json(array(hubspot_id))
             end as hubspot_company_ids,

--- a/dbt/project/tests/assert_candidacy_hubspot_company_ids_populated.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_company_ids_populated.sql
@@ -1,8 +1,7 @@
 -- A candidacy whose gp_api campaign carries a HubSpot company id must surface it
 -- as hubspot_company_ids. gp_api stores the HubSpot COMPANY id on the campaign;
 -- the mart must expose it. Failures mean the company id was dropped for current
--- candidacies. (The gp_api model currently carries that company id in its
--- hubspot_contact_id column; correcting that label is tracked separately.)
+-- candidacies.
 select cand.gp_candidacy_id
 from {{ ref("candidacy") }} as cand
 where
@@ -12,5 +11,6 @@ where
         from {{ ref("int__civics_candidacy_gp_api") }} as gp
         where
             gp.product_campaign_id = cand.product_campaign_id
-            and gp.hubspot_contact_id is not null
+            and gp.hubspot_company_ids is not null
+            and trim(gp.hubspot_company_ids) not in ('', '[]')
     )

--- a/dbt/project/tests/assert_candidacy_hubspot_contact_id_not_a_company.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_contact_id_not_a_company.sql
@@ -1,0 +1,8 @@
+-- hubspot_contact_id must reference a HubSpot CONTACT, never a company. gp_api
+-- candidacies previously stored the campaign's HubSpot company id here; this
+-- test fails on any candidacy whose hubspot_contact_id matches a company id.
+select cand.gp_candidacy_id
+from {{ ref("candidacy") }} as cand
+inner join
+    {{ ref("stg_airbyte_source__hubspot_api_companies") }} as co
+    on co.id = cand.hubspot_contact_id


### PR DESCRIPTION
## What this does

Corrects a mislabel in `int__civics_candidacy_gp_api` (DATA-2197, follow-up to the merged DATA-2196 / #719).

For gp_api (post-2026) candidacies, `hubspot_contact_id` held the campaign's HubSpot **company** id, not a contact id — the model did `hubspot_id as hubspot_contact_id`, where `hubspot_id` is the campaign's `data:hubspotid` (a company id, verified: 56,240 company matches / 0 contacts). This PR sources the **user's real HubSpot contact id** (`meta_data:hubspotid`) instead, mirroring how `int__civics_candidate_gp_api` already derives its `hubspot_contact_id`. The company id stays where #719 put it, in `hubspot_company_ids`.

## Verification (against production)

- `meta_data:hubspotid` is a real contact id: 60,193 HubSpot contact matches / 0 company.
- After the fix, of 40,828 gp_api-linked candidacies, **40,247 carry a real contact id and 0 match a company** (581/1.4% have no HubSpot contact → null).
- Reproduce test `assert_candidacy_hubspot_contact_id_not_a_company` (candidacies whose `hubspot_contact_id` matches a company id): **11,544 → 0**.

## Downstream (verified, no code changes)

- **prospects**: its main lookup reads `candidate.hubspot_contact_id`, which was already a real contact id (never mislabeled), so grain/population/uniqueness are unaffected. The candidacy fix only feeds the win-flag join, which now resolves correctly (company ids never matched a contact) — an attribution improvement.
- **candidacy_techspeed** (reverse-ETL to TechSpeed): the `hubspot_contact_id is null` "not already in HubSpot" guard is the only touchpoint. The fix flips 182 mislabeled candidacies to eligible; only 6 pass the coarse eligibility filters, and the 16-day window, email-match guard, and sent-log anti-join reduce it further. These are candidacies genuinely not in HubSpot and missing contact info — exactly what the enrichment feed targets. Outward-facing but minimal and more correct.
- **candidate**: uses its own already-real contact id; unaffected.

## Testing and CI note

`int__civics_candidacy_gp_api` materializes 0 rows in a partial local build (pre-existing production-deferral staleness in its upstream inner join to `int__civics_candidate_gp_api`, untouched here), so local candidacy tests are vacuous and a downstream `relationships` test fails locally only. Not a regression; verified against production instead. The reproduce test passes once the full DAG builds in production.

## candidacy_scored coverage (production)

In the current production build, `candidacy_scored` carries a populated `hubspot_company_ids` on **42,801** rows (identical to `candidacy`; populated by DATA-2196 / #719) and a `hubspot_contact_id` on 164,590 rows. This PR corrects those `hubspot_contact_id` values for gp_api rows — from the campaign company id to the user's real contact id.

## Data validation: HubSpot company id + score (before/after)

Scope: since-2026 gp_api (app) candidacies (`int__civics_candidacy_gp_api`) — the population that DATA-2196 (#719, company id) and DATA-2197 (this PR, contact id) affect. Reconstructed from source tables, so the numbers hold regardless of which fix is deployed.

| metric (n ≈ 11,858) | before (pre-2196 & 2197) | after (both) |
|---|---|---|
| `hubspot_company_ids` populated | 0 | 11,836 |
| `hubspot_contact_id` = a HubSpot **company** id (mislabel) | 11,836 | 0 |
| `hubspot_contact_id` = a real HubSpot **contact** id | 0 | 11,668 |
| `viability_score` present | 11,844 | 11,844 |
| company id **and** score both present | 0 | 11,822 |

The viability score is computed independently of the HubSpot linkage, so the scored count (~11,844) is unchanged by either fix. DATA-2196 is what puts the company id *alongside* the score (0 → 11,822).

**Per-candidacy lookup** (company id + contact id + score):

```sql
select
    gp_candidacy_id,
    hubspot_company_ids,        -- DATA-2196: the campaign's HubSpot company id
    hubspot_contact_id,         -- DATA-2197: the user's real HubSpot contact id
    viability_score,
    score_viability_automated
from goodparty_data_catalog.mart_civics.candidacy_scored
where product_campaign_id is not null;   -- app (gp_api) candidacies
```

**Before/after aggregate** (reconstructed from source, deploy-state independent):

```sql
with gp as (   -- since-2026 gp_api candidacies
    select product_campaign_id
    from goodparty_data_catalog.dbt.int__civics_candidacy_gp_api
),
camp as (
    select campaign_id, hubspot_id as company_id, user_id
    from goodparty_data_catalog.mart_civics.campaigns
    where is_latest_version
    qualify row_number() over (partition by campaign_id order by updated_at desc) = 1
),
usr as (
    select id as user_id, meta_data:hubspotid::string as contact_id
    from goodparty_data_catalog.dbt.stg_airbyte_source__gp_api_db_user
),
scored as (
    select product_campaign_id, max(viability_score) as viability_score
    from goodparty_data_catalog.mart_civics.candidacy_scored
    where product_campaign_id is not null
    group by product_campaign_id
)
select
    count(*)                       as gp_api_candidacies,
    -- DATA-2196: hubspot_company_ids  (BEFORE = 0; the mart read BallotReady's null)
    count(camp.company_id)         as company_id_after,
    -- DATA-2197: hubspot_contact_id
    count(camp.company_id)         as contact_id_before_was_a_company,
    count(usr.contact_id)          as contact_id_after_real_contact,
    -- viability score (unchanged by either fix)
    count(scored.viability_score)  as with_score
from gp
left join camp   on camp.campaign_id       = gp.product_campaign_id
left join usr    on usr.user_id            = camp.user_id
left join scored on scored.product_campaign_id = gp.product_campaign_id;
```

## Tickets

- DATA-2197 (this fix)
- DATA-2196 / #719 (populated `hubspot_company_ids`; already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


