### PR TITLE
Fix FIPS and audit-timestamp serving types to match prod

### DIFF
--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform.py
@@ -91,6 +91,7 @@ PERFORMANCE_PERCENTAGE_COLUMNS = [
 # leading zeros are preserved (e.g. a New Jersey ZIP 08731 is not stored as 8731).
 IDENTIFIER_STRING_COLUMNS = [
     "Residence_Addresses_Zip",
+    "Voters_FIPS",
     "Residence_Addresses_ZipPlus4",
     "Mailing_Addresses_Zip",
     "Mailing_Addresses_ZipPlus4",

--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -290,7 +290,7 @@ with
             `EXT_District`,
             `Exempted_Village_School_District`,
             `Facilities_Improvement_District`,
-            cast(`Voters_FIPS` as int) as `FIPS`,
+            `Voters_FIPS` as `FIPS`,
             `Fire_District`,
             `Fire_Maintenance_District`,
             `Fire_Protection_District`,

--- a/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
+++ b/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
@@ -74,7 +74,7 @@ CREATE TABLE public."Voter" (
     "Veteran_Status" TEXT,
     "VoterParties_Change_Changed_Party" TEXT,
     "Voter_Status" TEXT,
-    "Voter_Status_UpdatedAt" TIMESTAMPTZ,
+    "Voter_Status_UpdatedAt" TIMESTAMP,
     "VoterTelephones_CellConfidenceCode" INTEGER,
     "VoterTelephones_CellPhoneFormatted" TEXT,
     "VoterTelephones_LandlineConfidenceCode" INTEGER,
@@ -192,7 +192,7 @@ CREATE TABLE public."Voter" (
     "EXT_District" TEXT,
     "Exempted_Village_School_District" TEXT,
     "Facilities_Improvement_District" TEXT,
-    "FIPS" INTEGER,
+    "FIPS" TEXT,
     "Fire_District" TEXT,
     "Fire_Maintenance_District" TEXT,
     "Fire_Protection_District" TEXT,
@@ -351,8 +351,8 @@ CREATE TABLE public."Voter" (
     "Water_SubDistrict" TEXT,
     "Weed_District" TEXT,
     "hf_most_important_policy_item" TEXT,
-    "created_at" TIMESTAMPTZ,
-    "updated_at" TIMESTAMPTZ,
+    "created_at" TIMESTAMP,
+    "updated_at" TIMESTAMP,
     "Mailing_HHGender_Description" TEXT
 );
 
@@ -377,6 +377,6 @@ CREATE TABLE public."DistrictVoter" (
     "voter_id" UUID,
     "district_id" UUID,
     "State" "USState",
-    "created_at" TIMESTAMPTZ,
-    "updated_at" TIMESTAMPTZ
+    "created_at" TIMESTAMP,
+    "updated_at" TIMESTAMP
 );

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -107,6 +107,11 @@ TABLE_SPECS: dict[str, TableSpec] = {
             "VotingPerformanceEvenYearGeneralAndPrimary": "TEXT",
             "VotingPerformanceEvenYearPrimary": "TEXT",
             "VotingPerformanceMinorElection": "TEXT",
+            # created_at/updated_at/Voter_Status_UpdatedAt: mart emits timestamptz, but the Voter
+            # serving contract is timestamp WITHOUT time zone (like District/DistrictStats) — match it.
+            "created_at": "TIMESTAMP",
+            "updated_at": "TIMESTAMP",
+            "Voter_Status_UpdatedAt": "TIMESTAMP",
         },
         extra_columns=[("Mailing_HHGender_Description", "TEXT", True)],
     ),
@@ -115,7 +120,7 @@ TABLE_SPECS: dict[str, TableSpec] = {
         partition_by=None,
         # id is the salted-uuid string in the mart; Prisma types it @db.Uuid, so store UUID.
         # created_at/updated_at: the mart emits timestamptz, but the District serving contract is
-        # timestamp WITHOUT time zone (unlike DistrictVoter, which is timestamptz) — match the contract.
+        # timestamp WITHOUT time zone (as for Voter/DistrictVoter/DistrictStats) — match the contract.
         # state: the serving public."USState" enum, matching prod. The one country-scope row
         # (type=Country, state="US") that the 51-value enum can't hold is dropped in the
         # m_people_api__district mart (prod never carried it; nothing references it), so every
@@ -155,8 +160,10 @@ TABLE_SPECS: dict[str, TableSpec] = {
         type_overrides={
             "district_id": "UUID",
             "voter_id": "UUID",
-            "created_at": "TIMESTAMPTZ",
-            "updated_at": "TIMESTAMPTZ",
+            # timestamp WITHOUT time zone, matching the prod contract (same as District/DistrictStats;
+            # the mart emits timestamptz).
+            "created_at": "TIMESTAMP",
+            "updated_at": "TIMESTAMP",
             # the serving public."USState" enum, matching Voter/District.
             "state": '"USState"',
         },
@@ -181,10 +188,11 @@ LOADER_ADDED_COLUMNS: dict[str, set[str]] = {"Voter": {"geom", "hf_most_importan
 
 # Columns whose serving TYPE intentionally differs from the prod contract, so the validate
 # schema-type guardrail must not flag them as drift (the type analogue of LOADER_ADDED_COLUMNS).
-# Keyed by serving table -> column names. Currently empty: District.state (previously here because
-# the loader stored text) now matches prod as the USState enum, since the country-scope "US" row is
-# dropped in the district mart. Add an entry only for a genuinely intended, documented type divergence.
-ACCEPTED_TYPE_DIVERGENCES: dict[str, set[str]] = {}
+# Keyed by serving table -> column names.
+# Voter.State: served as the public."USState" enum (matching District/DistrictVoter and swain-db, so
+# the app needs no code change — the 2026-07-21 decision), while the current prod baseline still
+# stores Voter."State" as text. This is an intended forward migration, not drift.
+ACCEPTED_TYPE_DIVERGENCES: dict[str, set[str]] = {"Voter": {"State"}}
 
 
 def is_partitioned(table: str) -> bool:

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -100,6 +100,8 @@ TABLE_SPECS: dict[str, TableSpec] = {
             "CountyEthnic_LALEthnicCode": "TEXT",
             "SequenceOddEven": "TEXT",
             "SequenceZigZag": "TEXT",
+            # 3-digit code (001-840) — text so the leading zero survives (the mart keeps it raw too).
+            "FIPS": "TEXT",
             # geo coordinates + voting-performance scores (mart double precision -> contract text)
             "Residence_Addresses_Latitude": "TEXT",
             "Residence_Addresses_Longitude": "TEXT",

--- a/people-api-loader/tests/test_emit_ddl.py
+++ b/people-api-loader/tests/test_emit_ddl.py
@@ -82,6 +82,10 @@ def test_render_voter_forces_contract_types_to_text() -> None:
         MartColumn(name="VotingPerformanceMinorElection", spark_type="double", nullable=True),
         # 3-digit FIPS code: int-inferred by the mart, must stay TEXT so leading zeros survive.
         MartColumn(name="FIPS", spark_type="int", nullable=True),
+        # audit/status timestamps: timestamp-inferred (-> TIMESTAMPTZ) but overridden to TIMESTAMP.
+        MartColumn(name="created_at", spark_type="timestamp", nullable=False),
+        MartColumn(name="updated_at", spark_type="timestamp", nullable=False),
+        MartColumn(name="Voter_Status_UpdatedAt", spark_type="timestamp", nullable=True),
     ]
     ddl = render_create_table(TABLE_SPECS["Voter"], cols)
     for col in (
@@ -93,8 +97,11 @@ def test_render_voter_forces_contract_types_to_text() -> None:
         "FIPS",
     ):
         assert f'"{col}" TEXT' in ddl
+    for col in ("created_at", "updated_at", "Voter_Status_UpdatedAt"):
+        assert f'"{col}" TIMESTAMP' in ddl
     # none of the mart-inferred types may survive the override
     assert "BOOLEAN" not in ddl and "INTEGER" not in ddl and "DOUBLE PRECISION" not in ddl
+    assert "TIMESTAMPTZ" not in ddl
 
 
 def test_render_district_family_matches_contract_types() -> None:

--- a/people-api-loader/tests/test_emit_ddl.py
+++ b/people-api-loader/tests/test_emit_ddl.py
@@ -80,6 +80,8 @@ def test_render_voter_forces_contract_types_to_text() -> None:
         MartColumn(name="SequenceZigZag", spark_type="int", nullable=True),
         MartColumn(name="Residence_Addresses_Latitude", spark_type="double", nullable=True),
         MartColumn(name="VotingPerformanceMinorElection", spark_type="double", nullable=True),
+        # 3-digit FIPS code: int-inferred by the mart, must stay TEXT so leading zeros survive.
+        MartColumn(name="FIPS", spark_type="int", nullable=True),
     ]
     ddl = render_create_table(TABLE_SPECS["Voter"], cols)
     for col in (
@@ -88,6 +90,7 @@ def test_render_voter_forces_contract_types_to_text() -> None:
         "SequenceZigZag",
         "Residence_Addresses_Latitude",
         "VotingPerformanceMinorElection",
+        "FIPS",
     ):
         assert f'"{col}" TEXT' in ddl
     # none of the mart-inferred types may survive the override

--- a/people-api-loader/tests/test_emit_ddl.py
+++ b/people-api-loader/tests/test_emit_ddl.py
@@ -44,8 +44,8 @@ def test_render_districtvoter_projects_and_renames_to_serving_shape() -> None:
         '    "voter_id" UUID NOT NULL,\n'
         '    "district_id" UUID NOT NULL,\n'
         '    "State" "USState" NOT NULL,\n'
-        '    "created_at" TIMESTAMPTZ NOT NULL,\n'
-        '    "updated_at" TIMESTAMPTZ NOT NULL\n'
+        '    "created_at" TIMESTAMP NOT NULL,\n'
+        '    "updated_at" TIMESTAMP NOT NULL\n'
         ");"
     )
     # denormalized-only mart columns are dropped, and lowercase "state" never appears

--- a/people-api-loader/tests/test_schema_spec.py
+++ b/people-api-loader/tests/test_schema_spec.py
@@ -105,8 +105,8 @@ def test_districtvoter_spec() -> None:
     assert spec.type_overrides == {
         "district_id": "UUID",
         "voter_id": "UUID",
-        "created_at": "TIMESTAMPTZ",
-        "updated_at": "TIMESTAMPTZ",
+        "created_at": "TIMESTAMP",
+        "updated_at": "TIMESTAMP",
         "state": '"USState"',
     }
     # The other tables' marts already match serving -> no column map.

--- a/people-api-loader/tests/test_validate.py
+++ b/people-api-loader/tests/test_validate.py
@@ -480,8 +480,9 @@ def test_check_schema_types_mismatch_fails(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_check_schema_types_accepted_divergence_not_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A registered ACCEPTED_TYPE_DIVERGENCES column is skipped even when its type differs. The real
-    # registry is currently empty, so patch in an entry to exercise the mechanism.
+    # A registered ACCEPTED_TYPE_DIVERGENCES column is skipped even when its type differs. Patch in a
+    # synthetic entry to exercise the mechanism; the real registry is guarded by
+    # test_accepted_type_divergences_pins_voter_state below.
     monkeypatch.setattr(step, "ACCEPTED_TYPE_DIVERGENCES", {"Voter": {"legacy_col"}})
     prod = [("legacy_col", "text"), ("id", "uuid")]
     new = [("legacy_col", "int4"), ("id", "uuid")]
@@ -491,6 +492,14 @@ def test_check_schema_types_accepted_divergence_not_flagged(monkeypatch: pytest.
     assert check.passed is True
     assert check.details["accepted_divergences"] == ["legacy_col"]
     assert "legacy_col" not in check.details["mismatches"]
+
+
+def test_accepted_type_divergences_pins_voter_state() -> None:
+    # Voter.State is served as the USState enum while the prod baseline is still text; the entry must
+    # stay in the real registry or schema_types_match:Voter hard-fails every load.
+    from loader.people_api.schema.schema_spec import ACCEPTED_TYPE_DIVERGENCES
+
+    assert "State" in ACCEPTED_TYPE_DIVERGENCES.get("Voter", set())
 
 
 def test_check_schema_types_ignores_column_absent_from_new(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

The prod `load_people_api` validate step flagged four serving-type mismatches against the prod contract (`schema_types_match:Voter` and `:DistrictVoter`). This fixes all four so the next build passes cleanly:

- **FIPS** — the voter mart did `cast(Voters_FIPS as int)`. `Voters_FIPS` is a uniform 3-digit code (`001`–`840`), so int both **stripped the leading zero** and shipped it as `int4` where prod is `text`. Now passed through as the raw string, and added to the int model's `IDENTIFIER_STRING_COLUMNS` alongside the ZIP/DPBC codes so it stays string through the union.
- **Audit timestamps** — Voter `created_at`/`updated_at`/`Voter_Status_UpdatedAt` and DistrictVoter `created_at`/`updated_at` were emitted as `timestamptz`, but prod is `timestamp` without time zone (as District/DistrictStats already are). DistrictVoter was explicitly `TIMESTAMPTZ` on a wrong assumption; corrected.
- **Voter.State** — served as the `USState` enum (matching District and swain-db, per the 2026-07-21 decision so the app needs no code change) while the current prod baseline is still `text`. This is an intended forward migration, so it's added to `ACCEPTED_TYPE_DIVERGENCES` rather than left to fail the guardrail.

Everything else in validate passed (row counts match the unload for all 51 states, schema-diff clean, indexes valid, sample queries pass). The Maine voter-count delta is a real L2 purge (accepted, not a code issue).

## Rollout

Makes the **next** cluster build correct without any manual patching. The existing `prod-20260730` cluster is being fixed in place (FIPS is 3-digit so the stripped zeros are recoverable with a zero-pad; the timestamp/enum items are type-only) to avoid a full rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
