### PR TITLE
[DATA-2227] Scope the governance thread anchor to the PR's own metrics

### DIFF
--- a/analytics/diagnostics/semantic_catalog/slack_diff.py
+++ b/analytics/diagnostics/semantic_catalog/slack_diff.py
@@ -7,11 +7,19 @@ announced as incomplete, never hidden.
 
 from __future__ import annotations
 
+from dataclasses import replace
+from pathlib import Path
+
 from semantic_catalog.records import MetricRecord
 
 
 def _by_name(records: list[MetricRecord]) -> dict[str, MetricRecord]:
-    return {r.name: r for r in records}
+    # Compare on the file's basename, not the absolute path the parser stores.
+    # The before-set is parsed from a temp worktree, so the full path differs
+    # for EVERY record and whole-record equality would report the entire
+    # catalog as changed. The basename still catches a real change: a metric
+    # moving between sem files.
+    return {r.name: replace(r, yaml_file=Path(r.yaml_file).name) for r in records}
 
 
 def changed_metric_names(before: list[MetricRecord], after: list[MetricRecord]) -> list[str]:

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from semantic_catalog.pr_marker import ThreadState
 
@@ -21,6 +22,15 @@ TEAM_LABEL = {"data": "Data team", "business": "Business team"}
 
 def is_governed(files: Iterable[str]) -> bool:
     return any(GOVERNED_RE.match(f) for f in files)
+
+
+def governed_sem_files(files: Iterable[str]) -> frozenset[str]:
+    """Basenames of the governed sem_*.yml files this PR touches.
+
+    Bounds the anchor's metric list to definitions the PR actually owns, so a
+    reviewer never has to guess which metric is up for review.
+    """
+    return frozenset(Path(f).name for f in files if GOVERNED_RE.match(f))
 
 
 def team_approvers(reviews: list[dict], members: dict[str, list[str]]) -> dict[str, list[str]]:
@@ -141,7 +151,6 @@ import json  # noqa: E402
 import os  # noqa: E402
 import sys  # noqa: E402
 import urllib.request  # noqa: E402
-from pathlib import Path  # noqa: E402
 
 from semantic_catalog import mentions as mentions_mod  # noqa: E402
 from semantic_catalog import pr_marker, slack_diff, slack_reply  # noqa: E402
@@ -161,17 +170,33 @@ def _github_client(token: str, repo: str) -> GitHubClient:
     return GitHubClient(token, repo, urlopen=urllib.request.urlopen)
 
 
-def _changed_metrics(base_dir: Path | None) -> tuple[tuple[str, str], ...]:
+def _changed_metrics(
+    base_dir: Path | None, scope: frozenset[str] | None = None
+) -> tuple[tuple[str, str], ...]:
     """(name, one-line definition) per changed metric, for the anchor message.
 
     Definitions come from the post-change records, falling back to the
     pre-change ones for removed metrics.
+
+    `scope` is the basenames of the sem files the PR touches. It is a hard
+    bound: the anchor can only ever name metrics the PR actually owns. That
+    matters because the base tree is best-effort (an unfetchable base sha
+    leaves `base_dir` None), and without a before-set there is no diff to
+    narrow by, so the fallback below would otherwise name the whole catalog.
     """
     after = parse_semantic_tree([DBT_MODELS])
     before = parse_semantic_tree([base_dir / "dbt/project/models"]) if base_dir else []
     definitions = {r.name: r.definition for r in before}
     definitions.update({r.name: r.definition for r in after})
-    return tuple((n, definitions.get(n, "")) for n in slack_diff.changed_metric_names(before, after))
+
+    # With no before-set there is nothing to diff, so fall back to the whole
+    # after-set and let `scope` below bound it to the PR's own files.
+    names = slack_diff.changed_metric_names(before, after) if before else sorted({r.name for r in after})
+
+    if scope is not None:
+        owned = {r.name for r in (*before, *after) if Path(r.yaml_file).name in scope}
+        names = [n for n in names if n in owned]
+    return tuple((n, definitions.get(n, "")) for n in names)
 
 
 # ts as rendered by pr_marker: a bare "<seconds>.<fraction>" Slack timestamp.
@@ -253,7 +278,8 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
     gh = _github_client(gh_token, repo)
 
     try:
-        governed = is_governed(gh.pr_files(number))
+        pr_files = gh.pr_files(number)
+        governed = is_governed(pr_files)
     except (OSError, RuntimeError) as e:
         # Same graceful degrade as every other external call here: a transient
         # GitHub error must not turn the (non-blocking) workflow step red.
@@ -296,7 +322,7 @@ def _cmd_reconcile(event_path: Path, base_dir: Path | None) -> int:
         # in some webhook shapes); check both so a review event on an already-
         # merged PR doesn't misread it as merged=False.
         merged=bool(pr.get("merged") or pr.get("merged_at")),
