### PR TITLE
Add L2 residence ZIP length guardrail

### DIFF
--- a/dbt/project/tests/assert_w_haystaq_residence_zip_length.sql
+++ b/dbt/project/tests/assert_w_haystaq_residence_zip_length.sql
@@ -1,0 +1,17 @@
+-- Guardrail: once populated, an L2 residence ZIP must be 5 characters. The
+-- leading-zero states (NJ 08, MA 01, CT 06, NH 03, ME 04, RI 02, VT 05) silently
+-- lose the leading zero the moment any layer types the ZIP as a number instead of
+-- a string, turning 08731 into 8731. Stale rows in the incremental int layer have
+-- carried a len-4 ZIP toward the serving DB before. A small number of source
+-- values are genuinely malformed, so warn above that floor and error only on a
+-- real regression: the smallest leading-zero state is ~468k rows, so any single
+-- stripped state clears the error ceiling. Mailing_Addresses_Zip follows the same
+-- rule; residence is the district-assignment key, so it is the one gated here.
+{{ config(warn_if=">5000", error_if=">100000") }}
+
+select state_postal_code, residence_addresses_zip as bad_zip
+from {{ ref("int__l2_nationwide_uniform_w_haystaq") }}
+where
+    residence_addresses_zip is not null
+    and residence_addresses_zip <> ''
+    and length(residence_addresses_zip) <> 5

--- a/dbt/project/tests/test_int_haystaq_loaded_at_matches_source.sql
+++ b/dbt/project/tests/test_int_haystaq_loaded_at_matches_source.sql
@@ -1,12 +1,15 @@
--- m_people_api__voter derives updated_at directly from
--- int__l2_nationwide_uniform_w_haystaq's
--- loaded_at, so a mart-vs-int check would be tautological. Instead verify the
--- (incrementally
--- merged) w_haystaq intermediate actually picked up the latest L2 batch, by comparing
--- its max
--- loaded_at against the upstream int__l2_nationwide_uniform. Null-aware, and the
--- is-null guard
--- also fails an all-null loaded_at (both maxes null are "not distinct").
+-- Coherence check on the L2 intermediate layer. int__l2_nationwide_uniform_w_haystaq
+-- inherits loaded_at from int__l2_nationwide_uniform, so after a coherent build the two
+-- max(loaded_at) values must match. A mismatch means the layers are out of sync and
+-- were
+-- not built together, and EITHER side can be the stale one: the w_haystaq merge
+-- lagging a
+-- new uniform batch, or a regressed/partial uniform rebuild sitting behind an older,
+-- still
+-- coherent w_haystaq. So a red result is a signal to do a coherent full rebuild of
+-- both,
+-- not an instruction to rebuild w_haystaq (which can be the good side). Null-aware; the
+-- is-null guard also fails an all-null loaded_at (both maxes null are "not distinct").
 select *
 from
     (


### PR DESCRIPTION
## Why

The L2 leading-zero states (NJ, MA, CT, NH, ME, RI, VT) silently lose their leading ZIP zero the moment any layer types the ZIP as a number instead of a string: `08731` becomes `8731`. The ingest and `int` code already read/cast ZIPs as strings, but nothing *asserts* the invariant, so a regression can pass through unnoticed. We just caught 16.8M len-4 rows sitting in `int__l2_nationwide_uniform` (stale incremental rows from before the source was corrected). The good copy (`int__l2_nationwide_uniform_w_haystaq`, which every people-api mart reads) is clean, but there is no test that would fail loudly if a stripped state reached it on the next full rebuild.

This adds that guardrail on `int__l2_nationwide_uniform_w_haystaq`, the shared source of truth for the four people-api marts. It fires exactly when a regression would reach what ships.

## What

- **`assert_w_haystaq_residence_zip_length.sql`** — populated residence ZIPs must be 5 characters. Thresholds tolerate a small floor of genuinely-malformed source values (`warn_if > 5000`) and error only on a real regression (`error_if > 100000`); the smallest leading-zero state is ~468k rows, so any single stripped state clears the error ceiling. Currently passes with 0 violations.
- **Reworded the `loaded_at` coherence test comment.** Its prior wording implied `w_haystaq` is always the stale side. In practice a mismatch can come from *either* side (a lagging `w_haystaq` merge, or a regressed/partial `uniform` rebuild sitting behind an older but coherent `w_haystaq`). The remedy is a coherent full rebuild of both, not blindly rebuilding `w_haystaq` — which can be the good copy. No logic change.

Residence is the district-assignment key, so it is the column gated here; `Mailing_Addresses_Zip` follows the same rule and can be added later.