### PR TITLE
[DATA-2214] Resolve the Detroit school district board to a place so its races publish

### DIFF
--- a/dbt/project/models/intermediate/int__enhanced_race.sql
+++ b/dbt/project/models/intermediate/int__enhanced_race.sql
@@ -66,35 +66,40 @@ with
             tbl_filing_period.end_on as filing_date_end,
             tbl_position.database_id as br_position_database_id,
             tbl_position.geo_id as position_geo_id,
-            -- For some MTFCCs, need to roll up to parent geo_id of the position to
-            -- get the correct place by geo_id
+            -- The seeded override wins, for geographies BallotReady puts on a
+            -- position but publishes no Place for. Otherwise, for some MTFCCs,
+            -- need to roll up to parent geo_id of the position to get the
+            -- correct place by geo_id
             -- see:
             -- https://docs.google.com/spreadsheets/d/1t1U2oECqFRKPUVO7HYI2me-YzDgtvjbPzp5h9BqKHcU/edit?gid=0#gid=0
-            case
-                when tbl_position.mtfcc = 'X0005'
-                then left(tbl_position.geo_id, 5)  -- County Legislative District
-                when tbl_position.mtfcc = 'G5220'
-                then left(tbl_position.geo_id, 2)  -- State Legislative District (lower)
-                when tbl_position.mtfcc = 'X0001'
-                then left(tbl_position.geo_id, 7)  -- City Council District
-                when tbl_position.mtfcc = 'G5210'
-                then left(tbl_position.geo_id, 2)  -- State Legistlative District (upper)
-                when tbl_position.mtfcc = 'X0102'
-                then left(tbl_position.geo_id, 7)  -- Unified School District Subdistrict
-                when tbl_position.mtfcc = 'X0010'
-                then left(tbl_position.geo_id, 2)  -- Circuit Court
-                when tbl_position.mtfcc = 'G5200'
-                then left(tbl_position.geo_id, 2)  -- Congressional District
-                when tbl_position.mtfcc = 'X0014'
-                then left(tbl_position.geo_id, 2)  -- District Court
-                when tbl_position.mtfcc = 'X0027'
-                then left(tbl_position.geo_id, 5)  -- Fire District
-                when tbl_position.mtfcc = 'X0026'
-                then left(tbl_position.geo_id, 5)  -- Justice Precinct
-                when tbl_position.mtfcc = 'X0025'
-                then left(tbl_position.geo_id, 7)  -- Neighborhood Council District; Washington, DC
-                else tbl_position.geo_id
-            end as position_to_place_geo_id,
+            coalesce(
+                tbl_place_override.place_geo_id,
+                case
+                    when tbl_position.mtfcc = 'X0005'
+                    then left(tbl_position.geo_id, 5)  -- County Legislative District
+                    when tbl_position.mtfcc = 'G5220'
+                    then left(tbl_position.geo_id, 2)  -- State Legislative District (lower)
+                    when tbl_position.mtfcc = 'X0001'
+                    then left(tbl_position.geo_id, 7)  -- City Council District
+                    when tbl_position.mtfcc = 'G5210'
+                    then left(tbl_position.geo_id, 2)  -- State Legistlative District (upper)
+                    when tbl_position.mtfcc = 'X0102'
+                    then left(tbl_position.geo_id, 7)  -- Unified School District Subdistrict
+                    when tbl_position.mtfcc = 'X0010'
+                    then left(tbl_position.geo_id, 2)  -- Circuit Court
+                    when tbl_position.mtfcc = 'G5200'
+                    then left(tbl_position.geo_id, 2)  -- Congressional District
+                    when tbl_position.mtfcc = 'X0014'
+                    then left(tbl_position.geo_id, 2)  -- District Court
+                    when tbl_position.mtfcc = 'X0027'
+                    then left(tbl_position.geo_id, 5)  -- Fire District
+                    when tbl_position.mtfcc = 'X0026'
+                    then left(tbl_position.geo_id, 5)  -- Justice Precinct
+                    when tbl_position.mtfcc = 'X0025'
+                    then left(tbl_position.geo_id, 7)  -- Neighborhood Council District; Washington, DC
+                    else tbl_position.geo_id
+                end
+            ) as position_to_place_geo_id,
             tbl_position.mtfcc as position_mtfcc,
             tbl_race_to_positions.position_names
         from {{ ref("stg_airbyte_source__ballotready_api_race") }} as tbl_race
