### PR TITLE
Parse OfficialRegDate like the other reg-date columns

### DIFF
--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -85,7 +85,13 @@ with
             `Voters_MovedFrom_Party_Description` as `MovedFrom_Party_Description`,
             `Voters_MovedFrom_State` as `MovedFrom_State`,
             `Voters_NameSuffix` as `NameSuffix`,
-            `Voters_OfficialRegDate` as `OfficialRegDate`,
+            -- Same date handling as CalculatedRegDate/MovedFrom_Date: raw L2 is a
+            -- string, so parse ISO and MM/dd/yyyy and keep whichever succeeds,
+            -- otherwise the leading-zero source fix leaves this as a raw string.
+            coalesce(
+                try_to_date(`Voters_OfficialRegDate`, 'yyyy-MM-dd'),
+                try_to_date(`Voters_OfficialRegDate`, 'MM/dd/yyyy')
+            ) as `OfficialRegDate`,
             `Parties_Description`,
             `Voters_PlaceOfBirth` as `PlaceOfBirth`,
             `ConsumerData_Presence_Of_Children_in_HH` as `Presence_Of_Children`,


### PR DESCRIPTION
## Why

`m_people_api__voter` parses `CalculatedRegDate` and `MovedFrom_Date` from the raw L2 string (coalesce of ISO and `MM/dd/yyyy`, added when the source moved to all-string for the leading-zero fix). `OfficialRegDate` was left as a raw passthrough, so post-fix it surfaces as a `MM/dd/yyyy` string while its two sibling reg-date columns are real dates — an inconsistency for the people-api serving layer.

This applies the same coalesce parse so all three served reg-date columns are proper dates.

## Rollout

Takes effect on the next full-refresh of `m_people_api__voter`, which is the same rebuild that recreates the freshly-dropped L2 snapshot and lands the leading-zero fix. No separate run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
