### PR TITLE
Add DistrictVoter district_id serving indexes

### DIFF
--- a/people-api-loader/src/loader/people_api/schema/_serving_seed_extra.py
+++ b/people-api-loader/src/loader/people_api/schema/_serving_seed_extra.py
@@ -99,4 +99,33 @@ EXTRA_INDEXES: list[IndexDef] = [
         columns=["hf_most_important_policy_item"],
         where=None,
     ),
+    # DistrictVoter district lookups. The generated seed carries only the PK
+    # btree(district_id, voter_id, "State"); a `WHERE district_id = X [AND "State" = 'S']` scan can
+    # use it (district_id leads) but reads ~130x more index pages than a dedicated narrow index —
+    # ~83k buffers vs ~640 for a single ~700k-member district (measured). The wide PK can't
+    # deduplicate (every entry has a distinct voter_id); over a district's rows a narrow index shares
+    # one district_id, so btree dedup collapses it to a tiny posting list. Invisible warm (all cache
+    # hits) and to the planner (it costs both alike), but it drives cold / pool-pressure district
+    # timeouts. Both families, deliberately:
+    #   - (district_id, "State"): the one the planner actually picks for the app's queries, which
+    #     always carry the district's "State" — a plain (district_id) loses to the PK there because
+    #     the PK also contains "State". "State" is constant within a LIST partition, so this still
+    #     dedups (~430 MB).
+    #   - (district_id): covers any district_id-only pattern not carrying "State".
+    IndexDef(
+        table="DistrictVoter",
+        name="DistrictVoter_district_id_State_idx",
+        sql='CREATE INDEX "DistrictVoter_district_id_State_idx" ON public."DistrictVoter" USING btree (district_id, "State");',
+        unique=False,
+        columns=["district_id", "State"],
+        where=None,
+    ),
+    IndexDef(
+        table="DistrictVoter",
+        name="DistrictVoter_district_id_idx",
+        sql='CREATE INDEX "DistrictVoter_district_id_idx" ON public."DistrictVoter" USING btree (district_id);',
+        unique=False,
+        columns=["district_id"],
+        where=None,
+    ),
 ]


### PR DESCRIPTION
## Why

The loader-built `DistrictVoter` carries only the PK `btree(district_id, voter_id, "State")`. A `WHERE district_id = X [AND "State" = 'S']` scan *uses* it (district_id leads, Index Only Scan — not a seq scan), but reads **~130× more index pages** than a dedicated narrow index. Measured on `gp-people-db-20260727-prod`, one ~700k-member district: **~82,829 buffers on the PK vs ~639 with a narrow index** (~2.3 GB vs ~5 MB of index pages).

Root cause is btree deduplication: the wide PK can't dedup (every entry has a distinct `voter_id`), but over a single district's rows a narrow index shares one `district_id` and collapses to a posting list. It's invisible warm (all cache *hits*, comparable times) and invisible to the planner (it costs the two alike), so `EXPLAIN` looks fine — but cold or under connection-pool pressure it's the difference between 5 MB and 2.3 GB read per district query, which is how district queries time out.

The current serving cluster has these indexes (on its `green`/`_dedup_` structures); the loader's `public` replica lost them because the schema seed is extracted from `public`, where they don't exist.

## What

Two indexes added to `EXTRA_INDEXES` (hand-maintained, survives seed regeneration, built per-partition by the existing machinery):

- **`(district_id, "State")`** — the one the planner actually picks for the app's queries, which always carry the district's `"State"`. A plain `(district_id)` loses to the PK there because the PK also contains `"State"`; adding `"State"` makes this index cover the predicate and win. `"State"` is constant within a LIST partition, so it still dedups (~430 MB).
- **`(district_id)`** — covers any district_id-only pattern not carrying `"State"` (kept deliberately as a safety net for query shapes not enumerated here).

Not `(district_id, voter_id)` — genuinely redundant with the PK.

Takes effect on the next loader build; the existing `20260727` cluster is being indexed in place separately.