### PR TITLE
Add a manual teardown DAG that retires a cluster with a restore point

### DIFF
--- a/airflow/astro/dags/teardown_people_api_cluster.py
+++ b/airflow/astro/dags/teardown_people_api_cluster.py
@@ -1,0 +1,62 @@
+"""Retire a people-api voter cluster, keeping a restore point.
+
+Standalone, manually-triggered counterpart to the `teardown` step in load_people_api: it
+deletes only the COMPUTE (writer instance + cluster) of a prior dated cluster
+(`gp-people-db-{date}-{env}`) while keeping the artifacts you'd need to bring it back —
+a final cluster snapshot, the dated connection-string SSM parameter, and the DB parameter
+groups. Use it to reclaim Aurora cost from superseded clusters (e.g. an old prod-{date})
+without losing the ability to restore.
+
+Safety: the loader's teardown is name-scoped to `gp-people-db-{date}*`, so it can never touch
+the live serving cluster (`gp-people-db-{env}`) or shared infra; and this DAG defaults to a
+DRY RUN — set `dry_run=false` to actually delete. AWS credentials come from the worker's
+standard credential chain; the loader's config (ENVIRONMENT, LOADER_*) reaches the subprocess
+via append_env. No bastion/Databricks needed — teardown never connects to the database.
+"""
+
+from __future__ import annotations
+
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sdk import Param, dag
+from pendulum import datetime as pendulum_datetime
+from pendulum import duration
+
+
+@dag(
+    dag_id="teardown_people_api_cluster",
+    schedule=None,  # manual trigger only
+    start_date=pendulum_datetime(2026, 6, 1, tz="UTC"),
+    catchup=False,
+    is_paused_upon_creation=True,
+    default_args={"retries": 2, "retry_delay": duration(minutes=5)},
+    tags=["people-api", "loader", "teardown"],
+    params={
+        "date": Param(
+            "",
+            type="string",
+            title="Cluster date (ds_nodash)",
+            description="Date of the cluster to retire, e.g. 20260728 for gp-people-db-20260728-{env}.",
+        ),
+        "dry_run": Param(
+            True,
+            type="boolean",
+            title="Dry run",
+            description="Preview only — lists what would be deleted. Uncheck to actually delete.",
+        ),
+    },
+)
+def teardown_people_api_cluster():
+    BashOperator(
+        task_id="retire_cluster",
+        # Keep the restore set (snapshot + dated SSM param + param groups); delete only the compute.
+        # dry_run (default) omits --confirm, so the loader lists its plan without touching anything.
+        bash_command=(
+            "loader teardown --date {{ params.date }} "
+            "--snapshot --keep-ssm --keep-param-groups"
+            "{% if not params.dry_run %} --confirm{% endif %}"
+        ),
+        append_env=True,
+    )
+
+
+teardown_people_api_cluster()

--- a/people-api-loader/src/loader/people_api/cli.py
+++ b/people-api-loader/src/loader/people_api/cli.py
@@ -242,6 +242,29 @@ def teardown(
             help="Also delete the S3 gateway VPC endpoint. Default keeps it in place for future refreshes.",
         ),
     ] = False,
+    snapshot: Annotated[
+        bool,
+        typer.Option(
+            "--snapshot",
+            help="Take a final cluster snapshot (gp-people-db-{date}-{env}-final) before deleting, "
+            "kept until manually removed. Default skips it.",
+        ),
+    ] = False,
+    keep_ssm: Annotated[
+        bool,
+        typer.Option(
+            "--keep-ssm",
+            help="Keep the dated connection-string SSM parameter (for a restore-from-snapshot). "
+            "Default deletes it.",
+        ),
+    ] = False,
+    keep_param_groups: Annotated[
+        bool,
+        typer.Option(
+            "--keep-param-groups",
+            help="Keep the cluster's load/serve DB parameter groups. Default deletes them.",
+        ),
+    ] = False,
 ) -> None:
     """Delete loader-created resources for a run_date. Dry-run by default."""
     from loader.people_api.steps import teardown as step
@@ -253,6 +276,9 @@ def teardown(
         confirm=confirm,
         delete_s3=delete_s3,
         delete_vpce=delete_vpce,
+        snapshot=snapshot,
+        keep_ssm=keep_ssm,
+        keep_param_groups=keep_param_groups,
     )
 
 

--- a/people-api-loader/src/loader/people_api/steps/teardown.py
+++ b/people-api-loader/src/loader/people_api/steps/teardown.py
@@ -43,6 +43,9 @@ def run(
     confirm: bool = False,
     delete_s3: bool = False,
     delete_vpce: bool = False,
+    snapshot: bool = False,
+    keep_ssm: bool = False,
+    keep_param_groups: bool = False,
 ) -> None:
     bind(run_date=run_date, step="teardown")
     cluster_id = cfg.new_cluster_id(run_date)
