### PR TITLE
[DATA-2255] Carry district population on int__icp_offices

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -3894,6 +3894,59 @@ models:
               length(block_geoid) = 15 and length(block_group_geoid) = 12
               and length(tract_geoid) = 11
 
+  - name: int__district_population
+    description: >
+      The local-district rollup of the substrate: one row per
+      (state_postal_code, district_type, district_name), a pure GROUP BY over
+      int__district_census_allocation. Because the substrate conserves mass per
+      (block, district_type), district_population is the
+      block-population-weighted district total, and it is fractional by design.
+      Local (curated substrate) types only; statewide rows use a different
+      population basis (exact whole-state census including zero-voter blocks)
+      and live in district_census_stats, which unions this rollup with that
+      branch. Extracted out of that mart so district-grain consumers in the
+      intermediate layer can join population without an intermediate model
+      reading a mart. Read one district_type at a time: each type independently
+      tiles the country, so summing across types double-counts.
+    columns:
+      - name: state_postal_code
+        description: Uppercase two-letter state postal code
+        data_tests:
+          - not_null
+      - name: district_type
+        description: L2 district column name (the curated substrate subset)
+        data_tests:
+          - not_null
+      - name: district_name
+        description: Normalized L2 district name
+        data_tests:
+          - not_null
+      - name: district_population
+        description: >
+          Census population allocated to the district (fractional by design;
+          round for display). Voter-block allocated, so it carries the
+          substrate's documented zero-voter-block undercount.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: n_census_blocks
+        description: Distinct census blocks contributing to the district
+        data_tests:
+          - not_null
+      - name: registered_voters
+        description: L2 registered voters in the district, summed over its blocks
+        data_tests:
+          - not_null
+    data_tests:
+      - dbt_utils.unique_combination_of_columns:
+          name: district_population_unique_key
+          arguments:
+            combination_of_columns:
+              [state_postal_code, district_type, district_name]
+
   - name: int__serve_block_coverage
     description: >
       The count-once engine (DATA-1993, epic DATA-1359). One row per (census block,

--- a/dbt/project/models/intermediate/civics/int__district_population.sql
+++ b/dbt/project/models/intermediate/civics/int__district_population.sql
@@ -1,0 +1,28 @@
+-- int__district_population: the local-district rollup of the census substrate, one
+-- row per (state_postal_code, district_type, district_name). A pure GROUP BY over
+-- int__district_census_allocation, which already conserves mass per (block, type),
+-- so district_population is the block-population-weighted district total. It is
+-- FRACTIONAL by design; round for display downstream.
+--
+-- Local (curated substrate) types only. Statewide rows carry a different
+-- population basis (EXACT whole-state census, including zero-voter blocks) and
+-- stay in district_census_stats, which unions this rollup with that branch.
+--
+-- Extracted out of that mart so district-grain consumers in the intermediate
+-- layer (ICP office sizing) can join population without an intermediate model
+-- reaching up into a mart.
+--
+-- Read ONE district_type at a time: summing across types double-counts, since
+-- each type independently tiles the country.
+select
+    state_postal_code,
+    district_type,
+    district_name,
+    cast(sum(allocated_population) as double) as district_population,
+    -- count(distinct): unambiguously "distinct census blocks". The substrate's
+    -- tested (block, type, name) key makes this == count(*), but distinct is
+    -- self-documenting.
+    count(distinct block_geoid) as n_census_blocks,
+    sum(voters_in_block_district) as registered_voters
+from {{ ref("int__district_census_allocation") }}
+group by state_postal_code, district_type, district_name

--- a/dbt/project/models/intermediate/icp/int__icp.yaml
+++ b/dbt/project/models/intermediate/icp/int__icp.yaml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: int__icp_offices
-    description: "ICP offices with voter counts per district (state, district type, and district name)"
+    description: "ICP offices with voter counts and census population per district (state, district type, and district name)"
     columns:
       - name: br_database_position_id
         description: "BallotReady database position ID"
@@ -37,6 +37,17 @@ models:
           - accepted_values:
               arguments:
                 values: [true, false]
+      - name: district_population
+        description: >
+          Census constituents in the district, from int__district_population.
+          Carried for sizing and market analysis; no ICP gate reads it. Null
+          where the district's type falls outside the census substrate's curated
+          type set, so it is not yet a drop-in replacement for voter_count.
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+              row_condition: "district_population is not null"
       - name: voter_count
         description: "Number of voters in the district"
         tests:

--- a/dbt/project/models/intermediate/icp/int__icp_offices.sql
+++ b/dbt/project/models/intermediate/icp/int__icp_offices.sql
@@ -8,10 +8,20 @@ with
     ),
 
     l2_match as (
-        select * from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
+        -- the substrate normalizes district names (case, whitespace, trailing
+        -- "(EST.)"); the match snapshot does not, so carry a normalized copy for
+        -- the population join. The voter join stays on the raw name, which is
+        -- what int__l2_district_aggregations keys on.
+        select
+            *,
+            {{ normalize_l2_district_name("l2_district_name") }}
+            as normalized_district_name
+        from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
     ),
 
     district_counts as (select * from {{ ref("int__l2_district_aggregations") }}),
