### PR TITLE
[DATA-2201] Derive is_incumbent from BallotReady office-holder terms

### DIFF
--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -475,6 +475,11 @@ with
     --
     -- FALSE means BR shows a term covering election day held by someone else.
     -- A position with no covering term stays NULL: unknown, not challenger.
+    --
+    -- A NULL term_end_date reads as "no scheduled end, still serving" and so
+    -- covers election day. A NULL term_start_date carries no such reading -
+    -- assuming the term began before every election day would backdate the
+    -- holder over cycles they may not have served - so those terms are dropped.
     incumbency as (
         select
             ced.gp_candidacy_id,

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -460,8 +460,10 @@ with
     -- candidacy feed carries no incumbency field and TS (the only source that
     -- ever did) is retired, so without this 2026 is almost entirely unlabeled.
     --
-    -- FALSE means BR shows a term covering election day held by someone else.
-    -- A position with no covering term stays NULL: unknown, not challenger.
+    -- FALSE means BR shows a term covering election day held by someone else,
+    -- so it is only assertable once we know who the candidate is. A position
+    -- with no covering term, or a candidacy with no resolved person, stays
+    -- NULL: unknown, not challenger.
     --
     -- A NULL term_end_date reads as "no scheduled end, still serving" and so
     -- covers election day. A NULL term_start_date carries no such reading -
@@ -478,6 +480,7 @@ with
             on cp.br_position_database_id = t.br_position_id
             and t.term_start_date <= cp.election_day
             and (t.term_end_date is null or t.term_end_date >= cp.election_day)
+        where cp.gp_person_id is not null
         group by cp.gp_candidacy_id
     )
 

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -468,10 +468,12 @@ with
     -- equality safe here; a 10-case audit found no collisions. Drop the name
     -- arm once person resolution links these records.
     --
-    -- FALSE means BR shows a term covering election day held by someone else,
-    -- so it is only assertable once we know who the candidate is. A position
-    -- with no covering term, or a candidacy with no resolved person, stays
-    -- NULL: unknown, not challenger.
+    -- FALSE means BR shows the seat on election day in someone else's hands,
+    -- or vacant (a vacancy term carries no person, and nobody is the incumbent
+    -- of an empty seat). Either way this candidate does not hold it. It is only
+    -- assertable once we know who the candidate is, so a candidacy with no
+    -- resolved person, like a position with no covering term, stays NULL:
+    -- unknown, not challenger.
     --
     -- A NULL term_end_date reads as "no scheduled end, still serving" and so
     -- covers election day. A NULL term_start_date carries no such reading -

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -431,10 +431,18 @@ with
     ),
 
     -- gp_person_id: min over the person reached by HubSpot contact, product
-    -- campaign -> user, and the candidacy's stage rows.
+    -- campaign -> user, and the candidacy's stage rows. Carries the contest
+    -- date and position alongside it for the incumbency test below.
     candidacy_person as (
         select
             d.gp_candidacy_id,
+            d.br_position_database_id,
+            coalesce(
+                d.general_election_date,
+                d.primary_election_date,
+                d.general_runoff_election_date,
+                d.primary_runoff_election_date
+            ) as election_day,
             least(hp.gp_person_id, gpp.gp_person_id, sp.gp_person_id) as gp_person_id
         from deduplicated as d
         left join
@@ -447,31 +455,10 @@ with
         left join stage_person as sp on sp.gp_candidacy_id = d.gp_candidacy_id
     ),
 
-    -- The date the seat is contested, used to test whether a term is current.
-    candidacy_election_day as (
-        select
-            gp_candidacy_id,
-            br_position_database_id,
-            coalesce(
-                general_election_date,
-                primary_election_date,
-                general_runoff_election_date,
-                primary_runoff_election_date
-            ) as election_day
-        from deduplicated
-    ),
-
     -- Incumbency reconstructed from BR office-holder terms: does this candidate
     -- already hold the position they are running for on election day? The BR
     -- candidacy feed carries no incumbency field and TS (the only source that
     -- ever did) is retired, so without this 2026 is almost entirely unlabeled.
-    --
-    -- Matched on the canonical person id OR on first+last name. Position and
-    -- term window already narrow the comparison to that seat's handful of
-    -- holders, so name equality is near-deterministic there; it carries most of
-    -- the recall because ER has linked only a small share of product users to
-    -- their BR office-holder record (53 of 222 engaged 2026 matches come from
-    -- the person id).
     --
     -- FALSE means BR shows a term covering election day held by someone else.
     -- A position with no covering term stays NULL: unknown, not challenger.
