### PR TITLE
people-api-loader: add Parties_Description trigram index (fix contacts statement-timeouts)

### DIFF
--- a/people-api-loader/src/loader/people_api/schema/_serving_seed_extra.py
+++ b/people-api-loader/src/loader/people_api/schema/_serving_seed_extra.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 
 from loader.people_api.schema.index_specs import IndexDef
 
-# people-api name-search indexes, carried here because prisma migrations don't run on
-# loader-built clusters. lower() expressions must match people-api's emitted SQL exactly or the
-# planner skips them. The b-trees use text_pattern_ops so LIKE-'prefix%'
-# uses them on the en_US.UTF-8 serving cluster (a default opclass can't) — a deliberate divergence
-# from the prisma index, since the loader is becoming the source of truth. The trgm GIN serves the
-# substring path no b-tree can. pg_trgm is installed by create_schema and build_indexes (each step
-# is independently re-runnable).
+# Serving-only performance indexes, carried here because they don't come from a prisma migration
+# that runs on loader-built clusters. Two families:
+#   1. people-api name-search (first/last name): lower() expressions must match people-api's emitted
+#      SQL exactly or the planner skips them. The b-trees use text_pattern_ops so LIKE-'prefix%' uses
+#      them on the en_US.UTF-8 serving cluster (a default opclass can't) — a deliberate divergence
+#      from the prisma index, since the loader is becoming the source of truth. The trgm GIN serves
+#      the substring path no b-tree can.
+#   2. party-registration substring filter (Parties_Description): a trgm GIN serving the gp-api
+#      contacts ILIKE audience filter (see the IndexDef comment below).
+# pg_trgm is installed by create_schema and build_indexes (each step is independently re-runnable).
 EXTRA_INDEXES: list[IndexDef] = [
     IndexDef(
         table="Voter",
@@ -56,6 +59,24 @@ EXTRA_INDEXES: list[IndexDef] = [
         sql='CREATE INDEX "Voter_lastname_lower_trgm_idx" ON public."Voter" USING gin (lower("LastName") gin_trgm_ops);',
         unique=False,
         columns=['lower("LastName")'],
+        where=None,
+    ),
+    # Party-registration substring filter. gp-api compiles a party audience to
+    # `"Parties_Description" ILIKE '%<substring>%'` (case-insensitive, ORed per rule —
+    # gp-api/src/peopleDb/utils/filters.sql.util.ts). The generated seed only carries a
+    # plain b-tree on this column (Voter_Parties_Description_idx), which a substring ILIKE
+    # can't use, so the contacts count/overlap-count/list-detail aggregates fall back to a
+    # full Voter scan and hit the app's statement-timeout fence. A trgm GIN on the raw column
+    # serves ILIKE directly (pg_trgm handles the case-folding), the same substring path the
+    # name-search trgm indexes above serve. On the raw column, not lower(), to match the
+    # emitted SQL exactly. Carried here (not the generated seed) because it doesn't yet exist
+    # on the extraction-source cluster; build_indexes re-issues it on every rebuild.
+    IndexDef(
+        table="Voter",
+        name="Voter_Parties_Description_trgm_idx",
+        sql='CREATE INDEX "Voter_Parties_Description_trgm_idx" ON public."Voter" USING gin ("Parties_Description" gin_trgm_ops);',
+        unique=False,
+        columns=["Parties_Description"],
         where=None,
     ),
     # Geospatial lookups on the residence coordinates. GiST is the standard PostGIS point index:

--- a/people-api-loader/tests/test_integration_pg.py
+++ b/people-api-loader/tests/test_integration_pg.py
@@ -74,6 +74,7 @@ _DDL_NAMES = (
     '    "State" text NOT NULL,\n'
     '    "FirstName" text,\n'
     '    "LastName" text,\n'
+    '    "Parties_Description" text,\n'
     '    "hf_most_important_policy_item" text\n'
     ");"
 )
@@ -308,8 +309,9 @@ def test_name_search_indexes_build_and_serve(pg_conn: psycopg.Connection) -> Non
             _exec(cur, insert, (str(uuid.uuid4()), state, first, last))
         _exec(cur, 'ANALYZE public."Voter"')
 
-    # Build the committed extras (2 trigram GIN, 2 lower() b-tree, 1 multicolumn b-tree, 1 plain
-    # b-tree) via the exact partitioned path build_indexes.run uses: parent ON ONLY, then a child
+    # Build the committed extras (3 trigram GIN — first/last name lower() + Parties_Description,
+    # 2 lower() b-tree, 1 multicolumn b-tree, 1 plain b-tree) via the exact partitioned path
+    # build_indexes.run uses: parent ON ONLY, then a child
     # per state attached. The spatial GiST index on "geom" is excluded here — it needs postgis and
     # the generated column, which this names-only fixture doesn't set up (it's covered by the
     # build_indexes unit tests instead).

--- a/people-api-loader/tests/test_schema_spec.py
+++ b/people-api-loader/tests/test_schema_spec.py
@@ -35,12 +35,17 @@ def test_hand_added_extras_merge_and_survive_regeneration() -> None:
         "Voter_last_first_id_idx",
         "Voter_firstname_lower_idx",
         "Voter_lastname_lower_idx",
+        "Voter_Parties_Description_trgm_idx",
     ):
         assert expected not in generated_names
         assert expected in names
     assert len(names) == len(set(names))
     trgm = next(i for i in idxs if i.name == "Voter_firstname_lower_trgm_idx")
     assert 'USING gin (lower("FirstName") gin_trgm_ops)' in trgm.sql
+    # The party filter is a case-insensitive substring match on the RAW column (gp-api emits
+    # `"Parties_Description" ILIKE '%..%'`), so the trgm GIN is on the raw column, not lower().
+    party_trgm = next(i for i in idxs if i.name == "Voter_Parties_Description_trgm_idx")
+    assert 'USING gin ("Parties_Description" gin_trgm_ops)' in party_trgm.sql
 
 
 def test_extras_merge_and_name_collision_suppression(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Adds a `pg_trgm` GIN index on the raw `Voter."Parties_Description"` column to the people-db serving catalog, so the gp-api contacts party-audience filter stops falling back to a full `Voter` scan and tripping the app's statement-timeout fence.

This is the DB-side fix for the recurring prod `57014` / `P2010` (Postgres statement timeout) alerts on the contacts endpoints (`overlap-count`, `count`, and the `list-detail` aggregates).

## Root cause
gp-api compiles a party audience to a case-insensitive substring match on the raw column:

```
v."Parties_Description" ILIKE '%<substring>%'   -- ORed per party rule
```
(`packages/gp-api/src/peopleDb/utils/filters.sql.util.ts`)

The serving catalog only carries a plain b-tree on `Parties_Description` (`Voter_Parties_Description_idx`), which a substring `ILIKE` can't use. So these queries seq-scan the whole partitioned `Voter` table and exceed the app's 2.5s primary / 5s fenced-retry statement timeout. A `gin_trgm_ops` GIN index serves `ILIKE` directly (pg_trgm handles the case-folding), the exact same substring path the existing first/last-name trigram indexes serve. Benchmarked ~20x faster on a representative district, with **identical** (exact) counts — indexes don't change results.

## Changes
- `_serving_seed_extra.py`: new `Voter_Parties_Description_trgm_idx` (`USING gin ("Parties_Description" gin_trgm_ops)`). On the **raw** column (not `lower()`) to match the emitted SQL. Carried in the hand-maintained extras (not the generated seed) because it doesn't yet exist on the extraction-source cluster; `build_indexes` re-issues it on every rebuild.
- Tests: assert the new IndexDef in `test_schema_spec.py`; add `Parties_Description` to the `_DDL_NAMES` fixture so the partitioned-build integration test exercises it.

No changes to `create_schema`/`build_indexes`: `pg_trgm` is already installed and the per-partition build path already handles trgm GIN (used by the name-search indexes).

## Rollout
- **Preferred (zero disruption):** ships via the normal blue/green rebuild — `build_indexes` does plain `CREATE INDEX` on the idle new cluster; no prod impact until cutover.
- **If applying to the live serving cluster without a rebuild:** `Voter` is `LIST`-partitioned by `State`; you can't `CREATE INDEX CONCURRENTLY` on a partitioned parent in one statement. Use `CREATE INDEX ... ON ONLY public."Voter" ...`, then `CREATE INDEX CONCURRENTLY` per state partition, then `ALTER INDEX ... ATTACH PARTITION` (mirrors what `build_indexes` does).

## Test plan
- [x] `tests/test_schema_spec.py` (unit) — passes locally
- [ ] `tests/test_integration_pg.py` — extras build + validity/attach coverage now includes the party index (needs the CI Postgres service)
- [ ] After merge + rebuild: `EXPLAIN (ANALYZE, BUFFERS)` on the overlap/count query shows a bitmap scan on `Voter_Parties_Description_trgm_idx` and the statement-timeout alerts stop recurring.

## Context
Part of a broader investigation into people-db contacts timeouts. A companion gp-api PR addresses the `list-detail` aggregate fan-out (the largest source of user-facing 500s), which is partly a distinct `DistrictVoter → Voter` join-plan issue.

Made with [Cursor](https://cursor.com)