### PR TITLE
Loader: dev cluster ends serverless after resize; teardown is truly describe-first

### DIFF
--- a/people-api-loader/src/loader/people_api/steps/resize.py
+++ b/people-api-loader/src/loader/people_api/steps/resize.py
@@ -19,7 +19,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from loader.core.aws import flip_writer_to_provisioned, rds, retry_after_settle
+from loader.core.aws import (
+    flip_writer_to_provisioned,
+    flip_writer_to_serverless,
+    rds,
+    retry_after_settle,
+)
 from loader.core.log import bind, get_logger
 from loader.people_api.config import LoaderConfig
 from loader.people_api.db import connect_new
@@ -33,6 +38,12 @@ from loader.people_api.manifests import (
 log = get_logger(__name__)
 
 _BACKUP_RETENTION_DAYS = 14
+
+# Sentinel serve class: LOADER_SERVE_INSTANCE_CLASS=db.serverless (dev) makes resize leave the
+# writer on Serverless v2 instead of a provisioned class, so a dev cluster idles cheap after a
+# successful build the same way scale_down leaves it after a failed one. Prod keeps a provisioned
+# serve class. Matches scale_down._SERVERLESS_CLASS.
+_SERVERLESS_CLASS = "db.serverless"
 
 
 def run(cfg: LoaderConfig, run_date: str) -> ResizeManifest:
@@ -80,16 +91,28 @@ def run(cfg: LoaderConfig, run_date: str) -> ResizeManifest:
     # issuing the writer's class-change modify_db_instance below. This keeps the class-change
     # modify from landing while the cluster is still applying the lockdown settings.
     _wait_cluster()
-    # Shared conversion (writer instance class only — no cluster-level call for a provisioned
-    # class, unlike the Serverless v2 flip scale_down still uses on failure).
-    flip_writer_to_provisioned(rds_client, cluster_id, instance_id, instance_class=cfg.serve_instance_class)
+    # Flip the writer to the serve class. A provisioned class needs only the instance-level modify;
+    # db.serverless (dev) also needs the cluster's ServerlessV2 scaling config, which
+    # flip_writer_to_serverless sets — reusing the scale-down ACU band (nothing serves dev at scale).
+    if cfg.serve_instance_class == _SERVERLESS_CLASS:
+        flip_writer_to_serverless(
+            rds_client,
+            cluster_id,
+            instance_id,
+            min_acu=cfg.scale_down_min_acu,
+            max_acu=cfg.scale_down_max_acu,
+        )
+    else:
+        flip_writer_to_provisioned(
+            rds_client, cluster_id, instance_id, instance_class=cfg.serve_instance_class
+        )
     # A single db_instance_available waiter is NOT enough here: Aurora keeps reporting the
     # instance 'available' for a few seconds after a class-change modify before it flips to
     # 'modifying' and reboots, so a plain `_wait()` can return on the stale state — and the
     # explicit reboot below would then race the conversion's own delayed reboot
-    # (InvalidDBInstanceStateFault). flip_writer_to_provisioned already rides through the
-    # class-change reboot via wait_instance_class_applied; reboot here applies the serve
-    # parameter group, then wait for available again.
+    # (InvalidDBInstanceStateFault). Both flip helpers already ride through the class-change reboot
+    # via wait_instance_class_applied; reboot here applies the serve parameter group, then wait for
+    # available again.
     rds_client.reboot_db_instance(DBInstanceIdentifier=instance_id)
     _wait()
     log.info("resize.applied", instance_class=cfg.serve_instance_class)

--- a/people-api-loader/src/loader/people_api/steps/teardown.py
+++ b/people-api-loader/src/loader/people_api/steps/teardown.py
@@ -13,13 +13,36 @@ is a documented no-op — we reference a shared endpoint, never our own.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from botocore.exceptions import ClientError
 
 from loader.core.aws import ignore_client_errors, rds, retry_after_settle, s3, ssm
 from loader.core.log import bind, get_logger
 from loader.people_api.config import LoaderConfig
 
+if TYPE_CHECKING:
+    from botocore.client import BaseClient
+
 log = get_logger(__name__)
+
+
+def _describe_cluster(rds_client: BaseClient, cluster_id: str) -> dict[str, object] | None:
+    """The cluster's describe payload, or None if it no longer exists.
+
+    Lets teardown be genuinely describe-first: a re-run after a completed retire finds the cluster
+    already gone and skips the compute-deletion block below, rather than issuing a modify_db_cluster
+    that would come back AccessDenied. The rds:ModifyDBCluster grant is scoped by resource tags
+    (Environment/managedBy), and a deleted cluster has no tags to satisfy that condition — so AWS
+    denies the call rather than reporting it not-found, and the DBClusterNotFoundFault guard below
+    would not catch it.
+    """
+    try:
+        return rds_client.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "DBClusterNotFoundFault":
+            return None
+        raise
 
 
 def _delete_s3_prefix(cfg: LoaderConfig, run_date: str) -> None:
@@ -83,56 +106,64 @@ def run(
 
     rds_client = rds(cfg)
 
-    # 1. Writer instance, then wait for it to be gone (cluster can't delete with instances).
-    with ignore_client_errors("DBInstanceNotFound"):
-        rds_client.delete_db_instance(DBInstanceIdentifier=instance_id, SkipFinalSnapshot=True)
-    rds_client.get_waiter("db_instance_deleted").wait(DBInstanceIdentifier=instance_id)
+    # Describe-first, so a re-run after a completed retire is a clean no-op rather than an
+    # AccessDenied (see _describe_cluster). A gone cluster took its writer with it, so skip the whole
+    # compute-deletion block and fall through to the still-idempotent param-group / SSM / S3 cleanup.
+    cluster = _describe_cluster(rds_client, cluster_id)
+    if cluster is None:
+        log.info("teardown.cluster_absent", cluster=cluster_id, reason="already retired")
+    else:
+        # 1. Writer instance, then wait for it to be gone (cluster can't delete with instances).
+        with ignore_client_errors("DBInstanceNotFound"):
+            rds_client.delete_db_instance(DBInstanceIdentifier=instance_id, SkipFinalSnapshot=True)
+        rds_client.get_waiter("db_instance_deleted").wait(DBInstanceIdentifier=instance_id)
 
-    # 2. Cluster — disable deletion protection (resize enabled it) before deleting.
-    #    Tolerate InvalidDBClusterStateFault: an orphan stuck in `creating` (the rollback-failed
-    #    scenario provision documents) never reached resize, so protection is still False —
-    #    nothing to disable, so this modify is safely skipped. The delete below handles the
-    #    same `creating` state by waiting for it to settle first.
-    with ignore_client_errors("DBClusterNotFoundFault", "InvalidDBClusterStateFault"):
-        rds_client.modify_db_cluster(
-            DBClusterIdentifier=cluster_id, DeletionProtection=False, ApplyImmediately=True
+        # 2. Cluster — disable deletion protection (resize enabled it) before deleting, but only when
+        #    it is actually on. A failed build left on serverless never reached resize, and an orphan
+        #    stuck in `creating` likewise; both are already unprotected, so skip the modify entirely
+        #    rather than issue a needless tag-scoped call. Tolerate InvalidDBClusterStateFault for a
+        #    protection flip racing a transitional state.
+        if cluster.get("DeletionProtection"):
+            with ignore_client_errors("DBClusterNotFoundFault", "InvalidDBClusterStateFault"):
+                rds_client.modify_db_cluster(
+                    DBClusterIdentifier=cluster_id, DeletionProtection=False, ApplyImmediately=True
+                )
+        # Delete. A cluster still in `creating` can't be deleted yet (InvalidDBClusterStateFault);
+        # since this is the recovery tool for that orphan, wait for it to settle, then delete —
+        # rather than aborting (operator must retry) or swallowing (the cluster is never deleted
+        # and the deleted-waiter below would just time out). Mirrors resize's wait-then-retry.
+        delete_cluster_kwargs: dict[str, object] = (
+            {
+                "DBClusterIdentifier": cluster_id,
+                "SkipFinalSnapshot": False,
+                "FinalDBSnapshotIdentifier": snapshot_id,
+            }
+            if snapshot
+            else {"DBClusterIdentifier": cluster_id, "SkipFinalSnapshot": True}
         )
-    # Delete. A cluster still in `creating` can't be deleted yet (InvalidDBClusterStateFault);
-    # since this is the recovery tool for that orphan, wait for it to settle, then delete —
-    # rather than aborting (operator must retry) or swallowing (the cluster is never deleted
-    # and the deleted-waiter below would just time out). Mirrors resize's wait-then-retry.
-    delete_cluster_kwargs: dict[str, object] = (
-        {
-            "DBClusterIdentifier": cluster_id,
-            "SkipFinalSnapshot": False,
-            "FinalDBSnapshotIdentifier": snapshot_id,
-        }
-        if snapshot
-        else {"DBClusterIdentifier": cluster_id, "SkipFinalSnapshot": True}
-    )
 
-    def _delete_cluster() -> None:
-        try:
-            rds_client.delete_db_cluster(**delete_cluster_kwargs)
-        except ClientError as exc:
-            # A prior retire already captured this cluster's final snapshot — that snapshot IS the
-            # restore point, so reuse it and delete the cluster WITHOUT a duplicate. (A re-run where
-            # the cluster is already gone raises DBClusterNotFoundFault instead, caught below, and
-            # never touches the snapshot — so a retry-after-success can't delete the restore point.)
-            if snapshot and exc.response["Error"]["Code"] == "DBClusterSnapshotAlreadyExistsFault":
-                rds_client.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
-            else:
-                raise
+        def _delete_cluster() -> None:
+            try:
+                rds_client.delete_db_cluster(**delete_cluster_kwargs)
+            except ClientError as exc:
+                # A prior retire already captured this cluster's final snapshot — that snapshot IS
+                # the restore point, so reuse it and delete the cluster WITHOUT a duplicate. (A re-run
+                # after the cluster is fully gone is handled by the describe-first guard above and
+                # never reaches here, so a retry-after-success can't delete the restore point.)
+                if snapshot and exc.response["Error"]["Code"] == "DBClusterSnapshotAlreadyExistsFault":
+                    rds_client.delete_db_cluster(DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True)
+                else:
+                    raise
 
-    with ignore_client_errors("DBClusterNotFoundFault"):
-        retry_after_settle(
-            _delete_cluster,
-            fault_code="InvalidDBClusterStateFault",
-            settle=lambda: rds_client.get_waiter("db_cluster_available").wait(
-                DBClusterIdentifier=cluster_id, WaiterConfig={"Delay": 30, "MaxAttempts": 80}
-            ),
-        )
-    rds_client.get_waiter("db_cluster_deleted").wait(DBClusterIdentifier=cluster_id)
+        with ignore_client_errors("DBClusterNotFoundFault"):
+            retry_after_settle(
+                _delete_cluster,
+                fault_code="InvalidDBClusterStateFault",
+                settle=lambda: rds_client.get_waiter("db_cluster_available").wait(
+                    DBClusterIdentifier=cluster_id, WaiterConfig={"Delay": 30, "MaxAttempts": 80}
+                ),
+            )
+        rds_client.get_waiter("db_cluster_deleted").wait(DBClusterIdentifier=cluster_id)
 
     # 3. Parameter groups (only deletable once no cluster references them). Kept when
     #    keep_param_groups (retire-for-restore); they cost nothing and round out the restore set.

--- a/people-api-loader/tests/test_resize.py
+++ b/people-api-loader/tests/test_resize.py
@@ -28,6 +28,21 @@ _CFG = cast(
     ),
 )
 
+# Dev config: LOADER_SERVE_INSTANCE_CLASS=db.serverless makes resize leave the writer on
+# Serverless v2 (using the scale-down ACU band) instead of a provisioned serve class, so a dev
+# cluster idles cheap after a successful build.
+_CFG_SERVERLESS = cast(
+    LoaderConfig,
+    SimpleNamespace(
+        serve_instance_class="db.serverless",
+        scale_down_min_acu=0.5,
+        scale_down_max_acu=128.0,
+        new_cluster_id=lambda rd: f"gp-people-db-{rd}",
+        new_writer_instance_id=lambda rd: f"gp-people-db-{rd}-writer",
+        new_serve_param_group=lambda rd: f"gp-people-db-{rd}-serve",
+    ),
+)
+
 
 class _FakeWaiter:
     def wait(self, **kwargs: object) -> None:
@@ -116,6 +131,45 @@ def test_resize_applies_provisioned_class_and_writes_manifest(monkeypatch: pytes
     assert by["modify_instance"]["ApplyImmediately"] is True
     # Post-resize smoke check: a trivial SELECT 1 against the resized cluster, run after the
     # reboot settles and before the manifest is written.
+    assert executed_sql(conn) == ["SELECT 1"]
+
+
+def test_resize_applies_serverless_class_and_writes_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Dev serve class db.serverless: resize must flip the writer to Serverless v2 (not call
+    # flip_writer_to_provisioned with "db.serverless", which RDS would reject) and set the cluster's
+    # ServerlessV2 scaling config from the scale-down ACU band. The reboot + serve lockdown + smoke
+    # check still run, same as the provisioned path.
+    monkeypatch.setattr(aws.time, "sleep", lambda *a, **k: None)
+    rds_client = FakeRds(
+        describe_sequence=[
+            {"DBInstanceClass": "db.serverless", "DBInstanceStatus": "available", "PendingModifiedValues": {}}
+        ]
+    )
+    captured: dict = {}
+    conn = FakeConn().queue_result((1,))
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "read_manifest", lambda cfg, rd, name, model: None)
+    monkeypatch.setattr(step, "write_manifest", lambda cfg, m: captured.setdefault("m", m) or "uri")
+    monkeypatch.setattr(step, "connect_new", fake_connect(conn))
+
+    manifest = step.run(_CFG_SERVERLESS, "20260616")
+
+    assert manifest.status == "complete"
+    assert manifest.final_instance_class == "db.serverless"
+    assert manifest.backup_retention_days == 14 and manifest.deletion_protection is True
+    # Two modify_db_cluster calls: resize's own lockdown (param group/backup/deletion protection)
+    # AND flip_writer_to_serverless's ServerlessV2 scaling config.
+    cluster_calls = [kw for op, kw in rds_client.calls if op == "modify_cluster"]
+    assert len(cluster_calls) == 2
+    lockdown = next(kw for kw in cluster_calls if "DBClusterParameterGroupName" in kw)
+    assert lockdown["DBClusterParameterGroupName"] == "gp-people-db-20260616-serve"
+    assert lockdown["BackupRetentionPeriod"] == 14
+    assert lockdown["DeletionProtection"] is True
+    scaling = next(kw for kw in cluster_calls if "ServerlessV2ScalingConfiguration" in kw)
+    assert scaling["ServerlessV2ScalingConfiguration"] == {"MinCapacity": 0.5, "MaxCapacity": 128.0}
+    by = dict(rds_client.calls)
+    assert by["modify_instance"]["DBInstanceClass"] == "db.serverless"
+    assert by["modify_instance"]["ApplyImmediately"] is True
     assert executed_sql(conn) == ["SELECT 1"]
 
 

--- a/people-api-loader/tests/test_teardown.py
+++ b/people-api-loader/tests/test_teardown.py
@@ -43,6 +43,8 @@ class FakeRds:
         modify_error: str | None = None,
         delete_creating_once: bool = False,
         snapshot_exists: bool = False,
+        cluster_absent: bool = False,
+        deletion_protection: bool = True,
     ) -> None:
         self.calls: list[str] = []
         self.delete_cluster_kwargs: dict[str, Any] = {}  # last delete_db_cluster kwargs
@@ -52,6 +54,14 @@ class FakeRds:
         self._pg_error = pg_error  # which not-found code delete_db_cluster_parameter_group raises
         self._modify_error = modify_error  # error code modify_db_cluster raises (e.g. bad state)
         self._delete_creating_once = delete_creating_once  # 1st delete raises creating-state, then ok
+        self._cluster_absent = cluster_absent  # describe raises NotFound (already retired)
+        self._deletion_protection = deletion_protection  # DeletionProtection reported by describe
+
+    def describe_db_clusters(self, **kw: Any) -> dict:
+        # A read, deliberately kept out of `calls` (which tracks mutating ops the tests assert order on).
+        if self._cluster_absent:
+            raise _err("DBClusterNotFoundFault")
+        return {"DBClusters": [{"DeletionProtection": self._deletion_protection, "Status": "available"}]}
 
     def delete_db_instance(self, **kw: Any) -> None:
         self.calls.append("delete_instance")
@@ -176,14 +186,45 @@ def test_teardown_waits_then_deletes_creating_cluster(monkeypatch: pytest.Monkey
 
 
 def test_teardown_idempotent_on_missing_cluster(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Cluster was never created: modify/delete both raise DBClusterNotFoundFault, which the
-    # guards must swallow so teardown stays idempotent (covers the cluster-not-found branch).
+    # Race: describe still sees the cluster, but it's deleted before the mutating calls land, so
+    # modify/delete raise DBClusterNotFoundFault. The guards must swallow that so teardown stays
+    # idempotent (covers the cluster-not-found branch on the mutating calls).
     rds_client, ssm_client = FakeRds(missing={"cluster"}), FakeSsm()
     monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
     monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
     step.run(_CFG, "20260616", confirm=True)  # must not raise
     assert "delete_instance" in rds_client.calls
     assert ssm_client.deleted == ["people-db-connection-string-dev-20260616"]
+
+
+def test_teardown_skips_compute_when_cluster_already_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Re-running a completed retire: describe-first finds the cluster gone. The compute-deletion
+    # block must be skipped entirely — issuing modify_db_cluster on a deleted cluster comes back
+    # AccessDenied (the tag-scoped rds:ModifyDBCluster grant can't match a tag-less deleted
+    # cluster), not DBClusterNotFound, so it would escape the guards. The remaining cleanup (SSM,
+    # here) still runs so a half-finished prior teardown converges.
+    rds_client, ssm_client = FakeRds(cluster_absent=True), FakeSsm()
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
+    step.run(_CFG, "20260616", confirm=True)  # must not raise
+    # No compute mutation attempted (that's what would have hit AccessDenied); the fall-through
+    # cleanup of the other artifacts still runs.
+    assert "delete_instance" not in rds_client.calls
+    assert "disable_protection" not in rds_client.calls
+    assert "delete_cluster" not in rds_client.calls
+    assert ssm_client.deleted == ["people-db-connection-string-dev-20260616"]
+
+
+def test_teardown_skips_protection_disable_when_already_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A failed build left on serverless never reached resize, so its cluster is already
+    # unprotected. teardown must skip the (unnecessary, tag-scoped) modify_db_cluster and go
+    # straight to deleting the cluster.
+    rds_client, ssm_client = FakeRds(deletion_protection=False), FakeSsm()
+    monkeypatch.setattr(step, "rds", lambda cfg: rds_client)
+    monkeypatch.setattr(step, "ssm", lambda cfg: ssm_client)
+    step.run(_CFG, "20260616", confirm=True)
+    assert "disable_protection" not in rds_client.calls  # protection already off; no modify
+    assert rds_client.calls == ["delete_instance", "delete_cluster", "delete_pg", "delete_pg"]
 
 
 class _FakePaginator:


### PR DESCRIPTION
Two loader operational-robustness fixes, both surfaced while bringing the people-api cutover clusters online.

## Dev serving cluster ends on Serverless v2 after a successful build

`resize` flips the freshly-loaded writer to `cfg.serve_instance_class`. On prod that is a provisioned class (db.r6g.4xlarge) and `flip_writer_to_provisioned` is right. But a dev deployment wants the cluster to idle cheap after a build the same way `scale_down` leaves it after a failure — and passing `db.serverless` to `flip_writer_to_provisioned` would have RDS reject the modify. So `resize` now branches on the `db.serverless` sentinel and calls `flip_writer_to_serverless` (reusing the scale-down ACU band) for that case. Set `LOADER_SERVE_INSTANCE_CLASS=db.serverless` on the dev deployment to opt in; prod is unchanged.

## teardown is genuinely describe-first, so re-running a completed retire is a no-op

teardown's docstring said describe-first, but `run()` went straight to `modify_db_cluster` to disable deletion protection, tolerating only `DBClusterNotFoundFault`. The `rds:ModifyDBCluster` grant is scoped by resource tags, so a re-run against an already-deleted cluster comes back **AccessDenied** — a gone cluster has no tags to satisfy the condition, so AWS denies the call rather than reporting not-found — which escaped the guard and failed the task (observed on a repeat teardown of an already-retired dated cluster). It now describes the cluster first and skips the whole compute-deletion block when the cluster is absent, falling through to the still-idempotent param-group / SSM / S3 cleanup. It also only disables deletion protection when it is actually on, so a failed build left on serverless (never resized, never protected) no longer issues a needless tag-scoped modify.

Full loader suite (including the pg integration test) green.