### PR TITLE
[DATA-2134] Rename Active Serve Users to Activated Serve Users

### DIFF
--- a/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
+++ b/.claude/skills/serve-analytics-knowledge/references/canonical_metrics.md
@@ -24,7 +24,6 @@ live in the owning doc, not here, so this stays small enough to load on every re
 | Concept | Governed definition (one line) | Source (`table.column` / event) | Owns detail | Ratified |
 |---|---|---|---|---|
 | **Serve user / EO activated (canonical population)** | `is_serve_user` flag; currently identical to `eo_activated_at IS NOT NULL` (a data-state fact that may diverge) | `mart_analytics.users_serve_base.is_serve_user` | [sources.md](sources.md) | pending |
-| **Active serve user (behavioral)** | Sent ≥1 SMS poll AND has pledged; the behavioral half of the People Served cohort | `dbt.int__serve_active_user.is_active_serve_user` | [sources.md](sources.md) | pending |
 | **People Served cohort** | Active serve user AND Serve-ICP office AND not internal | `dbt.int__serve_district_resolution.in_people_served_cohort` | [sources.md](sources.md) | pending |
 | **People Served (North Star)** | Census population covered by the cohort's districts; headline = cohort `active`, count-once, office_type `all` | `mart_analytics.people_served` | [sources.md](sources.md) | pending |
 | **Onboarding completed (Serve)** | Sent first SMS poll (`first_sms_poll_sent_at IS NOT NULL`) | `users_serve_base.has_completed_serve_onboarding` | [segmentation.md](segmentation.md) | pending |
@@ -43,5 +42,5 @@ in office is parked until officeholder data lands in civics.
 <!-- semantic-catalog:begin -->
 | Concept | Governed definition (one line) | Source | Owns detail | Ratified |
 |---|---|---|---|---|
