### PR TITLE
[DATA-2129] Active Candidates 30 days

### DIFF
--- a/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/win-analytics-knowledge/references/canonical_metrics.md
@@ -21,10 +21,12 @@ Keep this file thin: one row per genuinely-canonical concept, a one-line definit
 owning `table.column` (or event), and the doc that owns the detail. Caveats and usage notes
 live in the owning doc, not here, so this stays small enough to load on every resolution.
 
+The table below holds the concepts **not yet encoded** in the semantic layer. Once a concept is
+encoded, its row is deleted here and it renders in the generated region at the bottom of this
+file instead (row-by-row takeover). Read both tables; nothing lives in both.
+
 | Concept | Governed definition (one line) | Source (`table.column` / event) | Owns detail | Ratified |
 |---|---|---|---|---|
-| **Active Candidates (OKR)** | Viewed the candidate dashboard in the trailing 30 days | ⚠ `users_win_base.is_active_candidate_30d` reads FALSE for all users (dead legacy anchor event, capped 2026-06-13; fix ticketed DATA-2173) — recompute from the 2-event dashboard-view union ([engagement.md](engagement.md)) | [engagement.md](engagement.md) | pending |
-| **Activated Candidates (OKR)** | Has sent ≥1 voter outreach campaign | `users_win_base.is_activated` | [engagement.md](engagement.md) | pending |
 | **Onboarded (canonical cohort)** | Viewed the candidate dashboard within 14 days of account creation; recomputed from the 2-event dashboard-view union (`Dashboard - Candidate Dashboard Viewed` ∪ `Dashboard - Campaign Plan Viewed` — the legacy event died in-data 2026-06-13; era-resolved across the onboarding rebuilds and the 2026-05/06 dashboard-surface migration) | recomputed from the dashboard-view union vs `users_win_candidacy.user_created_at` | [engagement.md](engagement.md) | pending |
 | **Onboarding completed (pledge)** | Fired any era-resolved pledge-completion event (`Onboarding - Candidate Pledge Completed` / `Onboarding - Pledge Completed` / `Onboarding V2 - Pledge Completed`) within 14 days of account creation (strict funnel completion) | recomputed from the era-resolved pledge union | [engagement.md](engagement.md) | pending |
 | **Outreach intensity** | Count of `Voter Outreach - Campaign Completed` events | `users_win_base.total_campaigns_sent` | [engagement.md](engagement.md) | pending |
@@ -47,5 +49,6 @@ a domain doc.
 | **GoodParty Cumulative Wins** | Running total of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. Accumulates all time, so each period shows the cumulative win count to date. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
 | **GoodParty Win Rate** | Count of gp_api-sourced candidacy stages flagged as won for 2026 elections whose stage date has already passed. | ref('candidacy_stage') | [outcomes.md](outcomes.md) | pending |
 | **Win Activated Users** | Count of Win-product users who have activated: sent at least one voter outreach campaign (first_campaign_sent_at is not null). The activated slice of win_users; the Activated Candidates OKR. | ref('users_win_base') | [engagement.md](engagement.md) | 2026-07-28 |
+| **Win Active Candidates 30d** | Count of Win-product users who viewed the candidate dashboard in the trailing 30 days: the Active Candidates OKR. Definition owned by users_win_base.is_active_candidate_30d, which is anchored on the 2-event dashboard-view union; the legacy single-event anchor died in-data 2026-06-13 and made the flag read FALSE for every user until the union repair landed. The window is evaluated against current_date() in the mart, so this metric is as-of-run-time and cannot be sliced historically by registered_at. | ref('users_win_base') | [engagement.md](engagement.md) | pending |
 | **Win Users** | Count of Win-product users. Slice or filter by the engagement dimensions (has_viewed_dashboard, is_active_candidate_30d, etc.) at query time. | ref('users_win_base') | [engagement.md](engagement.md) | 2026-08-03 |
 <!-- semantic-catalog:end -->

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -68,6 +68,7 @@ def test_records_by_target_routes_each_metric_to_its_skill():
     assert win_names == {
         "win_users",
         "win_activated_users",
+        "win_active_candidates_30d",
         "goodparty_win_rate",
         "goodparty_cumulative_wins",
     }

--- a/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
@@ -57,6 +57,26 @@ metrics:
         detail_doc: engagement.md
         ratified: 2026-08-03
 