@@ -482,29 +469,16 @@ with
     -- holder over cycles they may not have served - so those terms are dropped.
     incumbency as (
         select
-            ced.gp_candidacy_id,
-            max(
-                case
-                    when
-                        t.gp_person_id = cp.gp_person_id
-                        or (
-                            lower(trim(t.first_name)) = lower(trim(p.first_name))
-                            and lower(trim(t.last_name)) = lower(trim(p.last_name))
-                        )
-                    then 1
-                    else 0
-                end
-            )
+            cp.gp_candidacy_id,
+            max(case when t.gp_person_id = cp.gp_person_id then 1 else 0 end)
             = 1 as is_incumbent
-        from candidacy_election_day as ced
-        join candidacy_person as cp on ced.gp_candidacy_id = cp.gp_candidacy_id
-        left join {{ ref("people") }} as p on cp.gp_person_id = p.gp_person_id
+        from candidacy_person as cp
         join
             {{ ref("elected_official_terms") }} as t
-            on ced.br_position_database_id = t.br_position_id
-            and t.term_start_date <= ced.election_day
-            and (t.term_end_date is null or t.term_end_date >= ced.election_day)
-        group by ced.gp_candidacy_id
+            on cp.br_position_database_id = t.br_position_id
+            and t.term_start_date <= cp.election_day
+            and (t.term_end_date is null or t.term_end_date >= cp.election_day)
+        group by cp.gp_candidacy_id
     )
 
 select

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -460,6 +460,14 @@ with
     -- candidacy feed carries no incumbency field and TS (the only source that
     -- ever did) is retired, so without this 2026 is almost entirely unlabeled.
     --
+    -- Matched on the canonical person id, or on first+last name. The name arm
+    -- compensates for a person-resolution gap: product sign-ups are routinely
+    -- not linked to their BR office-holder record, and it supplies 30% of the
+    -- incumbent flags on the 2026 product base. Position and term window pin
+    -- the comparison to that seat's few holders, which is what makes bare name
+    -- equality safe here; a 10-case audit found no collisions. Drop the name
+    -- arm once person resolution links these records.
+    --
     -- FALSE means BR shows a term covering election day held by someone else,
     -- so it is only assertable once we know who the candidate is. A position
     -- with no covering term, or a candidacy with no resolved person, stays
