### PR TITLE
[DATA-2126] Ratify win_users metric

### DIFF
--- a/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
@@ -46,5 +46,5 @@ a domain doc.
 | **GoodParty Cumulative Wins** | Running total of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. Accumulates all time, so each period shows the cumulative win count to date. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
 | **GoodParty Win Rate** | Count of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
 | **Win Activated Users** | Count of Win-product users who have activated: sent at least one voter outreach campaign (first_campaign_sent_at is not null). The activated slice of win_users; the Activated Candidates OKR. | ref('users_win_base') | [engagement.md](engagement.md) | 2026-07-28 |
-| **Win Users** | Count of Win-product users. Slice or filter by the engagement dimensions (has_viewed_dashboard, is_active_candidate_30d, etc.) at query time. | ref('users_win_base') | [engagement.md](engagement.md) | pending |
+| **Win Users** | Count of Win-product users. Slice or filter by the engagement dimensions (has_viewed_dashboard, is_active_candidate_30d, etc.) at query time. | ref('users_win_base') | [engagement.md](engagement.md) | 2026-08-03 |
 <!-- semantic-catalog:end -->

--- a/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
@@ -55,6 +55,7 @@ metrics:
       meta:
         owner: semantic-layer-data
         detail_doc: engagement.md
+        ratified: 2026-08-03
 
   - name: win_activated_users
     label: Win Activated Users


### PR DESCRIPTION
Ratifies the win_users metric (pending -> 2026-08-03) in the dbt semantic layer.
Owner sign-off is the ratification; the semantic-layer CODEOWNERS reviewers are
auto-requested by the sem_*.yml change (soft two-group gate).

This is the metric-change half of the DATA-2199 automation work, split out from
the code PR (#748) so reviewers are tagged for the definition change only, not
for the automation code.

Sequencing: merge #748 (the assignee + threaded-reply automation) first, then
this PR. On merge, win_users transitions pending -> dated, so newly_ratified
fires and the publish workflow creates exactly one Sigma build task (assigned to
Audrey) and replies in the #data-alignment thread with its link.

Also regenerates the Win knowledge-skill canonical_metrics.md so the blocking
catalog-freshness check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only governance update; no SQL, measure logic, or metric definition changes.
> 
> **Overview**
> **Ratifies the `win_users` semantic-layer metric** by setting `config.meta.ratified` to **2026-08-03** in `sem_analytics__users_win.yml`. The metric definition, measure, and dimensions are unchanged—this is owner sign-off only (`pending` → dated).
> 
> The Win knowledge skill **`canonical_metrics.md`** semantic-catalog block is regenerated so **Win Users** shows the same ratification date and the catalog-freshness check stays green.
> 
> Per PR sequencing, this pairs with the separate automation PR: after merge, `newly_ratified` should fire for `win_users` and drive the Sigma build task / #data-alignment reply workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc19e7c4b273a6f278167a1874e3e31d894393d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->