@@ -120,8 +125,16 @@ with
         left join
             {{ ref("int__race_to_positions") }} as tbl_race_to_positions
             on tbl_race.database_id = tbl_race_to_positions.race_database_id
+        left join
+            {{ ref("br_position_place_overrides") }} as tbl_place_override
+            on tbl_position.geo_id = tbl_place_override.position_geo_id
+            and tbl_position.mtfcc = tbl_place_override.position_mtfcc
         {% if is_incremental() %}
-            where tbl_race.updated_at > (select max(updated_at) from {{ this }})
+            -- Re-emit overridden races every run so seed edits propagate without
+            -- a full refresh; their BR updated_at predates the watermark.
+            where
+                tbl_race.updated_at > (select max(updated_at) from {{ this }})
+                or tbl_place_override.place_geo_id is not null
         {% endif %}
     ),
     race_w_place as (

--- a/dbt/project/models/intermediate/int__enhanced_race.sql
+++ b/dbt/project/models/intermediate/int__enhanced_race.sql
@@ -1,12 +1,3 @@
-{{
-    config(
-        materialized="incremental",
-        incremental_strategy="merge",
-        unique_key="id",
-        auto_liquid_cluster=true,
-    )
-}}
-
 with
     election_frequencies as (
         select tbl_pos.database_id, e.databaseid as pe_frequency_database_id
@@ -129,13 +120,6 @@ with
             {{ ref("br_position_place_overrides") }} as tbl_place_override
             on tbl_position.geo_id = tbl_place_override.position_geo_id
             and tbl_position.mtfcc = tbl_place_override.position_mtfcc
-        {% if is_incremental() %}
-            -- Re-emit overridden races every run so seed edits propagate without
-            -- a full refresh; their BR updated_at predates the watermark.
-            where
-                tbl_race.updated_at > (select max(updated_at) from {{ this }})
-                or tbl_place_override.place_geo_id is not null
-        {% endif %}
     ),
     race_w_place as (
         select

--- a/dbt/project/seeds/br_position_place_overrides.csv
+++ b/dbt/project/seeds/br_position_place_overrides.csv
@@ -1,0 +1,2 @@
+position_geo_id,position_mtfcc,place_geo_id,place_name,reason
+2612000,G5420,2622000,Detroit,"BallotReady publishes no Place for the Detroit Public Schools Community District geography, so every race for its board lost its place FK and was dropped from the race mart. The district is coterminous with the city of Detroit (https://detroitk12.org)"

--- a/dbt/project/seeds/seeds_schema.yaml
+++ b/dbt/project/seeds/seeds_schema.yaml
@@ -224,6 +224,65 @@ seeds:
                 from {{ ref('m_election_api__race') }}
               )
 
+  - name: br_position_place_overrides
+    description: >
+      Points a BallotReady position geography at the Place it should resolve to,
+      for geographies BallotReady carries on a position but publishes no Place
+      row for. int__enhanced_race resolves place by geo_id and
+      m_election_api__race inner-joins the place mart (Race.placeId is a
+      required FK and supplies the race slug), so a position whose geography has
+      no Place loses every one of its races and the office becomes unselectable
+      in the picker. Keyed at geography grain rather than position, so every
+      position sharing the geography is fixed by one row, including ones
+      BallotReady adds later.
+    config:
+      column_types:
+        position_geo_id: string
+        place_geo_id: string
+    columns:
+      - name: position_geo_id
+        description: geo_id BallotReady puts on the position
+        data_tests:
+          - not_null
+      - name: position_mtfcc
+        description: >
+          MTFCC BallotReady puts on the position. Part of the key because a
+          geo_id is only unique within an MTFCC.
+        data_tests:
+          - not_null
+      - name: place_geo_id
+        description: geo_id of the Place the position's races should resolve to
+        data_tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('int__enhanced_place')
+                field: geo_id
+      - name: place_name
+        description: Name of that place (for documentation only, not used in joins)
+        data_tests:
+          - not_null
+      - name: reason
+        description: Why this override is needed
+        data_tests:
+          - not_null
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - position_geo_id
+              - position_mtfcc
+      # The override is a silent no-op if it never reaches the race grain, so
+      # assert the races it targets actually carry a place.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              position_geo_id in (
+                select position_geo_id
+                from {{ ref('int__enhanced_race') }}
+                where place_id is not null
+              )
+
   - name: icp_normalized_position_names
     description: >
       BallotReady normalized position names that qualify for ICP flags.


