### PR TITLE
Bump loader cache-bust to reinstall from @main

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # Pinned to @main so the loader co-versions with the DAG on main and survives feature-branch
 # deletion post-merge.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-28.1
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-30.1
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This


### PR DESCRIPTION
## Why

The Astro image installs `people-api-loader` from `git @main`, and the pip install layer is cached on `airflow/astro/requirements.txt`. Because the pin is `@main` (not a commit SHA), an unchanged file means the image keeps whatever loader was installed at the last image build — even after `@main` moves.

Bumping the cache-bust token (`2026-07-28.1` → `2026-07-30.1`) invalidates that layer so the next `astro deploy` reinstalls the loader from current `@main`, which carries the serving `type_overrides` that stamp the people-api contract types (Voter columns → TEXT, District/DistrictStats enum/uuid/timestamp). This is in prep for rebuilding the prod people-api cluster against the corrected mart.

## Note

Merging does not deploy — `airflow.yml` only runs tests. A manual `astro deploy` (buildx + `DOCKER_BUILDKIT=1`) is still required afterward to push the rebuilt image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
