### PR TITLE
[DATA-2264] Whole-person district_population on positions, plus [DATA-2242] normalized voter_count fallback

### DIFF
--- a/dbt/project/models/intermediate/icp/int__icp.yaml
+++ b/dbt/project/models/intermediate/icp/int__icp.yaml
@@ -49,7 +49,13 @@ models:
                 min_value: 0
               row_condition: "district_population is not null"
       - name: voter_count
-        description: "Number of voters in the district"
+        description: >
+          L2 registered voters in the matched district, and the input to all
+          three ICP gates. Resolved on the exact district name first, falling
+          back to the normalized name (case, whitespace, trailing "(EST.)") when
+          the exact name finds nothing, since the match snapshot carries naming
+          drift the aggregations table does not. NULL only where neither
+          spelling resolves, which leaves the ICP gates NULL rather than false.
         tests:
           - dbt_expectations.expect_column_values_to_be_between:
               arguments:

--- a/dbt/project/models/intermediate/icp/int__icp_offices.sql
+++ b/dbt/project/models/intermediate/icp/int__icp_offices.sql
@@ -10,8 +10,7 @@ with
     l2_match as (
         -- the substrate normalizes district names (case, whitespace, trailing
         -- "(EST.)"); the match snapshot does not, so carry a normalized copy for
-        -- the population join. The voter join stays on the raw name, which is
-        -- what int__l2_district_aggregations keys on.
+        -- the population join and the voter-count fallback below.
         select
             *,
             {{ normalize_l2_district_name("l2_district_name") }}
@@ -19,7 +18,35 @@ with
         from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
     ),
 
-    district_counts as (select * from {{ ref("int__l2_district_aggregations") }}),
+    -- aliased on both lookups: a bare voter_count on either would shadow the
+    -- coalesced select alias the gates read, silently gating on the exact name only.
+    district_counts as (
+        select
+            state_postal_code,
+            district_type,
+            district_name,
+            voter_count as voter_count_exact
+        from {{ ref("int__l2_district_aggregations") }}
+    ),
+
+    -- Fallback keyed on the normalized name: the match snapshot carries L2's
+    -- "(EST.)" and whitespace drift, so the exact join above misses and leaves the
+    -- position unsized with null ICP gates.
+    --
+    -- max() not sum(): 7 keys nationwide have two raw spellings of one district, so
+    -- summing double counts its voters. Deduping also keeps this join 1:1.
+    district_counts_normalized as (
+        select
+            state_postal_code,
+            district_type,
+            {{ normalize_l2_district_name("district_name") }} as district_name,
+            max(voter_count) as voter_count_normalized
+        from {{ ref("int__l2_district_aggregations") }}
+        group by
+            state_postal_code,
+            district_type,
+            {{ normalize_l2_district_name("district_name") }}
+    ),
 
     district_pop as (select * from {{ ref("int__district_population") }}),
 
@@ -37,7 +64,12 @@ select
     l2_match.l2_district_name,
     l2_match.l2_district_type,
     l2_match.is_matched,
-    district_counts.voter_count,
+    -- exact name first, normalized only as a fallback, so no already-sized position
+    -- changes value
+    coalesce(
+        district_counts.voter_count_exact,
+        district_counts_normalized.voter_count_normalized
+    ) as voter_count,
     -- census constituents for the same district. Carried for sizing and market
     -- analysis; no ICP gate reads it yet. Null where the district's type is
     -- outside the census substrate's curated type set, so it is not a
@@ -53,9 +85,9 @@ select
             or position.is_appointed
             or icp_position_names.name is null
         then false
-        when district_counts.voter_count is null
+        when voter_count is null
         then null
-        when district_counts.voter_count not between 500 and 100000
+        when voter_count not between 500 and 100000
         then false
         else true
     end as icp_office_win,
@@ -67,9 +99,9 @@ select
             or icp_position_names.name is null
             or not icp_position_names.serve_eligible
         then false
-        when district_counts.voter_count is null
+        when voter_count is null
         then null
-        when district_counts.voter_count not between 1000 and 100000
+        when voter_count not between 1000 and 100000
         then false
         else true
     end as icp_office_serve,
@@ -82,9 +114,9 @@ select
             or position.is_appointed
             or icp_position_names.name is null
         then false
-        when district_counts.voter_count is null
+        when voter_count is null
         then null
-        when district_counts.voter_count <= 100000
+        when voter_count <= 100000
         then false
         else true
     end as icp_win_supersize,
@@ -104,6 +136,12 @@ left join
     on l2_match.l2_district_name = district_counts.district_name
     and l2_match.l2_district_type = district_counts.district_type
     and position.state = district_counts.state_postal_code
+
+left join
+    district_counts_normalized
+    on l2_match.normalized_district_name = district_counts_normalized.district_name
+    and l2_match.l2_district_type = district_counts_normalized.district_type
+    and position.state = district_counts_normalized.state_postal_code
 
 left join
     district_pop

--- a/dbt/project/models/marts/civics/m_civics.yaml
+++ b/dbt/project/models/marts/civics/m_civics.yaml
@@ -2739,12 +2739,17 @@ models:
         description: >
           Census population of the matched district: the constituents the
           officeholder serves, as opposed to icp_voter_count's registered
-          voters. Voter-block allocated from the 2020 decennial frame, so it
-          carries the substrate's documented zero-voter-block undercount and is
-          fractional by design (round for display). No ICP gate reads it.
+          voters. A whole-person count, rounded from the exact allocation on
+          int__district_population, which stays fractional so that allocations
+          sum exactly to block population. Still an estimate: voter-block
+          allocated from the 2020 decennial frame, so it carries the substrate's
+          documented zero-voter-block undercount. No ICP gate reads it.
           NULL when the position has no matched L2 district, and also when its
           district type falls outside the census substrate's curated type set,
           so a NULL here does not imply a NULL icp_voter_count.