@@ -472,9 +480,21 @@ with
     incumbency as (
         select
             cp.gp_candidacy_id,
-            max(case when t.gp_person_id = cp.gp_person_id then 1 else 0 end)
+            max(
+                case
+                    when
+                        t.gp_person_id = cp.gp_person_id
+                        or (
+                            lower(trim(t.first_name)) = lower(trim(p.first_name))
+                            and lower(trim(t.last_name)) = lower(trim(p.last_name))
+                        )
+                    then 1
+                    else 0
+                end
+            )
             = 1 as is_incumbent
         from candidacy_person as cp
+        left join {{ ref("people") }} as p on cp.gp_person_id = p.gp_person_id
         join
             {{ ref("elected_official_terms") }} as t
             on cp.br_position_database_id = t.br_position_id

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -484,6 +484,11 @@ with
             cp.gp_candidacy_id,
             max(
                 case
+                    -- Vacancy terms keep the prior holder's name, so they must
+                    -- never satisfy the name arm. They still count as coverage
+                    -- below, which is what makes an empty seat read FALSE.
+                    when t.is_vacant
+                    then 0
                     when
                         t.gp_person_id = cp.gp_person_id
                         or (

--- a/dbt/project/models/marts/civics/candidacy.sql
+++ b/dbt/project/models/marts/civics/candidacy.sql
@@ -130,7 +130,8 @@ with
             gp_api.is_verified,
             gp_api.verification_status_reason,
             -- TS wins for is_incumbent (TS: 51k populated, BR: 0); gp_api/DDHQ
-            -- excluded.
+            -- excluded. Rows still NULL here fall back to the office-holder
+            -- derivation in the `incumbency` CTE below.
             coalesce(ts.is_incumbent, br.is_incumbent) as is_incumbent,
             -- office_type: BR > gp_api > DDHQ. BR derives office_type from
             -- BallotReady's normalized position name (low Other rate); gp_api
@@ -427,13 +428,83 @@ with
         from {{ ref("candidacy_stage") }}
         where gp_person_id is not null
         group by gp_candidacy_id
+    ),
+
+    -- gp_person_id: min over the person reached by HubSpot contact, product
+    -- campaign -> user, and the candidacy's stage rows.
+    candidacy_person as (
+        select
+            d.gp_candidacy_id,
+            least(hp.gp_person_id, gpp.gp_person_id, sp.gp_person_id) as gp_person_id
+        from deduplicated as d
+        left join
+            person_ids as hp
+            on hp.record_key = 'hubspot|' || cast(d.hubspot_contact_id as string)
+        left join
+            campaign_user as cu
+            on cu.campaign_id = cast(d.product_campaign_id as string)
+        left join person_ids as gpp on gpp.record_key = 'gp_api|' || cu.user_id
+        left join stage_person as sp on sp.gp_candidacy_id = d.gp_candidacy_id
+    ),
+
+    -- The date the seat is contested, used to test whether a term is current.
+    candidacy_election_day as (
+        select
+            gp_candidacy_id,
+            br_position_database_id,
+            coalesce(
+                general_election_date,
+                primary_election_date,
+                general_runoff_election_date,
+                primary_runoff_election_date
+            ) as election_day
+        from deduplicated
+    ),
+
+    -- Incumbency reconstructed from BR office-holder terms: does this candidate
+    -- already hold the position they are running for on election day? The BR
+    -- candidacy feed carries no incumbency field and TS (the only source that
+    -- ever did) is retired, so without this 2026 is almost entirely unlabeled.
+    --
+    -- Matched on the canonical person id OR on first+last name. Position and
+    -- term window already narrow the comparison to that seat's handful of
+    -- holders, so name equality is near-deterministic there; it carries most of
+    -- the recall because ER has linked only a small share of product users to
+    -- their BR office-holder record (53 of 222 engaged 2026 matches come from
+    -- the person id).
+    --
+    -- FALSE means BR shows a term covering election day held by someone else.
+    -- A position with no covering term stays NULL: unknown, not challenger.
+    incumbency as (
+        select
+            ced.gp_candidacy_id,
+            max(
+                case
+                    when
+                        t.gp_person_id = cp.gp_person_id
+                        or (
+                            lower(trim(t.first_name)) = lower(trim(p.first_name))
+                            and lower(trim(t.last_name)) = lower(trim(p.last_name))
+                        )
+                    then 1
+                    else 0
+                end
+            )
+            = 1 as is_incumbent
+        from candidacy_election_day as ced
+        join candidacy_person as cp on ced.gp_candidacy_id = cp.gp_candidacy_id
+        left join {{ ref("people") }} as p on cp.gp_person_id = p.gp_person_id
+        join
+            {{ ref("elected_official_terms") }} as t
+            on ced.br_position_database_id = t.br_position_id
+            and t.term_start_date <= ced.election_day
+            and (t.term_end_date is null or t.term_end_date >= ced.election_day)
+        group by ced.gp_candidacy_id
     )
 
 select
     deduplicated.gp_candidacy_id,
-    -- gp_person_id: min over the person reached by HubSpot contact, product
-    -- campaign -> user, and the candidacy's stage rows.
-    least(hp.gp_person_id, gpp.gp_person_id, sp.gp_person_id) as gp_person_id,
+    cp.gp_person_id,
     deduplicated.gp_candidate_id,
     deduplicated.gp_election_id,
     deduplicated.product_campaign_id,
@@ -441,7 +512,8 @@ select
     deduplicated.hubspot_company_ids,
     deduplicated.candidate_id_source,
     deduplicated.party_affiliation,
-    deduplicated.is_incumbent,
+    -- TS where it enriched the candidacy, else the office-holder derivation.
+    coalesce(deduplicated.is_incumbent, inc.is_incumbent) as is_incumbent,
     deduplicated.is_open_seat,
     deduplicated.candidate_office,
     deduplicated.official_office_name,
@@ -616,11 +688,5 @@ left join
     last_decided_stage_per_candidacy as decided
     on deduplicated.gp_candidacy_id = decided.gp_candidacy_id
 left join race_context as race on deduplicated.gp_candidacy_id = race.gp_candidacy_id
-left join
-    person_ids as hp
-    on hp.record_key = 'hubspot|' || cast(deduplicated.hubspot_contact_id as string)
-left join
-    campaign_user as cu
-    on cu.campaign_id = cast(deduplicated.product_campaign_id as string)
-left join person_ids as gpp on gpp.record_key = 'gp_api|' || cu.user_id
-left join stage_person as sp on sp.gp_candidacy_id = deduplicated.gp_candidacy_id
+left join candidacy_person as cp on cp.gp_candidacy_id = deduplicated.gp_candidacy_id
+left join incumbency as inc on inc.gp_candidacy_id = deduplicated.gp_candidacy_id

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -511,17 +511,21 @@ models:
           Whether the candidate already holds the position they are running
           for. TechSpeed's enrichment where it covered the candidacy;
           otherwise derived from BallotReady office-holder terms, matching the
-          candidate's canonical person id to a term on the same position that
-          covers election day.
+          candidate to a term on the same position that covers election day.
+          The match is on canonical person id, or on first+last name, which
+          the position and term window make near-deterministic. The name arm
+          compensates for a person-resolution gap and is expected to be
+          removed once entity resolution links these records.
 
           FALSE means BallotReady shows the seat held by someone else on
-          election day. NULL means the position has no office-holder term
-          covering that date, so incumbency is unknown rather than false.
-          Known misses: appointed or mid-term-succeeded officials whose term
-          dates do not straddle election day, and candidates entity resolution
-          has not linked to their office-holder record (mostly product
-          sign-ups with no BallotReady candidacy yet). Both miss toward
-          "challenger", never toward a false incumbent.
+          election day, and is only asserted for candidacies whose person
+          resolves. NULL means either the position has no office-holder term
+          covering that date or the candidate could not be identified, so
+          incumbency is unknown rather than false. Known misses: appointed or
+          mid-term-succeeded officials whose term dates do not straddle
+          election day, and name variants such as nicknames or changed
+          surnames. Both miss toward "challenger" rather than toward a false
+          incumbent.
         data_tests:
           - accepted_values:
               arguments:

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -517,11 +517,11 @@ models:
           compensates for a person-resolution gap and is expected to be
           removed once entity resolution links these records.
 
-          FALSE means BallotReady shows the seat held by someone else on
-          election day, and is only asserted for candidacies whose person
-          resolves. NULL means either the position has no office-holder term
-          covering that date or the candidate could not be identified, so
-          incumbency is unknown rather than false. Known misses: appointed or
+          FALSE means BallotReady shows the seat on election day either held
+          by someone else or vacant, and is only asserted for candidacies
+          whose person resolves. NULL means either the position has no
+          office-holder term covering that date or the candidate could not be
+          identified, so incumbency is unknown rather than false. Known misses: appointed or
           mid-term-succeeded officials whose term dates do not straddle
           election day, and name variants such as nicknames or changed
           surnames. Both miss toward "challenger" rather than toward a false

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -511,17 +511,17 @@ models:
           Whether the candidate already holds the position they are running
           for. TechSpeed's enrichment where it covered the candidacy;
           otherwise derived from BallotReady office-holder terms, matching the
-          candidate to a term on the same position that covers election day
-          (on canonical person id, or on first+last name, which the position
-          and term window make near-deterministic).
+          candidate's canonical person id to a term on the same position that
+          covers election day.
 
           FALSE means BallotReady shows the seat held by someone else on
           election day. NULL means the position has no office-holder term
           covering that date, so incumbency is unknown rather than false.
           Known misses: appointed or mid-term-succeeded officials whose term
-          dates do not straddle election day, and name variants (nicknames,
-          changed surnames) on candidates ER has not linked to their
-          office-holder record.
+          dates do not straddle election day, and candidates entity resolution
+          has not linked to their office-holder record (mostly product
+          sign-ups with no BallotReady candidacy yet). Both miss toward
+          "challenger", never toward a false incumbent.
         data_tests:
           - accepted_values:
               arguments:

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -409,8 +409,9 @@ models:
         gp_api only (PD-native):
           product_campaign_id, is_pledged, is_verified,
           verification_status_reason
-        TS > BR (gp_api/DDHQ excluded):
-          is_incumbent
+        TS, then derived from BR office-holder terms (gp_api/DDHQ excluded):
+          is_incumbent (no provider supplies this for 2026; see the column
+          description for the derivation)
         BR > TS > DDHQ (gp_api carries no value):
           is_open_seat
         BR-only:
@@ -506,7 +507,21 @@ models:
         description: Candidate's political party
 
       - name: is_incumbent
-        description: Whether the candidate is the incumbent
+        description: >
+          Whether the candidate already holds the position they are running
+          for. TechSpeed's enrichment where it covered the candidacy;
+          otherwise derived from BallotReady office-holder terms, matching the
+          candidate to a term on the same position that covers election day
+          (on canonical person id, or on first+last name, which the position
+          and term window make near-deterministic).
+
+          FALSE means BallotReady shows the seat held by someone else on
+          election day. NULL means the position has no office-holder term
+          covering that date, so incumbency is unknown rather than false.
+          Known misses: appointed or mid-term-succeeded officials whose term
+          dates do not straddle election day, and name variants (nicknames,
+          changed surnames) on candidates ER has not linked to their
+          office-holder record.
         data_tests:
           - accepted_values:
               arguments:


### PR DESCRIPTION
Closes [DATA-2201](https://goodparty.clickup.com/t/90132012119/DATA-2201).

## Problem

`candidacy.is_incumbent` is fed only by TechSpeed enrichment. The mart merge is `coalesce(ts.is_incumbent, br.is_incumbent)` and the BR side is a hardcoded NULL, because BallotReady's candidacy feed carries no incumbency field. gp_api and DDHQ are excluded outright.

TechSpeed is retired and barely touched the 2026 base, so the column is NULL for ~85% of engaged 2026 candidacies. That blocks challenger-vs-incumbent targeting and leaves the HubSpot `Candidate Type` property blank for most of the base.

(`candidacy_stage` has no incumbency column. Incumbency is a candidacy-grain attribute, so the fix lives on `candidacy` and reaches stage-level consumers from there.)

## Fix

Reconstruct incumbency from BallotReady office-holder terms, which carry it implicitly: a candidate is the incumbent when a term on the **same position** covers **election day**. The candidate is matched to that term on canonical person id, or on first+last name.

Three-valued output:

- `true` — a covering term on that position belongs to this candidate.
- `false` — a covering term exists and is either held by someone else or vacant. Nobody is the incumbent of an empty seat.
- `null` — no covering term for the position, or the candidate's person did not resolve, so incumbency is unknown rather than "challenger".

TechSpeed still wins wherever it enriched the candidacy, so no existing label changes; this is purely additive.

Also pulls the `gp_person_id` resolution out of the final SELECT into a `candidacy_person` CTE, which now carries the contest date too, so the incumbency join reuses both. Same joins, same result.

## Why the name arm is there

It compensates for a person-resolution gap, and it is not small: on the 2026 product base it supplies 30% of the incumbent flags.

| | 2026 product sign-ups | Pre-2026 |
|---|---|---|
| Candidacies | 12,071 | 29,135 |
| Labeled (either way) | 10,472 | 26,704 |
| Incumbents with name arm | 506 | 8,755 |
| Incumbents person-id only | 354 | 8,703 |

Coverage is identical either way, since a label depends on whether the position has a covering term rather than on which arm matched. What moves is the incumbent signal itself.

The arm was dropped in an earlier commit and restored after a hand audit. Ten candidacies that matched an office holder by name but not by person id were verified against Ballotpedia, state and county election records, and local news: **all ten were the same human, with no name collisions**, and nine were genuinely the incumbent. The tenth is the same human but not the incumbent, because BallotReady credits her a term she lost in a December runoff — an upstream data error that corrupts the person-id path equally, so it argues neither way.

Position and term window pin the comparison to that seat's handful of holders, which is what makes bare name equality safe here.

Person-level entity resolution is now tracked as [DATA-2268](https://app.clickup.com/t/86ajz7bbh), which carries removal of this name arm as its acceptance test.

## Validation

Built in dev.

| Segment | Labeled before | Labeled after | Total |
|---|---|---|---|
| 2026 product sign-ups | 700 | 9,963 | 11,536 |
| 2026 all | 47,615 | 105,462 | 122,882 |
| Pre-2026 product sign-ups | 21,647 | 26,705 | 29,145 |

478 of the 2026 product sign-ups come out as incumbents. Spot-checking against known officeholders (e.g. the LA mayoral race) looks right.

`unique_candidacy_gp_candidacy_id` and the `gp_person_id` relationship test pass, so the CTE refactor introduces no fan-out.

One test fails in my dev run: `assert_candidacy_hubspot_contact_id_not_a_company` (11,260). It is unrelated to this change — my personal dev schema holds a July copy of `int__civics_candidacy_gp_api` from before the `hubspot_contact_id` fix, and dbt Cloud's defer prefers it over prod. That stale relation has 11,260 rows whose `hubspot_contact_id` is a company id; the production relation has 0, and the same test passes against the production `candidacy` table. A clean PR schema will not hit it.

## Known limitations

- Appointed or mid-term-succeeded officials whose term dates do not straddle election day are missed.
- Name variants (nicknames, changed surnames) are missed on candidates ER has not linked. Exact equality only.
- Both misses run toward labeling an incumbent as a challenger (minor over-targeting), never toward a false incumbent.
- Positions with no BallotReady office-holder coverage stay NULL, about 14% of 2026 candidacies.
- BallotReady office-holder terms can credit a seat to someone who led a November plurality but lost a runoff. Noted as a separate follow-up on DATA-2268.

## Note for reviewers

This fills `is_incumbent` for roughly 58k more 2026 candidacies, which flows to the HubSpot reverse-ETL `Candidate Type` property (`candidacy_hubspot`) and to the election API candidacy writer. Both are intended, but the HubSpot write is outward-facing, so worth a look before merge.
