### PR TITLE
[DATA-2199] Auto-create ClickUp Sigma-build tasks on metric ratification

### DIFF
--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -68,24 +68,23 @@ jobs:
           fi
           echo "COV=$COV" >> "$GITHUB_ENV"
           echo "PR_URL=$PR_URL" >> "$GITHUB_ENV"
+      - name: Prepare base tree for diffing
+        run: |
+          set -euo pipefail
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+            git worktree add --detach /tmp/base "$BEFORE"
+          fi
       - name: Build Slack change summary
         working-directory: analytics
         env:
           PYTHONPATH: diagnostics
         run: |
           set -euo pipefail
-          BEFORE="${{ github.event.before }}"
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            # No prior commit to diff against — emit with an empty before-set.
-            uv run python -m semantic_catalog.cli --emit-slack /tmp/slack.txt --pr-url "$PR_URL" --coverage "$COV"
+          if [ -d /tmp/base ]; then
+            uv run python -m semantic_catalog.cli --emit-slack /tmp/slack.txt --base-dir /tmp/base --pr-url "$PR_URL" --coverage "$COV"
           else
-            git worktree add --detach /tmp/base "$BEFORE"
-            uv run python -m semantic_catalog.cli \
-              --emit-slack /tmp/slack.txt \
-              --base-dir /tmp/base \
-              --pr-url "$PR_URL" \
-              --coverage "$COV"
-            git worktree remove --force /tmp/base
+            uv run python -m semantic_catalog.cli --emit-slack /tmp/slack.txt --pr-url "$PR_URL" --coverage "$COV"
           fi
       - name: Post Slack change summary
         env:
@@ -107,3 +106,22 @@ jobs:
           # chat.postMessage returns HTTP 200 with {"ok":false} on errors (bad
           # channel, missing scope, auth), so check the body, not just status.
           echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); d.get("ok") or sys.exit("Slack API error: %s" % d.get("error","unknown"))'
