### PR TITLE
[DATA-2218] Slack governance timeline for governed metric PRs

### DIFF
--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -4,6 +4,8 @@ name: semantic-layer-publish
 # ClickUp MCP (no CI token), matching the omni analytics-governance pattern; the
 # in-repo canonical_metrics.md is the source of truth, kept fresh by the
 # blocking catalog-freshness PR check.
+# DATA-2218: when the governance thread exists (semantic-layer-thread.yml), the
+# summary posts as a threaded reply under its anchor.
 on:
   push:
     branches: [main]
@@ -11,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write   # DATA-2218: update the thread marker's merged flag
 
 jobs:
   publish:
@@ -64,6 +67,7 @@ jobs:
             COV=$(cd analytics && APPROVERS="$APPROVERS" DATA="$DATA" BIZ="$BIZ" PYTHONPATH="diagnostics" \
               uv run python -m semantic_catalog.composition)
             PR_URL="https://github.com/$REPO/pull/$PR"
+            echo "PR_NUM=$PR" >> "$GITHUB_ENV"
           else
             # No PR found for this commit (e.g. a direct push to main): fall
             # back to the conservative "incomplete" default rather than
@@ -91,6 +95,22 @@ jobs:
           else
             uv run python -m semantic_catalog.cli --emit-slack /tmp/slack.txt --pr-url "$PR_URL" --coverage "$COV"
           fi
+      - name: Read governance thread marker
+        # DATA-2218: recover the anchor ts written at PR-open so the merge
+        # summary lands as a threaded reply. Empty marker => top-level post
+        # (the pre-thread behavior is the permanent fallback).
+        if: ${{ env.PR_NUM != '' }}
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          uv run python -m semantic_catalog.thread --emit-marker /tmp/marker.json --pr "$PR_NUM"
+          {
+            echo "SLACK_THREAD_TS=$(python3 -c 'import json;print(json.load(open("/tmp/marker.json")).get("ts",""))')"
+            echo "MARKER_MERGED=$(python3 -c 'import json;print(str(json.load(open("/tmp/marker.json")).get("merged",False)).lower())')"
+          } >> "$GITHUB_ENV"
       - name: Post Slack change summary
         env:
           SLACK_APP_BOT_TOKEN: ${{ secrets.SLACK_APP_BOT_TOKEN }}
@@ -104,15 +124,36 @@ jobs:
             echo "SLACK_APP_BOT_TOKEN not provisioned; skipping Slack notification."
             exit 0
           fi
+          if [ "${MARKER_MERGED:-false}" = "true" ]; then
+            echo "Thread already marked merged; skipping duplicate merge post."
+            exit 0
+          fi
           RESP=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_APP_BOT_TOKEN" \
             -H "Content-type: application/json; charset=utf-8" \
-            --data "$(python3 -c 'import json,os;print(json.dumps({"channel":os.environ["SLACK_CHANNEL_ID"],"text":open("/tmp/slack.txt").read()}))')")
+            --data "$(python3 -c '
+          import json, os
+          p = {"channel": os.environ["SLACK_CHANNEL_ID"], "text": open("/tmp/slack.txt").read()}
+          t = os.environ.get("SLACK_THREAD_TS")
+          if t:
+              p["thread_ts"] = t  # DATA-2218: merge summary is a reply under the anchor
+          print(json.dumps(p))')")
           # chat.postMessage returns HTTP 200 with {"ok":false} on errors (bad
           # channel, missing scope, auth), so check the body, not just status.
           TS=$(echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); d.get("ok") or sys.exit("Slack API error: %s" % d.get("error","unknown")); print(d["ts"])')
-          # Expose the summary message ts so the Sigma-task step can reply in-thread.
-          echo "SLACK_TS=$TS" >> "$GITHUB_ENV"
+          # Sigma replies thread under the anchor when it exists, else under
+          # this post (pre-thread behavior).
+          echo "SLACK_TS=${SLACK_THREAD_TS:-$TS}" >> "$GITHUB_ENV"
+      - name: Mark governance thread merged
+        # Guard against publish re-runs double-posting the merge summary.
+        if: ${{ env.PR_NUM != '' && env.SLACK_THREAD_TS != '' }}
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          uv run python -m semantic_catalog.thread --mark-merged --pr "$PR_NUM"
       - name: Create Sigma build tasks for newly ratified metrics
         working-directory: analytics
         env:

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -111,15 +111,24 @@ jobs:
             echo "SLACK_THREAD_TS=$(python3 -c 'import json;print(json.load(open("/tmp/marker.json")).get("ts",""))')"
             echo "MARKER_MERGED=$(python3 -c 'import json;print(str(json.load(open("/tmp/marker.json")).get("merged",False)).lower())')"
           } >> "$GITHUB_ENV"
+          # The marker pins the channel the anchor was posted to. Honor it here
+          # (overriding the job-level SLACK_CHANNEL_ID default for the
+          # remaining steps) so a mid-PR #data-alignment channel change never
+          # splits the merge-summary reply from its anchor thread.
+          MARKER_CHANNEL=$(python3 -c 'import json;print(json.load(open("/tmp/marker.json")).get("channel",""))')
+          if [ -n "$MARKER_CHANNEL" ]; then
+            echo "SLACK_CHANNEL_ID=$MARKER_CHANNEL" >> "$GITHUB_ENV"
+          fi
       - name: Post Slack change summary
         env:
           SLACK_APP_BOT_TOKEN: ${{ secrets.SLACK_APP_BOT_TOKEN }}
         run: |
           set -euo pipefail
-          # LIVE-VERIFY SEAM: SLACK_APP_BOT_TOKEN is not yet provisioned. Once it
-          # lands, confirm this chat.postMessage payload (channel id, scopes)
-          # against the live Slack API before relying on it. Until then, skip
-          # cleanly so the first governed merge does not red-fail this job.
+          # SLACK_APP_BOT_TOKEN was provisioned and live-verified 2026-07-28.
+          # The empty-token guard below is a deliberate graceful-degrade seam
+          # (e.g. fork PRs, which don't get repo secrets), not a provisioning
+          # gap — keep it so a missing secret skips cleanly instead of
+          # red-failing the job.
           if [ -z "${SLACK_APP_BOT_TOKEN:-}" ]; then
             echo "SLACK_APP_BOT_TOKEN not provisioned; skipping Slack notification."
             exit 0

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -145,8 +145,11 @@ jobs:
           # this post (pre-thread behavior).
           echo "SLACK_TS=${SLACK_THREAD_TS:-$TS}" >> "$GITHUB_ENV"
       - name: Mark governance thread merged
-        # Guard against publish re-runs double-posting the merge summary.
-        if: ${{ env.PR_NUM != '' && env.SLACK_THREAD_TS != '' }}
+        # SLACK_TS is only exported once "Post Slack change summary" actually
+        # posts (threaded or fallback), so gating on it here guards against
+        # publish re-runs double-posting the merge summary, and also skips
+        # cleanly when the bot token isn't provisioned yet.
+        if: ${{ env.PR_NUM != '' && env.SLACK_THREAD_TS != '' && env.SLACK_TS != '' }}
         working-directory: analytics
         env:
           PYTHONPATH: diagnostics

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -157,8 +157,12 @@ jobs:
         # SLACK_TS is only exported once "Post Slack change summary" actually
         # posts (threaded or fallback), so gating on it here guards against
         # publish re-runs double-posting the merge summary, and also skips
-        # cleanly when the bot token isn't provisioned yet.
-        if: ${{ env.PR_NUM != '' && env.SLACK_THREAD_TS != '' && env.SLACK_TS != '' }}
+        # cleanly when the bot token is absent. Deliberately NOT gated on
+        # SLACK_THREAD_TS: when no anchor thread exists, --mark-merged
+        # bootstraps a merged marker from this run's post (SLACK_TS /
+        # SLACK_CHANNEL_ID env), so even fallback top-level posts are re-run
+        # idempotent.
+        if: ${{ env.PR_NUM != '' && env.SLACK_TS != '' }}
         working-directory: analytics
         env:
           PYTHONPATH: diagnostics