-        metrics=_changed_metrics(base_dir) if state is None else (),
+        metrics=(_changed_metrics(base_dir, governed_sem_files(pr_files)) if state is None else ()),
     )
     teams = mentions_mod.load(PKG / "config" / "slack_mentions.yml")
     mention_by_team = {t: mentions_mod.render_team(teams.get(t)) for t in ("data", "business")}

--- a/analytics/tests/test_semantic_catalog_slack.py
+++ b/analytics/tests/test_semantic_catalog_slack.py
@@ -85,3 +85,20 @@ def test_render_message_coverage_is_one_line_complete():
 def test_render_message_coverage_warns_when_incomplete():
     msg = render_message([], [_rec("a")], "http://pr", {"data": True, "business": False})
     assert ":warning: review coverage: data ✓ · business ✗" in msg
+
+
+def test_changed_metric_names_ignores_absolute_path_differences():
+    # The before-set is parsed from a temp worktree, so yaml_file differs by
+    # directory on every record even when nothing changed. Whole-record
+    # equality used to report the entire catalog as changed; the anchor then
+    # listed every metric in the layer instead of the one under review.
+    before = [_rec("a", yaml_file="/tmp/base/dbt/project/models/marts/analytics/sem_x.yml")]
+    after = [_rec("a", yaml_file="/home/runner/work/repo/repo/dbt/project/models/marts/analytics/sem_x.yml")]
+    assert changed_metric_names(before, after) == []
+
+
+def test_changed_metric_names_still_flags_a_move_between_sem_files():
+    # Basename normalization must not swallow a genuine relocation.
+    before = [_rec("a", yaml_file="/tmp/base/dbt/project/models/marts/analytics/sem_x.yml")]
+    after = [_rec("a", yaml_file="/checkout/dbt/project/models/marts/analytics/sem_y.yml")]
+    assert changed_metric_names(before, after) == ["a"]

--- a/analytics/tests/test_semantic_catalog_thread.py
+++ b/analytics/tests/test_semantic_catalog_thread.py
@@ -142,3 +142,74 @@ def test_team_approvers_skips_pending_reviews_without_submitted_at():
     ]
     members = {"data": ["alice", "bob", "carol"], "business": []}
     assert team_approvers(reviews, members) == {"data": ["bob"], "business": []}
+
+
+def test_governed_sem_files_returns_only_touched_sem_basenames():
+    from semantic_catalog.thread import governed_sem_files
+
+    files = [
+        "dbt/project/models/marts/analytics/sem_analytics__users_win.yml",
+        "dbt/project/models/marts/civics/sem_civics__candidacy_stage.yml",
+        "dbt/project/models/marts/analytics/m_analytics.yaml",  # not a sem file
+        "analytics/diagnostics/semantic_catalog/thread.py",
+        ".claude/skills/win-analytics-knowledge/references/canonical_metrics.md",
+    ]
+    assert governed_sem_files(files) == frozenset(
+        {"sem_analytics__users_win.yml", "sem_civics__candidacy_stage.yml"}
+    )
+
+
+def _stub_tree(monkeypatch, by_root):
+    """Stub parse_semantic_tree, keyed by whether the root is the base worktree."""
+    from semantic_catalog import thread as thread_mod
+
+    def fake(roots):
+        return by_root["before" if "basetree" in str(roots[0]) else "after"]
+
+    monkeypatch.setattr(thread_mod, "parse_semantic_tree", fake)
+
+
+def _mrec(name, yaml_name, definition="d"):
+    from semantic_catalog.records import MetricRecord
+
+    return MetricRecord(
+        name=name,
+        label=name,
+        definition=definition,
+        metric_type="simple",
+        source="ref('m')",
+        dimensions=(),
+        filter=None,
+        owner="semantic-layer-business",
+        ratified=None,
+        detail_doc="engagement.md",
+        retired=None,
+        yaml_file=f"/checkout/dbt/project/models/marts/analytics/{yaml_name}",
+        kind="metric",
+    )
+
+
+def test_changed_metrics_scope_excludes_metrics_the_pr_does_not_own(monkeypatch):
+    # Two metrics changed across two files, but the PR only touches one file.
+    from semantic_catalog import thread as thread_mod
+
+    before = [_mrec("win_a", "sem_win.yml", "old"), _mrec("serve_b", "sem_serve.yml", "old")]
+    after = [_mrec("win_a", "sem_win.yml", "new"), _mrec("serve_b", "sem_serve.yml", "new")]
+    _stub_tree(monkeypatch, {"before": before, "after": after})
+
+    from pathlib import Path
+
+    got = thread_mod._changed_metrics(Path("/basetree"), frozenset({"sem_win.yml"}))
+    assert got == (("win_a", "new"),)
+
+
+def test_changed_metrics_without_base_tree_is_bounded_by_scope(monkeypatch):
+    # No base tree => no diff to narrow by. The anchor must still name only the
+    # PR's own metrics, never the whole catalog.
+    from semantic_catalog import thread as thread_mod
+
+    after = [_mrec("win_a", "sem_win.yml"), _mrec("serve_b", "sem_serve.yml")]
+    _stub_tree(monkeypatch, {"before": [], "after": after})
+
+    got = thread_mod._changed_metrics(None, frozenset({"sem_win.yml"}))
+    assert got == (("win_a", "d"),)