+      - name: Create Sigma build tasks for newly ratified metrics
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+          CLICKUP_TASK_TOKEN: ${{ secrets.CLICKUP_TASK_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLICKUP_TASK_TOKEN:-}" ]; then
+            echo "CLICKUP_TASK_TOKEN not provisioned; skipping Sigma build-task creation."
+            exit 0
+          fi
+          if [ -d /tmp/base ]; then
+            uv run python -m semantic_catalog.cli --sync-sigma-tasks --base-dir /tmp/base
+          else
+            uv run python -m semantic_catalog.cli --sync-sigma-tasks
+          fi
+      - name: Clean up base tree
+        if: always()
+        run: git worktree remove --force /tmp/base || true

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           set -euo pipefail
           BEFORE="${{ github.event.before }}"
-          if [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+          if [ "$BEFORE" != "0000000000000000000000000000000000000000" ] && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
             git worktree add --detach /tmp/base "$BEFORE"
           fi
       - name: Build Slack change summary

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -164,6 +164,7 @@ def main(argv: list[str] | None = None) -> int:
             print("CLICKUP_TASK_TOKEN not set; skipping Sigma build-task creation.")
             return 0
         cfg = yaml.safe_load((PKG / "config" / "sigma_tasks.yml").read_text())
+        # No base dir (e.g. zero-sha before) => before is empty, so all currently-ratified metrics look new; ClickUp dedupe absorbs this. Matches the Slack step.
         before, after = _before_after(args.base_dir)
         client = ClickUpClient(token)
         result = sigma_tasks.sync(client, cfg["list_id"], cfg["build_key_field_id"], before, after)

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
 import yaml
 
 from semantic_catalog import lifecycle as lc_mod
+from semantic_catalog import sigma_tasks
+from semantic_catalog.clickup_client import ClickUpClient
 from semantic_catalog.clickup_page import render_page
 from semantic_catalog.lifecycle import Lifecycle
 from semantic_catalog.md_catalog import render_region, splice_region
@@ -103,12 +106,20 @@ def _lifecycles(records: list[MetricRecord]) -> dict[str, Lifecycle]:
     return {f: lc_mod.derive(f) for f in files}
 
 
+def _before_after(base_dir: Path | None) -> tuple[list[MetricRecord], list[MetricRecord]]:
+    """Records as of HEAD (after) and as of the merge base (before, empty if none)."""
+    after = parse_semantic_tree(SEM_ROOTS)
+    before = parse_semantic_tree([base_dir / "dbt/project/models"]) if base_dir else []
+    return before, after
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="semantic_catalog")
     parser.add_argument("--check", action="store_true")
     parser.add_argument("--write", action="store_true")
     parser.add_argument("--emit-clickup", type=Path)
     parser.add_argument("--emit-slack", type=Path)
+    parser.add_argument("--sync-sigma-tasks", action="store_true")
     parser.add_argument("--base-dir", type=Path, default=None)
     parser.add_argument("--pr-url", type=str, default="")
     parser.add_argument("--coverage", type=str, default="")
@@ -141,12 +152,24 @@ def main(argv: list[str] | None = None) -> int:
         print(f"wrote {args.emit_clickup}")
 
     if args.emit_slack:
-        after = records
-        before = parse_semantic_tree([args.base_dir / "dbt/project/models"]) if args.base_dir else []
+        before, after = _before_after(args.base_dir)
         coverage = json.loads(args.coverage) if args.coverage else {"data": False, "business": False}
         msg = render_message(before, after, args.pr_url, coverage)
         args.emit_slack.write_text(msg)
         print(f"wrote {args.emit_slack}")
+
+    if args.sync_sigma_tasks:
+        token = os.environ.get("CLICKUP_TASK_TOKEN")
+        if not token:
+            print("CLICKUP_TASK_TOKEN not set; skipping Sigma build-task creation.")
+            return 0
+        cfg = yaml.safe_load((PKG / "config" / "sigma_tasks.yml").read_text())
+        before, after = _before_after(args.base_dir)
+        client = ClickUpClient(token)
+        result = sigma_tasks.sync(client, cfg["list_id"], cfg["build_key_field_id"], before, after)
+        print(f"created {len(result.created)}: {', '.join(result.created) or '(none)'}")
+        print(f"skipped {len(result.skipped)}: {', '.join(result.skipped) or '(none)'}")
+        return 0
 
     return 0
 

--- a/analytics/diagnostics/semantic_catalog/clickup_client.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_client.py
@@ -1,0 +1,45 @@
+"""Thin ClickUp REST v2 client for interim Sigma-build tasks (DATA-2199).
+
+Stdlib only. All HTTP goes through _http_json so tests can replace one seam and
+never touch the network. The API token is passed in by the caller (read from the
+CLICKUP_TASK_TOKEN env var in cli.py); nothing here reads the environment.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from semantic_catalog.sigma_tasks import TaskPayload
+
+
+class ClickUpClient:
+    def __init__(self, token: str, api_base: str = "https://api.clickup.com/api/v2") -> None:
+        self._token = token
+        self._api_base = api_base.rstrip("/")
+
+    def _http_json(self, method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(f"{self._api_base}{path}", data=data, method=method)
+        req.add_header("Authorization", self._token)
+        req.add_header("Content-Type", "application/json")
+        with urllib.request.urlopen(req) as resp:  # fixed api base, not user input
+            return json.loads(resp.read().decode())
+
+    def find_task_by_build_key(self, list_id: str, field_id: str, build_key: str) -> str | None:
+        cf = json.dumps([{"field_id": field_id, "operator": "=", "value": build_key}])
+        query = urllib.parse.urlencode({"custom_fields": cf, "include_closed": "true"})
+        resp = self._http_json("GET", f"/list/{list_id}/task?{query}")
+        tasks = resp.get("tasks") or []
+        return tasks[0]["id"] if tasks else None
+
+    def create_task(self, list_id: str, payload: TaskPayload, field_id: str) -> str:
+        body = {
+            "name": payload.name,
+            "markdown_description": payload.markdown_description,
+            "custom_fields": [{"id": field_id, "value": payload.build_key}],
+        }
+        resp = self._http_json("POST", f"/list/{list_id}/task", body)
+        return resp["id"]

--- a/analytics/diagnostics/semantic_catalog/clickup_client.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_client.py
@@ -8,6 +8,7 @@ CLICKUP_TASK_TOKEN env var in cli.py); nothing here reads the environment.
 from __future__ import annotations
 
 import json
+import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Any
@@ -25,15 +26,24 @@ class ClickUpClient:
         req = urllib.request.Request(f"{self._api_base}{path}", data=data, method=method)
         req.add_header("Authorization", self._token)
         req.add_header("Content-Type", "application/json")
-        with urllib.request.urlopen(req, timeout=30) as resp:  # fixed api base, not user input
-            return json.loads(resp.read().decode())
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:  # fixed api base, not user input
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode(errors="replace")[:500]
+            raise RuntimeError(f"ClickUp API {method} {path} failed: HTTP {e.code} {detail}") from e
 
     def find_task_by_build_key(self, list_id: str, field_id: str, build_key: str) -> str | None:
         cf = json.dumps([{"field_id": field_id, "operator": "=", "value": build_key}])
         query = urllib.parse.urlencode({"custom_fields": cf, "include_closed": "true"})
         resp = self._http_json("GET", f"/list/{list_id}/task?{query}")
-        tasks = resp.get("tasks") or []
-        return tasks[0]["id"] if tasks else None
+        # ClickUp's "=" filter can be a substring match on short text, so confirm an
+        # EXACT build-key match client-side before treating it as a dedupe hit.
+        for task in resp.get("tasks") or []:
+            for field in task.get("custom_fields") or []:
+                if field.get("id") == field_id and field.get("value") == build_key:
+                    return task["id"]
+        return None
 
     def create_task(self, list_id: str, payload: TaskPayload, field_id: str) -> str:
         body = {

--- a/analytics/diagnostics/semantic_catalog/clickup_client.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_client.py
@@ -32,6 +32,8 @@ class ClickUpClient:
         except urllib.error.HTTPError as e:
             detail = e.read().decode(errors="replace")[:500]
             raise RuntimeError(f"ClickUp API {method} {path} failed: HTTP {e.code} {detail}") from e
+        except urllib.error.URLError as e:
+            raise RuntimeError(f"ClickUp API {method} {path} failed: {e.reason}") from e
 
     def find_task_by_build_key(self, list_id: str, field_id: str, build_key: str) -> str | None:
         cf = json.dumps([{"field_id": field_id, "operator": "=", "value": build_key}])

--- a/analytics/diagnostics/semantic_catalog/clickup_client.py
+++ b/analytics/diagnostics/semantic_catalog/clickup_client.py
@@ -25,7 +25,7 @@ class ClickUpClient:
         req = urllib.request.Request(f"{self._api_base}{path}", data=data, method=method)
         req.add_header("Authorization", self._token)
         req.add_header("Content-Type", "application/json")
-        with urllib.request.urlopen(req) as resp:  # fixed api base, not user input
+        with urllib.request.urlopen(req, timeout=30) as resp:  # fixed api base, not user input
             return json.loads(resp.read().decode())
 
     def find_task_by_build_key(self, list_id: str, field_id: str, build_key: str) -> str | None:

--- a/analytics/diagnostics/semantic_catalog/config/sigma_tasks.yml
+++ b/analytics/diagnostics/semantic_catalog/config/sigma_tasks.yml
@@ -1,0 +1,5 @@
+# ClickUp target for interim Sigma-build tracking tasks (DATA-2199).
+# Non-secret identifiers only. The API token is injected via the
+# CLICKUP_TASK_TOKEN CI secret and is never committed.
+list_id: "901326391561"                 # Data Board (start here; movable later)
+build_key_field_id: "REPLACE_WITH_FIELD_ID"  # id of the "Sigma build key" text custom field (prerequisite P1)

--- a/analytics/diagnostics/semantic_catalog/config/sigma_tasks.yml
+++ b/analytics/diagnostics/semantic_catalog/config/sigma_tasks.yml
@@ -2,4 +2,4 @@
 # Non-secret identifiers only. The API token is injected via the
 # CLICKUP_TASK_TOKEN CI secret and is never committed.
 list_id: "901326391561"                 # Data Board (start here; movable later)
-build_key_field_id: "REPLACE_WITH_FIELD_ID"  # id of the "Sigma build key" text custom field (prerequisite P1)
+build_key_field_id: "891e5e55-47af-4724-90d5-dca1b7fe9162"  # id of the "Sigma build key" custom field on the Data Board

--- a/analytics/diagnostics/semantic_catalog/sigma_tasks.py
+++ b/analytics/diagnostics/semantic_catalog/sigma_tasks.py
@@ -9,6 +9,7 @@ ClickUp (see sync()).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from semantic_catalog.records import MetricRecord
 
@@ -72,3 +73,36 @@ def newly_ratified(before: list[MetricRecord], after: list[MetricRecord]) -> lis
         if old is None or old.ratified != rec.ratified:
             out.append(rec)
     return out
+
+
+class ClickUpTaskClient(Protocol):
+    def find_task_by_build_key(self, list_id: str, field_id: str, build_key: str) -> str | None: ...
+
+    def create_task(self, list_id: str, payload: TaskPayload, field_id: str) -> str: ...
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    created: tuple[str, ...]
+    skipped: tuple[str, ...]
+
+
+def sync(
+    client: ClickUpTaskClient,
+    list_id: str,
+    field_id: str,
+    before: list[MetricRecord],
+    after: list[MetricRecord],
+) -> SyncResult:
+    """Create one ClickUp task per newly-ratified metric, skipping any that
+    already exist in ClickUp (keyed on the build key custom field)."""
+    created: list[str] = []
+    skipped: list[str] = []
+    for rec in newly_ratified(before, after):
+        key = build_key(rec)
+        if client.find_task_by_build_key(list_id, field_id, key) is not None:
+            skipped.append(rec.name)
+            continue
+        client.create_task(list_id, task_payload(rec), field_id)
+        created.append(rec.name)
+    return SyncResult(created=tuple(created), skipped=tuple(skipped))

--- a/analytics/diagnostics/semantic_catalog/sigma_tasks.py
+++ b/analytics/diagnostics/semantic_catalog/sigma_tasks.py
@@ -1,0 +1,33 @@
+"""Create interim ClickUp tasks for metrics that were just ratified (DATA-2199).
+
+Pure detection + payload logic here; the ClickUp HTTP calls live in
+semantic_catalog.clickup_client. A task fires when a metric transitions to a
+new ratified date; re-run idempotency is handled downstream by a check against
+ClickUp (see sync()).
+"""
+
+from __future__ import annotations
+
+from semantic_catalog.records import MetricRecord
+
+
+def build_key(rec: MetricRecord) -> str:
+    """Dedupe key: metric name plus the ratified date it was shipped under."""
+    return f"{rec.name}@{rec.ratified}"
+
+
+def newly_ratified(before: list[MetricRecord], after: list[MetricRecord]) -> list[MetricRecord]:
+    """Metrics whose ratified date is set in `after` and differs from `before`.
+
+    Excludes still-pending and retired metrics. A brand-new metric that arrives
+    already ratified counts as newly ratified.
+    """
+    prev = {r.name: r for r in before}
+    out: list[MetricRecord] = []
+    for rec in after:
+        if rec.retired or not rec.ratified:
+            continue
+        old = prev.get(rec.name)
+        if old is None or old.ratified != rec.ratified:
+            out.append(rec)
+    return out

--- a/analytics/diagnostics/semantic_catalog/sigma_tasks.py
+++ b/analytics/diagnostics/semantic_catalog/sigma_tasks.py
@@ -42,6 +42,8 @@ Build key: {build_key}
 
 
 def task_payload(rec: MetricRecord) -> TaskPayload:
+    # label and definition are echoed verbatim from config; the no-em-dash/no-emoji copy
+    # rule is enforced upstream at the governance layer (see DATA-2211).
     key = build_key(rec)
     return TaskPayload(
         name=f"Build in Sigma: {rec.label} ({rec.name})",

--- a/analytics/diagnostics/semantic_catalog/sigma_tasks.py
+++ b/analytics/diagnostics/semantic_catalog/sigma_tasks.py
@@ -8,12 +8,51 @@ ClickUp (see sync()).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from semantic_catalog.records import MetricRecord
 
 
 def build_key(rec: MetricRecord) -> str:
     """Dedupe key: metric name plus the ratified date it was shipped under."""
     return f"{rec.name}@{rec.ratified}"
+
+
+@dataclass(frozen=True)
+class TaskPayload:
+    name: str
+    markdown_description: str
+    build_key: str
+
+
+_DESCRIPTION = """\
+Build this ratified semantic-layer metric in Sigma.
+
+Metric: {name}
+Definition: {definition}
+Ratified: {ratified}
+
+Created automatically when the metric was ratified and merged. This is an interim
+step until the dbt to Sigma automation (DATA-2200) or Sigma's native OSI write-back
+is in place. Check this off once the metric exists in Sigma, and link the Sigma
+object here.
+
+Build key: {build_key}
+"""
+
+
+def task_payload(rec: MetricRecord) -> TaskPayload:
+    key = build_key(rec)
+    return TaskPayload(
+        name=f"Build in Sigma: {rec.label} ({rec.name})",
+        markdown_description=_DESCRIPTION.format(
+            name=rec.name,
+            definition=rec.definition,
+            ratified=rec.ratified,
+            build_key=key,
+        ),
+        build_key=key,
+    )
 
 
 def newly_ratified(before: list[MetricRecord], after: list[MetricRecord]) -> list[MetricRecord]:

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -92,3 +92,29 @@ def test_records_by_target_raises_on_unmapped_sem_file():
     )
     with pytest.raises(ValueError):
         cli.records_by_target([stray])
+
+
+def test_sync_sigma_tasks_skips_cleanly_without_token(capsys, monkeypatch):
+    monkeypatch.delenv("CLICKUP_TASK_TOKEN", raising=False)
+    rc = cli.main(["--sync-sigma-tasks"])
+    assert rc == 0
+    assert "skipping" in capsys.readouterr().out.lower()
+
+
+def test_sync_sigma_tasks_invokes_sync_when_token_present(capsys, monkeypatch):
+    monkeypatch.setenv("CLICKUP_TASK_TOKEN", "tok")
+    seen = {}
+
+    def fake_sync(client, list_id, field_id, before, after):
+        seen["list_id"] = list_id
+        seen["field_id"] = field_id
+        from semantic_catalog.sigma_tasks import SyncResult
+
+        return SyncResult(created=("m",), skipped=())
+
+    monkeypatch.setattr(cli.sigma_tasks, "sync", fake_sync)
+    rc = cli.main(["--sync-sigma-tasks"])
+    assert rc == 0
+    # list_id comes from the committed config, not a hardcoded literal in cli.py
+    assert seen["list_id"] == "901326391561"
+    assert "created 1" in capsys.readouterr().out.lower()

--- a/analytics/tests/test_semantic_catalog_clickup_client.py
+++ b/analytics/tests/test_semantic_catalog_clickup_client.py
@@ -1,0 +1,42 @@
+from semantic_catalog.clickup_client import ClickUpClient
+from semantic_catalog.sigma_tasks import TaskPayload
+
+
+def _client_with_recorder(responses):
+    """A ClickUpClient whose HTTP seam is replaced by a canned-response recorder."""
+    calls = []
+    client = ClickUpClient(token="tok")
+
+    def fake(method, path, body=None):
+        calls.append((method, path, body))
+        return responses.pop(0)
+
+    client._http_json = fake  # type: ignore[method-assign]
+    return client, calls
+
+
+def test_find_returns_task_id_when_present():
+    client, calls = _client_with_recorder([{"tasks": [{"id": "abc"}]}])
+    got = client.find_task_by_build_key("901", "field1", "m@2026-07-28")
+    assert got == "abc"
+    method, path, _ = calls[0]
+    assert method == "GET"
+    assert "/list/901/task" in path
+    assert "field1" in path and "m%40" in path  # custom_fields filter urlencoded
+
+
+def test_find_returns_none_when_absent():
+    client, _ = _client_with_recorder([{"tasks": []}])
+    assert client.find_task_by_build_key("901", "field1", "m@2026-07-28") is None
+
+
+def test_create_posts_name_description_and_build_key_field():
+    client, calls = _client_with_recorder([{"id": "new1"}])
+    payload = TaskPayload(name="Build in Sigma: M (m)", markdown_description="body", build_key="m@2026-07-28")
+    got = client.create_task("901", payload, "field1")
+    assert got == "new1"
+    method, path, body = calls[0]
+    assert method == "POST" and path == "/list/901/task"
+    assert body["name"] == "Build in Sigma: M (m)"
+    assert body["markdown_description"] == "body"
+    assert {"id": "field1", "value": "m@2026-07-28"} in body["custom_fields"]

--- a/analytics/tests/test_semantic_catalog_clickup_client.py
+++ b/analytics/tests/test_semantic_catalog_clickup_client.py
@@ -1,3 +1,8 @@
+import io
+import urllib.error
+import urllib.request
+
+import pytest
 from semantic_catalog.clickup_client import ClickUpClient
 from semantic_catalog.sigma_tasks import TaskPayload
 
@@ -16,7 +21,9 @@ def _client_with_recorder(responses):
 
 
 def test_find_returns_task_id_when_present():
-    client, calls = _client_with_recorder([{"tasks": [{"id": "abc"}]}])
+    client, calls = _client_with_recorder(
+        [{"tasks": [{"id": "abc", "custom_fields": [{"id": "field1", "value": "m@2026-07-28"}]}]}]
+    )
     got = client.find_task_by_build_key("901", "field1", "m@2026-07-28")
     assert got == "abc"
     method, path, _ = calls[0]
@@ -25,9 +32,37 @@ def test_find_returns_task_id_when_present():
     assert "field1" in path and "m%40" in path  # custom_fields filter urlencoded
 
 
+def test_find_rejects_substring_collision():
+    """ClickUp's "=" filter on short text can be a substring match, so a returned
+    task whose field value is a different, superset key must not be treated as a hit.
+    """
+    client, _ = _client_with_recorder(
+        [{"tasks": [{"id": "abc", "custom_fields": [{"id": "field1", "value": "win_users@2026-07-28"}]}]}]
+    )
+    got = client.find_task_by_build_key("901", "field1", "users@2026-07-28")
+    assert got is None
+
+
 def test_find_returns_none_when_absent():
     client, _ = _client_with_recorder([{"tasks": []}])
     assert client.find_task_by_build_key("901", "field1", "m@2026-07-28") is None
+
+
+def test_http_json_wraps_httperror(monkeypatch):
+    def fake_urlopen(req, timeout=30):
+        raise urllib.error.HTTPError(
+            "https://api.clickup.com/api/v2/list/901/task",
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=io.BytesIO(b'{"err":"bad field"}'),
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = ClickUpClient(token="tok")
+    payload = TaskPayload(name="n", markdown_description="d", build_key="k@2026-07-28")
+    with pytest.raises(RuntimeError, match="400"):
+        client.create_task("901", payload, "field1")
 
 
 def test_create_posts_name_description_and_build_key_field():

--- a/analytics/tests/test_semantic_catalog_clickup_client.py
+++ b/analytics/tests/test_semantic_catalog_clickup_client.py
@@ -65,6 +65,17 @@ def test_http_json_wraps_httperror(monkeypatch):
         client.create_task("901", payload, "field1")
 
 
+def test_http_json_wraps_urlerror(monkeypatch):
+    def fake_urlopen(req, timeout=30):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = ClickUpClient(token="tok")
+    payload = TaskPayload(name="n", markdown_description="d", build_key="k@2026-07-28")
+    with pytest.raises(RuntimeError, match="connection refused"):
+        client.create_task("901", payload, "field1")
+
+
 def test_create_posts_name_description_and_build_key_field():
     client, calls = _client_with_recorder([{"id": "new1"}])
     payload = TaskPayload(name="Build in Sigma: M (m)", markdown_description="body", build_key="m@2026-07-28")

--- a/analytics/tests/test_semantic_catalog_sigma_tasks.py
+++ b/analytics/tests/test_semantic_catalog_sigma_tasks.py
@@ -70,3 +70,46 @@ def test_task_payload_shape():
     assert "active_serve_users@2026-07-28" in p.markdown_description
     # Org copy rule: no em dashes, no emoji in generated copy.
     assert "—" not in p.name and "—" not in p.markdown_description
+
+
+class _FakeClient:
+    def __init__(self, existing_keys=()):
+        self.existing = set(existing_keys)
+        self.created = []
+
+    def find_task_by_build_key(self, list_id, field_id, build_key):
+        return "existing-id" if build_key in self.existing else None
+
+    def create_task(self, list_id, payload, field_id):
+        self.created.append(payload.build_key)
+        return "new-id"
+
+
+def test_sync_creates_task_for_newly_ratified():
+    client = _FakeClient()
+    result = sigma_tasks.sync(
+        client, "901", "field1", [_rec("m", ratified=None)], [_rec("m", ratified="2026-07-28")]
+    )
+    assert client.created == ["m@2026-07-28"]
+    assert result.created == ("m",)
+    assert result.skipped == ()
+
+
+def test_sync_is_idempotent_when_task_already_exists():
+    # Same transition seen again on a workflow re-run: ClickUp already has the task.
+    client = _FakeClient(existing_keys={"m@2026-07-28"})
+    result = sigma_tasks.sync(
+        client, "901", "field1", [_rec("m", ratified=None)], [_rec("m", ratified="2026-07-28")]
+    )
+    assert client.created == []
+    assert result.created == ()
+    assert result.skipped == ("m",)
+
+
+def test_sync_noop_when_nothing_newly_ratified():
+    client = _FakeClient()
+    result = sigma_tasks.sync(
+        client, "901", "field1", [_rec("m", ratified="2026-07-28")], [_rec("m", ratified="2026-07-28")]
+    )
+    assert client.created == []
+    assert result == sigma_tasks.SyncResult(created=(), skipped=())

--- a/analytics/tests/test_semantic_catalog_sigma_tasks.py
+++ b/analytics/tests/test_semantic_catalog_sigma_tasks.py
@@ -1,0 +1,58 @@
+from semantic_catalog import sigma_tasks
+from semantic_catalog.records import MetricRecord
+
+
+def _rec(name, ratified=None, retired=None, definition="def"):
+    return MetricRecord(
+        name=name,
+        label=name.replace("_", " ").title(),
+        definition=definition,
+        metric_type="simple",
+        source="ref('m')",
+        dimensions=(),
+        filter=None,
+        owner="semantic-layer-business",
+        ratified=ratified,
+        detail_doc="engagement.md",
+        retired=retired,
+        yaml_file="sem_analytics__users_serve.yml",
+        kind="metric",
+    )
+
+
+def test_newly_ratified_fires_on_pending_to_dated_transition():
+    before = [_rec("m", ratified=None)]
+    after = [_rec("m", ratified="2026-07-28")]
+    got = [r.name for r in sigma_tasks.newly_ratified(before, after)]
+    assert got == ["m"]
+
+
+def test_newly_ratified_ignores_already_ratified_unchanged():
+    before = [_rec("m", ratified="2026-07-28")]
+    after = [_rec("m", ratified="2026-07-28")]
+    assert sigma_tasks.newly_ratified(before, after) == []
+
+
+def test_newly_ratified_fires_again_on_new_ratified_date():
+    before = [_rec("m", ratified="2026-07-28")]
+    after = [_rec("m", ratified="2026-08-15")]
+    assert [r.name for r in sigma_tasks.newly_ratified(before, after)] == ["m"]
+
+
+def test_newly_ratified_treats_brand_new_ratified_metric_as_new():
+    before = []
+    after = [_rec("m", ratified="2026-07-28")]
+    assert [r.name for r in sigma_tasks.newly_ratified(before, after)] == ["m"]
+
+
+def test_newly_ratified_excludes_pending_and_retired():
+    before = []
+    after = [_rec("still_pending", ratified=None), _rec("dead", ratified="2026-07-28", retired="2026-07-30")]
+    assert sigma_tasks.newly_ratified(before, after) == []
+
+
+def test_build_key_is_name_at_ratified_date():
+    assert (
+        sigma_tasks.build_key(_rec("active_serve_users", ratified="2026-07-28"))
+        == "active_serve_users@2026-07-28"
+    )

--- a/analytics/tests/test_semantic_catalog_sigma_tasks.py
+++ b/analytics/tests/test_semantic_catalog_sigma_tasks.py
@@ -56,3 +56,17 @@ def test_build_key_is_name_at_ratified_date():
         sigma_tasks.build_key(_rec("active_serve_users", ratified="2026-07-28"))
         == "active_serve_users@2026-07-28"
     )
+
+
+def test_task_payload_shape():
+    p = sigma_tasks.task_payload(
+        _rec("active_serve_users", ratified="2026-07-28", definition="count of active serve users")
+    )
+    assert p.build_key == "active_serve_users@2026-07-28"
+    assert "active_serve_users" in p.name
+    assert p.name.startswith("Build in Sigma:")
+    assert "count of active serve users" in p.markdown_description
+    assert "2026-07-28" in p.markdown_description
+    assert "active_serve_users@2026-07-28" in p.markdown_description
+    # Org copy rule: no em dashes, no emoji in generated copy.
+    assert "—" not in p.name and "—" not in p.markdown_description


### PR DESCRIPTION
## Summary

Auto-create a ClickUp "build this in Sigma" task whenever a governed semantic-layer metric becomes ratified and merges. This is the interim mechanism agreed in the 2026-07-28 semantic-layer SLA review, until Sigma's native OSI write-back lands. It closes DATA-2199 (subtask of the OSI epic DATA-2126).

When a merge to `main` touches a governed `sem_*.yml` and flips a metric from pending to a ratified date, the publish workflow creates one tracked task on the Data Board so the business team can build that metric in Sigma by hand and check it off.

## What changed

All inside the existing `analytics/diagnostics/semantic_catalog` generator package, standard library only:

- `sigma_tasks.py` — pure logic: `newly_ratified` (detects the pending to dated transition off the same before/after records the Slack step already builds), `build_key` (`metric_name@ratified_date`), `task_payload`, and `sync` (check-before-create idempotency).
- `clickup_client.py` — thin ClickUp REST v2 client over `urllib` (find + create), one HTTP seam for testing, 30s timeout.
- `config/sigma_tasks.yml` — non-secret ids: the Data Board list and the `Sigma build key` custom field. The API token is never committed.
- `cli.py` — new `--sync-sigma-tasks` mode, guarded by the `CLICKUP_TASK_TOKEN` env var (skips cleanly when unset, mirroring the Slack token guard).
- `.github/workflows/semantic-layer-publish.yml` — new guarded step on the on-merge publish job, sharing the base worktree across the Slack and Sigma consumers with an explicit cleanup step.

## How dedupe works

The dedupe key is `metric_name@ratified_date`, stored in the `Sigma build key` custom field on each created task. Before creating, the workflow queries the list for that key and skips if a task already exists. State lives in ClickUp, not the repo, so nothing is pushed to protected `main`. This preserves the tokenless-to-protected-main property from #699. Re-runs of the same merge, and re-merges, do not create duplicates. A genuine re-ratification (new date) does create a fresh build task, which is the intended behavior.

## Governance note (please read)

This re-introduces a scoped ClickUp API token into CI as the `CLICKUP_TASK_TOKEN` repo secret. That partially reverses the tokenless CI decision from #699, which had moved ClickUp writes out of CI to an out-of-band MCP path. The scope here is narrow (create interim Sigma-build tasks only) and the secret is named distinctly from the old `CLICKUP_API_TOKEN` to signal that. The full automation that replaces this interim path (dbt to Sigma via the Sigma REST API) is tracked separately in DATA-2200.

## Prerequisites (both done)

- P1: the `Sigma build key` short_text custom field exists on the Data Board; its id is committed in `config/sigma_tasks.yml`.
- P2: the `CLICKUP_TASK_TOKEN` repo secret is set.

Until this merges the step is inert; after merge, the next ratified-metric merge fires the live path.

## Live-verify

The ClickUp find and create payloads are exercised against the real API for the first time on the first ratified-metric merge after this lands. Worth watching that first run: it should create exactly one task, and a workflow re-run should create no duplicate.

## Testing

- Full `semantic_catalog` suite: 61 passing, ruff and mypy clean.
- Built via TDD, task by task, each with an independent spec and quality review, plus a final whole-branch review (verdict: ready to merge, zero critical).

## Follow-up

- DATA-2211: enforce the no-em-dash / no-emoji copy rule on owner-authored metric `label` and `definition` at the governance layer. This PR echoes those fields faithfully and defers sanitization there (a code comment points to it).

Closes DATA-2199.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reintroduces a scoped ClickUp API token in CI and performs live task creation on merge; mitigated by token guard, dedupe keys, and narrow create-only scope.
> 
> **Overview**
> Adds **automatic ClickUp “build in Sigma” tasks** when governed semantic-layer metrics become ratified on merge to `main`, plus workflow refactors so Slack and ClickUp share the same before/after diff.
> 
> The publish workflow now **prepares a detached base worktree** once (`/tmp/base` from `github.event.before`), uses it for Slack summary generation and the new step, then **cleans up** in an `always()` step. `semantic_catalog.cli` gains **`--sync-sigma-tasks`** (guarded by `CLICKUP_TASK_TOKEN`, skips when unset) and a shared **`_before_after`** helper for Slack and sync.
> 
> New **`sigma_tasks`** logic detects **newly ratified** metrics (pending→dated or new ratified date), builds payloads keyed by `metric_name@ratified_date`, and **syncs idempotently** via ClickUp custom-field lookup before create. **`clickup_client`** is a thin stdlib REST v2 client; list/field ids live in **`config/sigma_tasks.yml`**. Tests cover detection, sync dedupe, client HTTP shape, and CLI token guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a7fef5fe1601be1270b901c7bddcfe35cb53d0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->