### PR TITLE
Add data-ticket-triage skill

### DIFF
--- a/.claude/skills/data-ticket-triage/SKILL.md
+++ b/.claude/skills/data-ticket-triage/SKILL.md
@@ -50,7 +50,7 @@ One row nationwide is a data-entry gap and takes a seeded override. Thousands cl
 
 ## 3. Read the consuming application when the mart looks fine
 
-If the mart has the data and the product still does not show it, the filter is in the app. The product monorepo is checked out at `~/projects/gp-data-parent/omni/packages/`:
+If the mart has the data and the product still does not show it, the filter is in the app. The product monorepo is the `omni` repository: https://github.com/thegoodparty/omni
 
 | Package | What it tells you |
 |---|---|
@@ -61,13 +61,11 @@ If the mart has the data and the product still does not show it, the filter is i
 | `contracts`, `gp-sdk`, `nest-common` | Shared types and clients. |
 | `runbooks` | Operational procedures. |
 
-Read-only. Never edit these from a data-platform ticket.
+Read-only. Never edit these from a data-platform ticket without user confirmation first.
 
 Two things worth checking every time: the service may read a *different* table than the ticket names (e.g. it uses one table only to collect IDs, then reads the real rows from another), and it may apply an env-var threshold or a `>= today` window that silently excludes the record. Both change the diagnosis.
 
-There is also a standalone `election-api` checkout under `~/projects/gp-data-parent/` — it is stale. Use the one in `omni`.
-
-Prod Postgres (`psql service=electiondb`) is VPC-only and will time out locally. `psql service=electiondb-dev` works. The dbt marts are the source of truth for what the writer will publish, so a mart query is usually sufficient evidence without touching Postgres at all.
+The dbt marts are the source of truth for what the writer will publish, so a mart query is usually sufficient evidence without touching Postgres at all.
 
 ## 4. Choose the smallest fix
 

