### PR TITLE
[DATA] Estimate number_of_opponents / is_uncontested from candidacy-stage rollup

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -940,6 +940,61 @@ models:
         data_tests:
           - not_null
 
+  - name: int__civics_election_estimated_opponents
+    description: >
+      Estimated opponent count per election, from counting the active
+      candidacies loaded within an election-stage. Feeds a contested-direction
+      fallback for number_of_opponents / is_uncontested on the election mart
+      (both come only from TechSpeed/DDHQ today; BallotReady hardcodes them
+      NULL).
+
+      Grain: One row per gp_election_id that has at least one loaded
+      candidacy-stage row.
+
+      One-directional by design: an estimate is present only when a stage has
+      >= 2 active candidates (>= 1 opponent). A field of <= 1 stays NULL because
+      it means the rest of the roster is not loaded, not that the race is
+      uncontested. Counts are per stage instance (not pooled across a
+      gp_election_id that spans several offices), and the rollup prefers the
+      general stage, falling back to the largest loaded stage only when no
+      general-stage candidacies exist.
+
+    columns:
+      - name: gp_election_id
+        description: Primary key - internally generated unique identifier for elections
+        data_tests:
+          - unique
+          - not_null
+          - is_uuid
+
+      - name: estimated_field_size
+        description: >
+          Active-candidate count of the chosen stage (general preferred, else
+          largest loaded stage). Always >= 1.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+
+      - name: estimated_number_of_opponents
+        description: >
+          estimated_field_size - 1, populated only when the chosen stage has
+          >= 2 active candidates. NULL otherwise (never asserts 0 opponents).
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+
+      - name: estimated_opponents_stage_basis
+        description: >
+          Which stage the estimate came from: 'general' (general-family stage)
+          or 'largest_stage' (fallback max). NULL when no estimate.
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: ["general", "largest_stage"]
+
   - name: int__civics_candidate_ddhq
     description: >
       DDHQ candidates transformed into civics mart candidate schema.

--- a/dbt/project/models/intermediate/civics/int__civics_election_estimated_opponents.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_estimated_opponents.sql
@@ -1,0 +1,70 @@
+-- Estimated opponent count per election, derived by counting the active
+-- candidacies loaded within an election-stage. Feeds a contested-direction
+-- fallback for number_of_opponents / is_uncontested on the election mart, which
+-- both come only from TechSpeed/DDHQ today (BallotReady hardcodes them NULL).
+--
+-- One-directional by design: a stage with >= 2 active candidates yields >= 1
+-- opponent. A field of <= 1 means we have not loaded the rest of the roster, NOT
+-- that the race is uncontested, so it stays NULL. We never assert 0 opponents.
+--
+-- Grain: one row per gp_election_id. Counting per stage instance (not per
+-- gp_election_id) keeps a single election id that spans several offices from
+-- pooling opponents across different races. The rollup prefers the general
+-- (deciding) contest and falls back to the largest loaded stage only when no
+-- general-stage candidacies exist.
+with
+    stage_candidates as (
+        -- Active candidates per election-stage. "Active" = actually competed in
+        -- the stage: drop Withdrew / Not on Ballot so a name that filed but never
+        -- ran is not counted as an opponent. Losers stay counted — losing a stage
+        -- still means they were on the ballot for it.
+        select
+            es.gp_election_id,
+            es.gp_election_stage_id,
+            es.stage_type,
+            count(
+                distinct coalesce(cs.gp_person_id, cs.gp_candidacy_id)
+            ) as active_candidate_count
+        from {{ ref("candidacy_stage") }} as cs
+        inner join
+            {{ ref("election_stage") }} as es
+            on cs.gp_election_stage_id = es.gp_election_stage_id
+        where
+            es.gp_election_id is not null
+            and (
+                cs.election_result is null
+                or cs.election_result not in ('Withdrew', 'Not on Ballot')
+            )
+        group by es.gp_election_id, es.gp_election_stage_id, es.stage_type
+    ),
+
+    election_rollup as (
+        select
+            gp_election_id,
+            -- deciding-contest field: the largest single general-stage race
+            max(
+                case
+                    when stage_type in ('general', 'general special')
+                    then active_candidate_count
+                end
+            ) as general_field_size,
+            max(active_candidate_count) as max_field_size
+        from stage_candidates
+        group by gp_election_id
+    )
+
+select
+    gp_election_id,
+    -- prefer the general stage; fall back to the largest loaded stage
+    coalesce(general_field_size, max_field_size) as estimated_field_size,
+    case
+        when estimated_field_size >= 2 then estimated_field_size - 1
+    end as estimated_number_of_opponents,
+    case
+        when estimated_field_size < 2
+        then null
+        when general_field_size is not null
+        then 'general'
+        else 'largest_stage'
+    end as estimated_opponents_stage_basis
+from election_rollup

