### PR TITLE
[DATA-2218] Drop definition text from the Slack governance thread

### DIFF
--- a/analytics/diagnostics/semantic_catalog/slack_diff.py
+++ b/analytics/diagnostics/semantic_catalog/slack_diff.py
@@ -31,16 +31,19 @@ def changed_metric_names(before: list[MetricRecord], after: list[MetricRecord]) 
 
 
 def diff_records(before: list[MetricRecord], after: list[MetricRecord]) -> list[str]:
+    # Definition TEXT is deliberately not rendered anywhere in the thread: the
+    # definitions run long and buried the lifecycle signal. The thread reports
+    # WHICH metric changed and how; the PR diff is where you read the wording.
     a, b = _by_name(before), _by_name(after)
     lines: list[str] = []
     for name in sorted(b.keys() - a.keys()):
-        lines.append(f"• added: {name} — {b[name].definition}")
+        lines.append(f"• added: {name}")
     for name in sorted(a.keys() - b.keys()):
-        lines.append(f"• removed: {name} — {a[name].definition}")
+        lines.append(f"• removed: {name}")
     for name in sorted(a.keys() & b.keys()):
         old, new = a[name], b[name]
         if old.definition != new.definition:
-            lines.append(f"• changed: {name}\n    before: {old.definition}\n    after:  {new.definition}")
+            lines.append(f"• changed: {name} (definition updated)")
         if old.ratified != new.ratified:
             lines.append(f"• ratified: {name} — {old.ratified or 'pending'} → {new.ratified or 'pending'}")
         if old.retired != new.retired:

--- a/analytics/diagnostics/semantic_catalog/thread.py
+++ b/analytics/diagnostics/semantic_catalog/thread.py
@@ -70,10 +70,11 @@ class Plan:
 
 
 def render_anchor(ctx: PRContext, mention_by_team: dict[str, str]) -> str:
-    # One bullet per metric with its one-line definition, matching the merge
-    # message's "name — definition" copy so the thread reads consistently.
+    # Names only, no definition text: definitions run long and made the anchor
+    # hard to scan. Reviewers read the wording in the PR diff. Matches the merge
+    # message, which also names metrics without quoting them.
     if ctx.metrics:
-        metric_lines = [f"• `{n}` — {d}" if d else f"• `{n}`" for n, d in ctx.metrics]
+        metric_lines = [f"• `{n}`" for n, _ in ctx.metrics]
         metrics_block = "Metrics:\n" + "\n".join(metric_lines)
     else:
         metrics_block = "Metrics: (see PR diff)"

--- a/analytics/tests/test_semantic_catalog_slack.py
+++ b/analytics/tests/test_semantic_catalog_slack.py
@@ -30,7 +30,9 @@ def test_diff_detects_added_removed_changed():
     lines = "\n".join(diff_records(before, after))
     assert "b" in lines and "added" in lines.lower()
     assert "gone" in lines and "removed" in lines.lower()
-    assert "a" in lines and "old def" in lines and "new def" in lines
+    assert "a" in lines and "changed" in lines.lower()
+    # Definition TEXT never appears in the thread; the PR diff owns the wording.
+    assert "old def" not in lines and "new def" not in lines and "brand new" not in lines
 
 
 def test_diff_detects_ratification():

--- a/analytics/tests/test_semantic_catalog_thread.py
+++ b/analytics/tests/test_semantic_catalog_thread.py
@@ -62,7 +62,9 @@ def test_draft_is_silent():
 def test_bootstrap_anchor_on_open_pr_without_state():
     plan = reconcile(None, NO_APPROVALS, _ctx(), MENTIONS)
     assert plan.anchor_text is not None
-    assert "• `win_users` — Distinct users with an activated Win account" in plan.anchor_text
+    # Names only: definition text is deliberately excluded from the thread.
+    assert "• `win_users`" in plan.anchor_text
+    assert "Distinct users with an activated Win account" not in plan.anchor_text
     assert "<@U1>" in plan.anchor_text
     assert plan.new_state is not None and plan.new_state.announced == {"data": None, "business": None}
 


### PR DESCRIPTION
## What

Reverses an earlier decision. Quoting each metric's one-line definition made the anchor and the merge summary long enough that the lifecycle signal (which metric, what changed, who approved) got buried in prose.

**Structure is unchanged.** Only the definition text is removed:

- anchor metric bullets are names only: ``• `serve_users` ``
- merge summary added/removed lines drop the trailing `— <definition>`
- a definition edit now reports `• changed: <name> (definition updated)` instead of printing the before and after wording

Untouched: the `ratified`, `retired`, and `owner` transition lines (those carry dates and owner slugs, not definitions), the review-coverage line and its warning prefix, the approval and dismissal replies, and the Sigma task reply.

The PR diff stays the place to read wording, which is where a reviewer has to go anyway in order to approve it.

## Before and after

Anchor:

```
- • `serve_users` — Count of Serve product user accounts, excluding internal @goodparty.org
-   accounts. Definition owned by users_serve_base.is_serve_user, which resolves to holding
-   a Serve organization or being a poll user, and is currently 1:1 with eo_activated_at
-   being set (a data-state fact that may diverge). This is the broad account population...
+ • `serve_users`
```

Merge summary:

```
- • added: serve_users — Count of Serve product user accounts, excluding internal...
+ • added: serve_users

- • changed: win_users
-     before: <full old wording>
-     after:  <full new wording>
+ • changed: win_users (definition updated)
```

## Full thread after this change

```
:scroll: Governed metric PR ready for review: *[DATA-2133] Serve Users*
https://github.com/thegoodparty/gp-data-platform/pull/764
Metrics:
• `serve_users`
Reviewers: data <@data-team> · business <@business-team>
Approvals will be tracked in this thread.

  └ :white_check_mark: Data team approved (...)
  └ :white_check_mark: Business team approved (...)
  └ *Semantic layer updated*
    PR: .../pull/764

    • added: serve_users

    review coverage: data ✓ · business ✓
  └ Sigma build task created for `serve_users`: https://app.clickup.com/t/...
```

## Two trade-offs this makes visible

Neither blocks the change, but both are worth knowing:

1. **A rename reads as a remove plus an add**, since the metric name is the dedupe key. Accurate, but a reader could take it as one metric deleted and a different one created.
2. **A definition-only edit now yields a single line** with no signal about the size of the change. The thread says to go look without saying how much changed.

## Verification

- analytics suite: 395 passed
- pre-commit clean
- every message shape rendered through the real `render_anchor`, `reconcile`, and `render_message` functions and eyeballed, rather than reasoned about: anchor, both approval replies, merge summary, Sigma reply, ratification flip, rename, definition-only edit, owner and retirement changes, and incomplete review coverage

Two tests encoded the old copy and now assert the inverse, that definition text does **not** appear in either message.

Touches no `sem_*.yml`, so the review teams are not tagged and the publish workflow does not fire on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to Slack notification formatting in diagnostics code; no auth, data paths, or semantic YAML touched.
> 
> **Overview**
> **Slack governance threads no longer quote metric definition text**, so anchors and merge summaries stay scannable and lifecycle signals (which metric, what changed, approvals) aren’t buried in long prose.
> 
> In **`diff_records`**, added/removed lines are metric names only; definition edits become `• changed: <name> (definition updated)` instead of before/after wording. **`render_anchor`** lists ``• `name` `` bullets without the one-line definition. **Ratified, retired, and owner** transition lines are unchanged.
> 
> Tests now assert definition strings do **not** appear in thread output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ba5743bca63f442a99668eb275f84e09609381. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->