--- a/.claude/skills/data-ticket-triage/SKILL.md
+++ b/.claude/skills/data-ticket-triage/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: data-ticket-triage
+description: Investigate a ClickUp data ticket end to end and ship the fix — read the ticket, trace the symptom through the dbt DAG in Databricks, post a root-cause note on the ticket, implement the smallest fix that reuses an existing repair pattern, verify in dev, open the PR, and iterate with the delegate reviewer until it approves. Use when given a ClickUp ticket ID or URL (DATA-XXXX) and asked to investigate, diagnose, or resolve it — production data bugs, missing or wrong records in a mart, a value the product should show but does not.
+---
+
+# Data ticket triage
+
+End-to-end workflow for a ClickUp data ticket. The seven steps below are the whole job; do all of them unless told to stop early.
+
+The hard part is almost never the fix. It is finding the exact model where the data stops existing, and resisting the urge to generalize before you know how isolated the case is.
+
+## 1. Read the ticket
+
+```
+mcp__clickup__clickup_get_task(task_id="DATA-XXXX", include=["description"])
+mcp__clickup__clickup_get_task_comments(task_id="DATA-XXXX")
+```
+
+Read the reporter's hypothesis but do not inherit it. Tickets routinely name the wrong layer ("the district is missing") when the break is somewhere else entirely. Treat the described symptom as fact and the diagnosis as a guess.
+
+Note the concrete identifiers: a customer email, a place, an office name, a race. You need at least one to anchor the trace.
+
+## 2. Trace the symptom through the DAG
+
+Find the **last model that has the record and the first that does not**. That boundary is the root cause; everything upstream of it is a distraction.
+
+Work backwards from the surface the user complained about, not forwards from the source. Read the model that serves the symptom, list its inputs, and check each. Then recurse into whichever one is empty. Usually 3-6 queries.
+
+Query prod relations directly with the dbt Cloud CLI from `dbt/project/`:
+
+```bash
+dbt show --inline "select ... from {{ ref('some_model') }} where ..." --output json --limit 20
+```
+
+`--output json` is much easier to read than the default table, which truncates columns to `...`.
+
+At each hop ask: is the record absent, or present with a null join key? A null FK that a downstream inner join drops is the most common shape of these bugs, and it looks identical to "missing data" from the outside.
+
+Once you find the boundary, **quantify how isolated it is** before choosing a fix. This decides everything in step 4:
+
+```sql
+-- how many rows have this defect, and does the defect cluster?
+select <suspect_dimension>, count(*) as n
+from {{ ref('the_model_where_it_breaks') }}
+where <the_null_or_missing_condition>
+group by <suspect_dimension>
+```
+
+One row nationwide is a data-entry gap and takes a seeded override. Thousands clustered on one dimension is a modeling bug and takes a code change. Do not guess which you have.
+
+## 3. Read the consuming application when the mart looks fine
+
+If the mart has the data and the product still does not show it, the filter is in the app. The product monorepo is checked out at `~/projects/gp-data-parent/omni/packages/`:
+
+| Package | What it tells you |
+|---|---|
+| `election-api` | Serves races, positions, places, districts, the office picker. `prisma/schema/*.prisma` shows required FKs and unique constraints — this is *why* a mart inner-joins and drops rows. `src/<domain>/*.service.ts` shows the real query, including thresholds and date windows the mart knows nothing about. |
+| `gp-api` | Win product backend — campaigns, onboarding, path-to-victory, voters. |
+| `gp-webapp` | Frontend. Useful for what the user literally saw. |
+| `gp-admin`, `candidate-sites` | Other surfaces. |
+| `contracts`, `gp-sdk`, `nest-common` | Shared types and clients. |
+| `runbooks` | Operational procedures. |
+
+Read-only. Never edit these from a data-platform ticket.
+
+Two things worth checking every time: the service may read a *different* table than the ticket names (e.g. it uses one table only to collect IDs, then reads the real rows from another), and it may apply an env-var threshold or a `>= today` window that silently excludes the record. Both change the diagnosis.
+
+There is also a standalone `election-api` checkout under `~/projects/gp-data-parent/` — it is stale. Use the one in `omni`.
+
+Prod Postgres (`psql service=electiondb`) is VPC-only and will time out locally. `psql service=electiondb-dev` works. The dbt marts are the source of truth for what the writer will publish, so a mart query is usually sufficient evidence without touching Postgres at all.
+
+## 4. Choose the smallest fix
+
+**Reuse an existing repair pattern if one exists. Do not build a generalized solution when we have no generalized pattern for the problem.** See `references/repair-patterns.md` for the catalog of override seeds and the chains they repair.
+
+Order of preference:
+
+1. A row in an existing override seed. Zero new machinery.
+2. A new override seed following the established shape (sparse match tuple or key + corrected value + a documented `reason` column), plus a `coalesce` at the point of use.
+3. A code change to the model logic — only when step 2's quantification showed the defect is systemic, not a single data gap.
+
+Key the override at the grain the defect actually lives at, which is often coarser than the reporting grain. Keying at geography rather than position, for instance, fixes every position in that geography and any the vendor adds later, from one row.
+
+If the fix touches an incremental model, a seed edit will not propagate: the source row's `updated_at` predates the watermark. Either re-emit override-matched rows on every run (`or <override>.<col> is not null` in the incremental filter — the established pattern) or document the required `--full-refresh`. Re-emitting is preferable when the model is large.
+
+Add a test only for a real failure mode, not for coverage. The two that matter for an override seed: a `relationships` test so a typo'd key fails loudly, and an `expression_is_true` asserting the override actually reached the target grain — otherwise a stale watermark or a bad key leaves it a silent no-op that looks fixed.
+
+## 5. Post the root cause on the ticket
+
+Do this **before** implementing, so the finding is recorded even if the fix takes another pass.
+
+```
+mcp__clickup__clickup_create_comment(task_id="DATA-XXXX", entity_id="<id>", entity_type="task", comment_text="...")
+```
+
+Write it as an engineer's note. Bullets are fine. Plain prose, no headers beyond a `Root cause` line, no bold-labeled sections, no emoji.
+
+What it must contain:
+
+- What is **not** wrong, when the ticket guessed wrong. Say so explicitly with the evidence that clears it.
+- The actual boundary: which model, which column, which join.
+- Why that boundary drops the row (the FK, the inner join, the filter).
+- How isolated it is, with the count.
+- One line on the intended fix.
+
+Skip the narrative of how you found it.
+
+## 6. Implement and verify in dev
+
+Branch and PR conventions are in `dbt/project/CLAUDE.md` — read it. Summary: branch `data-XXXX/short-slug`, PR title `[DATA-XXXX] Short title`, and the ticket ID never appears in committed code, only in the branch name and PR title. No real colleague names anywhere in the repo.
+
+Build only what you modified. Never use the `+` upstream selector — dbt Cloud defers to prod artifacts for everything you did not touch.
+
+```bash
+cd dbt/project
+dbt seed --select <new_seed>
+dbt build --select "<seed> <modified_model> <affected_mart>"
+```
+
+Then prove the change is surgical by diffing dev against prod:
+
+```sql
+select count(*) as differing_rows
+from goodparty_data_catalog.dbt_<user>.<model> as dev
+join goodparty_data_catalog.dbt.<model> as prod using (id)
+where not (dev.<changed_column> <=> prod.<changed_column>)
+```
+
+Expect the count to equal the number of records you meant to fix. If it is larger, the fix is too broad.
+
+Also list the rows present in dev but not prod (and vice versa) and account for every one. Unexplained rows usually mean a **stale relation in your dev schema** — dbt Cloud uses an existing dev table instead of deferring to prod, so an old build silently skews the diff. Check before concluding your change caused it.
+
+Run the affected mart too, not just the model you edited, and confirm the record now appears where the user would see it.
+
+## 7. Open the PR and clear review
+
+```bash
+pre-commit run --files <changed files>   # sqlfmt will reformat; re-run until clean
+```
+
+PR body: root cause, the fix and why it is shaped that way, and a verification section with the actual numbers. If a generalized process would help future tickets of this class, propose it in the PR description. Otherwise keep it short.
+
+Then the review loop:
+
+```bash
+gh pr comment <n> --body "delegate review"
+```
+
+`claude[bot]` posts a generic "comment `@claude review`" notice on open — that is not the reviewer and does not need action. Wait for `delegate-reviewer[bot]`.
+
+On requested changes, be judicious. Make the fix if it is real; comment declining with a reason if it is picky or an unlikely corner case. Do not overengineer to satisfy it. Then comment `delegate review` again and repeat until it approves.
+
+## dbt Cloud CLI gotchas
+
+- **One invocation at a time.** A second concurrent call fails with `Session occupied`. Retry until the first finishes.
+- **No `limit` inside inline SQL.** dbt appends its own; use `qualify row_number() over (order by ...) <= n`.
+- **Long runs can drop the log stream** on a network blip. The invocation usually keeps running — check the dev relation before re-running.
+- **Verify a column exists before selecting it.** Mart column names drift from what the docs and ticket call them.