+          Do not sum across rows to get a population total: districts overlap
+          and each district type independently tiles the country, so the sum
+          double-counts. Use people_served for a deduplicated total.
         data_tests:
           - dbt_utils.accepted_range:
               arguments:

--- a/dbt/project/models/marts/civics/positions.sql
+++ b/dbt/project/models/marts/civics/positions.sql
@@ -24,16 +24,10 @@ select
     icp.is_matched as is_l2_matched,
     icp.voter_count as icp_voter_count,
 
-    -- Census constituents for the same district. Keeps the canonical name it
-    -- carries everywhere else (int__district_population, district_census_stats)
-    -- rather than an icp_ prefix, since the population is a property of the
-    -- district and no ICP gate reads it.
-    --
-    -- Rounded to a whole person: the allocation is fractional upstream so that
-    -- allocations sum exactly to block population (the mass-conservation
-    -- invariant the rollups and binding tests rely on), but a leaf mart column
-    -- that reads as a count of people should not carry a fractional tail. The
-    -- exact value stays available on int__district_population.
+    -- Census constituents for the same district. No icp_ prefix: the population is a
+    -- property of the district and no ICP gate reads it. Rounded here because the
+    -- allocation is only fractional upstream to keep mass conservation exact; the
+    -- unrounded value stays on int__district_population.
     cast(round(icp.district_population) as bigint) as district_population,
 
     -- ICP eligibility flags (position-level, not date-gated)

--- a/dbt/project/models/marts/civics/positions.sql
+++ b/dbt/project/models/marts/civics/positions.sql
@@ -28,7 +28,13 @@ select
     -- carries everywhere else (int__district_population, district_census_stats)
     -- rather than an icp_ prefix, since the population is a property of the
     -- district and no ICP gate reads it.
-    icp.district_population,
+    --
+    -- Rounded to a whole person: the allocation is fractional upstream so that
+    -- allocations sum exactly to block population (the mass-conservation
+    -- invariant the rollups and binding tests rely on), but a leaf mart column
+    -- that reads as a count of people should not carry a fractional tail. The
+    -- exact value stays available on int__district_population.
+    cast(round(icp.district_population) as bigint) as district_population,
 
     -- ICP eligibility flags (position-level, not date-gated)
     icp.icp_office_win as is_win_icp,


### PR DESCRIPTION
Tickets: [DATA-2264](https://app.clickup.com/t/86ajyrfez) and [DATA-2242](https://app.clickup.com/t/86ajxb7jm)

Two changes. The first is value-neutral. **The second changes ICP flags on 3,724 positions and can grow the People Served cohort, so it needs metric-owner sign-off.**

## 1. `positions.district_population` as a whole-person integer

`double` to `bigint`. A mart column that reads as a count of people shouldn't carry a fractional tail. The allocation stays fractional upstream on purpose — that's what keeps allocations summing exactly to block population, which the rollups and binding tests depend on — so `int__district_population` keeps the exact value and the mart rounds.

Verified: **0** of 286,283 rows differ from the previous float rounded to nearest, and no other column changed.

Not applied to `district_census_stats` (a reference table `people_served` does arithmetic on, with a `1e-6` binding test) or `people_served` (the North Star).

## 2. Normalized-name fallback for `voter_count`

The match snapshot emits district names carrying L2's `(EST.)` and whitespace drift, which the exact-name join to `int__l2_district_aggregations` misses. 6,117 matched positions were left unsized, and an unsized position gets NULL ICP gates rather than false. `School_District` (3,867) and `City` (513) dominate.

Fix resolves on the exact name first and falls back to the normalized name **only where the exact join finds nothing**, so no already-sized position can change:

| safety check | result |
|---|---|
| Positions with an existing `voter_count` whose value changed | **0** of 286,283 |
| `int__icp_offices` uniqueness | passes (fallback deduped, join stays 1:1) |

Sizes 3,732 of the 6,117.

### What this moves

All changes are NULL leaving NULL, never a true/false flip:

| flag | NULL → true | NULL → false |
|---|---|---|
| `icp_office_win` | **3,313** | 411 |
| `icp_office_serve` | **361** | 169 |
| `icp_win_supersize` | 138 | 3,586 |

The 361 new Serve-ICP offices become eligible for `in_people_served_cohort`, so the North Star cohort can grow, and `icp_serve` syncs outward to HubSpot. These are corrections — the positions should always have been sized — but they're real value changes on governed surfaces, so please ratify rather than merging on a green test suite.

### Two notes for reviewers

Both lookups alias `voter_count`. A bare column on either would shadow the coalesced select alias the gates read, silently gating on the exact name alone. Databricks raised `AMBIGUOUS_REFERENCE` rather than resolving it quietly, which is the only reason it didn't ship as a silent bug.

`max()` not `sum()` on the fallback: 7 keys nationwide carry two raw spellings of one district (e.g. `SYCAMORE TWP` 13,442 vs `SYCAMORE TWP (EST.)` 935), so summing would double count. `max()` is a safe default here because the fallback can't touch an already-sized position, but what `(EST.)` means in L2 is unresolved.

The remaining 2,385 unsized positions are drift in the frozen snapshot. Accepted rather than fixed, since the crosswalk is being retired.

## Tests

`dbt build --select "int__icp_offices positions"`: **36 pass, 0 fail**, including uniqueness on `int__icp_offices` and the per-type coverage canary from #786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)