### PR TITLE
Bump loader cache-bust to deploy #762

### DIFF
--- a/airflow/astro/requirements.txt
+++ b/airflow/astro/requirements.txt
@@ -15,7 +15,7 @@ sshtunnel>=0.4.0,<1.0.0
 # Pinned to @main so the loader co-versions with the DAG on main and survives feature-branch
 # deletion post-merge.
 # cache-bust: bump this token whenever the loader source or this pin changes so the image reinstalls
-# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-08-01.2
+# (the install layer is keyed on this file; an unchanged file = a stale loader). bust=2026-08-04.1
 people-api-loader @ git+https://github.com/thegoodparty/gp-data-platform.git@main#subdirectory=people-api-loader
 # The voter-data gate runs in dbt Cloud (DbtCloudRunJobOperator) rather than locally — dbt cannot
 # run on the image's Python 3.14, and the full monorepo project needs ~24 parse-time env vars. This


### PR DESCRIPTION
Redeploys the loader install layer from `@main` so the Astro image picks up #762 (the dev-serverless `resize` branch and the describe-first `teardown` fix). The install layer is keyed on `airflow/astro/requirements.txt`; without a token bump the image keeps the stale loader.