### PR TITLE
[DATA-2258] Null the NOT_MATCHED sentinel on the L2-to-BR match snapshot

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api__position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__position.sql
@@ -34,11 +34,18 @@ with
             and coalesce(tbl_override.l2_district_name, tbl_match.l2_district_name)
             = tbl_district.l2_district_name
         where
-            tbl_match.l2_district_name not in (
-                'County Committee Female Member',
-                'County Committee Male Member',
-                'President of the United States',
-                'Vice President of the United States'
+            -- null-safe: an unmatched row carries a null district name, which is not
+            -- one of these non-office names. Bare NOT IN evaluates to NULL there and
+            -- would drop the row, silently discarding any override that exists to
+            -- give that very position a district.
+            (
+                tbl_match.l2_district_name is null
+                or tbl_match.l2_district_name not in (
+                    'County Committee Female Member',
+                    'County Committee Male Member',
+                    'President of the United States',
+                    'Vice President of the United States'
+                )
             )
             and tbl_district.id is not null
             and (

--- a/dbt/project/models/marts/mban2026/candidates_outreach.sql
+++ b/dbt/project/models/marts/mban2026/candidates_outreach.sql
@@ -28,7 +28,7 @@ with
     l2_districts as (
         select name, state, l2_district_name, l2_district_type
         from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
-        where l2_district_type != 'NOT_MATCHED'
+        where is_matched
         qualify
             row_number() over (partition by name, state order by l2_district_name) = 1
     )

--- a/dbt/project/models/staging/model_predictions_source/stg_model_predictions.yaml
+++ b/dbt/project/models/staging/model_predictions_source/stg_model_predictions.yaml
@@ -75,6 +75,26 @@ models:
         tests:
           - not_null
           - unique
+      - name: is_matched
+        description: >
+          Whether the model resolved this position to an L2 district. This is the
+          only predicate for match state: do not infer it from the district
+          columns being populated.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+      - name: l2_district_type
+        description: >
+          L2 district column name, null when is_matched is false. The raw snapshot
+          spells no-match as the literal NOT_MATCHED here; staging nulls it so the
+          column cannot be mistaken for a real district.
+      - name: l2_district_name
+        description: >
+          L2 district name, null when is_matched is false. Zero padding is stripped
+          (the snapshot is not self-consistent about it) and the NOT_MATCHED
+          sentinel is nulled.
     data_tests:
       # Earliest guard on name drift; other district types have a legitimate unresolvable tail.
       - l2_district_tuple_exists:

--- a/dbt/project/models/staging/model_predictions_source/stg_model_predictions__llm_l2_br_match_20260126.sql
+++ b/dbt/project/models/staging/model_predictions_source/stg_model_predictions__llm_l2_br_match_20260126.sql
@@ -9,8 +9,14 @@ with
             br_database_id,
             state,
             -- The snapshot is not self-consistent: 365 rows carry L2's padded form.
-            ltrim('0', l2_district_name) as l2_district_name,
-            l2_district_type,
+            -- The snapshot also spells "no match" as the literal NOT_MATCHED in both
+            -- district columns instead of null, which makes a `district_name is not
+            -- null` filter read ~12k unmatched positions as matched: the strings pass
+            -- not-null checks, look like data, and join to nothing. Null them so
+            -- is_matched is the only predicate for match state. The two-way contract
+            -- is pinned by assert_l2_br_match_unmatched_rows_have_null_district.
+            nullif(ltrim('0', l2_district_name), 'NOT_MATCHED') as l2_district_name,
+            nullif(l2_district_type, 'NOT_MATCHED') as l2_district_type,
             is_matched,
             llm_reason,
             confidence,

--- a/dbt/project/tests/assert_l2_br_match_unmatched_rows_have_null_district.sql
+++ b/dbt/project/tests/assert_l2_br_match_unmatched_rows_have_null_district.sql
@@ -1,0 +1,14 @@
+-- is_matched is the only predicate for match state, so the district columns must be
+-- null exactly when is_matched is false. The raw snapshot spells "no match" as the
+-- literal NOT_MATCHED in both columns; staging nulls it. Asserting both directions
+-- means a future snapshot that reintroduces the sentinel, or that ships a matched row
+-- with no district, fails here rather than downstream, where a `district_name is not
+-- null` filter would quietly count unmatched positions as matched.
+select id, is_matched, l2_district_type, l2_district_name
+from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
+where
+    (
+        not coalesce(is_matched, false)
+        and (l2_district_type is not null or l2_district_name is not null)
+    )
+    or (is_matched and (l2_district_type is null or l2_district_name is null))


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/86ajygzb8 (DATA-2258)

## The trap

The LLM L2-to-BallotReady match snapshot encodes "no match" as a literal string, not null:

```
is_matched = false,  l2_district_type = 'NOT_MATCHED',  l2_district_name = 'NOT_MATCHED'
```

12,272 rows. Exactly one spelling, no variants, no empty strings, no nulls.

The strings pass not-null checks, look like data in a preview, and join to nothing. So any filter using `l2_district_name is not null` to mean "this position has a district" quietly counts ~12k unmatched positions as matched.

This is not theoretical. While decomposing district-population coverage I attributed 1,700 offices to "no L2 match" when the real number was 13,820. The sentinel rows sailed through a not-null filter and hid 12,120 offices. Wrong by a factor of eight, in a number being used to reason about whether the Serve ICP could move to census constituents.

## The fix

Null both district columns for unmatched rows, so `is_matched` is the only predicate for match state and a null district means what it looks like.

Then pin the contract in **both** directions: the district columns are null exactly when `is_matched` is false. The current snapshot satisfies that with zero exceptions across 287,622 rows, so the test fixes the contract rather than tolerating drift. If a future snapshot reintroduces the sentinel, or ships a matched row with no district, it fails at staging instead of silently corrupting counts downstream.

## Behavior-neutral, verified per consumer

| consumer | why unaffected |
|---|---|
| `int__serve_district_resolution` | already `where is_matched` |
| `int__zip_code_to_br_office` | already `where ... and is_matched` |
| `m_election_api__district_top_issues` | already `where m.is_matched` |
| `int__icp_offices` | joins the district tuple; sentinel matched nothing, null matches nothing |
| `m_election_api__position` | requires a district to resolve, so these rows already fall to its `unmatched_br_positions` branch with a null `district_id` |
| `candidates_outreach` | the only reader of the string, changed to `is_matched` |

On that last one, the old and new predicates are provably equivalent on the current data:

| | rows |
|---|---|
| total | 287,622 |
| `l2_district_type != 'NOT_MATCHED'` keeps | 275,350 |
| `is_matched` keeps | 275,350 |
| **rows where they disagree** | **0** |

It is left as `is_matched` rather than the string because after this change the string no longer exists, and a filter comparing against a value that cannot occur is its own trap.

## Test results

`dbt build` on the changed models: the new contract test passes.

One pre-existing failure appears in my dev run, `l2_district_tuple_exists` with 298 rows, and it is **not** from this change: its `row_condition` gates on `is_matched`, and this change only touches rows where `is_matched` is false. Traced to a stale shadow copy of `int__l2_district_aggregations` in my personal dev schema, loaded 2026-07-10 and still carrying 290 zero-padded district names, which shadows production's clean 2026-08-07 build. Running the same comparison against production returns **0** rows for both the production and modified snapshots, so CI should be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)