--- a/.claude/skills/data-ticket-triage/references/repair-patterns.md
+++ b/.claude/skills/data-ticket-triage/references/repair-patterns.md
@@ -1,0 +1,49 @@
+# Repair patterns
+
+Catalog of the override seeds already in the project and the chains they repair. Check here before inventing a mechanism — most "missing record" tickets in the election-api marts land on a rung that already has a repair path.
+
+Verify any model or column named here against the live DAG before relying on it. These drift.
+
+## Override seeds
+
+All under `dbt/project/seeds/`, documented in `seeds_schema.yaml`.
+
+| Seed | Keyed on | Repairs | Applied in |
+|---|---|---|---|
+| `l2_manual_district_assignments` | sparse tuple (state, county, city, precinct, district type) where null means "do not constrain" | a district L2 carries no geography for | `int__l2_nationwide_uniform` (a view, so edits need no voter-file rebuild) |
+| `l2_br_match_overrides` | BR position `br_database_id` | LLM mapped a position to the wrong L2 district, scored below the confidence threshold, or has no match row at all | `m_election_api__position` |
+| `br_position_place_overrides` | position geography (geo_id + mtfcc) | BallotReady puts a geography on a position but publishes no Place row for it | `int__enhanced_race` |
+| `election_api_race_filing_address_overrides` | race `br_database_id` | BR supplies the wrong filing office address | `m_election_api__race` |
+| `seed_civics_election_2025_position_nullouts` | — | civics position corrections | civics models |
+
+Shared shape: the key, the corrected value, and a `reason` column that is `not_null` and carries a citation. Applied with a `coalesce` so the vendor stays authoritative wherever it supplies a value.
+
+## Worked example: office missing from the picker
+
+The chain a candidate's office travels to become selectable during onboarding. When an office is missing, walk it in order and stop at the first rung that is empty.
+
+1. **`m_election_api__district`** — does the L2 district exist for (state, district type, district name)?
+   No → L2 carries no geography for the seat. Add `l2_manual_district_assignments`.
+
+2. **`m_election_api__position`** — is `district_id` populated for the BR position?
+   No → the LLM match is wrong, below threshold (95 for `state` type, 90 otherwise), or absent. Add `l2_br_match_overrides`.
+
+3. **`m_election_api__zip_to_position`** — are there zip rows, and is `pct_districtzip_to_zip` above the API's threshold (`PCT_DISTRICTZIP_TO_ZIP_THRESHOLD`, default 0.005)?
+   Also note `future_elections` in this model only spans `current_date` to `+2 years`, so a position whose next election is further out will legitimately have no rows.
+
+4. **`m_election_api__race`** — are there races for the position?
+   No → check `int__enhanced_race.place_id`. Null there means BallotReady has no Place for the position's geography; add `br_position_place_overrides`. The race mart inner-joins the place mart because `Race.placeId` is a required FK that also supplies the race slug, so a placeless race cannot be served and is dropped.
+
+Rung 4 is easy to miss because rungs 1-3 can all look healthy. The picker needs **both** a covered position and a published race: `ZipToPositionService.search` uses ZipToPosition only to collect `positionId`s, then reads the actual rows off `Race.positionId` with `electionDate >= today`. A position with no race lists nothing.
+
+### Known gap
+
+About 4,656 future races (1.7%, across 3,183 positions) carry no `place_id`. Almost all are BallotReady `X`-prefixed special districts (fire, justice precinct, and similar) where no census place exists to point at, so a geo_id remap does not fix them. If a ticket lands on one of these, it needs a different treatment than `br_position_place_overrides` — do not force the seed onto it.
+
+## Geo_id mechanics
+
+`int__enhanced_race` resolves a race's place by geo_id, rolling the position's geo_id up to a parent for certain MTFCCs (the `position_to_place_geo_id` case). The mapping table is linked from a comment in that model.
+
+Useful when reading these: a 7-digit geo_id's parent is the state (first 2 digits), so "fall back to the parent geography" is not a usable generic fix for a school or special district — it would put the race under the state.
+
+Census GEOIDs that look similar are different geographies. A place FIPS and a unified school district LEA code can both be 7 digits for the same state, which is why the override seed keys on MTFCC as well as geo_id.