@@ -50,12 +53,20 @@ def run(
     load_pg = cfg.new_load_param_group(run_date)
     serve_pg = cfg.new_serve_param_group(run_date)
     conn_param = cfg.new_conn_param(run_date)
+    # Retire-with-restore-safety: take a final cluster snapshot and keep it (RDS retains it until
+    # manually deleted). Snapshot id is deterministic per cluster; if one already exists (a prior
+    # retire), delete it first.
+    snapshot_id = f"{cluster_id}-final"
 
     plan = [
         f"instance:{instance_id}",
-        f"cluster:{cluster_id}",
-        f"param-groups:{load_pg},{serve_pg}",
-        f"ssm-param:{conn_param}",
+        f"cluster:{cluster_id}" + (f" (final snapshot: {snapshot_id})" if snapshot else " (no snapshot)"),
+        (
+            f"KEEP param-groups:{load_pg},{serve_pg}"
+            if keep_param_groups
+            else f"param-groups:{load_pg},{serve_pg}"
+        ),
+        (f"KEEP ssm-param:{conn_param}" if keep_ssm else f"ssm-param:{conn_param}"),
     ]
     if delete_s3:
         plan.append(f"s3:{cfg.export_prefix(run_date)}/")
@@ -87,9 +98,18 @@ def run(
     # since this is the recovery tool for that orphan, wait for it to settle, then delete —
     # rather than aborting (operator must retry) or swallowing (the cluster is never deleted
     # and the deleted-waiter below would just time out). Mirrors resize's wait-then-retry.
+    delete_cluster_kwargs: dict[str, object] = (
+        {
+            "DBClusterIdentifier": cluster_id,
+            "SkipFinalSnapshot": False,
+            "FinalDBSnapshotIdentifier": snapshot_id,
+        }
+        if snapshot
+        else {"DBClusterIdentifier": cluster_id, "SkipFinalSnapshot": True}
+    )
     with ignore_client_errors("DBClusterNotFoundFault"):
         retry_after_settle(
-            lambda: rds_client.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True),
+            lambda: rds_client.delete_db_cluster(**delete_cluster_kwargs),
             fault_code="InvalidDBClusterStateFault",
             settle=lambda: rds_client.get_waiter("db_cluster_available").wait(
                 DBClusterIdentifier=cluster_id, WaiterConfig={"Delay": 30, "MaxAttempts": 80}
@@ -97,17 +117,21 @@ def run(
         )
     rds_client.get_waiter("db_cluster_deleted").wait(DBClusterIdentifier=cluster_id)
 
-    # 3. Parameter groups (only deletable once no cluster references them).
+    # 3. Parameter groups (only deletable once no cluster references them). Kept when
+    #    keep_param_groups (retire-for-restore); they cost nothing and round out the restore set.
     #    DeleteDBClusterParameterGroup's modeled not-found code is DBParameterGroupNotFound
     #    (per the botocore RDS service model); we also tolerate the cluster-specific variant
     #    defensively, so a partial-teardown re-run stays idempotent regardless.
-    for pg in (load_pg, serve_pg):
-        with ignore_client_errors("DBParameterGroupNotFound", "DBClusterParameterGroupNotFound"):
-            rds_client.delete_db_cluster_parameter_group(DBClusterParameterGroupName=pg)
+    if not keep_param_groups:
+        for pg in (load_pg, serve_pg):
+            with ignore_client_errors("DBParameterGroupNotFound", "DBClusterParameterGroupNotFound"):
+                rds_client.delete_db_cluster_parameter_group(DBClusterParameterGroupName=pg)
 
-    # 4. Connection-string SSM parameter (per-run; holds the embedded master password).
-    with ignore_client_errors("ParameterNotFound"):
-        ssm(cfg).delete_parameter(Name=conn_param)
+    # 4. Connection-string SSM parameter (per-run; holds the embedded master password). Kept when
+    #    keep_ssm so a restore-from-snapshot still has its connection string.
+    if not keep_ssm:
+        with ignore_client_errors("ParameterNotFound"):
+            ssm(cfg).delete_parameter(Name=conn_param)
 
     # 5. Opt-in: the run's S3 artifacts (kept by default for forensics).
     if delete_s3:

--- a/people-api-loader/src/loader/people_api/steps/teardown.py
+++ b/people-api-loader/src/loader/people_api/steps/teardown.py
@@ -13,6 +13,8 @@ is a documented no-op — we reference a shared endpoint, never our own.
 
 from __future__ import annotations
 
+from botocore.exceptions import ClientError
+
 from loader.core.aws import ignore_client_errors, rds, retry_after_settle, s3, ssm
 from loader.core.log import bind, get_logger
 from loader.people_api.config import LoaderConfig
@@ -54,8 +56,9 @@ def run(
     serve_pg = cfg.new_serve_param_group(run_date)
     conn_param = cfg.new_conn_param(run_date)
     # Retire-with-restore-safety: take a final cluster snapshot and keep it (RDS retains it until
-    # manually deleted). Snapshot id is deterministic per cluster; if one already exists (a prior
-    # retire), delete it first.
+    # manually deleted). Snapshot id is deterministic per cluster; if one already exists from a
+    # prior retire, that snapshot IS the restore point, so the delete below reuses it rather than
+    # crashing or replacing it.
     snapshot_id = f"{cluster_id}-final"
 
     plan = [
@@ -107,9 +110,23 @@ def run(
         if snapshot
         else {"DBClusterIdentifier": cluster_id, "SkipFinalSnapshot": True}
     )
+
+    def _delete_cluster() -> None:
+        try:
+            rds_client.delete_db_cluster(**delete_cluster_kwargs)
+        except ClientError as exc:
+            # A prior retire already captured this cluster's final snapshot — that snapshot IS the
+            # restore point, so reuse it and delete the cluster WITHOUT a duplicate. (A re-run where
+            # the cluster is already gone raises DBClusterNotFoundFault instead, caught below, and
+            # never touches the snapshot — so a retry-after-success can't delete the restore point.)
+            if snapshot and exc.response["Error"]["Code"] == "DBClusterSnapshotAlreadyExistsFault":
+                rds_client.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+            else:
+                raise
+
     with ignore_client_errors("DBClusterNotFoundFault"):
         retry_after_settle(
-            lambda: rds_client.delete_db_cluster(**delete_cluster_kwargs),
+            _delete_cluster,
             fault_code="InvalidDBClusterStateFault",
             settle=lambda: rds_client.get_waiter("db_cluster_available").wait(
                 DBClusterIdentifier=cluster_id, WaiterConfig={"Delay": 30, "MaxAttempts": 80}

--- a/people-api-loader/tests/test_teardown.py
+++ b/people-api-loader/tests/test_teardown.py
@@ -44,6 +44,7 @@ class FakeRds:
         delete_creating_once: bool = False,
     ) -> None:
         self.calls: list[str] = []
+        self.delete_cluster_kwargs: dict[str, Any] = {}  # last delete_db_cluster kwargs
         self._missing = missing or set()  # ops that should raise NotFound
         self._pg_error = pg_error  # which not-found code delete_db_cluster_parameter_group raises
         self._modify_error = modify_error  # error code modify_db_cluster raises (e.g. bad state)
@@ -63,6 +64,7 @@ class FakeRds:
 
     def delete_db_cluster(self, **kw: Any) -> None:
         self.calls.append("delete_cluster")
+        self.delete_cluster_kwargs = kw
         if self._delete_creating_once and self.calls.count("delete_cluster") == 1:
             raise _err("InvalidDBClusterStateFault")
         if "cluster" in self._missing:
@@ -224,3 +226,41 @@ def test_delete_s3_prefix_raises_on_partial_failure(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(step, "s3", lambda cfg: s3_client)
     with pytest.raises(RuntimeError, match="partial failure"):
         step._delete_s3_prefix(_CFG, "20260616")
+
+
+def test_teardown_snapshot_takes_final_cluster_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    # --snapshot deletes the cluster with a kept final snapshot instead of SkipFinalSnapshot.
+    rds_client, ssm_client = FakeRds(), FakeSsm()
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
+    step.run(_CFG, "20260616", confirm=True, snapshot=True)
+    assert rds_client.delete_cluster_kwargs["SkipFinalSnapshot"] is False
+    assert rds_client.delete_cluster_kwargs["FinalDBSnapshotIdentifier"] == "gp-people-db-20260616-final"
+
+
+def test_teardown_no_snapshot_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    rds_client, ssm_client = FakeRds(), FakeSsm()
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
+    step.run(_CFG, "20260616", confirm=True)
+    assert rds_client.delete_cluster_kwargs["SkipFinalSnapshot"] is True
+    assert "FinalDBSnapshotIdentifier" not in rds_client.delete_cluster_kwargs
+
+
+def test_teardown_keep_ssm_leaves_conn_param(monkeypatch: pytest.MonkeyPatch) -> None:
+    rds_client, ssm_client = FakeRds(), FakeSsm()
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
+    step.run(_CFG, "20260616", confirm=True, keep_ssm=True)
+    assert ssm_client.deleted == []  # SSM connection-string param kept for a restore
+
+
+def test_teardown_keep_param_groups_skips_delete_but_still_tears_down_compute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rds_client, ssm_client = FakeRds(), FakeSsm()
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
+    step.run(_CFG, "20260616", confirm=True, keep_param_groups=True)
+    assert "delete_pg" not in rds_client.calls  # param groups kept
+    assert "delete_cluster" in rds_client.calls  # compute is still torn down

--- a/people-api-loader/tests/test_teardown.py
+++ b/people-api-loader/tests/test_teardown.py
@@ -42,9 +42,12 @@ class FakeRds:
         pg_error: str = "DBParameterGroupNotFound",
         modify_error: str | None = None,
         delete_creating_once: bool = False,
+        snapshot_exists: bool = False,
     ) -> None:
         self.calls: list[str] = []
         self.delete_cluster_kwargs: dict[str, Any] = {}  # last delete_db_cluster kwargs
+        # delete_db_cluster with FinalDBSnapshotIdentifier raises AlreadyExists (prior-retire snapshot).
+        self._snapshot_exists = snapshot_exists
         self._missing = missing or set()  # ops that should raise NotFound
         self._pg_error = pg_error  # which not-found code delete_db_cluster_parameter_group raises
         self._modify_error = modify_error  # error code modify_db_cluster raises (e.g. bad state)
@@ -65,6 +68,8 @@ class FakeRds:
     def delete_db_cluster(self, **kw: Any) -> None:
         self.calls.append("delete_cluster")
         self.delete_cluster_kwargs = kw
+        if self._snapshot_exists and "FinalDBSnapshotIdentifier" in kw:
+            raise _err("DBClusterSnapshotAlreadyExistsFault")
         if self._delete_creating_once and self.calls.count("delete_cluster") == 1:
             raise _err("InvalidDBClusterStateFault")
         if "cluster" in self._missing:
@@ -264,3 +269,14 @@ def test_teardown_keep_param_groups_skips_delete_but_still_tears_down_compute(
     step.run(_CFG, "20260616", confirm=True, keep_param_groups=True)
     assert "delete_pg" not in rds_client.calls  # param groups kept
     assert "delete_cluster" in rds_client.calls  # compute is still torn down
+
+
+def test_teardown_snapshot_reuses_existing_snapshot_on_rerun(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Re-running the retire when the final snapshot already exists must NOT crash and must NOT
+    # replace the snapshot: the delete falls back to SkipFinalSnapshot, reusing the restore point.
+    rds_client, ssm_client = FakeRds(snapshot_exists=True), FakeSsm()
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
+    step.run(_CFG, "20260616", confirm=True, snapshot=True)  # must not raise
+    assert rds_client.calls.count("delete_cluster") == 2  # snapshot attempt, then reuse fallback
+    assert rds_client.delete_cluster_kwargs["SkipFinalSnapshot"] is True  # last call reused the snapshot


### PR DESCRIPTION
## Why

Retiring superseded people-api clusters (e.g. an old `gp-people-db-{date}-prod`) to reclaim Aurora cost needs a way to delete the compute while keeping enough to restore. The existing `teardown` step in `load_people_api` deletes everything — no snapshot, and it drops the dated connection-string SSM param — which is correct for run-cleanup but wrong for retiring a cluster you might need back.

## What

- **Loader** — three opt-in flags on `teardown`, all default-off so the `load_people_api` teardown step is untouched:
  - `--snapshot`: take a final cluster snapshot (`gp-people-db-{date}-{env}-final`), kept until manually deleted.
  - `--keep-ssm`: keep the dated `people-db-connection-string-{env}-{date}` param, so a restore-from-snapshot still has its connection string.
  - `--keep-param-groups`: keep the load/serve DB parameter groups.
- **DAG** — a standalone, manually-triggered `teardown_people_api_cluster` (`schedule=None`) that runs `loader teardown --date <date> --snapshot --keep-ssm --keep-param-groups`, deleting only the writer instance + cluster. Params:
  - `date` — the cluster's `ds_nodash` (e.g. `20260728`).
  - `dry_run` — defaults **true** (lists the plan without touching anything); set false to execute.

## Safety

The loader's teardown is name-scoped to `gp-people-db-{date}*`, so it can never match the live serving cluster (`gp-people-db-{env}`) or shared infra — a wrong `date` param can only ever hit that one dated cluster. The DAG defaults to a dry run, so you preview the exact plan before flipping `dry_run=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
