### PR TITLE
chore: remove leftover poetry config and docs

### DIFF
--- a/.claude/agents/code-critic.md
+++ b/.claude/agents/code-critic.md
@@ -15,8 +15,8 @@ You are a strict code reviewer for `gp-data-platform`. Your job is to read the r
 6. Cross-check `.pre-commit-config.yaml` against the diff. If a Python file would fail black / isort / flake8 / mypy / sqlfmt as configured, that's a Blocker. Don't run the formatters yourself — predict their output from the rules in the config.
 7. Pay special attention to:
    - **Single-venv assumptions** — don't accept code or docs that assume `gp-data-platform` has one Python env. It has several.
-   - **Wrong package manager for the subproject** — `apps/genie-slack-bot/` is pip + requirements.txt, not poetry. `dbt/`, `airflow/`, `apps/genie-tools/` are poetry.
-   - **Direct `dbt` invocation via `poetry`** — that's wrong; dbt Cloud CLI is system-installed.
+   - **Wrong package manager for the subproject** — every Python subproject with a `pyproject.toml` + `uv.lock` is uv-managed (`dbt/`, `airflow/`, `analytics/`, `matcha/`, `people-api-loader/`, `apps/genie-tools/`, `apps/genie-slack-bot/`). Only `airflow/astro/` is pip + requirements.txt, because the Astro runtime image installs it. Poetry is no longer used anywhere; flag any reintroduction of `poetry`, `poetry.lock`, or `poetry.toml`.
+   - **Direct `dbt` invocation via the subproject env** — that's wrong; dbt Cloud CLI is system-installed.
    - **Python 3.12 features in code that CI runs on 3.11** — flag if the test workflow could break.
    - **Edits inside `ai-rules/`** — that's a submodule; changes belong in the submodule's repo, not here.
    - **Edits inside `.claude/skills/l2-uniform-drift-remediator/`** that aren't explicitly part of the diff's scope.