### PR DESCRIPTION
Adds the `data-ticket-triage` skill, which has been living untracked in a local checkout. Nothing else in the repo changes.

## What it does

Covers a ClickUp data ticket end to end: read the ticket, trace the symptom through the dbt DAG to the model where the record stops existing, post the root cause before implementing, ship the smallest fix that reuses an existing repair pattern, verify against prod from dev, open the PR, and iterate with the delegate reviewer.

The parts that carry the most weight in practice:

- **Find the boundary, not the source.** Work backwards from the surface the user complained about to the last model that has the record and the first that does not. Everything upstream of that boundary is a distraction.
- **Quantify isolation before choosing a fix.** One row nationwide is a data-entry gap and takes a seeded override. Thousands clustered on one dimension is a modeling bug and takes a code change. The skill makes this an explicit step rather than a judgment call.
- **Check the consuming application when the mart looks fine.** Points at the `omni` packages and flags the two things that most often change a diagnosis: the service reading a different table than the ticket names, and env-var thresholds or date windows the mart knows nothing about.
- **Read-only boundaries.** The product monorepo is never edited from a data-platform ticket.

## references/repair-patterns.md

Catalogs the override seeds already in the project, what each one keys on, what it repairs, and where it is applied, plus the four-rung chain an office travels to become selectable in the picker. The point is that a missing-record ticket usually lands on a rung that already has a repair path, so we stop growing new machinery for problems that have an established shape. It also records the known `place_id` gap on BallotReady `X`-prefixed special districts, so nobody forces the wrong seed onto one.

## Notes

Both files are prose, so CI is limited to the generic pre-commit hooks. Those pass.

The reference doc opens by telling the reader to verify any model or column named in it against the live DAG before relying on it, since those drift. That caveat is doing real work and should stay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no changes to pipelines, marts, or application code.
> 
> **Overview**
> Adds a new **data-ticket-triage** Claude skill under `.claude/skills/` plus a **repair-patterns** reference doc. No application or dbt code changes.
> 
> The skill defines a seven-step workflow for ClickUp `DATA-*` tickets: read the ticket, trace backward through the dbt DAG to the model boundary where data disappears, quantify how widespread the defect is, check `omni` app code when marts look fine (read-only), pick the smallest fix (override seed before model logic), post root cause on ClickUp before coding, verify in dev with a surgical dev-vs-prod diff, then open a PR and loop on **delegate-reviewer**.
> 
> It also documents dbt Cloud CLI constraints (single session, no inline `limit`, stale dev schemas) and branch/PR naming from `dbt/project/CLAUDE.md`.
> 
> The reference catalogs existing override seeds (`l2_manual_district_assignments`, `l2_br_match_overrides`, `br_position_place_overrides`, etc.), the four-rung **office picker** diagnostic chain, and the known BallotReady `X`-district `place_id` gap where `br_position_place_overrides` is the wrong tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7409acd8a76c6e9407e8fd388cab1e21db08d285. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->