### PR DESCRIPTION
## Symptom

The #data-alignment anchor post for a governed metric PR listed **every metric in the semantic layer**, each with its full definition, instead of the one the PR changes. On PR #760 that meant 6 metrics listed when 1 changed. A reviewer could not tell which definition they were being asked to approve, which defeats the point of the soft review gate.

PR #749 had the same anchor problem retroactively.

## Root cause

`MetricRecord.yaml_file` stores an **absolute** path. The anchor diff parses the before-set from a temporary git worktree and the after-set from the PR checkout, so that one field differs on every record:

```
FIELD yaml_file:
   base: /tmp/base/dbt/project/models/marts/analytics/sem_analytics__users_win.yml
   head: /home/runner/work/.../dbt/project/models/marts/analytics/sem_analytics__users_win.yml
```

`slack_diff.changed_metric_names` compares whole records (`a[n] != b[n]`), so the path difference alone marked all of them changed.

**Only the anchor was affected.** `diff_records`, which builds the merge summary, emits a line only when `definition` / `ratified` / `retired` / `owner` differs, so the path noise was invisible to it. That is why the merge post on #749 was correct while its anchor was not.

## Why the tests passed

`tests/test_semantic_catalog_slack.py` builds fixtures with `yaml_file="sem.yml"`, a bare basename, identical on both sides. The parser emits absolute paths. The fixture's shape and production's shape disagreed on exactly the field that broke, so `test_changed_metric_names_empty_when_identical` passed while the real code path could never produce an empty diff.

## Fix 1: compare on the basename

Normalized in `_by_name`, which both `changed_metric_names` and `diff_records` already route through, so it lands once. A basename still catches a genuine change, a metric moving between sem files; it does not catch a checkout-directory difference.

**Considered and rejected:** making the parser emit repo-relative paths, which is arguably the truer fix. `lifecycle.derive` shells out to `git log -- <yaml_file>` and the CLI runs from `analytics/`, so a repo-relative path would stop resolving and silently break the created/last-updated data on the ClickUp page. Containing the change to the comparison avoids that blast radius.

## Fix 2: bound the anchor by the PR's own files

Independent of the equality bug, and it would have survived fixing only Fix 1.

The base tree is **best-effort**: the workflow creates it only if the base sha is fetchable and passes no `--base-dir` otherwise. With no before-set, `changed_metric_names` returns every name in the after-set, so the anchor names the whole catalog again.

`thread.governed_sem_files(pr_files)` returns the basenames of the governed sem files the PR touches, and `_changed_metrics` intersects against it. `gh.pr_files` is already fetched for the governed-file gate, so there is no new API call and no workflow wiring.

Behavior now:

| Condition | Before | After |
|---|---|---|
| Base tree present (normal) | whole catalog (6) | exactly what changed (1) |
| Base tree missing (degraded) | whole catalog (6) | metrics in the touched files (3) |

## On multiple metrics under review at once

Worth stating since it drove the design:

- **Several metrics changed in one PR:** all of them are listed. That is correct, they are all under review in that PR.
- **Several PRs open at once, one metric each:** no cross-talk. Thread state is per-PR (marker comment on the PR, concurrency group keyed by PR number), and each anchor is now scoped to its own PR's files.
- The real hazard was never "multiple metrics", it was the unbounded fallback. Fix 2 closes it.

## Verification

Reproduced against the real PR #760 trees, not just fixtures: 6 metrics before the fix, 1 after, and the degraded no-base-tree path drops from 6 to 3.

Regression tests use genuinely divergent absolute paths, which the old fixtures could not express, plus coverage that a real cross-file move is still flagged and that the no-base-tree path stays scoped. 395 tests pass; pre-commit clean.

Touches no `sem_*.yml`, so the review teams are deliberately not tagged and the publish workflow does not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Slack governance anchor metric selection in the semantic catalog diagnostics tooling; no auth, data pipelines, or governed YAML definitions are modified.
> 
> **Overview**
> Fixes governed PR **Slack anchor** posts that listed **every metric in the semantic layer** instead of metrics the PR actually changes.
> 
> **Root cause:** `changed_metric_names` compared full `MetricRecord` values, so differing **absolute** `yaml_file` paths between the base worktree and PR checkout made the entire catalog look changed. **`_by_name`** now normalizes `yaml_file` to its **basename** before equality (still flags a metric moving between `sem_*.yml` files).
> 
> **Second guard:** **`governed_sem_files`** derives basenames of touched `sem_*.yml` files from the PR file list; **`_changed_metrics`** intersects changed names with metrics in those files. When the base tree is missing, the fallback to all after metrics is still bounded by that scope—no extra GitHub API calls.
> 
> Regression tests cover path-only diffs, cross-file moves, and scoped behavior without a base tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab71207b0f4409031afc7a3846cba4493d2cd460. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->