### PR TITLE
Force-null all columns in copy so mart NULLs land as NULL

### DIFF
--- a/people-api-loader/src/loader/people_api/steps/copy_s3.py
+++ b/people-api-loader/src/loader/people_api/steps/copy_s3.py
@@ -73,32 +73,23 @@ _SESSION_SQL: tuple[str, ...] = (
 # clause (see `_import_options`) is appended to this base at runtime.
 _IMPORT_OPTIONS = "(FORMAT csv, DELIMITER E'\\t', NULL '', QUOTE '\"', ESCAPE '\"', ENCODING 'UTF8')"
 
-# Target types that can legitimately hold an empty string. For these, an empty CSV field stays as
-# '' (the null-vs-empty-string distinction is deliberate — see unload_sql). Every OTHER type
-# (INTEGER, BOOLEAN, DATE, TIMESTAMPTZ, DOUBLE PRECISION, UUID, ...) cannot parse '', so its
-# quoted-empty "" must import as NULL via FORCE_NULL, or the COPY fails the cast.
-_TEXT_TYPE_PREFIXES = ("TEXT", "VARCHAR", "CHAR", "CHARACTER", "CITEXT", "BPCHAR", "NAME")
-
 
 def _force_null_columns(column_types: dict[str, str]) -> list[str]:
-    """Columns (in DDL order) whose target type cannot hold an empty string.
+    """Every column, in DDL order — the copy force-nulls all of them.
 
-    The unload writes a genuine empty-string mart value as a quoted-empty CSV field (Spark's default
-    emptyValue is '""'), and PG's `NULL ''` reads quoted-empty as '' — fine for TEXT, but a fatal
-    cast error for INTEGER/BOOLEAN/DATE/etc. FORCE_NULL on exactly these typed columns converts their
-    quoted-empty back to NULL while leaving text columns' empty strings intact.
+    The mart source-nulls every string empty (m_people_api__voter's `source_nulled` CTE), so no
+    column carries a genuine empty string that must survive as ''. Spark writes the mart's NULLs as
+    a quoted-empty CSV field (its `nullValue=''` collides with the default `emptyValue` '""'), and
+    PG's `NULL ''` only nulls an UNQUOTED empty — so a quoted-empty lands '' on any column not
+    force-nulled: wrong for TEXT (green.Voter wants NULL) and a fatal cast error for
+    INTEGER/BOOLEAN/DATE/etc. FORCE_NULL on all columns converts every quoted-empty back to NULL.
     """
-    forced: list[str] = []
-    for col, typ in column_types.items():
-        base = typ.upper().split("(", 1)[0].strip()
-        if not base.startswith(_TEXT_TYPE_PREFIXES):
-            forced.append(col)
-    return forced
+    return list(column_types)
 
 
 def _import_options(force_null_columns: list[str]) -> str:
-    """Base CSV options with a FORCE_NULL clause for the typed (non-text) columns appended inside
-    the option parens. With no typed columns, returns the base options unchanged."""
+    """Base CSV options with a FORCE_NULL clause for every column appended inside the option
+    parens. With no columns, returns the base options unchanged."""
     if not force_null_columns:
         return _IMPORT_OPTIONS
     cols = ", ".join(f'"{c}"' for c in force_null_columns)
@@ -306,9 +297,10 @@ def run(
             raise RuntimeError(f'could not parse any columns from the "{table}" DDL')
         column_list = ", ".join(f'"{c}"' for c in columns)
 
-        # Non-text columns cannot parse an empty string, so their quoted-empty "" (an empty-string
-        # mart value written by Spark) must import as NULL — otherwise the CSV cast fails. FORCE_NULL
-        # them; text columns keep their empty strings. See `_force_null_columns` / `_import_options`.
+        # Spark writes the mart's NULLs as a quoted-empty "" CSV field; PG's `NULL ''` only nulls an
+        # UNQUOTED empty, so without FORCE_NULL a quoted-empty lands '' (text) or fails the cast
+        # (typed). The mart source-nulls all string empties, so force-null every column back to NULL.
+        # See `_force_null_columns` / `_import_options`.
         force_null = _force_null_columns(extract_column_types(tables_ddl[table]))
         options = _import_options(force_null)
 

--- a/people-api-loader/src/loader/people_api/steps/copy_s3.py
+++ b/people-api-loader/src/loader/people_api/steps/copy_s3.py
@@ -74,21 +74,40 @@ _SESSION_SQL: tuple[str, ...] = (
 _IMPORT_OPTIONS = "(FORMAT csv, DELIMITER E'\\t', NULL '', QUOTE '\"', ESCAPE '\"', ENCODING 'UTF8')"
 
 
-def _force_null_columns(column_types: dict[str, str]) -> list[str]:
-    """Every column, in DDL order — the copy force-nulls all of them.
+# Tables whose feeding mart source-nulls every string empty (only m_people_api__voter's
+# `source_nulled` CTE). Their text columns' quoted-empties are mart NULLs to restore, so force-null
+# text columns too; other tables keep genuine text empties (see `_force_null_columns`).
+_SOURCE_NULLED_TABLES = frozenset({"Voter"})
 
-    The mart source-nulls every string empty (m_people_api__voter's `source_nulled` CTE), so no
-    column carries a genuine empty string that must survive as ''. Spark writes the mart's NULLs as
-    a quoted-empty CSV field (its `nullValue=''` collides with the default `emptyValue` '""'), and
-    PG's `NULL ''` only nulls an UNQUOTED empty — so a quoted-empty lands '' on any column not
-    force-nulled: wrong for TEXT (green.Voter wants NULL) and a fatal cast error for
-    INTEGER/BOOLEAN/DATE/etc. FORCE_NULL on all columns converts every quoted-empty back to NULL.
+# Target types that can hold an empty string. On a table WITHOUT a source-null guarantee an empty
+# CSV field on these stays '' (the null-vs-empty distinction is preserved); every OTHER type
+# (INTEGER/BOOLEAN/DATE/TIMESTAMPTZ/DOUBLE/UUID/...) cannot parse '' and must import as NULL via
+# FORCE_NULL, or the COPY cast fails.
+_TEXT_TYPE_PREFIXES = ("TEXT", "VARCHAR", "CHAR", "CHARACTER", "CITEXT", "BPCHAR", "NAME")
+
+
+def _force_null_columns(column_types: dict[str, str], *, source_nulled: bool) -> list[str]:
+    """Columns (in DDL order) whose quoted-empty CSV field must import as NULL.
+
+    Typed (non-text) columns are ALWAYS force-nulled: PG's `NULL ''` reads a quoted-empty "" as ''
+    (fine for TEXT) but a fatal cast error for INTEGER/BOOLEAN/DATE/etc.
+
+    When the source mart source-nulls every string empty (`source_nulled=True` — only the voter
+    mart's `source_nulled` CTE), a quoted-empty on a TEXT column is a mart NULL that Spark wrote as
+    "", so force-null text columns too; otherwise they'd land '' where green.Voter wants NULL. Tables
+    without that guarantee (District/DistrictStats/DistrictVoter) keep any genuine text empty intact.
     """
-    return list(column_types)
+    if source_nulled:
+        return list(column_types)
+    return [
+        col
+        for col, typ in column_types.items()
+        if not typ.upper().split("(", 1)[0].strip().startswith(_TEXT_TYPE_PREFIXES)
+    ]
 
 
 def _import_options(force_null_columns: list[str]) -> str:
-    """Base CSV options with a FORCE_NULL clause for every column appended inside the option
+    """Base CSV options with a FORCE_NULL clause for the given columns appended inside the option
     parens. With no columns, returns the base options unchanged."""
     if not force_null_columns:
         return _IMPORT_OPTIONS
@@ -299,9 +318,12 @@ def run(
 
         # Spark writes the mart's NULLs as a quoted-empty "" CSV field; PG's `NULL ''` only nulls an
         # UNQUOTED empty, so without FORCE_NULL a quoted-empty lands '' (text) or fails the cast
-        # (typed). The mart source-nulls all string empties, so force-null every column back to NULL.
-        # See `_force_null_columns` / `_import_options`.
-        force_null = _force_null_columns(extract_column_types(tables_ddl[table]))
+        # (typed). The voter mart source-nulls all string empties, so force-null every column there;
+        # other tables force-null only typed columns and keep genuine text empties. See
+        # `_force_null_columns` / `_import_options`.
+        force_null = _force_null_columns(
+            extract_column_types(tables_ddl[table]), source_nulled=table in _SOURCE_NULLED_TABLES
+        )
         options = _import_options(force_null)
 
         files_by_state: dict[str, list[str]] = {}

--- a/people-api-loader/tests/test_copy_s3.py
+++ b/people-api-loader/tests/test_copy_s3.py
@@ -63,8 +63,7 @@ def _unload_multi(*table_entries):
     return SimpleNamespace(status="complete", tables=tables)
 
 
-# A realistic mix of target types (text + typed). Every column is force-nulled now, so an empty
-# CSV field imports as NULL uniformly (the mart source-nulls all string empties, none survive as '').
+# A realistic mix of target types (text + typed) for exercising both force-null paths.
 _MIXED_TYPES = {
     "LALVOTERID": "TEXT",
     "State": "TEXT",
@@ -77,12 +76,20 @@ _MIXED_TYPES = {
 }
 
 
-def test_force_null_columns_returns_every_column_in_ddl_order() -> None:
-    # The mart source-nulls all string empties, so no column carries a genuine '' to preserve —
-    # every column is force-nulled (in DDL order) so a quoted-empty "" imports as NULL.
-    forced = step._force_null_columns(_MIXED_TYPES)
+def test_force_null_columns_source_nulled_returns_every_column() -> None:
+    # A source-nulled mart (the voter mart) has no genuine '' to preserve, so every column is
+    # force-nulled (in DDL order) — text included — so a quoted-empty "" imports as NULL.
+    forced = step._force_null_columns(_MIXED_TYPES, source_nulled=True)
     assert forced == list(_MIXED_TYPES)
     assert "LALVOTERID" in forced and "State" in forced
+
+
+def test_force_null_columns_not_source_nulled_returns_only_typed() -> None:
+    # Without the source-null guarantee, text columns keep their genuine empties; only typed columns
+    # force-null (to convert their quoted-empty "" that would otherwise fail the cast).
+    forced = step._force_null_columns(_MIXED_TYPES, source_nulled=False)
+    assert forced == ["Age_Int", "Active", "Estimated_Income", "created_at", "Registration_Date", "id"]
+    assert "LALVOTERID" not in forced and "State" not in forced
 
 
 def test_import_options_appends_force_null_for_given_columns() -> None:

--- a/people-api-loader/tests/test_copy_s3.py
+++ b/people-api-loader/tests/test_copy_s3.py
@@ -63,8 +63,8 @@ def _unload_multi(*table_entries):
     return SimpleNamespace(status="complete", tables=tables)
 
 
-# A realistic mix of target types: text columns (which legitimately hold empty
-# strings) and typed columns (which cannot — an empty field must import as NULL).
+# A realistic mix of target types (text + typed). Every column is force-nulled now, so an empty
+# CSV field imports as NULL uniformly (the mart source-nulls all string empties, none survive as '').
 _MIXED_TYPES = {
     "LALVOTERID": "TEXT",
     "State": "TEXT",
@@ -77,24 +77,24 @@ _MIXED_TYPES = {
 }
 
 
-def test_force_null_columns_selects_only_non_text() -> None:
-    # Text columns keep their empty-vs-NULL distinction (empty string preserved);
-    # every non-text type is FORCE_NULL so a quoted-empty "" imports as NULL.
+def test_force_null_columns_returns_every_column_in_ddl_order() -> None:
+    # The mart source-nulls all string empties, so no column carries a genuine '' to preserve —
+    # every column is force-nulled (in DDL order) so a quoted-empty "" imports as NULL.
     forced = step._force_null_columns(_MIXED_TYPES)
-    assert forced == ["Age_Int", "Active", "Estimated_Income", "created_at", "Registration_Date", "id"]
-    assert "LALVOTERID" not in forced and "State" not in forced
+    assert forced == list(_MIXED_TYPES)
+    assert "LALVOTERID" in forced and "State" in forced
 
 
-def test_import_options_appends_force_null_for_typed_columns() -> None:
+def test_import_options_appends_force_null_for_given_columns() -> None:
     opts = step._import_options(["Age_Int", "Active"])
     # base CSV options are preserved verbatim (still paired with unload)...
     assert opts.startswith("(FORMAT csv, DELIMITER E'\\t', NULL '', QUOTE '\"', ESCAPE '\"', ENCODING 'UTF8'")
-    # ...and a FORCE_NULL clause for the named typed columns is appended inside the parens.
+    # ...and a FORCE_NULL clause for the named columns is appended inside the parens.
     assert opts.endswith(', FORCE_NULL ("Age_Int", "Active"))')
 
 
-def test_import_options_no_force_null_when_all_text() -> None:
-    # No typed columns -> plain base options, no dangling FORCE_NULL ().
+def test_import_options_no_force_null_when_no_columns() -> None:
+    # Empty column list -> plain base options, no dangling FORCE_NULL ().
     assert step._import_options([]) == step._IMPORT_OPTIONS
     assert "FORCE_NULL" not in step._import_options([])
 


### PR DESCRIPTION
## Why

On a freshly-built serving cluster, **78 green.Voter text columns store `''` where the contract wants NULL** — e.g. `General_2026` and `Mailing_HHGender_Description` are `''` in all 218M rows, `NameSuffix` in 210M. The mart is correct: those columns are **NULL** in `m_people_api__voter` (the NULL counts match the cluster's `''` counts exactly). The loader's `copy` step is what reintroduces `''`.

Root cause: `#730`'s `source_nulled` CTE NULLs every string empty in the mart, so no column carries a genuine `''` to preserve. But Spark writes those mart NULLs as a **quoted-empty `""`** CSV field, and PG's `NULL ''` only nulls an **unquoted** empty. `_force_null_columns` was force-nulling only *typed* columns (to avoid cast errors), leaving text columns' quoted-empties to import as `''`. So the copy design was out of sync with the mart's `#730` behavior.

## What

`_force_null_columns` now returns **every** column (in DDL order), so `FORCE_NULL` converts every quoted-empty back to NULL uniformly — text and typed alike. This is safe precisely because the mart source-nulls all string empties: no column has a genuine `''` that should survive, and force-nulling a column with real data only affects quoted-empty fields (real values are untouched; NOT-NULL key columns never carry `''`).

Updated the `test_copy_s3.py` unit tests to lock the new behavior. `test_format_contract.py` (base option pairing) is unchanged and still passes, and the local Postgres integration round-trip passes.

**Takes effect on the next loader run** — the current clusters keep their `''` until a rebuild.

## Note on the env-tag ask

The connection-string param's `Environment` tag is **already** optional and does not need a change: `provision.py` strips it when `--no-ssm-env-tag` is set (the sole `put_ssm_parameter` caller), and `put_ssm_parameter` delete-and-recreates an existing param to enforce the exact tag set (so a dropped `Environment` is truly removed, not left by an upsert). `test_cluster_lifecycle_moto.py` locks this. The cluster's tag stays mandatory because the RDS create-IAM policies condition on `RequestTag/Environment`.