--- a/dbt/project/models/intermediate/civics/int__civics_election_estimated_opponents.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_election_estimated_opponents.sql
@@ -41,10 +41,19 @@ with
     election_rollup as (
         select
             gp_election_id,
-            -- deciding-contest field: the largest single general-stage race
+            -- deciding-contest field: the largest single general-family race.
+            -- Includes runoff variants — a general/special runoff is a deciding
+            -- contest too, and folding it in stops a runoff-only race from
+            -- falling through to an earlier, larger primary field.
             max(
                 case
-                    when stage_type in ('general', 'general special')
+                    when
+                        stage_type in (
+                            'general',
+                            'general special',
+                            'general runoff',
+                            'general special runoff'
+                        )
                     then active_candidate_count
                 end
             ) as general_field_size,

--- a/dbt/project/models/marts/civics/election.sql
+++ b/dbt/project/models/marts/civics/election.sql
@@ -176,8 +176,25 @@ select
     deduplicated.population,
     deduplicated.seats_available,
     deduplicated.term_start_date,
-    deduplicated.is_uncontested,
-    deduplicated.number_of_opponents,
+    -- number_of_opponents / is_uncontested come only from TS/DDHQ (BR hardcodes
+    -- them NULL). Fall back to the candidacy-stage estimate in the contested
+    -- direction only: an estimate is present just when >= 2 active candidacies
+    -- were loaded, so it only ever fills a positive opponent count / a
+    -- contested (false) flag. It never asserts 0 opponents or uncontested.
+    coalesce(
+        deduplicated.is_uncontested,
+        case when est_opp.estimated_number_of_opponents is not null then false end
+    ) as is_uncontested,
+    deduplicated.is_uncontested is null
+    and est_opp.estimated_number_of_opponents
+    is not null as is_uncontested_is_estimated,
+    coalesce(
+        deduplicated.number_of_opponents,
+        cast(est_opp.estimated_number_of_opponents as string)
+    ) as number_of_opponents,
+    deduplicated.number_of_opponents is null
+    and est_opp.estimated_number_of_opponents
+    is not null as number_of_opponents_is_estimated,
     deduplicated.is_open_seat,
     deduplicated.has_ddhq_match,
     deduplicated.br_position_database_id,
@@ -231,3 +248,6 @@ left join
     on deduplicated.br_position_database_id = pos_ot.br_position_database_id
 left join stage_dates on deduplicated.gp_election_id = stage_dates.gp_election_id
 left join gp_api_membership as gp on deduplicated.gp_election_id = gp.gp_election_id
+left join
+    {{ ref("int__civics_election_estimated_opponents") }} as est_opp
+    on deduplicated.gp_election_id = est_opp.gp_election_id

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -1400,14 +1400,45 @@ models:
         description: Start date of the term
 
       - name: is_uncontested
-        description: Whether the election is uncontested
+        description: >
+          Whether the election is uncontested. Sourced from TechSpeed (with
+          DDHQ fallback). Where those are NULL, filled to false only when the
+          candidacy-stage estimate finds >= 1 opponent
+          (int__civics_election_estimated_opponents). Never filled to true from
+          the estimate: a sparse roster is unknown, not uncontested. See
+          is_uncontested_is_estimated.
         data_tests:
           - accepted_values:
               arguments:
                 values: [true, false]
 
+      - name: is_uncontested_is_estimated
+        description: >
+          True when is_uncontested was filled (to false) from the
+          candidacy-stage estimate rather than a source system.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+
       - name: number_of_opponents
-        description: Number of opponents in the race (may contain string values like '10+')
+        description: >
+          Number of opponents in the race (may contain string values like
+          '10+'). Sourced from TechSpeed (with BR/DDHQ fallback). Where those
+          are NULL, filled from the candidacy-stage estimate but only when it
+          finds >= 1 opponent (>= 2 active candidacies in a stage); a field of
+          <= 1 stays NULL rather than assert 0. See number_of_opponents_is_estimated.
+
+      - name: number_of_opponents_is_estimated
+        description: >
+          True when number_of_opponents was filled from the candidacy-stage
+          estimate rather than a source system.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
 
       - name: is_open_seat
         description: Whether the election is for an open seat


### PR DESCRIPTION
## Summary

`number_of_opponents` and `is_uncontested` on `mart_civics.election` come only from TechSpeed (with a DDHQ fallback for `is_uncontested`). BallotReady — the spine behind ~90% of elections — hardcodes both to NULL. So organic-lead races that exist only in BallotReady show blank contested/opponent data, which is what surfaced this.

This adds a candidacy-derived estimate that fills those two fields in the **contested direction only**, from a new intermediate model `int__civics_election_estimated_opponents`.

## How it works

For each election-stage, count the distinct **active** candidacies loaded (`candidacy_stage` joined to `election_stage`), excluding `Withdrew` / `Not on Ballot` so a name that filed but never ran is not counted. Roll each election up to the **general (deciding) stage**, falling back to the largest loaded stage only when no general-stage candidacies exist. Counting per stage instance (not per `gp_election_id`) keeps a single election id that spans several offices from pooling opponents across different races.

- `estimated_number_of_opponents = field_size - 1`, populated **only when a stage has >= 2 active candidacies** (>= 1 opponent).
- A field of <= 1 stays **NULL**. It means the rest of the roster is not loaded, not that the race is uncontested. **We never assert 0 opponents or `is_uncontested = true` from the estimate.**

The estimate is coalesced into the existing fields as a fallback (sourced values always win), with provenance flags so blended values stay auditable:

- `number_of_opponents = coalesce(sourced, estimate_when_ge2)` + new `number_of_opponents_is_estimated`
- `is_uncontested = coalesce(sourced, false_when_estimate_ge1)` + new `is_uncontested_is_estimated`

## Why one-directional (the core constraint)

Counting loaded candidacies can only ever confirm **contested**. It can never confirm **uncontested**, because a count of <= 1 is indistinguishable from "we have not loaded the other candidates yet." Validated against the values TechSpeed already provides:

- Where TechSpeed says a race is **contested**, our stage count reaches >= 2 only ~59% of the time (the rest have <= 1 candidacy loaded). So we fill under half of the genuinely contested nulls — recall is limited by what is loaded.
- Where TechSpeed says a race is **uncontested**, a naive count still hits >= 2 about 16% of the time (crowded primaries, withdrawn/also-ran filers). The per-stage grain + active-candidacy filter + general-stage preference in this model exist to suppress exactly those false positives.

## Coverage (split by period)

Fills applied on the election mart (rows where the sourced value was NULL):

| Period | Elections | `number_of_opponents` filled | `is_uncontested` filled |
|---|---|---|---|
| 2026+ | ~419k | 13,782 | 11,627 |
| Pre-2026 / archive | ~69k | 14,792 | 1,766 |
| **Total** | ~488k | **28,574** | **13,393** |

The forward-looking 2026+ races (the organic-lead use case) get ~13.8k newly populated opponent counts. Everything below 2 loaded candidacies stays NULL. Overall `number_of_opponents` null rate drops from ~91% to ~85%.

Note the general-stage preference is deliberately conservative: for many upcoming 2026 races only the tracked candidate is loaded in the general stage, so they correctly stay NULL rather than be labeled uncontested.

## Accuracy vs TechSpeed truth

On the ~17.3k elections where a TechSpeed opponent count and our estimate both exist:

| Agreement | Count | Share |
|---|---|---|
| Exact match | 13,102 | 76% |
| Overcount | 1,894 | 11% |
| Undercount | 2,259 | 13% |

## Downstream impact

Two models consume these fields from the mart. The change is value-only (no schema change; `number_of_opponents` stays string), so both still build, but their **outputs shift** for the newly filled rows:

1. **`sales_reverse_etl/candidacy_hubspot.sql` writes to HubSpot.** It maps `is_uncontested` → the `Uncontested` property (`Contested` / `Uncontested`) and `number_of_opponents + 1` → `Number of Candidates`. After merge, estimated `Contested` and candidate counts will flow to HubSpot for organic-lead companies that were previously blank. **Decided: let the estimate flow through** — this is the intended outcome (getting contested info to organic leads is what prompted this). The `number_of_opponents_is_estimated` / `is_uncontested_is_estimated` flags remain on the mart for anyone who needs to distinguish estimated from sourced; the HubSpot push does not gate on them.
2. **`int__civics_viability_scoring.py`** uses `number_of_opponents` as the `raw_n_opponents` fallback feature. Newly filled races will now get a real opponent signal instead of the weaker no-opponent-data fallback. Likely an improvement, but it does move viability inputs for those races.

Neither downstream model was rebuilt in this PR (value-only change).

## Testing

`dbt build` on `int__civics_election_estimated_opponents` and `election`: **PASS=41, ERROR=0**. New tests: uniqueness / not-null / is_uuid on the estimate key, `accepted_range >= 1` on the counts, `accepted_values` on the stage basis, and not-null / accepted-values on both provenance flags. Verified on live data that 0 rows assert `< 1` opponents or `is_uncontested = true` from the estimate, and that a spot-checked BR-only race with no loaded candidacies stays NULL.

The one remaining test warning (`candidacy` → `election` relationships, 254) is pre-existing and matches prod; it is not introduced here.

## Follow-ups

- Ticket number to be added to the PR title.
- The deeper coverage gap (races with 0–1 loaded candidacies) is upstream: it needs fuller BallotReady rosters or expanded TechSpeed race selection, not a counting change.
