### PR TITLE
[DATA-2209] Drive people-api Voter_Status from in-house turnout propensity model

### DIFF
--- a/dbt/project/models/marts/mban2026/m_mban2026.yml
+++ b/dbt/project/models/marts/mban2026/m_mban2026.yml
@@ -79,12 +79,13 @@ models:
 
       - name: Voter_Status
         description: |
-          Voter engagement status based on recent turnout:
-          - First Time: No votes in last 10 elections
-          - Unlikely: No votes in last 3 elections
-          - Likely: 2 votes in last 3 elections
-          - Super: 3 votes in last 3 elections
-          - Unknown: Other patterns
+          Turnout-propensity bucket for the 2026 General, derived from an
+          in-house model's turnout probability:
+          - Unlikely: probability below 0.25
+          - Unreliable: probability below 0.50
+          - Likely: probability below 0.75
+          - Super: probability 0.75 or above
+          - Unknown: no score available
 
       - name: Residence_Addresses_Latitude
         description: Residence latitude rounded to 3 decimal places (~100m precision)

--- a/dbt/project/models/marts/people_api/m_people_api.yaml
+++ b/dbt/project/models/marts/people_api/m_people_api.yaml
@@ -113,18 +113,33 @@ models:
               arguments:
                 values: "{{ get_us_states_list(include_DC=true, include_US=true) }}"
       - name: Voter_Status
-        description: Status of the voter
+        description: >
+          Turnout-propensity bucket for the 2026 General, derived from the
+          in-house model probability: Unlikely (<0.25), Unreliable (<0.50),
+          Likely (<0.75), Super (>=0.75), Unknown (no score).
         data_type: varchar
         tests:
           - not_null
           - accepted_values:
               arguments:
                 values:
-                  - First Time
                   - Unlikely
+                  - Unreliable
                   - Likely
                   - Super
                   - Unknown
+      - name: Voter_Turnout_Probability
+        description: >
+          In-house modeled turnout probability in [0,1] for the 2026 General;
+          null when the voter has no score.
+        data_type: double
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 1
+              config:
+                where: "Voter_Turnout_Probability is not null"
 
   - name: m_people_api__districtstats
     config:

--- a/dbt/project/models/marts/people_api/m_people_api__voter.sql
+++ b/dbt/project/models/marts/people_api/m_people_api__voter.sql
@@ -133,23 +133,6 @@ with
             -- + (case when {{ '`OtherElection_' ~ modules.datetime.datetime.now().strftime('%Y') ~ '`'}} is true then 1 else 0 end)
             -- + (case when {{ '`AnyElection_' ~ modules.datetime.datetime.now().strftime('%Y') ~ '`'}} is true then 1 else 0 end)
             -- ) as `Voter_Status`,
-            (case when `AnyElection_2025` is true then 1 else 0 end)
-            + (case when `General_2024` is true then 1 else 0 end)
-            + (case when `Primary_2024` is true then 1 else 0 end)
-            + (case when `PresidentialPrimary_2024` is true then 1 else 0 end)
-            + (case when `OtherElection_2024` is true then 1 else 0 end)
-            + (case when `AnyElection_2023` is true then 1 else 0 end)
-            + (case when `General_2022` is true then 1 else 0 end)
-            + (case when `Primary_2022` is true then 1 else 0 end)
-            + (case when `OtherElection_2022` is true then 1 else 0 end)
-            + (
-                case when `AnyElection_2021` is true then 1 else 0 end
-            ) as `Last_10_Elections_Voted`,
-            (case when `AnyElection_2025` is true then 1 else 0 end)
-            + (case when `General_2024` is true then 1 else 0 end)
-            + (
-                case when `Primary_2024` is true then 1 else 0 end
-            ) as `Last_3_Elections_Voted`,
             current_timestamp() as `Voter_Status_UpdatedAt`,
             cast(
                 `VoterTelephones_CellConfidenceCode` as int
@@ -459,6 +442,10 @@ with
         qualify
             row_number() over (partition by lalvoterid order by dbt_valid_from desc) = 1
     ),