-| **Active Serve Users** | Count of active serve users: completed Serve onboarding by sending an SMS poll AND pledged. Definition owned by int__serve_active_user, surfaced through users_serve_base; the gold membership view users_serve_active exposes the same population for direct dashboard reads. Time series bucket by onboarding-completion date (the metric's aggregation time is first_sms_poll_sent_at), not by pledge or account registration date. | ref('users_serve_base') | [sources.md](sources.md) | 2026-07-28 |
+| **Activated Serve Users** | Count of Serve users who have passed the activation gate: ever sent an SMS poll AND ever pledged. Excludes internal accounts. Definition owned by int__serve_active_user, surfaced through users_serve_base; the gold membership view users_serve_active exposes the same population for direct dashboard reads. Named "activated", not "active", because both components are lifetime-ever flags with no recency window. The count is monotonically non-decreasing and cannot detect churn, so it does NOT answer "how many Serve users are active now". Use the trailing-window Serve activity metric for that. Time series bucket by onboarding-completion date (the metric's aggregation time is first_sms_poll_sent_at), not by pledge or account registration date. | ref('users_serve_base') | [sources.md](sources.md) | 2026-07-28 |
 <!-- semantic-catalog:end -->

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -16,7 +16,7 @@ def test_real_repo_parses_without_error():
     records = parse_semantic_tree(cli.SEM_ROOTS)
     names = {r.name for r in records}
     # The four metrics that exist today must all parse.
-    assert {"win_users", "active_serve_users", "goodparty_win_rate", "goodparty_cumulative_wins"} <= names
+    assert {"win_users", "activated_serve_users", "goodparty_win_rate", "goodparty_cumulative_wins"} <= names
 
 
 def test_write_then_check_is_idempotent(tmp_path):
@@ -71,8 +71,8 @@ def test_records_by_target_routes_each_metric_to_its_skill():
         "goodparty_win_rate",
         "goodparty_cumulative_wins",
     }
-    assert serve_names == {"active_serve_users"}
-    assert "active_serve_users" not in win_names
+    assert serve_names == {"activated_serve_users"}
+    assert "activated_serve_users" not in win_names
 
 
 def test_records_by_target_raises_on_unmapped_sem_file():

--- a/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
+++ b/dbt/project/models/marts/analytics/sem_analytics__users_serve.yml
@@ -44,25 +44,42 @@ semantic_models:
           gate of the People Served active cohort.
         type: categorical
     measures:
-      - name: active_serve_user_count
-        description: Count of active serve users (sent an SMS poll AND pledged).
+      # Internal accounts are excluded in the measure, not left to the consumer:
+      # the mart keeps all users, so any read that forgets the filter is wrong.
+      - name: activated_serve_user_count
+        description: >
+          Count of activated serve users (ever sent an SMS poll AND ever
+          pledged), excluding internal accounts.
         agg: sum
-        expr: "case when is_active_serve_user then 1 else 0 end"
+        expr: >
+          case
+            when is_active_serve_user
+              and (email is null or lower(email) not like '%@goodparty.org')
+            then 1 else 0
+          end
 
 metrics:
-  - name: active_serve_users
-    label: Active Serve Users
+  - name: activated_serve_users
+    label: Activated Serve Users
     description: >
-      Count of active serve users: completed Serve onboarding by sending an
-      SMS poll AND pledged. Definition owned by int__serve_active_user,
-      surfaced through users_serve_base; the gold membership view
-      users_serve_active exposes the same population for direct dashboard
-      reads. Time series bucket by onboarding-completion date (the metric's
+      Count of Serve users who have passed the activation gate: ever sent an
+      SMS poll AND ever pledged. Excludes internal accounts. Definition owned
+      by int__serve_active_user, surfaced through users_serve_base; the gold
+      membership view users_serve_active exposes the same population for
+      direct dashboard reads.
+
+      Named "activated", not "active", because both components are
+      lifetime-ever flags with no recency window. The count is monotonically
+      non-decreasing and cannot detect churn, so it does NOT answer "how many
+      Serve users are active now". Use the trailing-window Serve activity
+      metric for that.
+
+      Time series bucket by onboarding-completion date (the metric's
       aggregation time is first_sms_poll_sent_at), not by pledge or account
       registration date.
     type: simple
     type_params:
-      measure: active_serve_user_count
+      measure: activated_serve_user_count
     config:
       meta:
         owner: semantic-layer-business


### PR DESCRIPTION
## What

Two corrections to the same governed metric. They ride together because both are definition changes needing the same approval.

**1. Rename `active_serve_users` to `activated_serve_users`** ("Active Serve Users" to "Activated Serve Users").

**2. Exclude internal accounts**, which restates the value **1,038 to 1,026**.

## Why the rename

Both halves of the definition are lifetime-ever flags: *ever* sent an SMS poll, *ever* pledged. There is no recency window anywhere in it. So the count is monotonically non-decreasing, it cannot go down, and it cannot detect churn.

Calling that "active" invites exactly one reading, "active now", which this metric has never measured. The tell was already in its own description, which instructs you to bucket the time series by onboarding-completion date. That is what you do with a cohort, not with an activity measure.

The description now states the limitation outright and points readers at the trailing-window metric for the other question.

## Why the internal exclusion

12 of the 1,038 are `@goodparty.org` staff. `users_serve_base` keeps all users by design so funnel denominators stay correct, so the exclusion has to live somewhere. Putting it in the measure means every read is right by default instead of depending on each consumer remembering the filter.

## This restates a ratified metric

**1,038 to 1,026.** That is the part worth your attention. I left `ratified: 2026-07-28` in place rather than changing it, since re-approving a restated definition is the owner's call, not the author's.

## Where this sits in the Serve picture

There are three distinct concepts. This PR fixes the middle one's name and makes it comparable to the first.

| Concept | Definition | Value |
|---|---|---|
| Serve Users | Has a Serve org or is a poll user | 1,846 (separate PR) |
| **Activated Serve Users** (this PR) | Ever sent an SMS poll AND ever pledged | **1,026** |
| Active Serve Users 30d | Trailing-30-day activity | ~102, blocked on a dbt model rebuild |

Note the two shipped metrics are **not cleanly nested**: one user carries the activated flag without the Serve-user flag. Neither is a strict subset of the other.

## Scope note

This renames the **semantic-layer metric and measure only**. The upstream column `is_active_serve_user` and the gold view `users_serve_active` keep the old name, so the misnomer still exists one layer down. Renaming those reaches into the People Served cohort, which consumes the flag as its behavioral half, so that is a separate and larger change rather than something to smuggle in here.

## Verification

- `dbt parse` clean (only the 2 pre-existing OSI warnings on the civics metrics)
- catalog-freshness `--check` up to date
- analytics suite: 395 passed
- pre-commit clean
- values cross-checked against prod: 1,038 flagged, 12 internal, 1,026 net

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a ratified semantic-layer metric definition and headline value; downstream dashboards/queries keyed on the old metric name need to follow the rename.
> 
> **Overview**
> Renames the governed Serve semantic metric **`active_serve_users`** → **`activated_serve_users`** (and the underlying measure **`activated_serve_user_count`**) so the name matches a **lifetime-ever** definition (ever SMS poll + ever pledged), with updated copy that it is **not** a recency-based “active now” count.
> 
> The measure expression now **excludes `@goodparty.org` internal accounts** in the semantic layer (mart still keeps all users), which **restates the headline from 1,038 to 1,026**. The semantic-catalog projection in `canonical_metrics.md` and **`test_semantic_catalog_cli.py`** expectations are updated to match; upstream **`is_active_serve_user`** / **`users_serve_active`** naming is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5967ea86075da744ffda7c707aacd44e2dbbcf51. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->