### PR TITLE
Bump loader cache-bust to deploy #730 validate warn-only

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # Pinned to @main so the loader co-versions with the DAG on main and survives feature-branch
 # deletion post-merge.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-07-31.2
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-08-01.1
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This


### PR DESCRIPTION
## Why

The loader image running in astro-prod predates #730, so `prod_row_counts_within_tolerance` in the validate step is still a **fatal** check. A correct end-to-end prod run just failed validation on it: Maine legitimately dropped from 1,136,823 to 970,306 voters (~14.6%) in the current L2 vintage — real voter-roll maintenance, and the new number matches the coherent mart exactly. That exceeds the 10% tolerance.

#730 downgraded this exact check to warn-only precisely because it false-positives on legitimate per-state L2 removals. But merging #730 did not redeploy the loader: the astro image installs the loader from `@main` and the install layer is keyed on `requirements.txt`, so an unchanged file leaves a stale loader (and the merge-triggered redeploy path does not bump it).

Bumping the cache-bust token forces the image to reinstall the loader from `@main`, picking up the warn-only behavior. After this deploys, a fresh `load_people_api` run validates cleanly (Maine becomes a warning), and future monthly runs stop failing on legitimate roll changes.

No code change — one-line cache-bust bump.