### PR TITLE
Bump loader cache-bust to reinstall from @main (picks up #725 schema)

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # Pinned to @main so the loader co-versions with the DAG on main and survives feature-branch
 # deletion post-merge.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-30.1
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-31.1
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This


### PR DESCRIPTION
## Why

The Astro image installs `people-api-loader` from `git @main`, with the pip install layer cached on `airflow/astro/requirements.txt`. Because the pin is `@main` (not a SHA), an unchanged file means the image keeps whatever loader was last built — even after `@main` moves.

Bumping the cache-bust (`2026-07-30.1` → `2026-07-31.1`) forces the next `astro deploy` to reinstall the loader from current `@main`, picking up #725's serving-schema change (the new `Voter_Turnout_Probability` column in `target_schema.sql`) on top of #724's FIPS/timestamp fixes. Without this, a fresh `load_people_api` cluster would be missing that column.

## Note

Merging alone doesn't deploy — the merge-triggered deploy needs this bump to reinstall the loader layer, and a manual `astro deploy` remains the reliable fallback. This is in prep for the next prod `load_people_api` run, once the mart rebuild (#724 + #725) finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
