### PR TITLE
Bump loader cache-bust to deploy the copy force-null fix (#734)

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # Pinned to @main so the loader co-versions with the DAG on main and survives feature-branch
 # deletion post-merge.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-08-01.1
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-08-01.2
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This


### PR DESCRIPTION
## Why

#734 changed `copy_s3` so the Voter table's text-column empties import as NULL (fixing the 78 green.Voter columns that stored `''`). The astro-prod image reinstalls the loader from `@main`, and that install layer is keyed on `requirements.txt` — an unchanged file leaves a stale loader. Bump the cache-bust so merging this reinstalls the loader with #734.

Follow-up to #734 (matching the #730 → #733 pattern: code PR, then a standalone cache-bust to deploy it). After this deploys, the next `load_people_api` rebuild produces NULL, not `''`, for those columns.

One-line cache-bust bump; no code change.