### PR TITLE
[DATA-2261] Expose district_population on positions, add the coverage canary

### DIFF
--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -2735,6 +2735,23 @@ models:
               config:
                 where: "icp_voter_count is not null"
 
+      - name: district_population
+        description: >
+          Census population of the matched district: the constituents the
+          officeholder serves, as opposed to icp_voter_count's registered
+          voters. Voter-block allocated from the 2020 decennial frame, so it
+          carries the substrate's documented zero-voter-block undercount and is
+          fractional by design (round for display). No ICP gate reads it.
+          NULL when the position has no matched L2 district, and also when its
+          district type falls outside the census substrate's curated type set,
+          so a NULL here does not imply a NULL icp_voter_count.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+              config:
+                where: "district_population is not null"
+
       - name: is_win_icp
         description: >
           Whether this position meets the Win ICP criteria (office type and

--- a/dbt/project/models/marts/civics/positions.sql
+++ b/dbt/project/models/marts/civics/positions.sql
@@ -24,6 +24,12 @@ select
     icp.is_matched as is_l2_matched,
     icp.voter_count as icp_voter_count,
 
+    -- Census constituents for the same district. Keeps the canonical name it
+    -- carries everywhere else (int__district_population, district_census_stats)
+    -- rather than an icp_ prefix, since the population is a property of the
+    -- district and no ICP gate reads it.
+    icp.district_population,
+
     -- ICP eligibility flags (position-level, not date-gated)
     icp.icp_office_win as is_win_icp,
     icp.icp_office_serve as is_serve_icp,

--- a/dbt/project/tests/assert_icp_offices_district_population_null_share_by_type.sql
+++ b/dbt/project/tests/assert_icp_offices_district_population_null_share_by_type.sql
@@ -1,0 +1,44 @@
+-- Coverage canary for district_population, the population twin of
+-- assert_icp_offices_voter_count_null_share_by_type. A band canary, not a fixed count.
+--
+-- Why per type rather than an overall coverage rate: a join break concentrates in one
+-- district type instead of spreading evenly, so the aggregate hides it. The L2
+-- zero-padding drift moved overall coverage by under two points while pushing
+-- State_House_District's null share to 73%, which is invisible in a headline number and
+-- glaring here.
+--
+-- Scoped to (state, type) pairs the substrate actually covers. Types outside the
+-- curated substrate subset are 100% null by design, not by breakage, so including them
+-- would make the test meaningless.
+--
+-- Threshold: 35%. The worst covered type today is City_School_District at 13.9% over 41
+-- qualifying types, so this clears real drift while still tripping on a padding-class
+-- regression. Raise it only with the measurement that justifies it.
+with
+    substrate_covered as (
+        select distinct state_postal_code as state, district_type
+        from {{ ref("int__district_population") }}
+    ),
+
+    sizeable_offices as (
+        select icp.l2_district_type, icp.district_population
+        from {{ ref("int__icp_offices") }} as icp
+        join
+            substrate_covered
+            on substrate_covered.state = icp.state
+            and substrate_covered.district_type = icp.l2_district_type
+        where
+            icp.is_matched
+            and not coalesce(icp.is_judicial, false)
+            and not coalesce(icp.is_appointed, false)
+    )
+
+select
+    l2_district_type,
+    count(*) as offices,
+    count(case when district_population is null then 1 end) as unsized_offices
+from sizeable_offices
+group by l2_district_type
+having
+    count(*) >= 100
+    and count(case when district_population is null then 1 end) * 1.0 / count(*) > 0.35


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/86ajymmwq (DATA-2261). Also closes the one deferred acceptance criterion on DATA-2255.

Two things, both small.

## 1. `district_population` on the `positions` civics mart

Requested on the #778 review thread:

> is there a reason not to go all the way and push this population column into the positions table in the civics mart? ... it would be extra sweet to just be able to work on these questions using a canonical column in the civics mart

With the stated reason it matters: this match has been done ad hoc by agents repeatedly, "and they've found so many wrong ways to do it." A canonical column removes a recurring source of wrong answers, which is a better argument for it than convenience.

`positions` is already a thin projection over `int__icp_offices`, so this is one pass-through column plus docs.

**On the name.** `district_population`, not `icp_district_population`. It matches the name the column carries in `int__district_population` and `district_census_stats`, and the population is a property of the district that no ICP gate reads, so its sibling's `icp_` prefix does not apply. Happy to flip it if reviewers prefer local consistency with `icp_voter_count` over cross-model consistency.

The docs also spell out something easy to get wrong: a null `district_population` does **not** imply a null `icp_voter_count`. They have different causes. A position can be perfectly well matched to an L2 district with a real voter count and still have no population, because its district type falls outside the census substrate's curated type set. That is the case for 1,625 Serve-ICP offices today.

## 2. The per-type coverage canary

Deferred from #778 because CI defers unmodified models to production, and production's substrate still carried zero-padded district names at the time, so a correctly written test would have failed. That has since propagated, so the threshold is now measurable rather than guessed.

**Threshold 35%**, measured against production: 41 qualifying district types, worst is `City_School_District` at 13.9%.

**Per type, not overall.** This is the part worth keeping. When the zero-padding drift broke State House districts, overall coverage moved from 89.3% to 87.7% — under two points, invisible in any dashboard. Within `State_House_District` the null share hit 73%. A join break concentrates in one type instead of spreading evenly, so the aggregate is exactly where it hides. That reasoning is already encoded in `assert_icp_offices_voter_count_null_share_by_type` from #774; this is its population twin.

Scoped to `(state, type)` pairs the substrate actually covers, since types outside the curated subset are 100% null by design rather than by breakage.

## Verification

`dbt build` on `positions` plus the new test: the canary passes, and passes standalone on a re-run.

The new column carries its source exactly. Comparing dev `positions` against production `int__icp_offices` across all 286,283 rows, `district_population` differs on **0** rows.

`positions.sql` is a flat SELECT over one CTE plus one left join, so adding a projected column cannot alter sibling expressions.

**Caveat, stated plainly.** I could not produce a clean full parity table locally. My dev schema holds stale shadow copies that make several unrelated columns differ: `int__l2_district_aggregations` is stuck on a 2026-07-10 load with padded names, which corrupts `icp_voter_count` there, and `int__civics_position_office_type` is short 568 rows, which is the sole cause of a `not_null_positions_office_type` failure in my run. Production has zero null `office_type`, so that failure is local. CI builds against production artifacts and should be clean, but it is the real verifier here, not my run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)