+    voter_propensity as (
+        select `LALVOTERID`, `prob_vote`
+        from {{ ref("stg_model_predictions__voter_turnout_scores_20260730") }}
+    ),
     /*
         Note that here we need to list each column individually since we need to
         explicitly case protect each column name with backticks to match the Voter table
@@ -545,16 +532,17 @@ with
             tbl_updated.`Veteran_Status`,
             tbl_updated.`VoterParties_Change_Changed_Party`,
             case
-                when tbl_updated.`Last_10_Elections_Voted` = 0
-                then 'First Time'
-                when tbl_updated.`Last_3_Elections_Voted` = 0
+                when tbl_propensity.`prob_vote` is null
+                then 'Unknown'
+                when tbl_propensity.`prob_vote` < 0.25
                 then 'Unlikely'
-                when tbl_updated.`Last_3_Elections_Voted` = 3
-                then 'Super'
-                when tbl_updated.`Last_3_Elections_Voted` = 2
+                when tbl_propensity.`prob_vote` < 0.50
+                then 'Unreliable'
+                when tbl_propensity.`prob_vote` < 0.75
                 then 'Likely'
-                else 'Unknown'
+                else 'Super'
             end as `Voter_Status`,
+            tbl_propensity.`prob_vote` as `Voter_Turnout_Probability`,
             tbl_updated.`Voter_Status_UpdatedAt`,
             tbl_updated.`VoterTelephones_CellConfidenceCode`,
             tbl_updated.`VoterTelephones_CellPhoneFormatted`,
@@ -849,6 +837,9 @@ with
             -- Always set updated_at to dbt_valid_from
             tbl_updated.`dbt_valid_from` as updated_at
         from updated_voters as tbl_updated
+        left join
+            voter_propensity as tbl_propensity
+            on tbl_updated.`LALVOTERID` = tbl_propensity.`LALVOTERID`
         {% if is_incremental() %}
             left join
                 {{ this }} as tbl_existing

--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -1226,6 +1226,8 @@ sources:
         description: raw data load from voter turnout projections for 2027
       - name: ballots_projected_2028
         description: raw data load from voter turnout projections for 2028
+      - name: voter_turnout_scores_20260730
+        description: In-house per-voter turnout propensity scores (prob_vote) for 2026 General
 
   - name: segment_storage_source
     database: segment_storage

--- a/dbt/project/models/staging/model_predictions_source/stg_model_predictions.yaml
+++ b/dbt/project/models/staging/model_predictions_source/stg_model_predictions.yaml
@@ -333,3 +333,16 @@ models:
             - election_code
             - model_version
             - inference_at
+
+  - name: stg_model_predictions__voter_turnout_scores_20260730
+    description: In-house per-voter turnout propensity scores (prob_vote) for 2026 General
+    columns:
+      - name: LALVOTERID
+        description: L2 voter id; join key to m_people_api__voter
+        data_tests:
+          - not_null
+          - unique
+      - name: prob_vote
+        description: Modeled turnout probability in [0, 1] for the 2026 General
+        data_tests:
+          - not_null

--- a/dbt/project/models/staging/model_predictions_source/stg_model_predictions__voter_turnout_scores_20260730.sql
+++ b/dbt/project/models/staging/model_predictions_source/stg_model_predictions__voter_turnout_scores_20260730.sql
@@ -1,0 +1,18 @@
+with
+    source as (
+        select * from {{ source("model_predictions", "voter_turnout_scores_20260730") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("LALVOTERID") }},
+            {{ adapter.quote("prob_vote") }},
+            {{ adapter.quote("prediction") }},
+            {{ adapter.quote("election_year") }},
+            {{ adapter.quote("election_code") }},
+            {{ adapter.quote("model_version") }},
+            {{ adapter.quote("state") }}
+
+        from source
+    )
+select *
+from renamed

--- a/dbt/project/models/write/write__people_api_db.py
+++ b/dbt/project/models/write/write__people_api_db.py
@@ -94,6 +94,7 @@ VOTER_COLUMN_LIST: list = [
     "VoterParties_Change_Changed_Party",
     "Voter_Status",
     "Voter_Status_UpdatedAt",
+    "Voter_Turnout_Probability",
     "VoterTelephones_CellConfidenceCode",
     "VoterTelephones_CellPhoneFormatted",
     "VoterTelephones_LandlineConfidenceCode",

--- a/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
+++ b/people-api-loader/src/loader/people_api/schema/data/target_schema.sql
@@ -74,6 +74,7 @@ CREATE TABLE public."Voter" (
     "Veteran_Status" TEXT,
     "VoterParties_Change_Changed_Party" TEXT,
     "Voter_Status" TEXT,
+    "Voter_Turnout_Probability" DOUBLE PRECISION,
     "Voter_Status_UpdatedAt" TIMESTAMPTZ,
     "VoterTelephones_CellConfidenceCode" INTEGER,
     "VoterTelephones_CellPhoneFormatted" TEXT,

--- a/people-api-loader/src/loader/people_api/schema/schema_spec.py
+++ b/people-api-loader/src/loader/people_api/schema/schema_spec.py
@@ -185,7 +185,9 @@ TABLE_SPECS: dict[str, TableSpec] = {
 # loader-created-post-load columns whose DDL build_indexes owns ("geom"), and newly-projected mart
 # columns the serving schema gained while the prod baseline still predates them
 # ("hf_most_important_policy_item"). Keyed by serving table.
-LOADER_ADDED_COLUMNS: dict[str, set[str]] = {"Voter": {"geom", "hf_most_important_policy_item"}}
+LOADER_ADDED_COLUMNS: dict[str, set[str]] = {
+    "Voter": {"geom", "hf_most_important_policy_item", "Voter_Turnout_Probability"}
+}
 
 
 # Columns whose serving TYPE intentionally differs from the prod contract, so the validate


### PR DESCRIPTION
## Summary

Replaces the naive participation-count `Voter_Status` on `m_people_api__voter` with our in-house per-voter turnout propensity model, so the outreach UI's Super / Likely / Unreliable / Unlikely (+ Unknown) selectors are driven by the model probability rather than a raw count of past elections voted.

Ticket: [DATA-2209](https://app.clickup.com/t/86ajtqq7r)

## What changed

- **New source + staging model** for the manually-promoted scores table `model_predictions.voter_turnout_scores_20260730` (per-voter `prob_vote` for the 2026 General, one row per `LALVOTERID`). Passthrough staging model with `not_null` + `unique` on `LALVOTERID` and `not_null` on `prob_vote`.
- **`m_people_api__voter`**: left join the scores on `LALVOTERID`, add a `Voter_Turnout_Probability` column, and replace the `Last_10/Last_3_Elections_Voted` `Voter_Status` CASE with probability bucketing (lower-inclusive edges):
  - null / no score → `Unknown`
  - `< 0.25` → `Unlikely`
  - `< 0.50` → `Unreliable`
  - `< 0.75` → `Likely`
  - `>= 0.75` → `Super`
  - The now-dead `Last_10/Last_3_Elections_Voted` computations are removed.
- **Schema/tests**: updated the `Voter_Status` `accepted_values` test to the new bucket set (adds `Unreliable`, drops the retired `First Time`), documented `Voter_Turnout_Probability` with a null-safe `accepted_range [0,1]`, and refreshed the stale `Voter_Status` description in the `mban2026` mart (it passes the column through).
- **Product DB**: added `Voter_Turnout_Probability` to the people-api writer's `VOTER_COLUMN_LIST` so the raw score propagates to the product `Voter` table alongside the (already-propagated) `Voter_Status`.

## Testing

- `dbt build` on the new staging model: model + 3 tests pass; bucketed row counts sum to the full source (218,102,378), matching the promoted table exactly.
- `dbt compile` on `m_people_api__voter` renders the join, CASE, and new column correctly; no dead references remain.
- `dbt parse` clean on the full project.
- The full `m_people_api__voter` build (~5h, ~220MM rows) is intentionally **not** run in CI — see cutover note below.

## Operational notes (for the cutover)

Run these in order at cutover:

1. **Prod DB migration** (existing serving cluster) — add the new column before the loader writes it:
   ```sql
   ALTER TABLE public."Voter" ADD COLUMN "Voter_Turnout_Probability" DOUBLE PRECISION;
   ```
   New clusters are covered automatically: `Voter_Turnout_Probability` is now in `target_schema.sql`, which `create_schema` provisions from.
2. **Mart full refresh (required):** `dbt run --select m_people_api__voter --full-refresh`. Because the model is incremental, a normal run would leave unchanged voters on their old count-based `Voter_Status` with a NULL probability (mixed semantics); a full refresh recomputes every row. Coordinate so the monthly schedule does not fire an incremental run first.
3. **people-api-loader run** — lands the new `Voter_Status` values and `Voter_Turnout_Probability` in the product DB.

**Behavior change:** `Voter_Status` semantics shift from historical participation to 2026-General turnout probability, and the old `First Time` bucket is retired. Any downstream consumer filtering on `First Time` (or the old count-based meanings) should be reviewed.

**Coverage check (validated against real data):** running the mart's exact left join + bucket over the full voter universe (227,375,529 voters) against the CI-built staging table gives Super 79.77M / Unlikely 53.94M / Unreliable 45.07M / Likely 39.12M / Unknown 9.47M — 95.8% of voters scored, 4.2% Unknown (no score), buckets summing to the full voter count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
