### PR TITLE
docs(semantic-layer): sem_*.yml supersedes the canonical_metrics projection

### DIFF
--- a/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
@@ -1,5 +1,12 @@
 # Canonical metrics (governed)
 
+> **⚠ HIGH PRIORITY — the semantic layer supersedes this table.** Where a concept exists in the
+> dbt semantic layer (`dbt/project/models/**/sem_*.yml`), that model's `config.meta` is the source
+> of truth, including its `ratified:` date, and **overrides this projected table, which can lag the
+> yml**. Check `sem_*.yml` as a first-class step *before* trusting a `Ratified` value here. Known
+> drift (2026-08): `active_serve_users` was ratified `2026-07-28` in `sem_analytics__users_serve.yml`
+> while this projection still read `pending` — regenerate the catalog projection to reconcile.
+
 The single governed answer for each Serve-product concept. **Resolve a concept here first**;
 follow the "owns detail" link for the full definition's caveats, coverage, and query patterns.
 

--- a/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
@@ -1,5 +1,12 @@
 # Canonical metrics (governed)
 
+> **⚠ HIGH PRIORITY — the semantic layer supersedes this table.** Where a concept exists in the
+> dbt semantic layer (`dbt/project/models/**/sem_*.yml`), that model's `config.meta` is the source
+> of truth, including its `ratified:` date, and **overrides this projected table, which can lag the
+> yml**. Check `sem_*.yml` as a first-class step *before* trusting a `Ratified` value here. This
+> projection is regenerated from the yml and can be stale between regenerations (observed 2026-08 on
+> the Serve catalog).
+
 The single governed answer for each Win-product concept. **Resolve a concept here first**;
 follow the "owns detail" link for the full definition's caveats, coverage, and query patterns.
 


### PR DESCRIPTION
## What

Adds a high-priority header callout to both product knowledge skills' `canonical_metrics.md` (Win + Serve) stating that the dbt semantic layer (`dbt/project/models/**/sem_*.yml` `config.meta`) is the source of truth for a metric's governance status, and **supersedes** the projected table, which can lag between regenerations.

## Why

The `canonical_metrics.md` tables are a generated projection of the semantic-layer catalog. They can fall behind the yml between regenerations, so the projected `Ratified`/`pending` column is not authoritative. Observed drift prompted this: a metric ratified in `sem_analytics__users_serve.yml` still read `pending` in the projection, which led to an incorrect "nothing is ratified" statement. The callout tells any future reader (human or agent) to check the yml first.

## Scope

Docs only — two header callouts, no metric definitions or table rows changed. The clean follow-up is to regenerate the catalog projection so the `Ratified` column matches the yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent knowledge files; no metric rows, pipelines, or runtime behavior modified.
> 
> **Overview**
> Adds a **high-priority header callout** to Win and Serve analytics knowledge skills' `canonical_metrics.md`, directing readers and agents to treat **`dbt/project/models/**/sem_*.yml`** `config.meta` (including **`ratified:`**) as authoritative over the projected **`Ratified`** column in those markdown tables.
> 
> The Serve callout documents a concrete **stale-projection** example (`active_serve_users` ratified in yml but still `pending` in the table) and points to **regenerating the catalog projection** as the fix; Win's callout states the same precedence rule without that example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9086bd29a2c8178fb18a3d63407c8a5fecc615c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->