### PR DESCRIPTION
Resolves [DATA-2214](https://goodparty.clickup.com/t/90132012119/DATA-2214). The Detroit Public Schools Community District Board was missing from the office picker.

## Root cause

Not a district or L2 problem. `m_election_api__district` carries School_District / DETROIT COMMUNITY SCHOOL DISTRICT, the LLM matched both BR cohort positions (318131, 318132) to it at confidence 100, and `m_election_api__zip_to_position` already covers 33 Detroit zips for the 2026 seat.

The break is the Race table. The picker uses ZipToPosition only to collect positionIds, then reads the races off `Race.positionId`. `m_election_api__race` had zero rows for either position.

Races were dropped for lack of a Place. BallotReady puts geo_id `2612000` / mtfcc `G5420` on both positions but publishes no Place row for that geography - MI school-district geo_ids jump from 2611970 (DeTour) to 2612030 (Dexter). `int__enhanced_race` resolves place by geo_id, so `place_id` landed null, and `m_election_api__race` inner-joins the place mart because `Race.placeId` is a required FK that also supplies the race slug and the city label. Every DPSCD race back to 2020 was dropped there.

That is the geo_id the ticket suspected, and it is isolated: exactly one future race nationwide has mtfcc G5420 and no place, and it is this one. Every other unified school district resolves a place.

## Fix

New seed `br_position_place_overrides` points a BallotReady position geography at the Place its races should resolve to, coalesced into the place lookup in `int__enhanced_race`. DPSCD is coterminous with the city of Detroit, so `2612000`/`G5420` maps to place `2622000`.

Two details worth noting for review:

- The seed is keyed at geography grain, not position, so one row covers both cohort positions and any BallotReady adds later.
- `int__enhanced_race` drops its incremental materialization and becomes a view. It rebuilt from source in 17-19s as a table, so the merge strategy was buying very little, and with no watermark a seed edit propagates on the next run by construction instead of needing a re-emit clause in the incremental filter. The directory default in `dbt_project.yml` is already view, so the `config()` block goes away entirely.
- A seed test asserts the targeted races actually carry a place, since a typo'd `place_geo_id` would otherwise leave the override a silent no-op.

## Proposed pattern for future occurrences

This seed is the general mechanism for BallotReady place gaps, and it now sits alongside the two other override seeds that cover the rest of the picker chain. When an office is missing from the picker, the chain to walk is:

1. `m_election_api__district` - does the L2 district exist? If L2 carries no geography for the seat, add `l2_manual_district_assignments`.
2. `m_election_api__position` - is `district_id` populated? If the LLM matched wrong or scored below threshold, add `l2_br_match_overrides`.
3. `m_election_api__zip_to_position` - are there zip rows above the API's 0.005 pct threshold?
4. `m_election_api__race` - **are there races for the position?** If not, check `int__enhanced_race.place_id`. A null there means BallotReady has no Place for the position's geography, so add `br_position_place_overrides`.

Step 4 was the missing rung. The picker needs both a covered position and a published race, and until now only the position side had a repair path.

There is a broader gap behind this: 4,656 future races (1.7%) have no place, across 3,183 positions. Those are almost entirely BR X-prefixed special districts (fire, justice precinct, and similar), where no census place exists to point at, so they need a different treatment than a geo_id remap. Left out of scope here.

## Verification

Built in dev against prod for everything upstream.

- Exactly 4 races enter `m_election_api__race` (2020, 2022, 2024, 2026-11-03) and nothing else changes.
- Only 6 rows in `int__enhanced_race` differ from prod on `position_to_place_geo_id`, all DPSCD.
- The 2026-11-03 race attaches to position `e2104202-3d58-5c25-9fd2-bc89086c4325`, the one ZipToPosition already covers for 32 Detroit zips above the API threshold.
- Race slug resolves to `mi/detroit/local-school-board`; `assert_race_slug_prefix_matches_place_slug` passes.
- `dbt build` on the seed, `int__enhanced_race`, and `m_election_api__race`: 33 pass, 0 fail.
- View row count matches the previous incremental table exactly (1,627,073).
- Materialization cost: each of the three consumers recomputes the join graph, which added ~5s to `m_election_api__race` (22.6s -> 27.4s). Against ~18s saved by not materializing, total build time is flat to slightly faster. `m_election_api__place` 27.2s and `m_election_api__candidacy` 20.7s against the view.