+  - name: win_active_candidates_30d
+    label: Win Active Candidates 30d
+    description: >
+      Count of Win-product users who viewed the candidate dashboard in the
+      trailing 30 days: the Active Candidates OKR. Definition owned by
+      users_win_base.is_active_candidate_30d, which is anchored on the
+      2-event dashboard-view union; the legacy single-event anchor died
+      in-data 2026-06-13 and made the flag read FALSE for every user until
+      the union repair landed. The window is evaluated against
+      current_date() in the mart, so this metric is as-of-run-time and
+      cannot be sliced historically by registered_at.
+    type: simple
+    type_params:
+      measure: win_user_count
+    filter: "{{ Dimension('user__is_active_candidate_30d') }}"
+    config:
+      meta:
+        owner: semantic-layer-business
+        detail_doc: engagement.md
+
   - name: win_activated_users
     label: Win Activated Users
     description: >


### PR DESCRIPTION
## What

Encodes the **Active Candidates (OKR)** concept in the dbt semantic layer as `win_active_candidates_30d`, label **Win Active Candidates 30d**.

The `30d` is in the name and label on purpose: the definition is a **trailing-30-day** window, and the metric name should not let a reader assume it means "candidates who are currently active" in some looser sense.

**Definition:** count of Win-product users who viewed the candidate dashboard in the trailing 30 days. Owned by `users_win_base.is_active_candidate_30d`; this metric only surfaces it.

**Value: 532** as of 2026-08-04, verified directly against `mart_analytics.users_win_base` in prod.

## Why now

This concept was not safely encodable until recently. `is_active_candidate_30d` read `FALSE` for **every** user because its anchor event died in-data on 2026-06-13. The dashboard-view union repair fixed that, and the flag is now live and non-zero. Encoding it before the repair would have shipped a governed metric that always returned zero.

## Two things a reviewer should know before approving

1. **This is as-of-run-time, not a time series.** The 30-day window is evaluated against `current_date()` inside the mart, so the metric answers "how many are active right now". It cannot be sliced historically by `registered_at`: asking for it by registration month gives you today's active users bucketed by when they signed up, which is almost never the question. A historical monthly series would need a different, period-anchored model.

2. **The number moves on its own.** It is a rolling window, so it changes daily with no code change. Do not treat a week-over-week difference as a release effect.

## Implementation notes

A filtered metric over the existing `win_user_count` measure, the same shape as `win_activated_users`, so no new measure was needed.

Also in this diff: the hand-authored **Active Candidates** row is deleted from the Win catalog, since the concept now renders in the generated region (row-by-row takeover per the governance SOP). A note above each hand-authored table now states that it holds only not-yet-encoded concepts, so a deleted row does not read as a deleted metric.

## Ratification is deliberately NOT in this diff

`config.meta` carries `owner` and `detail_doc` but **no `ratified:` date**. Ratifying is the metric owner's decision, not the author's. To consummate it, add one line under this metric's `config.meta`:

```yaml
        ratified: 2026-08-04
```

then re-run `uv run python -m semantic_catalog.cli --write` from `analytics/` so the projection matches, or the catalog-freshness gate will fail.

## Verification

- `dbt parse` clean (only the 2 pre-existing OSI warnings on the civics metrics)
- catalog-freshness `--check` reports the region up to date
- semantic-layer naming guard clean
- analytics suite: 390 passed
- pre-commit clean on all changed files
- metric value cross-checked against prod: 532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a governed semantic metric and catalog projection on an existing mart flag; no auth, pipeline, or definition changes to `users_win_base` itself.
> 
> **Overview**
> Adds the **Active Candidates (OKR)** concept to the dbt semantic layer as **`win_active_candidates_30d`**: a filtered count over `win_user_count` when `is_active_candidate_30d` is true (same pattern as `win_activated_users`). The metric text documents the trailing-30-day window, the post-2026-06-13 dashboard-view union anchor, and that the value is **as-of `current_date()`** in the mart—not a historical time series by registration month.
> 
> **Win analytics knowledge** is updated so the hand-authored **Active Candidates** row is removed (semantic takeover) and the concept appears only in the generated catalog region; prose above the manual table clarifies that encoded metrics move out of the hand table.
> 
> **Tests** expect `win_active_candidates_30d` in the Win skill metric routing set. Ratification is intentionally omitted from `config.meta` until the metric owner signs off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c31ab0993cf5b29ec874203a554cf04ac7f7f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->