--- a/.github/workflows/semantic-layer-thread.yml
+++ b/.github/workflows/semantic-layer-thread.yml
@@ -1,0 +1,90 @@
+name: semantic-layer-thread
+# DATA-2218: keep the #data-alignment governance thread in sync with the PR
+# lifecycle (anchor at open, approval/dismissal replies, closed/reopened).
+# The merge + Sigma replies stay in semantic-layer-publish.yml.
+#
+# pull_request_review does NOT support paths: filtering, so the cheap gate
+# step below checks the PR's changed files before installing anything. The
+# pull_request trigger is left unfiltered too so both event families take the
+# identical path (one filter, in one place).
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize, closed]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: write   # marker comment create/update
+
+# One reconcile at a time per PR: simultaneous events (e.g. open + instant
+# review) would otherwise race the marker read-modify-write.
+concurrency:
+  group: sem-thread-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    # Drafts are silent by design (anchor posts at ready_for_review).
+    if: ${{ github.event.pull_request.draft == false }}
+    env:
+      SLACK_CHANNEL_ID: C08K22X9ZNH
+    steps:
+      - name: Gate on governed files (cheap, before any setup)
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' \
+            | grep -Eq '^dbt/project/models/(.+/)?sem_[^/]+\.yml$'; then
+            echo "governed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "governed=false" >> "$GITHUB_OUTPUT"
+            echo "No governed sem_*.yml touched; skipping."
+          fi
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.governed == 'true'
+        with:
+          # head sha, not the merge ref: it exists for closed PRs too, and the
+          # anchor diff should show what reviewers see on the branch.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v6
+        if: steps.gate.outputs.governed == 'true'
+        with:
+          enable-cache: true
+          cache-dependency-glob: analytics/uv.lock
+      - name: Install analytics env
+        if: steps.gate.outputs.governed == 'true'
+        working-directory: analytics
+        run: uv sync --frozen
+      - name: Prepare base tree for the anchor's metric diff
+        if: steps.gate.outputs.governed == 'true'
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            git worktree add --detach /tmp/base "$BASE"
+          fi
+      - name: Reconcile governance thread
+        if: steps.gate.outputs.governed == 'true'
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+          GH_TOKEN: ${{ github.token }}
+          ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          SLACK_APP_BOT_TOKEN: ${{ secrets.SLACK_APP_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -d /tmp/base ]; then
+            uv run python -m semantic_catalog.thread --event-path "$GITHUB_EVENT_PATH" --base-dir /tmp/base
+          else
+            uv run python -m semantic_catalog.thread --event-path "$GITHUB_EVENT_PATH"
+          fi
+      - name: Clean up base tree
+        if: always()
+        run: git worktree remove --force /tmp/base || true

--- a/analytics/diagnostics/semantic_catalog/config/slack_mentions.yml
+++ b/analytics/diagnostics/semantic_catalog/config/slack_mentions.yml
@@ -1,0 +1,17 @@
+# GitHub-team -> Slack mention mapping for the governance-thread anchor message.
+# Non-secret identifiers only.
+#
+# Deliberately decoupled from GitHub team membership; drift is acceptable
+# because the Slack mention is a courtesy ping, not the gate. The GitHub
+# approval and the composition check remain authoritative (DATA-2218).
+#
+# Prefer usergroup_id (a Slack user group "subteam" id, managed in Slack) once
+# usergroups exist; when set it takes precedence over member_ids.
+# member_ids are Slack member ids (e.g. U012ABC3DEF), NOT display names.
+teams:
+  data:
+    usergroup_id: null
+    member_ids: []  # TODO(Tristan): fill Slack member ids before live verify
+  business:
+    usergroup_id: null
+    member_ids: []  # Amanda, Audrey, Joe; fill before live verify

--- a/analytics/diagnostics/semantic_catalog/config/slack_mentions.yml
+++ b/analytics/diagnostics/semantic_catalog/config/slack_mentions.yml
@@ -9,19 +9,19 @@
 # usergroups exist; when set it takes precedence over member_ids.
 # member_ids are Slack member ids (e.g. U012ABC3DEF), NOT display names.
 # Snapshot of GitHub team membership as of 2026-08-04.
+# Swain Molster (swain) is on both GitHub teams but deliberately excluded from
+# both mention lists per Tristan (2026-08-04) - his approvals still count.
 teams:
   data:
     usergroup_id: null
     member_ids:
       - U09T5BQQUTH  # Dan Ball (danpelota)
       - U085CFQ96BG  # Tristan Aubert (datawithtristan)
-      - U09HGPTHHAT  # Swain Molster (swain)
       - U08BSR3MM3K  # Hugh Karimi (hhkarimi)
       - U0A34SFCV5E  # Sanjay Roberts (sanjayr1)
   business:
     usergroup_id: null
     member_ids:
-      - U09HGPTHHAT  # Swain Molster (swain)
       - U08NXF2J3GW  # Amanda (amanda847)
       - U0A126JHUBW  # Audrey Hunsberger (audrey-gp)
       - U0AG7JH6GEL  # Joe Murray (JoeGoodParty2)

--- a/analytics/diagnostics/semantic_catalog/config/slack_mentions.yml
+++ b/analytics/diagnostics/semantic_catalog/config/slack_mentions.yml
@@ -8,10 +8,20 @@
 # Prefer usergroup_id (a Slack user group "subteam" id, managed in Slack) once
 # usergroups exist; when set it takes precedence over member_ids.
 # member_ids are Slack member ids (e.g. U012ABC3DEF), NOT display names.
+# Snapshot of GitHub team membership as of 2026-08-04.
 teams:
   data:
     usergroup_id: null
-    member_ids: []  # TODO(Tristan): fill Slack member ids before live verify
+    member_ids:
+      - U09T5BQQUTH  # Dan Ball (danpelota)
+      - U085CFQ96BG  # Tristan Aubert (datawithtristan)
+      - U09HGPTHHAT  # Swain Molster (swain)
+      - U08BSR3MM3K  # Hugh Karimi (hhkarimi)
+      - U0A34SFCV5E  # Sanjay Roberts (sanjayr1)
   business:
     usergroup_id: null
-    member_ids: []  # Amanda, Audrey, Joe; fill before live verify
+    member_ids:
+      - U09HGPTHHAT  # Swain Molster (swain)
+      - U08NXF2J3GW  # Amanda (amanda847)
+      - U0A126JHUBW  # Audrey Hunsberger (audrey-gp)
+      - U0AG7JH6GEL  # Joe Murray (JoeGoodParty2)

--- a/analytics/diagnostics/semantic_catalog/github_client.py
+++ b/analytics/diagnostics/semantic_catalog/github_client.py
@@ -1,0 +1,66 @@
+"""Minimal GitHub REST client for the governance-thread workflow.
+
+Stdlib-only, injectable urlopen seam (matches slack_reply/clickup_client).
+Token travels in the Authorization header, never on the command line. Note two
+tokens exist at the call sites: the workflow GITHUB_TOKEN (PR files/reviews/
+comments) and ORG_READ_TOKEN (org team membership); this class is token-agnostic
+and gets instantiated once per token.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+API = "https://api.github.com"
+_PER_PAGE = 100
+
+
+class GitHubClient:
+    def __init__(self, token: str, repo: str, *, urlopen: Callable[..., Any] = urllib.request.urlopen):
+        self._token = token
+        self.repo = repo
+        self._urlopen = urlopen
+
+    def _request(self, method: str, path: str, payload: dict | None = None) -> Any:
+        data = json.dumps(payload).encode() if payload is not None else None
+        req = urllib.request.Request(f"{API}{path}", data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self._token}")
+        req.add_header("Accept", "application/vnd.github+json")
+        if data is not None:
+            req.add_header("Content-type", "application/json; charset=utf-8")
+        with self._urlopen(req, timeout=30) as resp:
+            return json.load(resp)
+
+    def _paginate(self, path: str) -> list[Any]:
+        out: list[Any] = []
+        page = 1
+        while True:
+            sep = "&" if "?" in path else "?"
+            batch = self._request("GET", f"{path}{sep}per_page={_PER_PAGE}&page={page}")
+            out.extend(batch)
+            if len(batch) < _PER_PAGE:
+                return out
+            page += 1
+
+    def pr_files(self, pr_number: int) -> list[str]:
+        return [f["filename"] for f in self._paginate(f"/repos/{self.repo}/pulls/{pr_number}/files")]
+
+    def pr_reviews(self, pr_number: int) -> list[dict]:
+        return self._paginate(f"/repos/{self.repo}/pulls/{pr_number}/reviews")
+
+    def team_members(self, org: str, team_slug: str) -> list[str]:
+        return [m["login"] for m in self._paginate(f"/orgs/{org}/teams/{team_slug}/members")]
+
+    def issue_comments(self, pr_number: int) -> list[dict]:
+        return self._paginate(f"/repos/{self.repo}/issues/{pr_number}/comments")
+
+    def create_comment(self, pr_number: int, body: str) -> int:
+        return int(
+            self._request("POST", f"/repos/{self.repo}/issues/{pr_number}/comments", {"body": body})["id"]
+        )
+
+    def update_comment(self, comment_id: int, body: str) -> None:
+        self._request("PATCH", f"/repos/{self.repo}/issues/comments/{comment_id}", {"body": body})

--- a/analytics/diagnostics/semantic_catalog/mentions.py
+++ b/analytics/diagnostics/semantic_catalog/mentions.py
@@ -1,0 +1,29 @@
+"""GitHub-team -> Slack mention rendering for the governance thread anchor.
+
+Config is a non-secret YAML next to sigma_tasks.yml. Empty or missing config
+degrades to no mentions; a missing courtesy ping must never fail the thread.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def load(path: Path) -> dict:
+    """Return the teams mapping from slack_mentions.yml ({} when absent/empty)."""
+    if not path.exists():
+        return {}
+    doc = yaml.safe_load(path.read_text()) or {}
+    return doc.get("teams") or {}
+
+
+def render_team(team_cfg: dict | None) -> str:
+    """Render one team's mention string: usergroup wins, then member ids, then nothing."""
+    if not team_cfg:
+        return ""
+    usergroup = team_cfg.get("usergroup_id")
+    if usergroup:
+        return f"<!subteam^{usergroup}>"
+    return " ".join(f"<@{m}>" for m in team_cfg.get("member_ids") or [])

--- a/analytics/diagnostics/semantic_catalog/pr_marker.py
+++ b/analytics/diagnostics/semantic_catalog/pr_marker.py
@@ -1,0 +1,57 @@
+"""Parse/render the PR comment that persists the Slack governance-thread state.
+
+One bot comment per governed PR: a human-visible link to the Slack thread, then
+the state as JSON inside an HTML comment. Pure module: no network, no env. A
+missing or corrupt marker parses to None, which callers treat as "bootstrap a
+fresh thread" (degrade, never crash).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+
+MARKER_OPEN = "<!-- semantic-layer-thread v1"
+MARKER_CLOSE = "-->"
+_MARKER_RE = re.compile(re.escape(MARKER_OPEN) + r"\n(?P<json>.*?)\n" + re.escape(MARKER_CLOSE), re.DOTALL)
+
+
+@dataclass
+class ThreadState:
+    ts: str
+    channel: str
+    permalink: str
+    announced: dict[str, str | None] = field(default_factory=lambda: {"data": None, "business": None})
+    pr_state: str = "open"  # "open" | "closed"
+    merged: bool = False
+
+
+def is_marker(body: str) -> bool:
+    return MARKER_OPEN in body
+
+
+def parse(body: str) -> ThreadState | None:
+    m = _MARKER_RE.search(body)
+    if m is None:
+        return None
+    try:
+        d = json.loads(m.group("json"))
+        return ThreadState(
+            ts=str(d["ts"]),
+            channel=str(d["channel"]),
+            permalink=str(d.get("permalink", "")),
+            announced={
+                "data": d.get("announced", {}).get("data"),
+                "business": d.get("announced", {}).get("business"),
+            },
+            pr_state=str(d.get("pr_state", "open")),
+            merged=bool(d.get("merged", False)),
+        )
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError):
+        return None  # corrupt marker degrades to "no marker" so the thread re-bootstraps
+
+
+def render(state: ThreadState) -> str:
+    payload = json.dumps(asdict(state), indent=1, sort_keys=True)
+    return f"Slack governance thread: {state.permalink}\n{MARKER_OPEN}\n{payload}\n{MARKER_CLOSE}"

--- a/analytics/diagnostics/semantic_catalog/slack_diff.py
+++ b/analytics/diagnostics/semantic_catalog/slack_diff.py
@@ -14,6 +14,14 @@ def _by_name(records: list[MetricRecord]) -> dict[str, MetricRecord]:
     return {r.name: r for r in records}
 
 
+def changed_metric_names(before: list[MetricRecord], after: list[MetricRecord]) -> list[str]:
+    """Names added, removed, or changed in any field; feeds the thread anchor message."""
+    a, b = _by_name(before), _by_name(after)
+    names = set(a.keys() ^ b.keys())
+    names.update(n for n in a.keys() & b.keys() if a[n] != b[n])
+    return sorted(names)
+
+
 def diff_records(before: list[MetricRecord], after: list[MetricRecord]) -> list[str]:
     a, b = _by_name(before), _by_name(after)
     lines: list[str] = []
@@ -44,10 +52,13 @@ def render_message(
     changes = diff_records(before, after)
     body.extend(changes if changes else ["(no metric-level changes detected)"])
     body.append("")
-    missing = [g for g in ("data", "business") if not coverage.get(g)]
-    if missing:
-        noun = "group" if len(missing) == 1 else "groups"
-        body.append(f":warning: review incomplete — missing approval from: {', '.join(missing)} {noun}")
-    else:
-        body.append(":white_check_mark: review complete — both groups approved")
+
+    def _mark(ok: bool) -> str:
+        return "✓" if ok else "✗"
+
+    # One authoritative line; the live approval history is in the thread now.
+    line = f"review coverage: data {_mark(bool(coverage.get('data')))} · business {_mark(bool(coverage.get('business')))}"
+    if not (coverage.get("data") and coverage.get("business")):
+        line = f":warning: {line}"
+    body.append(line)
     return "\n".join(body)

--- a/analytics/diagnostics/semantic_catalog/slack_reply.py
+++ b/analytics/diagnostics/semantic_catalog/slack_reply.py
@@ -1,4 +1,4 @@
-"""Post threaded Slack replies linking the Sigma build tasks a run created.
+"""Slack Web API helpers for the governance thread (post, permalink, Sigma replies).
 
 Stdlib only. The HTTP call goes through an injectable ``urlopen`` seam so tests
 never touch the network. The bot token is passed in by the caller (read from the
@@ -9,11 +9,56 @@ reads the environment.
 from __future__ import annotations
 
 import json
+import urllib.parse
 import urllib.request
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
+SLACK_GET_PERMALINK_URL = "https://slack.com/api/chat.getPermalink"
+
+
+def _check(d: Mapping[str, Any], what: str) -> Mapping[str, Any]:
+    # Slack returns HTTP 200 with ok:false on errors; check the body.
+    if not d.get("ok"):
+        raise RuntimeError(f"{what} failed: {d.get('error', 'unknown')}")
+    return d
+
+
+def post_message(
+    token: str,
+    channel: str,
+    text: str,
+    *,
+    thread_ts: str | None = None,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> str:
+    """Post a message (threaded when thread_ts is given); return its ts."""
+    payload: dict[str, Any] = {"channel": channel, "text": text}
+    if thread_ts:
+        payload["thread_ts"] = thread_ts
+    req = urllib.request.Request(SLACK_POST_MESSAGE_URL, data=json.dumps(payload).encode(), method="POST")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-type", "application/json; charset=utf-8")
+    with urlopen(req, timeout=30) as resp:  # fixed Slack URL, not user input
+        d = json.load(resp)
+    return str(_check(d, "Slack chat.postMessage")["ts"])
+
+
+def get_permalink(
+    token: str,
+    channel: str,
+    ts: str,
+    *,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> str:
+    """Resolve the permanent URL of a posted message (for the PR marker comment)."""
+    qs = urllib.parse.urlencode({"channel": channel, "message_ts": ts})
+    req = urllib.request.Request(f"{SLACK_GET_PERMALINK_URL}?{qs}", method="GET")
+    req.add_header("Authorization", f"Bearer {token}")
+    with urlopen(req, timeout=30) as resp:
+        d = json.load(resp)
+    return str(_check(d, "Slack chat.getPermalink")["permalink"])
 
 
 def reply_in_thread(
@@ -24,20 +69,10 @@ def reply_in_thread(
     *,
     urlopen: Callable[..., Any] = urllib.request.urlopen,
 ) -> None:
-    """Post one threaded reply per created task, each linking its ClickUp task.
-
-    tasks are the dicts emitted by ``cli --emit-created`` (metric, task_id, url).
-    Raises RuntimeError on a Slack ok:false body (200 with an error), matching the
-    other clients in this package.
-    """
+    """Post one threaded reply per created task, each linking its ClickUp task."""
     for t in tasks:
         text = f"Sigma build task created for `{t['metric']}`: {t['url']}"
-        body = json.dumps({"channel": channel, "thread_ts": thread_ts, "text": text}).encode()
-        req = urllib.request.Request(SLACK_POST_MESSAGE_URL, data=body, method="POST")
-        req.add_header("Authorization", f"Bearer {token}")
-        req.add_header("Content-type", "application/json; charset=utf-8")
-        with urlopen(req, timeout=30) as resp:  # fixed Slack URL, not user input
-            d = json.load(resp)
-        # chat.postMessage returns HTTP 200 with ok:false on errors; check the body.
-        if not d.get("ok"):
-            raise RuntimeError(f"Slack thread reply failed for {t['metric']}: {d.get('error', 'unknown')}")
+        try:
+            post_message(token, channel, text, thread_ts=thread_ts, urlopen=urlopen)
+        except RuntimeError as e:
+            raise RuntimeError(f"Slack thread reply failed for {t['metric']}: {e}") from e

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -114,3 +114,171 @@ def reconcile(
 
     plan.new_state = state
     return plan
+
+
+# --- orchestration (env + clients live only below this line) -----------------
+
+import argparse  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+import sys  # noqa: E402
+import urllib.request  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from semantic_catalog import mentions as mentions_mod  # noqa: E402
+from semantic_catalog import pr_marker, slack_diff, slack_reply  # noqa: E402
+from semantic_catalog.github_client import GitHubClient  # noqa: E402
+from semantic_catalog.parser import parse_semantic_tree  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DBT_MODELS = REPO_ROOT / "dbt" / "project" / "models"
+PKG = Path(__file__).parent
+TEAM_SLUG = {"data": "semantic-layer-data", "business": "semantic-layer-business"}
+
+
+def _github_client(token: str, repo: str) -> GitHubClient:
+    # Forward a fresh `urllib.request.urlopen` lookup rather than relying on
+    # GitHubClient's own default: that default is bound once at import time,
+    # so a test-time monkeypatch of the module attribute never reaches it.
+    return GitHubClient(token, repo, urlopen=urllib.request.urlopen)
+
+
+def _changed_names(base_dir: Path | None) -> tuple[str, ...]:
+    after = parse_semantic_tree([DBT_MODELS])
+    before = parse_semantic_tree([base_dir / "dbt/project/models"]) if base_dir else []
+    return tuple(slack_diff.changed_metric_names(before, after))
+
+
+def _find_marker(gh: GitHubClient, pr: int) -> tuple[int, pr_marker.ThreadState] | None:
+    for c in gh.issue_comments(pr):
+        if pr_marker.is_marker(c.get("body", "")):
+            state = pr_marker.parse(c["body"])
+            if state is not None:
+                return int(c["id"]), state
+    return None
+
+
+def _cmd_emit_marker(gh: GitHubClient, pr: int, out: Path) -> int:
+    found = _find_marker(gh, pr)
+    if found is None:
+        out.write_text("{}")
+        print("no marker found")
+        return 0
+    _, state = found
+    out.write_text(json.dumps({"ts": state.ts, "merged": state.merged, "channel": state.channel}))
+    print(f"marker: ts={state.ts} merged={state.merged}")
+    return 0
+
+
+def _cmd_mark_merged(gh: GitHubClient, pr: int) -> int:
+    found = _find_marker(gh, pr)
+    if found is None:
+        print("no marker found; nothing to mark")
+        return 0
+    comment_id, state = found
+    state.merged = True
+    gh.update_comment(comment_id, pr_marker.render(state))
+    print("marker marked merged")
+    return 0
+
+
+def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
+    gh_token = os.environ.get("GH_TOKEN")
+    slack_token = os.environ.get("SLACK_APP_BOT_TOKEN")
+    channel = os.environ.get("SLACK_CHANNEL_ID")
+    org_token = os.environ.get("ORG_READ_TOKEN")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    if not gh_token or not repo:
+        print("GH_TOKEN/GITHUB_REPOSITORY not set; skipping thread reconcile.")
+        return 0
+
+    event = json.loads(event_path.read_text())
+    pr = event["pull_request"]
+    number = int(pr["number"])
+    gh = _github_client(gh_token, repo)
+
+    if not is_governed(gh.pr_files(number)):
+        print(f"PR #{number} not governed; nothing to do.")
+        return 0
+    if not slack_token or not channel:
+        print("SLACK_APP_BOT_TOKEN/SLACK_CHANNEL_ID not set; skipping thread reconcile.")
+        return 0
+
+    approvals: dict[str, list[str]] | None = None
+    if org_token:
+        gh_org = _github_client(org_token, repo)
+        org = repo.split("/")[0]
+        members = {team: gh_org.team_members(org, slug) for team, slug in TEAM_SLUG.items()}
+        approvals = team_approvers(gh_org.pr_reviews(number), members)
+    else:
+        print("ORG_READ_TOKEN not set; skipping approval diff (lifecycle only).")
+
+    found = _find_marker(gh, number)
+    comment_id, state = found if found else (None, None)
+    ctx = PRContext(
+        number=number,
+        title=pr["title"],
+        url=pr["html_url"],
+        draft=bool(pr.get("draft")),
+        pr_state="closed" if pr.get("state") == "closed" else "open",
+        merged=bool(pr.get("merged")),
+        metric_names=_changed_names(base_dir) if state is None else (),
+    )
+    teams = mentions_mod.load(PKG / "config" / "slack_mentions.yml")
+    mention_by_team = {t: mentions_mod.render_team(teams.get(t)) for t in ("data", "business")}
+
+    plan = reconcile(state, approvals, ctx, mention_by_team)
+    if plan.anchor_text is not None and plan.new_state is not None:
+        ts = slack_reply.post_message(slack_token, channel, plan.anchor_text, urlopen=urllib.request.urlopen)
+        plan.new_state.ts, plan.new_state.channel = ts, channel
+        try:
+            plan.new_state.permalink = slack_reply.get_permalink(
+                slack_token, channel, ts, urlopen=urllib.request.urlopen
+            )
+        except RuntimeError as e:  # cosmetic only; the marker link degrades to blank
+            print(f"permalink lookup failed: {e}")
+    for text in plan.replies:
+        slack_reply.post_message(
+            slack_token,
+            plan.new_state.channel or channel,
+            text,
+            thread_ts=plan.new_state.ts,
+            urlopen=urllib.request.urlopen,
+        )
+    if plan.new_state is not None:
+        body = pr_marker.render(plan.new_state)
+        if comment_id is not None:
+            gh.update_comment(comment_id, body)
+        else:
+            gh.create_comment(number, body)
+    print(f"reconciled: anchor={'yes' if plan.anchor_text else 'no'} replies={len(plan.replies)}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="semantic_catalog.thread")
+    ap.add_argument("--event-path", type=Path)
+    ap.add_argument("--base-dir", type=Path, default=None)
+    ap.add_argument("--emit-marker", type=Path)
+    ap.add_argument("--mark-merged", action="store_true")
+    ap.add_argument("--pr", type=int)
+    args = ap.parse_args(argv)
+
+    if args.emit_marker or args.mark_merged:
+        gh_token = os.environ.get("GH_TOKEN")
+        repo = os.environ.get("GITHUB_REPOSITORY", "")
+        if not gh_token or not repo or args.pr is None:
+            print("GH_TOKEN/GITHUB_REPOSITORY/--pr required; skipping.", file=sys.stderr)
+            return 0
+        gh = _github_client(gh_token, repo)
+        if args.emit_marker:
+            return _cmd_emit_marker(gh, args.pr, args.emit_marker)
+        return _cmd_mark_merged(gh, args.pr)
+
+    if args.event_path is None:
+        ap.error("--event-path is required for reconcile mode")
+    return _cmd_reconcile(args.event_path, args.base_dir)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -44,7 +44,8 @@ class PRContext:
     draft: bool
     pr_state: str  # "open" | "closed"
     merged: bool
-    metric_names: tuple[str, ...] = ()
+    # (name, one-line definition) per changed metric; definition may be "".
+    metrics: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass
@@ -55,13 +56,19 @@ class Plan:
 
 
 def render_anchor(ctx: PRContext, mention_by_team: dict[str, str]) -> str:
-    names = ", ".join(f"`{n}`" for n in ctx.metric_names) or "(see PR diff)"
+    # One bullet per metric with its one-line definition, matching the merge
+    # message's "name — definition" copy so the thread reads consistently.
+    if ctx.metrics:
+        metric_lines = [f"• `{n}` — {d}" if d else f"• `{n}`" for n, d in ctx.metrics]
+        metrics_block = "Metrics:\n" + "\n".join(metric_lines)
+    else:
+        metrics_block = "Metrics: (see PR diff)"
     reviewers = " · ".join(f"{team} {mention_by_team.get(team, '')}".strip() for team in ("data", "business"))
     return "\n".join(
         [
             f":scroll: Governed metric PR ready for review: *{ctx.title}*",
             ctx.url,
-            f"Metrics: {names}",
+            metrics_block,
             f"Reviewers: {reviewers}",
             "Approvals will be tracked in this thread.",
         ]
@@ -150,16 +157,26 @@ def _github_client(token: str, repo: str) -> GitHubClient:
     return GitHubClient(token, repo, urlopen=urllib.request.urlopen)
 
 
-def _changed_names(base_dir: Path | None) -> tuple[str, ...]:
+def _changed_metrics(base_dir: Path | None) -> tuple[tuple[str, str], ...]:
+    """(name, one-line definition) per changed metric, for the anchor message.
+
+    Definitions come from the post-change records, falling back to the
+    pre-change ones for removed metrics.
+    """
     after = parse_semantic_tree([DBT_MODELS])
     before = parse_semantic_tree([base_dir / "dbt/project/models"]) if base_dir else []
-    return tuple(slack_diff.changed_metric_names(before, after))
+    definitions = {r.name: r.definition for r in before}
+    definitions.update({r.name: r.definition for r in after})
+    return tuple((n, definitions.get(n, "")) for n in slack_diff.changed_metric_names(before, after))
 
 
 # ts as rendered by pr_marker: a bare "<seconds>.<fraction>" Slack timestamp.
 # Enforced before the value flows into GITHUB_ENV in the publish workflow, so a
 # forged marker comment can't smuggle a newline (e.g. an env-var injection) in.
 _TS_RE = re.compile(r"^\d+\.\d+$")
+# Slack channel ids are uppercase alphanumeric. Same GITHUB_ENV-injection guard
+# as _TS_RE: the marker's channel is exported as SLACK_CHANNEL_ID at merge time.
+_CHANNEL_RE = re.compile(r"^[A-Z0-9]+$")
 
 
 def _find_marker(gh: GitHubClient, pr: int) -> tuple[int, pr_marker.ThreadState, str] | None:
@@ -183,6 +200,10 @@ def _cmd_emit_marker(gh: GitHubClient, pr: int, out: Path) -> int:
         out.write_text("{}")
         print(f"warning: marker ts {state.ts!r} failed format validation; treating as no-marker")
         return 0
+    if state.channel and not _CHANNEL_RE.match(state.channel):
+        out.write_text("{}")
+        print(f"warning: marker channel {state.channel!r} failed format validation; treating as no-marker")
+        return 0
     out.write_text(json.dumps({"ts": state.ts, "merged": state.merged, "channel": state.channel}))
     print(f"marker: ts={state.ts} merged={state.merged}")
     return 0
@@ -191,7 +212,19 @@ def _cmd_emit_marker(gh: GitHubClient, pr: int, out: Path) -> int:
 def _cmd_mark_merged(gh: GitHubClient, pr: int) -> int:
     found = _find_marker(gh, pr)
     if found is None:
-        print("no marker found; nothing to mark")
+        # No governance thread existed for this PR (pre-thread PR, or a lost
+        # marker). Bootstrap a merged marker from the merge post itself (its
+        # ts/channel arrive via GITHUB_ENV from the publish workflow's post
+        # step), so a publish re-run still sees merged:true and never
+        # double-posts the merge summary.
+        ts = os.environ.get("SLACK_TS", "")
+        chan = os.environ.get("SLACK_CHANNEL_ID", "")
+        if not _TS_RE.match(ts) or not _CHANNEL_RE.match(chan):
+            print("no marker found and no valid SLACK_TS/SLACK_CHANNEL_ID; nothing to mark")
+            return 0
+        state = pr_marker.ThreadState(ts=ts, channel=chan, permalink="", merged=True)
+        gh.create_comment(pr, pr_marker.render(state))
+        print("no marker found; bootstrapped a merged marker from the merge post")
         return 0
     comment_id, state, _ = found
     state.merged = True
@@ -252,7 +285,7 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
         # in some webhook shapes); check both so a review event on an already-
         # merged PR doesn't misread it as merged=False.
         merged=bool(pr.get("merged") or pr.get("merged_at")),
-        metric_names=_changed_names(base_dir) if state is None else (),
+        metrics=_changed_metrics(base_dir) if state is None else (),
     )
     teams = mentions_mod.load(PKG / "config" / "slack_mentions.yml")
     mention_by_team = {t: mentions_mod.render_team(teams.get(t)) for t in ("data", "business")}
@@ -268,13 +301,21 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
         except (RuntimeError, OSError) as e:  # cosmetic only; the marker link degrades to blank
             print(f"permalink lookup failed: {e}")
     for text in plan.replies:
-        slack_reply.post_message(
-            slack_token,
-            plan.new_state.channel or channel,
-            text,
-            thread_ts=plan.new_state.ts,
-            urlopen=urllib.request.urlopen,
-        )
+        try:
+            slack_reply.post_message(
+                slack_token,
+                plan.new_state.channel or channel,
+                text,
+                thread_ts=plan.new_state.ts,
+                urlopen=urllib.request.urlopen,
+            )
+        except (RuntimeError, OSError) as e:
+            # Non-fatal: the marker MUST still be written below, or the next
+            # event finds no marker, re-bootstraps, and posts a duplicate
+            # anchor (same failure class as the permalink lookup above).
+            # Trade-off: this reply is lost (its transition is recorded as
+            # announced), which beats a split thread.
+            print(f"reply post failed ({e!r}); continuing so the marker is still written")
     if plan.new_state is not None:
         body = pr_marker.render(plan.new_state)
         if comment_id is not None:

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -27,6 +27,10 @@ def team_approvers(reviews: list[dict], members: dict[str, list[str]]) -> dict[s
     """Latest review per login; APPROVED only; bucketed by team, case-insensitive."""
     latest: dict[str, dict] = {}
     for r in reviews:
+        # PENDING reviews come back from GET /pulls/{n}/reviews without a
+        # submitted_at; they carry no verdict yet, so skip them.
+        if not r.get("submitted_at"):
+            continue
         login = r["user"]["login"].lower()
         if login not in latest or r["submitted_at"] >= latest[login]["submitted_at"]:
             latest[login] = r
@@ -248,7 +252,14 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
     number = int(pr["number"])
     gh = _github_client(gh_token, repo)
 
-    if not is_governed(gh.pr_files(number)):
+    try:
+        governed = is_governed(gh.pr_files(number))
+    except (OSError, RuntimeError) as e:
+        # Same graceful degrade as every other external call here: a transient
+        # GitHub error must not turn the (non-blocking) workflow step red.
+        print(f"pr_files lookup failed ({e}); skipping thread reconcile.")
+        return 0
+    if not governed:
         print(f"PR #{number} not governed; nothing to do.")
         return 0
     if not slack_token or not channel:

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -1,0 +1,116 @@
+"""Reconcile the Slack governance thread for a governed metric PR (DATA-2218).
+
+Pure state machine: given the persisted ThreadState (or None), the current
+approval picture, and the PR context, decide which Slack posts to make and the
+new state to persist. No network in this half; orchestration (main) wires the
+GitHub/Slack clients and lives in the same module to keep the entry point
+discoverable as `python -m semantic_catalog.thread`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from semantic_catalog.pr_marker import ThreadState
+
+GOVERNED_RE = re.compile(r"^dbt/project/models/(?:.+/)?sem_[^/]+\.yml$")
+TEAM_LABEL = {"data": "Data team", "business": "Business team"}
+
+
+def is_governed(files: Iterable[str]) -> bool:
+    return any(GOVERNED_RE.match(f) for f in files)
+
+
+def team_approvers(reviews: list[dict], members: dict[str, list[str]]) -> dict[str, list[str]]:
+    """Latest review per login; APPROVED only; bucketed by team, case-insensitive."""
+    latest: dict[str, dict] = {}
+    for r in reviews:
+        login = r["user"]["login"].lower()
+        if login not in latest or r["submitted_at"] >= latest[login]["submitted_at"]:
+            latest[login] = r
+    approvers = {login for login, r in latest.items() if r["state"] == "APPROVED"}
+    return {
+        team: sorted(approvers & {m.lower() for m in team_members}) for team, team_members in members.items()
+    }
+
+
+@dataclass(frozen=True)
+class PRContext:
+    number: int
+    title: str
+    url: str
+    draft: bool
+    pr_state: str  # "open" | "closed"
+    merged: bool
+    metric_names: tuple[str, ...] = ()
+
+
+@dataclass
+class Plan:
+    anchor_text: str | None = None
+    replies: list[str] = field(default_factory=list)
+    new_state: ThreadState | None = None  # None => persist nothing
+
+
+def render_anchor(ctx: PRContext, mention_by_team: dict[str, str]) -> str:
+    names = ", ".join(f"`{n}`" for n in ctx.metric_names) or "(see PR diff)"
+    reviewers = " · ".join(f"{team} {mention_by_team.get(team, '')}".strip() for team in ("data", "business"))
+    return "\n".join(
+        [
+            f":scroll: Governed metric PR ready for review: *{ctx.title}*",
+            ctx.url,
+            f"Metrics: {names}",
+            f"Reviewers: {reviewers}",
+            "Approvals will be tracked in this thread.",
+        ]
+    )
+
+
+def reconcile(
+    state: ThreadState | None,
+    approvals: dict[str, list[str]] | None,
+    ctx: PRContext,
+    mention_by_team: dict[str, str],
+) -> Plan:
+    """One diff-based pass; every trigger event takes this same path.
+
+    approvals=None means the org token was unavailable: skip the approval diff
+    entirely (never dismiss on missing data). Lifecycle diffs still run.
+    """
+    plan = Plan()
+    if ctx.draft:
+        return plan
+    if state is None:
+        if ctx.pr_state != "open":
+            return plan  # never bootstrap a thread just to announce a close
+        plan.anchor_text = render_anchor(ctx, mention_by_team)
+        state = ThreadState(
+            ts="", channel="", permalink=""
+        )  # ts/channel/permalink filled by caller after posting
+
+    if approvals is not None:
+        for team in ("data", "business"):
+            approved = bool(approvals.get(team))
+            announced = state.announced.get(team)
+            if approved and announced != "approved":
+                who = ", ".join(approvals[team])
+                plan.replies.append(f":white_check_mark: {TEAM_LABEL[team]} approved ({who})")
+                state.announced[team] = "approved"
+            elif not approved and announced == "approved":
+                plan.replies.append(
+                    f":leftwards_arrow_with_hook: {TEAM_LABEL[team]} approval dismissed, re-review needed"
+                )
+                state.announced[team] = "dismissed"
+
+    if ctx.pr_state == "closed" and state.pr_state == "open":
+        if not ctx.merged:
+            plan.replies.append(":x: Closed without merging.")
+        state.pr_state = "closed"
+    elif ctx.pr_state == "open" and state.pr_state == "closed":
+        plan.replies.append(":arrows_counterclockwise: Reopened.")
+        state.pr_state = "open"
+
+    plan.new_state = state
+    return plan

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -206,10 +206,15 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
 
     approvals: dict[str, list[str]] | None = None
     if org_token:
-        gh_org = _github_client(org_token, repo)
-        org = repo.split("/")[0]
-        members = {team: gh_org.team_members(org, slug) for team, slug in TEAM_SLUG.items()}
-        approvals = team_approvers(gh_org.pr_reviews(number), members)
+        try:
+            gh_org = _github_client(org_token, repo)
+            org = repo.split("/")[0]
+            members = {team: gh_org.team_members(org, slug) for team, slug in TEAM_SLUG.items()}
+            # PR reviews belong to the workflow-token client (gh); org_token is
+            # scoped to org team membership only (see github_client.py docstring).
+            approvals = team_approvers(gh.pr_reviews(number), members)
+        except (OSError, RuntimeError) as e:  # narrowly-scoped/expired org token, transient error
+            print(f"ORG_READ_TOKEN lookup failed ({e}); skipping approval diff (lifecycle only).")
     else:
         print("ORG_READ_TOKEN not set; skipping approval diff (lifecycle only).")
 
@@ -235,7 +240,7 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
             plan.new_state.permalink = slack_reply.get_permalink(
                 slack_token, channel, ts, urlopen=urllib.request.urlopen
             )
-        except RuntimeError as e:  # cosmetic only; the marker link degrades to blank
+        except (RuntimeError, OSError) as e:  # cosmetic only; the marker link degrades to blank
             print(f"permalink lookup failed: {e}")
     for text in plan.replies:
         slack_reply.post_message(

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -105,9 +105,16 @@ def reconcile(
                 state.announced[team] = "dismissed"
 
     if ctx.pr_state == "closed" and state.pr_state == "open":
-        if not ctx.merged:
+        if ctx.merged:
+            # Merged PRs cannot reopen and nothing downstream needs
+            # pr_state="closed" for them, so leave state untouched: this keeps
+            # the re-rendered marker byte-identical to what's already posted,
+            # which lets _cmd_reconcile skip the write entirely (fix for the
+            # lost-update race against the publish workflow's mark-merged PATCH).
+            pass
+        else:
             plan.replies.append(":x: Closed without merging.")
-        state.pr_state = "closed"
+            state.pr_state = "closed"
     elif ctx.pr_state == "open" and state.pr_state == "closed":
         plan.replies.append(":arrows_counterclockwise: Reopened.")
         state.pr_state = "open"
@@ -149,12 +156,19 @@ def _changed_names(base_dir: Path | None) -> tuple[str, ...]:
     return tuple(slack_diff.changed_metric_names(before, after))
 
 
-def _find_marker(gh: GitHubClient, pr: int) -> tuple[int, pr_marker.ThreadState] | None:
+# ts as rendered by pr_marker: a bare "<seconds>.<fraction>" Slack timestamp.
+# Enforced before the value flows into GITHUB_ENV in the publish workflow, so a
+# forged marker comment can't smuggle a newline (e.g. an env-var injection) in.
+_TS_RE = re.compile(r"^\d+\.\d+$")
+
+
+def _find_marker(gh: GitHubClient, pr: int) -> tuple[int, pr_marker.ThreadState, str] | None:
     for c in gh.issue_comments(pr):
-        if pr_marker.is_marker(c.get("body", "")):
-            state = pr_marker.parse(c["body"])
+        body = c.get("body", "")
+        if pr_marker.is_marker(body):
+            state = pr_marker.parse(body)
             if state is not None:
-                return int(c["id"]), state
+                return int(c["id"]), state, body
     return None
 
 
@@ -164,7 +178,11 @@ def _cmd_emit_marker(gh: GitHubClient, pr: int, out: Path) -> int:
         out.write_text("{}")
         print("no marker found")
         return 0
-    _, state = found
+    _, state, _ = found
+    if not _TS_RE.match(state.ts):
+        out.write_text("{}")
+        print(f"warning: marker ts {state.ts!r} failed format validation; treating as no-marker")
+        return 0
     out.write_text(json.dumps({"ts": state.ts, "merged": state.merged, "channel": state.channel}))
     print(f"marker: ts={state.ts} merged={state.merged}")
     return 0
@@ -175,7 +193,7 @@ def _cmd_mark_merged(gh: GitHubClient, pr: int) -> int:
     if found is None:
         print("no marker found; nothing to mark")
         return 0
-    comment_id, state = found
+    comment_id, state, _ = found
     state.merged = True
     gh.update_comment(comment_id, pr_marker.render(state))
     print("marker marked merged")
@@ -213,20 +231,27 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
             # PR reviews belong to the workflow-token client (gh); org_token is
             # scoped to org team membership only (see github_client.py docstring).
             approvals = team_approvers(gh.pr_reviews(number), members)
-        except (OSError, RuntimeError) as e:  # narrowly-scoped/expired org token, transient error
-            print(f"ORG_READ_TOKEN lookup failed ({e}); skipping approval diff (lifecycle only).")
+        except (OSError, RuntimeError) as e:
+            # Covers both the org-token team-membership lookup and the
+            # workflow-token gh.pr_reviews call in this same try, so the
+            # message stays token-neutral rather than blaming ORG_READ_TOKEN
+            # for a failure that could originate from either call.
+            print(f"approval lookup failed ({e}); skipping approval diff (lifecycle only).")
     else:
         print("ORG_READ_TOKEN not set; skipping approval diff (lifecycle only).")
 
     found = _find_marker(gh, number)
-    comment_id, state = found if found else (None, None)
+    comment_id, state, original_body = found if found else (None, None, None)
     ctx = PRContext(
         number=number,
         title=pr["title"],
         url=pr["html_url"],
         draft=bool(pr.get("draft")),
         pr_state="closed" if pr.get("state") == "closed" else "open",
-        merged=bool(pr.get("merged")),
+        # pull_request_review payloads omit `merged` (only `merged_at` shows up
+        # in some webhook shapes); check both so a review event on an already-
+        # merged PR doesn't misread it as merged=False.
+        merged=bool(pr.get("merged") or pr.get("merged_at")),
         metric_names=_changed_names(base_dir) if state is None else (),
     )
     teams = mentions_mod.load(PKG / "config" / "slack_mentions.yml")
@@ -253,7 +278,13 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
     if plan.new_state is not None:
         body = pr_marker.render(plan.new_state)
         if comment_id is not None:
-            gh.update_comment(comment_id, body)
+            # Skip no-change writes: a re-render that matches the marker
+            # already on the PR means nothing to persist, so don't PATCH it.
+            # Every synchronize/review event otherwise re-wrote an unchanged
+            # marker, widening the race window against the publish workflow's
+            # mark-merged PATCH (last-writer-wins on the same comment).
+            if body != original_body:
+                gh.update_comment(comment_id, body)
         else:
             gh.create_comment(number, body)
     print(f"reconciled: anchor={'yes' if plan.anchor_text else 'no'} replies={len(plan.replies)}")

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -292,7 +292,16 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
 
     plan = reconcile(state, approvals, ctx, mention_by_team)
     if plan.anchor_text is not None and plan.new_state is not None:
-        ts = slack_reply.post_message(slack_token, channel, plan.anchor_text, urlopen=urllib.request.urlopen)
+        try:
+            ts = slack_reply.post_message(
+                slack_token, channel, plan.anchor_text, urlopen=urllib.request.urlopen
+            )
+        except (RuntimeError, OSError) as e:
+            # No anchor => nothing to thread under and no state worth writing.
+            # Log and exit cleanly so the job stays green and the next event
+            # retries the whole bootstrap.
+            print(f"anchor post failed ({e!r}); aborting reconcile so the next event retries")
+            return 0
         plan.new_state.ts, plan.new_state.channel = ts, channel
         try:
             plan.new_state.permalink = slack_reply.get_permalink(

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -43,8 +43,7 @@ def test_emit_slack_writes_rendered_message(tmp_path):
     assert rc == 0
     text = out.read_text()
     assert "http://pr/1" in text
-    assert "incomplete" in text.lower()
-    assert "business" in text.lower()
+    assert ":warning: review coverage: data ✓ · business ✗" in text
 
 
 def test_region_is_current_false_on_half_marked_file(tmp_path):

--- a/analytics/tests/test_semantic_catalog_github_client.py
+++ b/analytics/tests/test_semantic_catalog_github_client.py
@@ -1,0 +1,61 @@
+import json
+
+from semantic_catalog.github_client import GitHubClient
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+
+def _client(pages):
+    """pages: list of successive JSON payloads returned per request, in order."""
+    calls = []
+    seq = list(pages)
+
+    def fake_urlopen(req, timeout=30):
+        calls.append(req)
+        return _FakeResp(seq.pop(0))
+
+    return GitHubClient("ghtok", "thegoodparty/gp-data-platform", urlopen=fake_urlopen), calls
+
+
+def test_pr_files_paginates_until_short_page():
+    page1 = [{"filename": f"f{i}.txt"} for i in range(100)]
+    page2 = [{"filename": "dbt/project/models/marts/sem_analytics__users_win.yml"}]
+    gh, calls = _client([page1, page2])
+    files = gh.pr_files(7)
+    assert len(files) == 101 and files[-1].endswith("sem_analytics__users_win.yml")
+    assert "per_page=100" in calls[0].full_url and "page=1" in calls[0].full_url
+    assert "page=2" in calls[1].full_url
+    assert calls[0].get_header("Authorization") == "Bearer ghtok"
+
+
+def test_team_members_extracts_logins():
+    gh, _ = _client([[{"login": "alice"}, {"login": "bob"}]])
+    assert gh.team_members("thegoodparty", "semantic-layer-data") == ["alice", "bob"]
+
+
+def test_create_comment_posts_body_and_returns_id():
+    gh, calls = _client([{"id": 991}])
+    cid = gh.create_comment(7, "marker body")
+    assert cid == 991
+    assert calls[0].get_method() == "POST"
+    assert json.loads(calls[0].data) == {"body": "marker body"}
+    assert calls[0].full_url.endswith("/repos/thegoodparty/gp-data-platform/issues/7/comments")
+
+
+def test_update_comment_patches():
+    gh, calls = _client([{"id": 991}])
+    gh.update_comment(991, "new body")
+    assert calls[0].get_method() == "PATCH"
+    assert calls[0].full_url.endswith("/repos/thegoodparty/gp-data-platform/issues/comments/991")

--- a/analytics/tests/test_semantic_catalog_mentions.py
+++ b/analytics/tests/test_semantic_catalog_mentions.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from semantic_catalog import mentions
+
+
+def test_render_team_usergroup_takes_precedence():
+    cfg = {"usergroup_id": "S0ABC", "member_ids": ["U1", "U2"]}
+    assert mentions.render_team(cfg) == "<!subteam^S0ABC>"
+
+
+def test_render_team_member_ids():
+    assert mentions.render_team({"usergroup_id": None, "member_ids": ["U1", "U2"]}) == "<@U1> <@U2>"
+
+
+def test_render_team_empty_config_degrades_to_no_mention():
+    assert mentions.render_team({"usergroup_id": None, "member_ids": []}) == ""
+    assert mentions.render_team(None) == ""
+
+
+def test_load_missing_file_returns_empty(tmp_path):
+    assert mentions.load(tmp_path / "nope.yml") == {}
+
+
+def test_load_shipped_config_parses():
+    shipped = Path(mentions.__file__).parent / "config" / "slack_mentions.yml"
+    teams = mentions.load(shipped)
+    assert set(teams) == {"data", "business"}

--- a/analytics/tests/test_semantic_catalog_pr_marker.py
+++ b/analytics/tests/test_semantic_catalog_pr_marker.py
@@ -1,0 +1,40 @@
+from semantic_catalog import pr_marker
+from semantic_catalog.pr_marker import ThreadState
+
+
+def _state(**kw):
+    base = dict(ts="1722.0001", channel="C08K22X9ZNH", permalink="https://gp.slack.com/p1722")
+    base.update(kw)
+    return ThreadState(**base)
+
+
+def test_round_trip():
+    s = _state(announced={"data": "approved", "business": None}, pr_state="open", merged=False)
+    body = pr_marker.render(s)
+    assert pr_marker.parse(body) == s
+
+
+def test_render_has_visible_link_and_hidden_json():
+    body = pr_marker.render(_state())
+    assert body.startswith("Slack governance thread: https://gp.slack.com/p1722")
+    assert "<!-- semantic-layer-thread v1" in body and body.rstrip().endswith("-->")
+
+
+def test_parse_returns_none_without_marker():
+    assert pr_marker.parse("just a human comment") is None
+
+
+def test_parse_returns_none_on_corrupt_json():
+    body = "<!-- semantic-layer-thread v1\n{not json\n-->"
+    assert pr_marker.parse(body) is None
+
+
+def test_defaults():
+    s = _state()
+    assert s.announced == {"data": None, "business": None}
+    assert s.pr_state == "open" and s.merged is False
+
+
+def test_is_marker():
+    assert pr_marker.is_marker(pr_marker.render(_state()))
+    assert not pr_marker.is_marker("unrelated bot comment")

--- a/analytics/tests/test_semantic_catalog_slack.py
+++ b/analytics/tests/test_semantic_catalog_slack.py
@@ -1,11 +1,11 @@
 import dataclasses
 
 from semantic_catalog.records import MetricRecord
-from semantic_catalog.slack_diff import diff_records, render_message
+from semantic_catalog.slack_diff import changed_metric_names, diff_records, render_message
 
 
-def _rec(name, definition, ratified=None):
-    return MetricRecord(
+def _rec(name, definition="d", ratified=None, **kw):
+    base = dict(
         name=name,
         label=name.title(),
         definition=definition,
@@ -20,6 +20,8 @@ def _rec(name, definition, ratified=None):
         yaml_file="sem.yml",
         kind="metric",
     )
+    base.update(kw)
+    return MetricRecord(**base)
 
 
 def test_diff_detects_added_removed_changed():
@@ -41,20 +43,18 @@ def test_diff_detects_ratification():
 def test_message_flags_incomplete_review():
     msg = render_message([], [_rec("a", "d")], "http://pr/1", {"data": True, "business": False})
     assert "http://pr/1" in msg
-    assert "incomplete" in msg.lower() or "missing" in msg.lower()
-    assert "business" in msg.lower()
-    assert "business group" in msg.lower()
-    assert "business groups" not in msg.lower()
+    assert ":warning: review coverage: data ✓ · business ✗" in msg
 
 
 def test_message_flags_incomplete_review_both_groups_pluralizes():
     msg = render_message([], [_rec("a", "d")], "http://pr/1", {"data": False, "business": False})
-    assert "data, business groups" in msg.lower()
+    assert ":warning: review coverage: data ✗ · business ✗" in msg
 
 
 def test_message_confirms_complete_review():
     msg = render_message([], [_rec("a", "d")], "http://pr/1", {"data": True, "business": True})
-    assert "both groups" in msg.lower() or "complete" in msg.lower()
+    assert "review coverage: data ✓ · business ✓" in msg
+    assert ":warning:" not in msg
 
 
 def test_diff_detects_retired_and_owner_changes():
@@ -63,3 +63,25 @@ def test_diff_detects_retired_and_owner_changes():
     lines = "\n".join(diff_records([base], [after]))
     assert "retired: a" in lines and "2026-07-01" in lines
     assert "owner: a" in lines and "semantic-layer-data" in lines
+
+
+def test_changed_metric_names_added_removed_changed():
+    before = [_rec("kept"), _rec("gone"), _rec("edited", definition="old")]
+    after = [_rec("kept"), _rec("new"), _rec("edited", definition="new")]
+    assert changed_metric_names(before, after) == ["edited", "gone", "new"]
+
+
+def test_changed_metric_names_empty_when_identical():
+    recs = [_rec("a"), _rec("b")]
+    assert changed_metric_names(recs, recs) == []
+
+
+def test_render_message_coverage_is_one_line_complete():
+    msg = render_message([], [_rec("a")], "http://pr", {"data": True, "business": True})
+    assert "review coverage: data ✓ · business ✓" in msg
+    assert ":warning:" not in msg
+
+
+def test_render_message_coverage_warns_when_incomplete():
+    msg = render_message([], [_rec("a")], "http://pr", {"data": True, "business": False})
+    assert ":warning: review coverage: data ✓ · business ✗" in msg

--- a/analytics/tests/test_semantic_catalog_slack_reply.py
+++ b/analytics/tests/test_semantic_catalog_slack_reply.py
@@ -18,18 +18,19 @@ class _FakeResp:
         return json.dumps(self._payload).encode()
 
 
-def _recorder(ok=True, error=None):
+def _recorder(ok=True, error=None, extra=None):
     calls = []
 
     def fake_urlopen(req, timeout=30):
         calls.append(req)
-        return _FakeResp({"ok": True} if ok else {"ok": False, "error": error or "bad"})
+        payload = {"ok": True, **(extra or {})} if ok else {"ok": False, "error": error or "bad"}
+        return _FakeResp(payload)
 
     return fake_urlopen, calls
 
 
 def test_reply_in_thread_posts_one_reply_per_task():
-    urlopen, calls = _recorder(ok=True)
+    urlopen, calls = _recorder(ok=True, extra={"ts": "1699.0002"})
     tasks = [
         {"metric": "win_users", "task_id": "a", "url": "https://app.clickup.com/t/a"},
         {"metric": "active_serve_users", "task_id": "b", "url": "https://app.clickup.com/t/b"},
@@ -55,3 +56,32 @@ def test_reply_in_thread_noop_on_empty_tasks():
     urlopen, calls = _recorder(ok=True)
     slack_reply.reply_in_thread("tok", "C123", "ts", [], urlopen=urlopen)
     assert calls == []
+
+
+def test_post_message_returns_ts_and_posts_top_level():
+    urlopen, calls = _recorder(ok=True, extra={"ts": "1722.0042"})
+    ts = slack_reply.post_message("tok", "C123", "hello", urlopen=urlopen)
+    assert ts == "1722.0042"
+    body = json.loads(calls[0].data)
+    assert body == {"channel": "C123", "text": "hello"}
+    assert calls[0].get_header("Authorization") == "Bearer tok"
+
+
+def test_post_message_threads_when_thread_ts_given():
+    urlopen, calls = _recorder(ok=True, extra={"ts": "1722.0043"})
+    slack_reply.post_message("tok", "C123", "reply", thread_ts="1722.0001", urlopen=urlopen)
+    assert json.loads(calls[0].data)["thread_ts"] == "1722.0001"
+
+
+def test_post_message_raises_on_slack_error():
+    urlopen, _ = _recorder(ok=False, error="invalid_auth")
+    with pytest.raises(RuntimeError, match="invalid_auth"):
+        slack_reply.post_message("tok", "C123", "x", urlopen=urlopen)
+
+
+def test_get_permalink_uses_get_with_params():
+    urlopen, calls = _recorder(ok=True, extra={"permalink": "https://gp.slack.com/archives/C123/p1722"})
+    link = slack_reply.get_permalink("tok", "C123", "1722.0042", urlopen=urlopen)
+    assert link == "https://gp.slack.com/archives/C123/p1722"
+    assert calls[0].get_method() == "GET"
+    assert "channel=C123" in calls[0].full_url and "message_ts=1722.0042" in calls[0].full_url

--- a/analytics/tests/test_semantic_catalog_thread.py
+++ b/analytics/tests/test_semantic_catalog_thread.py
@@ -1,0 +1,123 @@
+from semantic_catalog.pr_marker import ThreadState
+from semantic_catalog.thread import PRContext, is_governed, reconcile, render_anchor, team_approvers
+
+
+def _ctx(**kw):
+    base = dict(
+        number=7,
+        title="Ratify win_users",
+        url="https://github.com/x/pull/7",
+        draft=False,
+        pr_state="open",
+        merged=False,
+        metric_names=("win_users",),
+    )
+    base.update(kw)
+    return PRContext(**base)
+
+
+def _state(**kw):
+    base = dict(ts="1722.0001", channel="C1", permalink="https://p")
+    base.update(kw)
+    return ThreadState(**base)
+
+
+NO_APPROVALS = {"data": [], "business": []}
+MENTIONS = {"data": "<@U1>", "business": "<@U2> <@U3>"}
+
+
+# --- is_governed -------------------------------------------------------------
+
+
+def test_is_governed_matches_nested_and_direct_sem_files():
+    assert is_governed(["dbt/project/models/marts/sem_analytics__users_win.yml"])
+    assert is_governed(["dbt/project/models/sem_x.yml", "README.md"])
+    assert not is_governed(["dbt/project/models/marts/users_win.yml", "analytics/foo.py"])
+    assert not is_governed([])
+
+
+# --- team_approvers ----------------------------------------------------------
+
+
+def test_team_approvers_latest_review_wins_and_buckets_by_team():
+    reviews = [
+        {"user": {"login": "Alice"}, "state": "APPROVED", "submitted_at": "2026-08-01T10:00:00Z"},
+        {"user": {"login": "alice"}, "state": "CHANGES_REQUESTED", "submitted_at": "2026-08-02T10:00:00Z"},
+        {"user": {"login": "joe"}, "state": "APPROVED", "submitted_at": "2026-08-02T11:00:00Z"},
+        {"user": {"login": "rando"}, "state": "APPROVED", "submitted_at": "2026-08-02T12:00:00Z"},
+    ]
+    members = {"data": ["alice"], "business": ["Joe", "amanda"]}
+    out = team_approvers(reviews, members)
+    assert out == {"data": [], "business": ["joe"]}  # alice superseded; rando in no team
+
+
+# --- reconcile ---------------------------------------------------------------
+
+
+def test_draft_is_silent():
+    plan = reconcile(None, NO_APPROVALS, _ctx(draft=True), MENTIONS)
+    assert plan.anchor_text is None and plan.replies == [] and plan.new_state is None
+
+
+def test_bootstrap_anchor_on_open_pr_without_state():
+    plan = reconcile(None, NO_APPROVALS, _ctx(), MENTIONS)
+    assert plan.anchor_text is not None
+    assert "`win_users`" in plan.anchor_text and "<@U1>" in plan.anchor_text
+    assert plan.new_state is not None and plan.new_state.announced == {"data": None, "business": None}
+
+
+def test_no_bootstrap_for_closed_pr_without_state():
+    plan = reconcile(None, NO_APPROVALS, _ctx(pr_state="closed"), MENTIONS)
+    assert plan.anchor_text is None and plan.replies == [] and plan.new_state is None
+
+
+def test_approval_posts_once_then_replays_are_silent():
+    st = _state()
+    plan = reconcile(st, {"data": ["alice"], "business": []}, _ctx(), MENTIONS)
+    assert plan.replies == [":white_check_mark: Data team approved (alice)"]
+    assert plan.new_state.announced["data"] == "approved"
+    replay = reconcile(plan.new_state, {"data": ["alice"], "business": []}, _ctx(), MENTIONS)
+    assert replay.replies == []
+
+
+def test_dismissal_and_reapproval_both_post():
+    st = _state(announced={"data": "approved", "business": None})
+    plan = reconcile(st, NO_APPROVALS, _ctx(), MENTIONS)
+    assert plan.replies == [":leftwards_arrow_with_hook: Data team approval dismissed, re-review needed"]
+    assert plan.new_state.announced["data"] == "dismissed"
+    again = reconcile(plan.new_state, {"data": ["alice"], "business": []}, _ctx(), MENTIONS)
+    assert again.replies == [":white_check_mark: Data team approved (alice)"]
+
+
+def test_approvals_none_skips_approval_diff():
+    st = _state(announced={"data": "approved", "business": None})
+    plan = reconcile(st, None, _ctx(), MENTIONS)
+    assert plan.replies == []  # no spurious dismissal when ORG_READ_TOKEN is missing
+    assert plan.new_state.announced["data"] == "approved"
+
+
+def test_close_without_merge_posts_and_close_with_merge_is_silent():
+    plan = reconcile(_state(), NO_APPROVALS, _ctx(pr_state="closed", merged=False), MENTIONS)
+    assert ":x: Closed without merging." in plan.replies
+    assert plan.new_state.pr_state == "closed"
+    merged = reconcile(_state(), NO_APPROVALS, _ctx(pr_state="closed", merged=True), MENTIONS)
+    assert merged.replies == [] and merged.new_state.pr_state == "closed"
+
+
+def test_reopen_posts_and_rerun_is_silent():
+    st = _state(pr_state="closed")
+    plan = reconcile(st, NO_APPROVALS, _ctx(pr_state="open"), MENTIONS)
+    assert ":arrows_counterclockwise: Reopened." in plan.replies
+    rerun = reconcile(plan.new_state, NO_APPROVALS, _ctx(pr_state="open"), MENTIONS)
+    assert rerun.replies == []
+
+
+def test_bootstrap_and_approval_in_same_event():
+    plan = reconcile(None, {"data": ["alice"], "business": []}, _ctx(), MENTIONS)
+    assert plan.anchor_text is not None
+    assert plan.replies == [":white_check_mark: Data team approved (alice)"]
+
+
+def test_render_anchor_without_mentions_or_names():
+    text = render_anchor(_ctx(metric_names=()), {"data": "", "business": ""})
+    assert "(see PR diff)" in text and "Reviewers" in text

--- a/analytics/tests/test_semantic_catalog_thread.py
+++ b/analytics/tests/test_semantic_catalog_thread.py
@@ -100,8 +100,13 @@ def test_close_without_merge_posts_and_close_with_merge_is_silent():
     plan = reconcile(_state(), NO_APPROVALS, _ctx(pr_state="closed", merged=False), MENTIONS)
     assert ":x: Closed without merging." in plan.replies
     assert plan.new_state.pr_state == "closed"
+    # A merged close posts nothing (unchanged) AND must not persist the
+    # pr_state transition either: merged PRs cannot reopen, so nothing
+    # downstream needs pr_state="closed", and leaving state untouched lets the
+    # orchestration layer recognize the marker as unchanged and skip the write
+    # (avoids racing the publish workflow's mark-merged PATCH).
     merged = reconcile(_state(), NO_APPROVALS, _ctx(pr_state="closed", merged=True), MENTIONS)
-    assert merged.replies == [] and merged.new_state.pr_state == "closed"
+    assert merged.replies == [] and merged.new_state.pr_state == "open"
 
 
 def test_reopen_posts_and_rerun_is_silent():

--- a/analytics/tests/test_semantic_catalog_thread.py
+++ b/analytics/tests/test_semantic_catalog_thread.py
@@ -10,7 +10,7 @@ def _ctx(**kw):
         draft=False,
         pr_state="open",
         merged=False,
-        metric_names=("win_users",),
+        metrics=(("win_users", "Distinct users with an activated Win account"),),
     )
     base.update(kw)
     return PRContext(**base)
@@ -22,7 +22,7 @@ def _state(**kw):
     return ThreadState(**base)
 
 
-NO_APPROVALS = {"data": [], "business": []}
+NO_APPROVALS: dict[str, list[str]] = {"data": [], "business": []}
 MENTIONS = {"data": "<@U1>", "business": "<@U2> <@U3>"}
 
 
@@ -62,8 +62,14 @@ def test_draft_is_silent():
 def test_bootstrap_anchor_on_open_pr_without_state():
     plan = reconcile(None, NO_APPROVALS, _ctx(), MENTIONS)
     assert plan.anchor_text is not None
-    assert "`win_users`" in plan.anchor_text and "<@U1>" in plan.anchor_text
+    assert "• `win_users` — Distinct users with an activated Win account" in plan.anchor_text
+    assert "<@U1>" in plan.anchor_text
     assert plan.new_state is not None and plan.new_state.announced == {"data": None, "business": None}
+
+
+def test_render_anchor_metric_without_definition_gets_bare_bullet():
+    text = render_anchor(_ctx(metrics=(("win_users", ""),)), MENTIONS)
+    assert "• `win_users`" in text and "• `win_users` —" not in text
 
 
 def test_no_bootstrap_for_closed_pr_without_state():
@@ -124,5 +130,5 @@ def test_bootstrap_and_approval_in_same_event():
 
 
 def test_render_anchor_without_mentions_or_names():
-    text = render_anchor(_ctx(metric_names=()), {"data": "", "business": ""})
+    text = render_anchor(_ctx(metrics=()), {"data": "", "business": ""})
     assert "(see PR diff)" in text and "Reviewers" in text

--- a/analytics/tests/test_semantic_catalog_thread.py
+++ b/analytics/tests/test_semantic_catalog_thread.py
@@ -132,3 +132,13 @@ def test_bootstrap_and_approval_in_same_event():
 def test_render_anchor_without_mentions_or_names():
     text = render_anchor(_ctx(metrics=()), {"data": "", "business": ""})
     assert "(see PR diff)" in text and "Reviewers" in text
+
+
+def test_team_approvers_skips_pending_reviews_without_submitted_at():
+    reviews = [
+        {"user": {"login": "alice"}, "state": "PENDING"},
+        {"user": {"login": "bob"}, "state": "APPROVED", "submitted_at": "2026-08-04T10:00:00Z"},
+        {"user": {"login": "carol"}, "state": "PENDING", "submitted_at": None},
+    ]
+    members = {"data": ["alice", "bob", "carol"], "business": []}
+    assert team_approvers(reviews, members) == {"data": ["bob"], "business": []}

--- a/analytics/tests/test_semantic_catalog_thread_main.py
+++ b/analytics/tests/test_semantic_catalog_thread_main.py
@@ -1,0 +1,143 @@
+import json
+
+import semantic_catalog.github_client as ghmod
+import semantic_catalog.slack_reply as slmod
+from semantic_catalog import thread
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+
+def _script(monkeypatch, responses):
+    """Route fake responses by URL substring; record all requests."""
+    calls = []
+
+    def fake_urlopen(req, timeout=30):
+        calls.append(req)
+        for frag, payload in responses:
+            if frag in req.full_url:
+                return _FakeResp(payload)
+        raise AssertionError(f"unexpected URL: {req.full_url}")
+
+    monkeypatch.setattr(ghmod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(slmod.urllib.request, "urlopen", fake_urlopen)
+    return calls
+
+
+def _env(monkeypatch, **over):
+    base = dict(
+        GH_TOKEN="ghtok",
+        ORG_READ_TOKEN="orgtok",
+        SLACK_APP_BOT_TOKEN="slacktok",
+        SLACK_CHANNEL_ID="C1",
+        GITHUB_REPOSITORY="thegoodparty/gp-data-platform",
+    )
+    base.update(over)
+    for k, v in base.items():
+        (monkeypatch.delenv(k, raising=False) if v is None else monkeypatch.setenv(k, v))
+
+
+def _event(tmp_path, **over):
+    pr = dict(
+        number=7,
+        title="Ratify win_users",
+        html_url="https://github.com/x/pull/7",
+        draft=False,
+        state="open",
+        merged=False,
+    )
+    pr.update(over)
+    p = tmp_path / "event.json"
+    p.write_text(json.dumps({"pull_request": pr}))
+    return p
+
+
+def test_reconcile_skips_non_governed_pr(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch)
+    calls = _script(monkeypatch, [("/pulls/7/files", [{"filename": "README.md"}])])
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    assert len(calls) == 1  # stopped after the files check
+    assert "not governed" in capsys.readouterr().out
+
+
+def test_reconcile_bootstraps_anchor_and_creates_marker(tmp_path, monkeypatch):
+    _env(monkeypatch)
+    calls = _script(
+        monkeypatch,
+        [
+            ("/pulls/7/files", [{"filename": "dbt/project/models/marts/sem_analytics__users_win.yml"}]),
+            ("/pulls/7/reviews", []),
+            ("/teams/semantic-layer-data/members", [{"login": "tristan"}]),
+            ("/teams/semantic-layer-business/members", [{"login": "joe"}]),
+            ("/issues/7/comments?", []),
+            ("chat.postMessage", {"ok": True, "ts": "1722.0042"}),
+            ("chat.getPermalink", {"ok": True, "permalink": "https://gp.slack.com/p42"}),
+            ("/issues/7/comments", {"id": 991}),  # create marker (POST matches after the paginated GET)
+        ],
+    )
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    created = [c for c in calls if c.get_method() == "POST" and "/issues/7/comments" in c.full_url]
+    assert created, "marker comment must be created"
+    body = json.loads(created[-1].data)["body"]
+    assert "semantic-layer-thread v1" in body and "1722.0042" in body
+
+
+def test_reconcile_without_slack_token_skips_cleanly(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch, SLACK_APP_BOT_TOKEN=None)
+    _script(monkeypatch, [("/pulls/7/files", [{"filename": "dbt/project/models/sem_x.yml"}])])
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    assert "SLACK_APP_BOT_TOKEN" in capsys.readouterr().out
+
+
+def test_emit_marker_writes_state_json(tmp_path, monkeypatch):
+    from semantic_catalog import pr_marker
+    from semantic_catalog.pr_marker import ThreadState
+
+    _env(monkeypatch)
+    marker_body = pr_marker.render(ThreadState(ts="1722.0042", channel="C1", permalink="https://p"))
+    _script(monkeypatch, [("/issues/7/comments?", [{"id": 991, "body": marker_body}])])
+    out = tmp_path / "marker.json"
+    rc = thread.main(["--emit-marker", str(out), "--pr", "7"])
+    assert rc == 0
+    d = json.loads(out.read_text())
+    assert d == {"ts": "1722.0042", "merged": False, "channel": "C1"}
+
+
+def test_emit_marker_writes_empty_object_when_absent(tmp_path, monkeypatch):
+    _env(monkeypatch)
+    _script(monkeypatch, [("/issues/7/comments?", [{"id": 1, "body": "human chatter"}])])
+    out = tmp_path / "marker.json"
+    assert thread.main(["--emit-marker", str(out), "--pr", "7"]) == 0
+    assert json.loads(out.read_text()) == {}
+
+
+def test_mark_merged_updates_marker(tmp_path, monkeypatch):
+    from semantic_catalog import pr_marker
+    from semantic_catalog.pr_marker import ThreadState
+
+    _env(monkeypatch)
+    marker_body = pr_marker.render(ThreadState(ts="1722.0042", channel="C1", permalink="https://p"))
+    calls = _script(
+        monkeypatch,
+        [
+            ("/issues/7/comments?", [{"id": 991, "body": marker_body}]),
+            ("/issues/comments/991", {"id": 991}),
+        ],
+    )
+    assert thread.main(["--mark-merged", "--pr", "7"]) == 0
+    patch = [c for c in calls if c.get_method() == "PATCH"][-1]
+    assert '"merged": true' in json.loads(patch.data)["body"]

--- a/analytics/tests/test_semantic_catalog_thread_main.py
+++ b/analytics/tests/test_semantic_catalog_thread_main.py
@@ -280,3 +280,87 @@ def test_mark_merged_updates_marker(tmp_path, monkeypatch):
     assert thread.main(["--mark-merged", "--pr", "7"]) == 0
     patch = [c for c in calls if c.get_method() == "PATCH"][-1]
     assert '"merged": true' in json.loads(patch.data)["body"]
+
+
+def test_reconcile_reply_failure_still_writes_marker(tmp_path, monkeypatch, capsys):
+    """A failed threaded reply must not orphan the marker (duplicate-anchor risk)."""
+    _env(monkeypatch)
+    calls = []
+    post_count = {"n": 0}
+    responses = [
+        ("/pulls/7/files", [{"filename": "dbt/project/models/sem_x.yml"}]),
+        (
+            "/pulls/7/reviews",
+            [{"user": {"login": "tristan"}, "state": "APPROVED", "submitted_at": "2026-08-04T10:00:00Z"}],
+        ),
+        ("/teams/semantic-layer-data/members", [{"login": "tristan"}]),
+        ("/teams/semantic-layer-business/members", [{"login": "joe"}]),
+        ("/issues/7/comments?", []),
+        ("chat.getPermalink", {"ok": True, "permalink": "https://p"}),
+        ("/issues/7/comments", {"id": 991}),
+    ]
+
+    def fake_urlopen(req, timeout=30):
+        calls.append(req)
+        if "chat.postMessage" in req.full_url:
+            post_count["n"] += 1
+            # First post is the anchor (succeeds); the approval reply fails.
+            if post_count["n"] == 1:
+                return _FakeResp({"ok": True, "ts": "1722.0042"})
+            return _FakeResp({"ok": False, "error": "ratelimited"})
+        for frag, payload in responses:
+            if frag in req.full_url:
+                return _FakeResp(payload)
+        raise AssertionError(f"unexpected URL: {req.full_url}")
+
+    monkeypatch.setattr(ghmod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(slmod.urllib.request, "urlopen", fake_urlopen)
+
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    assert "reply post failed" in capsys.readouterr().out
+    created = [c for c in calls if c.get_method() == "POST" and "/issues/7/comments" in c.full_url]
+    assert created, "marker must still be written after a failed reply"
+    assert "1722.0042" in json.loads(created[-1].data)["body"]
+
+
+def test_emit_marker_rejects_malformed_channel(tmp_path, monkeypatch, capsys):
+    from semantic_catalog import pr_marker
+    from semantic_catalog.pr_marker import ThreadState
+
+    _env(monkeypatch)
+    forged = pr_marker.render(
+        ThreadState(ts="1722.0042", channel="C0\nSLACK_APP_BOT_TOKEN=attacker", permalink="")
+    )
+    _script(monkeypatch, [("/issues/7/comments?", [{"id": 991, "body": forged}])])
+    out = tmp_path / "marker.json"
+    assert thread.main(["--emit-marker", str(out), "--pr", "7"]) == 0
+    assert json.loads(out.read_text()) == {}
+    assert "channel" in capsys.readouterr().out
+
+
+def test_mark_merged_bootstraps_marker_when_absent(tmp_path, monkeypatch):
+    """A pre-thread PR still gets a merged marker so publish re-runs are idempotent."""
+    _env(monkeypatch)
+    monkeypatch.setenv("SLACK_TS", "1722.0099")
+    calls = _script(
+        monkeypatch,
+        [
+            ("/issues/7/comments?", []),
+            ("/issues/7/comments", {"id": 992}),
+        ],
+    )
+    assert thread.main(["--mark-merged", "--pr", "7"]) == 0
+    created = [c for c in calls if c.get_method() == "POST"]
+    assert created, "bootstrap marker must be created"
+    body = json.loads(created[-1].data)["body"]
+    assert '"merged": true' in body and "1722.0099" in body
+
+
+def test_mark_merged_without_marker_or_post_env_is_a_noop(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch)
+    monkeypatch.delenv("SLACK_TS", raising=False)
+    calls = _script(monkeypatch, [("/issues/7/comments?", [])])
+    assert thread.main(["--mark-merged", "--pr", "7"]) == 0
+    assert all(c.get_method() != "POST" for c in calls)
+    assert "nothing to mark" in capsys.readouterr().out

--- a/analytics/tests/test_semantic_catalog_thread_main.py
+++ b/analytics/tests/test_semantic_catalog_thread_main.py
@@ -185,6 +185,39 @@ def test_reconcile_degrades_when_permalink_lookup_raises_transport_error(tmp_pat
     assert state.permalink == ""
 
 
+def test_reconcile_merged_close_with_current_marker_writes_nothing(tmp_path, monkeypatch):
+    """A merged PR's close event must not touch the comments API at all when the
+    marker is already current: any write there (even a no-op PATCH) widens the
+    race window against the publish workflow's mark-merged PATCH on the same
+    comment (last-writer-wins)."""
+    from semantic_catalog import pr_marker
+    from semantic_catalog.pr_marker import ThreadState
+
+    _env(monkeypatch)
+    marker_body = pr_marker.render(
+        ThreadState(ts="1722.0042", channel="C1", permalink="https://p", pr_state="open")
+    )
+    calls = _script(
+        monkeypatch,
+        [
+            ("/pulls/7/files", [{"filename": "dbt/project/models/marts/sem_analytics__users_win.yml"}]),
+            ("/pulls/7/reviews", []),
+            ("/teams/semantic-layer-data/members", []),
+            ("/teams/semantic-layer-business/members", []),
+            ("/issues/7/comments?", [{"id": 991, "body": marker_body}]),
+        ],
+    )
+    rc = thread.main(["--event-path", str(_event(tmp_path, state="closed", merged=True))])
+    assert rc == 0
+    comment_writes = [
+        c
+        for c in calls
+        if c.get_method() in ("POST", "PATCH")
+        and ("/issues/7/comments" in c.full_url or "/issues/comments/" in c.full_url)
+    ]
+    assert comment_writes == []
+
+
 def test_reconcile_without_slack_token_skips_cleanly(tmp_path, monkeypatch, capsys):
     _env(monkeypatch, SLACK_APP_BOT_TOKEN=None)
     _script(monkeypatch, [("/pulls/7/files", [{"filename": "dbt/project/models/sem_x.yml"}])])
@@ -213,6 +246,22 @@ def test_emit_marker_writes_empty_object_when_absent(tmp_path, monkeypatch):
     out = tmp_path / "marker.json"
     assert thread.main(["--emit-marker", str(out), "--pr", "7"]) == 0
     assert json.loads(out.read_text()) == {}
+
+
+def test_emit_marker_rejects_malformed_ts(tmp_path, monkeypatch, capsys):
+    """A forged/corrupt marker with a non-numeric ts must not flow through to
+    GITHUB_ENV in the publish workflow (a newline in ts could inject an env
+    var); treat it as no-marker instead."""
+    from semantic_catalog import pr_marker
+    from semantic_catalog.pr_marker import ThreadState
+
+    _env(monkeypatch)
+    marker_body = pr_marker.render(ThreadState(ts="x\nFOO=bar", channel="C1", permalink="https://p"))
+    _script(monkeypatch, [("/issues/7/comments?", [{"id": 991, "body": marker_body}])])
+    out = tmp_path / "marker.json"
+    assert thread.main(["--emit-marker", str(out), "--pr", "7"]) == 0
+    assert json.loads(out.read_text()) == {}
+    assert "warning" in capsys.readouterr().out.lower()
 
 
 def test_mark_merged_updates_marker(tmp_path, monkeypatch):

--- a/analytics/tests/test_semantic_catalog_thread_main.py
+++ b/analytics/tests/test_semantic_catalog_thread_main.py
@@ -415,3 +415,11 @@ def test_reconcile_review_payload_with_merged_at_only_is_treated_as_merged(tmp_p
     assert rc == 0
     slack_posts = [c for c in calls if "chat.postMessage" in c.full_url]
     assert slack_posts == []  # merged close is silent (publish owns the merge reply)
+
+
+def test_reconcile_pr_files_failure_skips_cleanly(tmp_path, monkeypatch, capsys):
+    _env(monkeypatch)
+    _script(monkeypatch, [("/pulls/7/files", urllib.error.URLError("boom"))])
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    assert "pr_files lookup failed" in capsys.readouterr().out

--- a/analytics/tests/test_semantic_catalog_thread_main.py
+++ b/analytics/tests/test_semantic_catalog_thread_main.py
@@ -364,3 +364,54 @@ def test_mark_merged_without_marker_or_post_env_is_a_noop(tmp_path, monkeypatch,
     assert thread.main(["--mark-merged", "--pr", "7"]) == 0
     assert all(c.get_method() != "POST" for c in calls)
     assert "nothing to mark" in capsys.readouterr().out
+
+
+def test_reconcile_anchor_post_failure_aborts_cleanly_without_marker(tmp_path, monkeypatch, capsys):
+    """A failed anchor post leaves no marker and exits 0; the next event retries."""
+    _env(monkeypatch)
+    calls = _script(
+        monkeypatch,
+        [
+            ("/pulls/7/files", [{"filename": "dbt/project/models/sem_x.yml"}]),
+            ("/pulls/7/reviews", []),
+            ("/teams/semantic-layer-data/members", []),
+            ("/teams/semantic-layer-business/members", []),
+            ("/issues/7/comments?", []),
+            ("chat.postMessage", {"ok": False, "error": "not_in_channel"}),
+        ],
+    )
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    assert "anchor post failed" in capsys.readouterr().out
+    comment_writes = [c for c in calls if c.get_method() == "POST" and "/issues/7/comments" in c.full_url]
+    assert comment_writes == []
+
+
+def test_reconcile_review_payload_with_merged_at_only_is_treated_as_merged(tmp_path, monkeypatch):
+    """pull_request_review payloads omit `merged`; a non-null merged_at must mean
+    merged, so a closed PR gets NO "Closed without merging." reply."""
+    from semantic_catalog import pr_marker
+    from semantic_catalog.pr_marker import ThreadState
+
+    _env(monkeypatch)
+    marker_body = pr_marker.render(
+        ThreadState(ts="1722.0042", channel="C1", permalink="https://p", pr_state="open")
+    )
+    calls = _script(
+        monkeypatch,
+        [
+            ("/pulls/7/files", [{"filename": "dbt/project/models/sem_x.yml"}]),
+            ("/pulls/7/reviews", []),
+            ("/teams/semantic-layer-data/members", []),
+            ("/teams/semantic-layer-business/members", []),
+            ("/issues/7/comments?", [{"id": 991, "body": marker_body}]),
+        ],
+    )
+    event = _event(tmp_path, state="closed", merged_at="2026-08-04T12:00:00Z")
+    payload = json.loads(event.read_text())
+    del payload["pull_request"]["merged"]
+    event.write_text(json.dumps(payload))
+    rc = thread.main(["--event-path", str(event)])
+    assert rc == 0
+    slack_posts = [c for c in calls if "chat.postMessage" in c.full_url]
+    assert slack_posts == []  # merged close is silent (publish owns the merge reply)

--- a/analytics/tests/test_semantic_catalog_thread_main.py
+++ b/analytics/tests/test_semantic_catalog_thread_main.py
@@ -1,4 +1,5 @@
 import json
+import urllib.error
 
 import semantic_catalog.github_client as ghmod
 import semantic_catalog.slack_reply as slmod
@@ -20,13 +21,20 @@ class _FakeResp:
 
 
 def _script(monkeypatch, responses):
-    """Route fake responses by URL substring; record all requests."""
+    """Route fake responses by URL substring; record all requests.
+
+    A response entry may pair a fragment with an Exception instance instead of
+    a payload; matching that fragment raises it (simulates a transport failure
+    such as urllib.error.URLError) instead of returning a fake response.
+    """
     calls = []
 
     def fake_urlopen(req, timeout=30):
         calls.append(req)
         for frag, payload in responses:
             if frag in req.full_url:
+                if isinstance(payload, Exception):
+                    raise payload
                 return _FakeResp(payload)
         raise AssertionError(f"unexpected URL: {req.full_url}")
 
@@ -93,6 +101,88 @@ def test_reconcile_bootstraps_anchor_and_creates_marker(tmp_path, monkeypatch):
     assert created, "marker comment must be created"
     body = json.loads(created[-1].data)["body"]
     assert "semantic-layer-thread v1" in body and "1722.0042" in body
+
+
+def test_reconcile_routes_reviews_and_team_lookups_to_the_right_token(tmp_path, monkeypatch):
+    """PR reviews are a workflow-token (GH_TOKEN) concern; team membership is org-token."""
+    _env(monkeypatch)
+    calls = _script(
+        monkeypatch,
+        [
+            ("/pulls/7/files", [{"filename": "dbt/project/models/marts/sem_analytics__users_win.yml"}]),
+            ("/pulls/7/reviews", []),
+            ("/teams/semantic-layer-data/members", [{"login": "tristan"}]),
+            ("/teams/semantic-layer-business/members", [{"login": "joe"}]),
+            ("/issues/7/comments?", []),
+            ("chat.postMessage", {"ok": True, "ts": "1722.0042"}),
+            ("chat.getPermalink", {"ok": True, "permalink": "https://gp.slack.com/p42"}),
+            ("/issues/7/comments", {"id": 991}),
+        ],
+    )
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    reviews_calls = [c for c in calls if "/pulls/7/reviews" in c.full_url]
+    team_calls = [c for c in calls if "/teams/" in c.full_url]
+    assert reviews_calls and all(c.get_header("Authorization") == "Bearer ghtok" for c in reviews_calls)
+    assert team_calls and all(c.get_header("Authorization") == "Bearer orgtok" for c in team_calls)
+
+
+def test_reconcile_degrades_when_org_token_lookup_fails(tmp_path, monkeypatch):
+    """A narrowly-scoped/expired ORG_READ_TOKEN must degrade, not crash the whole reconcile."""
+    _env(monkeypatch)
+    calls = _script(
+        monkeypatch,
+        [
+            ("/pulls/7/files", [{"filename": "dbt/project/models/marts/sem_analytics__users_win.yml"}]),
+            ("/pulls/7/reviews", []),
+            ("/teams/", urllib.error.URLError("no route to host")),
+            ("/issues/7/comments?", []),
+            ("chat.postMessage", {"ok": True, "ts": "1722.0042"}),
+            ("chat.getPermalink", {"ok": True, "permalink": "https://gp.slack.com/p42"}),
+            ("/issues/7/comments", {"id": 991}),
+        ],
+    )
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    posted = [c for c in calls if "chat.postMessage" in c.full_url]
+    assert posted, "anchor must still be posted"
+    created = [c for c in calls if c.get_method() == "POST" and "/issues/7/comments" in c.full_url]
+    assert created, "marker comment must still be created"
+    body = json.loads(created[-1].data)["body"]
+    from semantic_catalog import pr_marker
+
+    state = pr_marker.parse(body)
+    assert state is not None
+    assert state.announced == {"data": None, "business": None}  # no approval diff was possible
+
+
+def test_reconcile_degrades_when_permalink_lookup_raises_transport_error(tmp_path, monkeypatch):
+    """A permalink timeout/URLError must not crash after the anchor is posted, or the
+    marker never gets written and the next event re-bootstraps a duplicate anchor."""
+    _env(monkeypatch)
+    calls = _script(
+        monkeypatch,
+        [
+            ("/pulls/7/files", [{"filename": "dbt/project/models/marts/sem_analytics__users_win.yml"}]),
+            ("/pulls/7/reviews", []),
+            ("/teams/semantic-layer-data/members", [{"login": "tristan"}]),
+            ("/teams/semantic-layer-business/members", [{"login": "joe"}]),
+            ("/issues/7/comments?", []),
+            ("chat.postMessage", {"ok": True, "ts": "1722.0042"}),
+            ("chat.getPermalink", urllib.error.URLError("timed out")),
+            ("/issues/7/comments", {"id": 991}),
+        ],
+    )
+    rc = thread.main(["--event-path", str(_event(tmp_path))])
+    assert rc == 0
+    created = [c for c in calls if c.get_method() == "POST" and "/issues/7/comments" in c.full_url]
+    assert created, "marker comment must still be created despite the permalink failure"
+    body = json.loads(created[-1].data)["body"]
+    from semantic_catalog import pr_marker
+
+    state = pr_marker.parse(body)
+    assert state is not None
+    assert state.permalink == ""
 
 
 def test_reconcile_without_slack_token_skips_cleanly(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Redesigns the semantic-layer Slack automation into a per-PR governance timeline in #data-alignment (ClickUp DATA-2218, part of the OSI epic DATA-2126). One thread per governed metric PR:

1. Anchor message at PR-open (ready_for_review for drafts) with changed metric names and courtesy mentions for both review teams
2. Threaded reply when the data team approves, when the business team approves, and when an announced approval is dismissed (diff-based, idempotent across re-reviews and re-runs)
3. Threaded replies for closed-without-merge and reopened
4. The merge summary now posts as a reply under the anchor (top-level fallback preserved for PRs without a thread), with the coverage recap slimmed to one authoritative line
5. Sigma build-task replies (PR #748 behavior) thread under the same anchor

## How it works

- New workflow `semantic-layer-thread.yml` on pull_request + pull_request_review events. pull_request_review cannot be paths-filtered, so a cheap `gh api` gate checks the changed files before any setup. Runs are serialized per PR via a concurrency group.
- Thread state (anchor ts, channel, announced approvals, pr_state, merged) persists in a hidden-JSON marker comment on the PR, with a visible link to the Slack thread. Corrupt or deleted markers self-heal by re-bootstrapping.
- `semantic-layer-publish.yml` reads the marker at merge time (`--emit-marker`), posts threaded, then flags `merged: true` (`--mark-merged`) so re-runs never double-post; mark-merged is gated on a post actually happening.
- New modules in `analytics/diagnostics/semantic_catalog/`: `pr_marker.py`, `mentions.py` + `config/slack_mentions.yml`, `github_client.py`, `thread.py` (pure reconcile state machine + CLI). All stdlib with injectable urlopen seams; 46 new tests (suite 381 green).
- Mention mapping is a courtesy ping, deliberately decoupled from GitHub team membership (the GitHub approval + composition check remain the gate). Swain is excluded from both mention lists by request; the config supports Slack usergroup ids for a later swap.

## Permission changes

- `semantic-layer-thread.yml`: `pull-requests: write` (marker comment)
- `semantic-layer-publish.yml`: adds `pull-requests: write` (merged flag)
- No new secrets; missing secrets degrade to printed skips (fork PRs included)

## Test plan

- [x] Full analytics suite green (381 passed), pre-commit all-files green
- [ ] Post-merge live verify on a throwaway governed PR (10-step checklist in the plan doc): anchor + mentions, approval and dismissal replies, workflow re-run posts nothing, closed/reopened replies, merge reply threads under the anchor, publish re-run guarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI automation, external Slack/GitHub APIs, and shared PR comment state with deliberate race-avoidance; failures degrade to skips rather than blocking merges, but mis-threading or duplicate posts are possible until live verification.
> 
> **Overview**
> Introduces a **per-PR governance timeline** in #data-alignment for PRs that touch governed `sem_*.yml` files, instead of isolated top-level merge posts only.
> 
> A new **`semantic-layer-thread.yml`** workflow runs on `pull_request` and `pull_request_review` events (with a cheap files gate before setup, per-PR concurrency). It posts a **thread anchor** when the PR is ready for review, **threaded replies** for data/business approvals and dismissals, and messages for close-without-merge / reopen. State lives in a **PR comment marker** (visible Slack link + hidden JSON); corrupt markers re-bootstrap.
> 
> **`semantic-layer-publish.yml`** now reads that marker at merge (`--emit-marker`), posts the change summary as a **`thread_ts` reply** when an anchor exists (top-level fallback otherwise), honors the marker’s channel, skips duplicate merge posts when `merged` is already set, and **`--mark-merged`** updates the marker. Sigma task replies use the anchor ts when present.
> 
> New **`semantic_catalog`** pieces: `thread.py` (reconcile state machine + CLI), `pr_marker.py`, `github_client.py`, `mentions.py` + `slack_mentions.yml`; **`slack_reply`** gains `post_message` / `get_permalink`; merge Slack text uses a **single-line review coverage** recap. Broad test coverage for thread behavior, races, and degradation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a9cfdd37a2ba80b91b4dffe4fe3686674c451f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->