+
+    district_pop as (select * from {{ ref("int__district_population") }}),
 
     icp_position_names as (
         select name, serve_eligible, win_effective_date
@@ -28,6 +38,11 @@ select
     l2_match.l2_district_type,
     l2_match.is_matched,
     district_counts.voter_count,
+    -- census constituents for the same district. Carried for sizing and market
+    -- analysis; no ICP gate reads it yet. Null where the district's type is
+    -- outside the census substrate's curated type set, so it is not a
+    -- drop-in replacement for voter_count today.
+    district_pop.district_population,
     position.is_judicial,
     position.is_appointed,
     position.updated_at,
@@ -89,5 +104,11 @@ left join
     on l2_match.l2_district_name = district_counts.district_name
     and l2_match.l2_district_type = district_counts.district_type
     and position.state = district_counts.state_postal_code
+
+left join
+    district_pop
+    on l2_match.normalized_district_name = district_pop.district_name
+    and l2_match.l2_district_type = district_pop.district_type
+    and position.state = district_pop.state_postal_code
 
 left join icp_position_names on normalized_position.name = icp_position_names.name

--- a/dbt/project/models/marts/civics/district_census_stats.sql
+++ b/dbt/project/models/marts/civics/district_census_stats.sql
@@ -3,7 +3,8 @@
 -- district_name) -- for every district of the substrate's curated office-bearing types
 -- nationwide, PLUS one clearly-flagged statewide row per state (50 + DC).
 --