--- a/.claude/skills/analytics-process/references/methodology.md
+++ b/.claude/skills/analytics-process/references/methodology.md
@@ -120,7 +120,7 @@ Product-specific source pointers (contributing project scouts, authoritative dbt
 
 **Conventions:**
 - `CLAUDE.md` (repo root) — multi-venv reality + don't-disable-pre-commit rules.
-- `dbt/project/CLAUDE.md` — dbt-development conventions (do not invoke dbt via poetry; use `dbt show --inline`; branch / commit naming; etc.).
+- `dbt/project/CLAUDE.md` — dbt-development conventions (do not invoke dbt through the subproject env; use `dbt show --inline`; branch / commit naming; etc.).
 - `ai-rules/` (submodule) — broader AI-assisted-development rules.
 
 **External tickets / documentation:**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     # job (default pre-commit stage), so CI is not duplicated — each directory's
     # own workflow is the CI coverage. Each hook runs the suite in that
     # directory's environment, so that env must be set up locally first
-    # (`uv sync` / `poetry install` / `pip install ...`). `files:` means a push
+    # (`uv sync`, or `pip install ...` for `airflow/astro`). `files:` means a push
     # only runs the suites for directories it actually touched.
     -   id: pytest-people-api-loader
         name: people-api-loader tests (pre-push)

--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ brew install git
 git --version    # confirm 2.4x or newer
 ```
 
-Pre-commit hooks and `poetry run git` both invoke whichever `git` is first on your `PATH` — there's only one git installation; `poetry run` just makes the poetry env available to hook subprocesses (so the pytest hook can find `pyspark`/`airflow`).
+Pre-commit hooks and `uv run git` both invoke whichever `git` is first on your `PATH` — there's only one git installation; `uv run` just makes the project env available to hook subprocesses (so the pytest hook can find `pyspark`/`airflow`).
 
 ### Using Python locally
 
 To manage Python versions locally, we use [`pyenv`](https://github.com/pyenv/pyenv?tab=readme-ov-file#installation). This ensures consistent Python versions across development environments.
 
-The environment is managed by [`poetry`](https://python-poetry.org/docs/#installing-with-pipx), which is installed via [`pipx`](https://pipx.pypa.io/stable/installation/).
+Environments are managed by [`uv`](https://docs.astral.sh/uv/getting-started/installation/). Each subproject with a `pyproject.toml` has its own `uv.lock` and its own virtualenv — this repo does not have a single shared environment.
 
-Enter the subdirectory of development and run `poetry install` where there is a `pyproject.toml` to install dependencies. To [activate the environment](https://python-poetry.org/docs/managing-environments/#bash-csh-zsh), run `eval $(poetry env activate)`, and `deactivate` to deactivate. Dependencies can be added with `poetry add <package>`.
+Enter the subdirectory of development and run `uv sync` to install dependencies exactly as locked. Run commands inside that environment with `uv run <command>` (for example `uv run pytest`); no separate activation step is needed. Dependencies can be added with `uv add <package>`, which updates both `pyproject.toml` and `uv.lock`.
 
-For integration with VS Code, use the output path from `poetry env info --executable` when selecting the Python interpreter. For example on Mac:
+For integration with VS Code, select the interpreter at `.venv/bin/python` inside the subproject directory. For example:
 ```shell
-/Users/my_user_name/Library/Caches/pypoetry/virtualenvs/dbt-goodparty-gN6X-qpi-py3.12/bin/python
+dbt/.venv/bin/python
 ```
 
 ### Pre-commit Hooks
@@ -58,8 +58,7 @@ To set up pre-commit:
 1. Install dependencies (includes pre-commit as a dev dependency):
 ```bash
 cd dbt
-poetry install
-eval $(poetry env activate)
+uv sync
 ```
 
 2. Install the git hooks:

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -30,8 +30,13 @@ curl -sSL install.astronomer.io | sudo bash -s
 
 ## Getting Started
 
-### Step 0: Activate local python environment with poetry
-The current version of astro used in project is 3.0-7, as defined in `astro/Dockerfile`. The release notes can be found [here](https://www.astronomer.io/docs/astro/runtime-release-notes#astro-runtime-30-7), which list Airflow 3.0.4 as the included package over python 3.12. Packages for the development environment are defined in `pyproject.toml`.
+### Step 0: Set up the local python environment with uv
+The current version of astro used in project is 3.0-7, as defined in `astro/Dockerfile`. The release notes can be found [here](https://www.astronomer.io/docs/astro/runtime-release-notes#astro-runtime-30-7), which list Airflow 3.0.4 as the included package over python 3.12. Packages for the development environment are defined in `pyproject.toml` and locked in `uv.lock`. Install them with:
+
+```bash
+cd airflow
+uv sync
+```
 
 ### Step 1: Use the Existing Astro Project
 

--- a/airflow/astro/README.md
+++ b/airflow/astro/README.md
@@ -107,6 +107,6 @@ If Astronomer upgrades the runtime, update the tag in the `Dockerfile` to match.
 ## Adding Dependencies
 
 1. Add the Python package to `requirements.txt`
-2. Add the matching pinned version to `airflow/pyproject.toml` (used by the local poetry dev environment)
+2. Add the matching pinned version to `airflow/pyproject.toml` (used by the local uv dev environment)
 3. For OS-level dependencies, add to `packages.txt`
 4. Test locally with `astro dev start` to verify the image builds

--- a/airflow/astro/tests/test_postgres_utils.py
+++ b/airflow/astro/tests/test_postgres_utils.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # Stub external modules so the test file can be collected by pytest
-# in any environment (the Astro runtime, the dbt poetry env, or bare).
-# Using direct assignment (not setdefault) because the dbt poetry env
+# in any environment (the Astro runtime, the airflow or dbt uv env, or bare).
+# Using direct assignment (not setdefault) because the dbt uv env
 # ships an incompatible airflow.sdk that lacks BaseHook/Variable.
 _STUBS = (
     "airflow",

--- a/apps/genie-tools/README.md
+++ b/apps/genie-tools/README.md
@@ -23,9 +23,8 @@ That means it will use your existing Databricks auth configuration, for example:
 
 No custom auth handling is built into this tool.
 
-In this repo, the most reliable way to run the tool is to use the existing Poetry
-environment from `dbt/project` and a Databricks CLI profile stored in
-`~/.databrickscfg`.
+In this repo, the most reliable way to run the tool is to use its own uv
+environment and a Databricks CLI profile stored in `~/.databrickscfg`.
 
 Example auth checks:
 
@@ -45,16 +44,15 @@ From the repo root:
 python3 -m pip install -e apps/genie-tools
 ```
 
-For this repo, an already-working option is:
+For this repo, the preferred option is the subproject's own uv environment:
 
 ```bash
-export REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT/dbt/project"
-eval "$(poetry env activate)"
-export PYTHONPATH="$REPO_ROOT/apps/genie-tools/src"
+cd "$(git rev-parse --show-toplevel)/apps/genie-tools"
+uv sync
 ```
 
-That reuses the existing Poetry environment, which already includes `databricks-sdk`.
+`uv sync` installs `databricks-sdk` from `uv.lock`, and `uv run` puts the package
+on the path without any `PYTHONPATH` juggling.
 
 ## Local Env File
 
@@ -106,20 +104,18 @@ Using the local env file:
 
 ```bash
 export REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT/dbt/project"
-eval "$(poetry env activate)"
+cd "$REPO_ROOT/apps/genie-tools"
 set -a
-source "$REPO_ROOT/apps/genie-tools/.env.local"
+source .env.local
 set +a
-export PYTHONPATH="$REPO_ROOT/apps/genie-tools/src"
 
-python -m genie_tools.cli export \
+uv run python -m genie_tools.cli export \
   --space-id "$GENIE_TOOLS_SPACE_ID" \
   --out-dir "$REPO_ROOT/$GENIE_TOOLS_OUT_DIR" \
   --write-redacted \
   --write-metadata
 
-python -m genie_tools.cli validate \
+uv run python -m genie_tools.cli validate \
   --file "$REPO_ROOT/$GENIE_TOOLS_OUT_DIR/normalized/$GENIE_TOOLS_SPACE_ID.json"
 ```
 

--- a/dbt/poetry.toml
+++ b/dbt/poetry.toml
@@ -1,3 +1,0 @@
-[virtualenvs]
-create = true
-in-project = false


### PR DESCRIPTION
## Why

While looking into the 12 open Dependabot alerts, it turned out none of them needed a dependency bump. All 12 pointed at `dbt/poetry.lock` and `airflow/poetry.lock`, which were deleted in #466 and #468 during the uv migration. Every current `uv.lock` on `main` already pins the patched versions (cryptography 50.0.0, PyJWT 2.13.0, pyasn1 0.6.4) — Dependabot itself had already merged those in #750 through #756.

The alerts were phantoms fired against stale dependency-graph entries. They have been dismissed as `not_used`. This PR handles the separate, real issue that surfaced along the way: the repo still had poetry config and setup instructions in it.

## What changed

Docs and config only. No dependency or runtime changes.

| File | Change |
|---|---|
| `dbt/poetry.toml` | Deleted — poetry-only virtualenv config, nothing reads it |
| `README.md` | `uv sync` / `uv run` for env setup, VS Code interpreter path, pre-commit bootstrap |
| `airflow/README.md` | Step 0 now sets up the uv env, with the command |
| `airflow/astro/README.md` | `pyproject.toml` feeds the uv dev env |
| `apps/genie-tools/README.md` | Use the subproject's own uv env instead of borrowing dbt's; drops the `PYTHONPATH` workaround |
| `.pre-commit-config.yaml` | Corrected the env-setup comment |
| `airflow/astro/tests/test_postgres_utils.py` | Corrected stub comments |
| `.claude/agents/code-critic.md` | Fixed the package-manager rule |
| `.claude/skills/analytics-process/references/methodology.md` | Dropped the poetry invocation note |

The `code-critic.md` fix is the one with teeth. It was telling reviewers that `dbt/`, `airflow/`, and `apps/genie-tools/` were poetry projects and that `apps/genie-slack-bot/` was pip + requirements.txt. All four are uv now, so the rule was actively producing wrong review feedback. It now describes the real layout and flags any reintroduction of poetry.

## Verification

- `pre-commit run --files <all changed>` — passed
- `cd airflow && uv run pytest` — 104 passed, 2 skipped (this suite owns `astro/tests` via `testpaths`)

## Follow-ups, not in this PR

- **The dependency graph still holds the ghost `poetry.lock` snapshots.** The SBOM lists cryptography 46.0.7, pyjwt 2.12.0/2.12.1, and pyasn1 0.6.3 alongside the correct entries. Nothing in the repo can update those, so new advisories will keep matching them and opening alerts against poetry. Clearing it needs an admin to toggle Dependency graph off and back on in Settings → Advanced Security, which wipes and rebuilds it. There is no API for this.
- `.claude/agents/code-critic.md` also references Python 3.11 / 3.12, but subprojects declare `requires-python = ">=3.14"`. Left alone to keep this PR scoped to poetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)