### PR TITLE
[DATA] Fix stale/dropped company associations in int__hubspot_contacts_w_companies

### DIFF
--- a/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot.yaml
@@ -147,6 +147,9 @@ models:
         description: "HubSpot ID of the contact from the source system"
         tests:
           - not_null
+          # One row per contact is the model's grain and the incremental merge
+          # key; this guards the row_rank dedup against silently fanning out.
+          - unique
       - name: gp_candidacy_id
         description: "GoodParty Candidacy ID of the contact"
         tests:
@@ -156,12 +159,6 @@ models:
         description: "Indicates whether the candidate has been verified"
       - name: is_pledged
         description: Whether the candidate has taken the GoodParty pledge
-    tests:
-    - dbt_utils.unique_combination_of_columns:
-        arguments:
-          combination_of_columns:
-            - contact_id
-            - gp_candidacy_id
 
   - name: int__hubspot_contest
     description: >

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_contacts_w_companies.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_contacts_w_companies.sql
@@ -1,7 +1,12 @@
+-- Incremental key is contact_id alone (the output grain: ranked_matches keeps a
+-- single row per contact_id). gp_candidacy_id is a hash of mutable contact
+-- fields, so including it in the key would orphan the prior row -- leaving a
+-- stale company_id-null row -- whenever a contact's identity changes, e.g. when
+-- a company association enriches the contact.
 {{
     config(
         materialized="incremental",
-        unique_key=["contact_id", "gp_candidacy_id"],
+        unique_key="contact_id",
         on_schema_change="append_new_columns",
         auto_liquid_cluster=true,
     )
@@ -20,7 +25,12 @@ with
     joined_data as (
         select
             tbl_contacts.id as contact_id,
-            tbl_companies.id as company_id,
+            -- Carry the association's company_id from the contact side, not the
+            -- enrichment join: HubSpot can associate a company that never synced
+            -- into the companies source, and sourcing from tbl_companies.id would
+            -- null out (drop) that real association. Enrichment fields below stay
+            -- null when the company row is absent, which is accurate.
+            tbl_pairs.company_id as company_id,
             {{
                 generate_salted_uuid(
                     fields=[

--- a/dbt/project/models/intermediate/hubspot/int__hubspot_contacts_w_companies.sql
+++ b/dbt/project/models/intermediate/hubspot/int__hubspot_contacts_w_companies.sql
@@ -254,10 +254,7 @@ with
             row_number() over (
                 partition by contact_id
                 order by email_match desc, name_match desc, updated_at desc
-            ) as row_rank,
-            row_number() over (
-                partition by gp_candidacy_id order by updated_at desc
-            ) as row_rank_gp_candidacy_id
+            ) as row_rank
         from joined_data
     )
 
@@ -328,5 +325,9 @@ select
     win_number,
     win_number_model,
     product_campaign_id
+-- One row per contact (best company match). Dedup to the candidacy grain
+-- happens in the downstream candidacy/candidate marts, which each re-rank by
+-- gp_candidacy_id; deduping here too would silently drop a contact whenever two
+-- distinct contacts hash to the same gp_candidacy_id.
 from ranked_matches
-where 1 = 1 and row_rank = 1 and row_rank_gp_candidacy_id = 1
+where row_rank = 1


### PR DESCRIPTION
## Problem

The `assert_hubspot_contacts_w_companies_direct_assoc_has_company` test fails in the scheduled `dbt build`. It asserts that every contact HubSpot directly associates with a company resolves a non-null `company_id` in `int__hubspot_contacts_w_companies`. At failure time 7 contacts were affected; the count had grown to 14 during investigation.

## Root causes

Investigation (via `dbt show` against the built tables) found **three distinct causes**:

**1. Orphaned incremental rows (13 of 14).**
The model's output grain is one row per `contact_id`. But the incremental `unique_key` was `["contact_id", "gp_candidacy_id"]`. `gp_candidacy_id` is a salted hash of *mutable* contact fields (name, state, party, office, election date, district). When a contact's identity changes — which happens when a company association arrives and enriches the contact — the merge inserts a row under the new key and **never updates or deletes** the prior `company_id`-null row. That orphan sits below the incremental watermark forever and trips the test.

**2. Dropped associations for unsynced companies (1 of 14).**
`company_id` was sourced from the companies enrichment join (`tbl_companies.id`), so it went null whenever the associated company id was never synced into `hubspot_api_companies` (confirmed: the failing contact's associated company existed in neither companies staging nor the raw source). The association is real and known from the contact side; only the enrichment data is missing.

**3. Silent cross-contact drop (surfaced in review).**
The final SELECT also filtered on `row_rank_gp_candidacy_id = 1`, which partitions the whole result set by `gp_candidacy_id` and keeps only the most-recently-updated contact per hash. Two distinct contacts that collide on the identity hash had one silently dropped — no error, and a `unique(contact_id)` test can't catch a row that was never emitted. This was also the reason a full refresh diverged from an incremental run.

## Fix

1. `unique_key` → `contact_id` (the true output grain), so reprocessing a contact updates its row in place instead of orphaning it.
2. Source `company_id` from the contact-side association pair (`tbl_pairs.company_id`) rather than the enrichment join. Enrichment columns stay null when the company row is absent, which is accurate.
3. Remove the `row_rank_gp_candidacy_id = 1` cross-contact dedup. The candidacy-grain dedup belongs downstream, where every consumer (`m_general__candidacy`/`_v2`/`_preview`, `m_general__candidate`/`_v2`) already re-ranks by `gp_candidacy_id` with the same `order by updated_at desc`, so mart output is unchanged.
4. Test `unique` on `contact_id` (replacing the weaker two-column combination test), matching the sibling `int__hubspot_contest` model.

## Verification

Full-refresh dev build:
- Target test `assert_..._direct_assoc_has_company`: **PASS** (was 14 failures).
- `unique(contact_id)`, `not_null`, `is_uuid`: **PASS**.
- `m_general__candidate`/`_v2` `hubspot_contact_id → contact_id` relationship tests: **PASS** (were ~3.1k failures pre-fix — the contacts the cross-contact dedup had been dropping).
- The two `gp_candidacy_id` relationship tests improved (1577→1211, 1576→1210) and now only marginally exceed their loose `>1000` threshold; the residual is a dev-vs-prod deferral artifact (prod marts reference `gp_candidacy_id`s from the prod model's accumulated history that a fresh dev build doesn't reproduce). Removing the filter can only add `gp_candidacy_id` coverage, never remove it, so this moves the tests in the right direction; prod rebuilds mart+model consistently and passes them.

## Deployment note

Deploy runs incrementally; the affected contacts are all at/above the current incremental watermark, so a normal run reprocesses and heals them. With cause 3 fixed, a full refresh now reproduces the same contact set as an incremental run (the earlier "do not full-refresh" caveat no longer applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)