--- Rolls up int__district_census_allocation (THE SUBSTRATE). The substrate already
+-- Local rows come from int__district_population, the rollup of
+-- int__district_census_allocation (THE SUBSTRATE). The substrate already
 -- conserves mass (allocations sum to block population per (block, type)), so
 -- district_population = sum(allocated_population) is the block-population-weighted
 -- district total. It is FRACTIONAL by design (exact mass conservation; round for
@@ -32,23 +33,11 @@
 with
     substrate as (select * from {{ ref("int__district_census_allocation") }}),
 
-    -- the local (substrate-type) districts: a pure rollup of the substrate.
-    -- Exact-binds to
-    -- the substrate (assert_district_census_stats_binds_substrate).
-    local_districts as (
-        select
-            state_postal_code,
-            district_type,
-            district_name,
-            cast(sum(allocated_population) as double) as district_population,
-            -- count(distinct): unambiguously "distinct census blocks". The
-            -- substrate's tested (block, type, name) key makes this == count(*),
-            -- but distinct is self-documenting.
-            count(distinct block_geoid) as n_census_blocks,
-            sum(voters_in_block_district) as registered_voters
-        from substrate
-        group by state_postal_code, district_type, district_name
-    ),
+    -- the local (substrate-type) districts: a pure rollup of the substrate, which
+    -- lives in int__district_population so district-grain consumers in the
+    -- intermediate layer can join population without reading a mart. Exact-binds
+    -- to the substrate (assert_district_census_stats_binds_substrate).
+    local_districts as (select * from {{ ref("int__district_population") }}),
 
     -- statewide population: EXACT whole-state 2020 census total via the SAME
     -- geoid-FIPS -> fips_codes derivation the substrate uses for state_postal_code,


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/86ajxx3ax (DATA-2255)

**CI note:** the failing check is unrelated to this PR. See #779, which removes a stale padded district override that blocks every build. This PR should go green once that merges and this branch is rebased.

Prep work for moving the Serve ICP off registered voters and onto census constituents. This is deliberately the non-breaking half: it makes population available where the gate lives, without touching the gate.

## What changed

**`int__district_population` (new)** — the substrate's local-district rollup, one row per `(state_postal_code, district_type, district_name)`. `int__icp_offices` is an intermediate model and `district_census_stats` is a mart, and no intermediate model reads that mart today; extracting the rollup avoids inverting the layering. No cycle: the substrate lineage (block district map, allocation, L2) never touches ICP.

**`district_census_stats`** — now unions that rollup with its existing statewide branch. Identical output; the statewide branch keeps its own exact whole-state census basis.

**`int__icp_offices`** — exposes `district_population` next to `voter_count`. The match snapshot does not normalize district names and the substrate does, so the population join carries a normalized copy of the name. The voter join is untouched and still keys on the raw name that `int__l2_district_aggregations` uses.

## No gate changes

`icp_office_serve`, `icp_office_win` and `icp_win_supersize` keep their voter-count definitions, and nothing downstream moves.

Row counts match production exactly (286,283 both sides), and `int__district_population` is unique on its group-by key, so the added left join cannot fan out. Beyond that, I checked that no gate moved independently of its own input:

| check | result |
|---|---|
| `icp_office_serve` moved where `voter_count` unchanged | 0 |
| `icp_office_win` moved where `voter_count` unchanged | 0 |
| `icp_win_supersize` moved where `voter_count` unchanged | 0 |
| `is_judicial` differences | 0 |
| `normalized_position_type` differences | 0 |

Reproduce with:

```sql
with dev as (select * from {{ ref('int__icp_offices') }}),
prod as (select * from goodparty_data_catalog.dbt.int__icp_offices)
select
    sum(case when (d.voter_count <=> p.voter_count)
             and not (d.icp_office_serve <=> p.icp_office_serve) then 1 else 0 end) as serve_moved_input_same,
    sum(case when (d.voter_count <=> p.voter_count)
             and not (d.icp_office_win <=> p.icp_office_win) then 1 else 0 end) as win_moved_input_same,
    sum(case when (d.voter_count <=> p.voter_count)
             and not (d.icp_win_supersize <=> p.icp_win_supersize) then 1 else 0 end) as supersize_moved_input_same
from dev d join prod p on d.br_database_position_id = p.br_database_position_id
```

### About the 118,407 `voter_count` differences

That count is real but unrelated to this PR. Production has not rebuilt since #774 landed today, so `dbt.int__l2_nationwide_uniform` still returns zero-padded district names (`001` for OH State House). Every gate difference tracks its own input; none move independently, which is what the table above shows.

## Test results

`dbt build --select "int__district_population district_census_stats int__icp_offices"`: **44 pass, 0 fail**.

That includes `assert_district_census_stats_binds_substrate`, which is the check that proves the extraction is behavior-preserving, plus the three ICP tests added by #774.

## Where to inspect the built objects

Everything is materialized in the `dbt_hugh` dev schema, so reviewers can query it without rebuilding:

- `goodparty_data_catalog.dbt_hugh.int__district_population`
- `goodparty_data_catalog.dbt_hugh.district_census_stats`
- `goodparty_data_catalog.dbt_hugh.int__icp_offices`

## Coverage, measured after the padding fix

I rebuilt the L2 chain in dev with #774's padding strip applied (`int__l2_nationwide_uniform`, the match snapshot, `int__l2_block_district_map`, `int__district_census_allocation`, `int__district_population`), so these are real numbers rather than the earlier suppressed ones.

| | before rebuild | after |
|---|---|---|
| Offices with `district_population` | 87.7% | **89.3%** (255,615 of 286,283) |
| **Serve ICP offices covered** | not measured | **98.4%** (106,397 of 108,122) |

The 98.4% is the number that matters for the eventual gate swap. Serve ICP offices concentrate in district types the substrate covers well, so office-level coverage is far better than the district-level figure suggested.

Per-type null share, scoped to types the substrate covers, offices >= 100:

| district type | offices | unsized | null share |
|---|---|---|---|
| City_School_District | 770 | 107 | 13.9% |
| Community_College_District | 574 | 28 | 4.9% |
| Fire_Protection_District | 287 | 14 | 4.9% |
| School_District | 24,194 | 1,022 | 4.2% |
| everything else | | | under 3.5% |

`State_House_District`, `State_Senate_District`, `US_Congressional_District` and `State_Legislative_District` have dropped off this list entirely. Before the rebuild they were at 72.9%, 21.5%, 64.7% and 66.1%. That was the padding signature, and it is gone.

## Why the coverage canary is still not in this PR

The numbers above now make the threshold obvious: **35%** would sit well clear of the 13.9% worst case while still catching a padding-class regression, which pushed State House to 72.9%.

It still cannot ship here. CI defers unmodified models to production, and production's substrate is still on the pre-#774 padded build, so the canary would fail in CI even though it passes against a correctly rebuilt substrate. It should land once production has rebuilt, at which point it is a small, fully specified follow-up.

## Follow-on work

- Per-type coverage canary plus the true coverage baseline, once the substrate rebuilds.
- Widen the substrate's district-type scope beyond cohort-occupied types, validated with the census-direct backtest from DATA-2018.
- The gate swap itself, which needs an owner-ratified threshold and re-ratification of People Served, since the definition fingerprint changes.
- `candidacy_hubspot.sql` already falls back to `population between 1000 and 100000` using the voter-band thresholds. That fallback silently changes meaning once the gate is population-based.
- Align the snapshot skew between `int__l2_district_aggregations` (2026-07-10) and the census substrate (2026-08-04) before publishing any before-and-after comparison.

## Note for reviewers building locally

The dbt Cloud CLI can report a phantom duplicate metric in `sem_analytics__users_win.yml` (`win_active_candidates_30d` defined twice, both pointing at the same file). The file is clean; it is a stale partial-parse cache. `dbt parse` forces a full reparse and clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
