### PR TITLE
[DATA-2276] Auto-record semantic-layer ratifications on the earning merge

### DIFF
--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -17,7 +17,7 @@ on:
       - 'analytics/diagnostics/semantic_catalog/config/ratifications.yml'
 
 permissions:
-  contents: read
+  contents: write        # open the ratification PR branch (never pushes to main)
   pull-requests: write   # DATA-2218: update the thread marker's merged flag
 
 jobs:
@@ -175,6 +175,36 @@ jobs:
         run: |
           set -euo pipefail
           uv run python -m semantic_catalog.thread --mark-merged --pr "$PR_NUM"
+      - name: Record the ratifications this merge earned
+        # Writes the sidecar + regenerated catalog into the WORKING TREE only.
+        # The next step's Sigma sync re-parses that tree, so a build task is
+        # created on THIS merge rather than waiting on the ratification PR.
+        # Placed after the thread marker update, not straight after the Slack
+        # post: this step exits 1 on a self-verification failure, and between
+        # those two steps that would leave the thread unmarked and make a re-run
+        # double-post the merge summary.
+        if: ${{ env.PR_NUM != '' }}
+        working-directory: analytics
+        env:
+          PYTHONPATH: diagnostics
+          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+            set -euo pipefail
+            if [ -z "${GH_TOKEN:-}" ]; then
+              echo "ORG_READ_TOKEN not provisioned; skipping ratification recording."
+              exit 0
+            fi
+            gh api "repos/$REPO/pulls/$PR_NUM/reviews" --paginate \
+              --jq '[.[] | {login: .user.login, state: .state, submitted_at: .submitted_at}]' > /tmp/reviews.json
+            DATA=$(gh api orgs/thegoodparty/teams/semantic-layer-data/members --jq '[.[].login] | join(",")')
+            BIZ=$(gh api orgs/thegoodparty/teams/semantic-layer-business/members --jq '[.[].login] | join(",")')
+            ARGS=(--record-ratifications --reviews /tmp/reviews.json \
+                  --data-members "$DATA" --business-members "$BIZ" \
+                  --pr-number "$PR_NUM" \
+                  --emit-recorded /tmp/recorded.json --emit-pr-body /tmp/ratify-body.md)
+            if [ -d /tmp/base ]; then ARGS+=(--base-dir /tmp/base); fi
+            uv run python -m semantic_catalog.cli "${ARGS[@]}"
       - name: Create Sigma build tasks for newly ratified metrics
         working-directory: analytics
         env:
@@ -205,6 +235,39 @@ jobs:
         run: |
           set -euo pipefail
           uv run python -m semantic_catalog.cli --reply-created /tmp/created_tasks.json
+      - name: Open the ratification PR
+        # Branch is keyed on the source PR so a workflow re-run updates the same
+        # branch in place instead of opening a rival PR. Never pushes to main.
+        if: ${{ env.PR_NUM != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+            if [ ! -s /tmp/recorded.json ]; then
+              echo "nothing recorded; no PR to open."
+              exit 0
+            fi
+            COUNT=$(python3 -c 'import json;print(len(json.load(open("/tmp/recorded.json"))["metrics"]))')
+            if [ "$COUNT" = "0" ]; then
+              echo "nothing recorded; no PR to open."
+              exit 0
+            fi
+            BRANCH="auto/ratify-pr-${PR_NUM}"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git checkout -b "$BRANCH"
+            git add analytics/diagnostics/semantic_catalog/config/ratifications.yml \
+                    '.claude/skills/*/references/canonical_metrics.md'
+            git commit -m "Record the ratifications earned by #${PR_NUM}"
+            git fetch origin "$BRANCH" || true
+            git push --force-with-lease origin "$BRANCH"
+            if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""')" ]; then
+              gh pr create --base main --head "$BRANCH" \
+                --title "Record the ratifications earned by #${PR_NUM}" \
+                --body-file /tmp/ratify-body.md
+            else
+              echo "PR for $BRANCH already open; branch updated in place."
+            fi
       - name: Clean up base tree
         if: always()
         run: git worktree remove --force /tmp/base || true

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -65,10 +65,15 @@ jobs:
           if [ -n "$PR" ]; then
             # Count only each reviewer's LATEST review, so a superseded or
             # dismissed approval no longer counts as current coverage.
-            APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" \
-              --jq 'group_by(.user.login) | map(max_by(.submitted_at)) | map(select(.state=="APPROVED").user.login) | join(",")')
-            DATA=$(gh api "orgs/thegoodparty/teams/semantic-layer-data/members" --jq '[.[].login] | join(",")')
-            BIZ=$(gh api "orgs/thegoodparty/teams/semantic-layer-business/members" --jq '[.[].login] | join(",")')
+            # Every call here paginates, and every aggregation happens AFTER the
+            # pages are collapsed. Grouping inside --jq would group per page, so
+            # "latest review per reviewer" would silently become "latest per
+            # reviewer per page" once a PR passes 30 reviews.
+            APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
+              --jq '.[] | {login: .user.login, state: .state, submitted_at: .submitted_at}' \
+              | jq -rs 'group_by(.login) | map(max_by(.submitted_at)) | map(select(.state=="APPROVED").login) | join(",")')
+            DATA=$(gh api --paginate "orgs/thegoodparty/teams/semantic-layer-data/members" --jq '.[].login' | paste -sd, -)
+            BIZ=$(gh api --paginate "orgs/thegoodparty/teams/semantic-layer-business/members" --jq '.[].login' | paste -sd, -)
             COV=$(cd analytics && APPROVERS="$APPROVERS" DATA="$DATA" BIZ="$BIZ" PYTHONPATH="diagnostics" \
               uv run python -m semantic_catalog.composition)
             PR_URL="https://github.com/$REPO/pull/$PR"
@@ -202,8 +207,11 @@ jobs:
             gh api "repos/$REPO/pulls/$PR_NUM/reviews" --paginate \
               --jq '.[] | {login: .user.login, state: .state, submitted_at: .submitted_at}' \
               | jq -s '.' > /tmp/reviews.json
-            DATA=$(gh api orgs/thegoodparty/teams/semantic-layer-data/members --jq '[.[].login] | join(",")')
-            BIZ=$(gh api orgs/thegoodparty/teams/semantic-layer-business/members --jq '[.[].login] | join(",")')
+            # Paginated for the same reason as the reviews call above: a member
+            # past position 30 would be missing from the list, could never match
+            # an approver, and coverage would read as incomplete forever.
+            DATA=$(gh api --paginate orgs/thegoodparty/teams/semantic-layer-data/members --jq '.[].login' | paste -sd, -)
+            BIZ=$(gh api --paginate orgs/thegoodparty/teams/semantic-layer-business/members --jq '.[].login' | paste -sd, -)
             ARGS=(--record-ratifications --reviews /tmp/reviews.json \
                   --data-members "$DATA" --business-members "$BIZ" \
                   --pr-number "$PR_NUM" \

--- a/.github/workflows/semantic-layer-publish.yml
+++ b/.github/workflows/semantic-layer-publish.yml
@@ -195,8 +195,13 @@ jobs:
               echo "ORG_READ_TOKEN not provisioned; skipping ratification recording."
               exit 0
             fi
+            # --paginate emits ONE ARRAY PER PAGE, so a PR with more than 30
+            # reviews would write `[...]\n[...]` and break json.loads. Emit one
+            # object per line and slurp them into a single array instead.
+            # (`gh --slurp` is not usable here: it is rejected with --jq.)
             gh api "repos/$REPO/pulls/$PR_NUM/reviews" --paginate \
-              --jq '[.[] | {login: .user.login, state: .state, submitted_at: .submitted_at}]' > /tmp/reviews.json
+              --jq '.[] | {login: .user.login, state: .state, submitted_at: .submitted_at}' \
+              | jq -s '.' > /tmp/reviews.json
             DATA=$(gh api orgs/thegoodparty/teams/semantic-layer-data/members --jq '[.[].login] | join(",")')
             BIZ=$(gh api orgs/thegoodparty/teams/semantic-layer-business/members --jq '[.[].login] | join(",")')
             ARGS=(--record-ratifications --reviews /tmp/reviews.json \

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -161,9 +161,16 @@ def _record(args, records: list[MetricRecord]) -> int:
         print("no base tree to diff against; recording nothing.")
     else:
         before, after = _before_after(args.base_dir)
-        earned = ratifications.ratified_by_merge(before, after, date, args.pr_number)
-        if not earned:
-            print("no metric was newly ratified by this merge.")
+        if not before:
+            # A base tree that parses to zero metrics is either the wrong path or
+            # a commit predating the semantic layer. Both leave every metric
+            # looking new, which is the same bystander hazard as having no base
+            # at all, so refuse here too rather than trust an empty diff.
+            print("base tree parsed no metrics; recording nothing.")
+        else:
+            earned = ratifications.ratified_by_merge(before, after, date, args.pr_number)
+            if not earned:
+                print("no metric was newly ratified by this merge.")
 
     if earned:
         sidecar = ratifications.DEFAULT_PATH

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -151,6 +151,14 @@ def _record(args, records: list[MetricRecord]) -> int:
 
     if date is None:
         print("review coverage incomplete; recording nothing.")
+    elif args.base_dir is None or not args.base_dir.is_dir():
+        # Without a base tree there is nothing to compare fingerprints against,
+        # so `before` is empty and EVERY pending metric looks newly earned:
+        # bystanders sharing a file with the reviewed metric would collect a
+        # sign-off nobody gave. A missing base is not evidence of approval, so
+        # record nothing. The workflow only passes --base-dir when /tmp/base
+        # exists, which is the path this guards.
+        print("no base tree to diff against; recording nothing.")
     else:
         before, after = _before_after(args.base_dir)
         earned = ratifications.ratified_by_merge(before, after, date, args.pr_number)

--- a/analytics/diagnostics/semantic_catalog/cli.py
+++ b/analytics/diagnostics/semantic_catalog/cli.py
@@ -15,8 +15,8 @@ from pathlib import Path
 
 import yaml
 
+from semantic_catalog import composition, ratifications, recording, sigma_tasks, slack_reply
 from semantic_catalog import lifecycle as lc_mod
-from semantic_catalog import ratifications, sigma_tasks, slack_reply
 from semantic_catalog.clickup_client import ClickUpClient
 from semantic_catalog.clickup_page import render_page
 from semantic_catalog.lifecycle import Lifecycle
@@ -132,6 +132,60 @@ def _before_after(base_dir: Path | None) -> tuple[list[MetricRecord], list[Metri
     return before, after
 
 
+def _record(args, records: list[MetricRecord]) -> int:
+    """Record the sign-offs this merge earned, if both groups approved it.
+
+    Writes into the WORKING TREE only. The publish workflow commits the result
+    to a branch and opens a PR; nothing here pushes to main. The Sigma step runs
+    after this one and re-parses the same working tree, which is how a build
+    task gets created on the definition PR's merge instead of waiting for the
+    ratification PR to land.
+    """
+    reviews = json.loads(args.reviews.read_text()) if args.reviews else []
+    date = composition.completion_date(
+        reviews,
+        [m for m in args.data_members.split(",") if m],
+        [m for m in args.business_members.split(",") if m],
+    )
+    earned: dict[str, ratifications.Ratification] = {}
+
+    if date is None:
+        print("review coverage incomplete; recording nothing.")
+    else:
+        before, after = _before_after(args.base_dir)
+        earned = ratifications.ratified_by_merge(before, after, date, args.pr_number)
+        if not earned:
+            print("no metric was newly ratified by this merge.")
+
+    if earned:
+        sidecar = ratifications.DEFAULT_PATH
+        sidecar.write_text(recording.apply(sidecar.read_text(), earned, args.pr_number))
+        records = parse_semantic_tree(SEM_ROOTS)
+        for target, recs in records_by_target(records).items():
+            write_region(target, recs)
+
+        # Self-verify. catalog-freshness cannot run on a PR opened with the
+        # default token, so this is the only check the bot's own output gets.
+        by_name = {r.name: r for r in records}
+        for name in earned:
+            rec = by_name.get(name)
+            if rec is None or rec.ratified != date or rec.ratified_stale:
+                print(f"recorded {name} but it does not read as freshly ratified; aborting.", file=sys.stderr)
+                return 1
+        print(f"recorded {len(earned)}: {', '.join(sorted(earned))}")
+
+    if args.emit_recorded:
+        args.emit_recorded.write_text(json.dumps(recording.manifest(earned, records, date, args.pr_number)))
+    if args.emit_pr_body and earned:
+        args.emit_pr_body.write_text(
+            recording.pr_body(
+                recording.manifest(earned, records, date, args.pr_number),
+                repo=os.environ.get("GITHUB_REPOSITORY", "thegoodparty/gp-data-platform"),
+            )
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="semantic_catalog")
     parser.add_argument("--check", action="store_true")
@@ -145,6 +199,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base-dir", type=Path, default=None)
     parser.add_argument("--pr-url", type=str, default="")
     parser.add_argument("--coverage", type=str, default="")
+    parser.add_argument("--record-ratifications", action="store_true")
+    parser.add_argument("--reviews", type=Path)
+    parser.add_argument("--data-members", type=str, default="")
+    parser.add_argument("--business-members", type=str, default="")
+    parser.add_argument("--pr-number", type=int, default=0)
+    parser.add_argument("--emit-recorded", type=Path)
+    parser.add_argument("--emit-pr-body", type=Path)
     args = parser.parse_args(argv)
 
     try:
@@ -163,6 +224,9 @@ def main(argv: list[str] | None = None) -> int:
         for rec in records:
             print(f"{rec.name}: '{ratifications.definition_sha(rec)}'")
         return 0
+
+    if args.record_ratifications:
+        return _record(args, records)
 
     if args.check:
         grouped = records_by_target(records)

--- a/analytics/diagnostics/semantic_catalog/composition.py
+++ b/analytics/diagnostics/semantic_catalog/composition.py
@@ -37,6 +37,54 @@ def evaluate(
     }
 
 
+def _latest_per_reviewer(reviews: list[dict]) -> list[dict]:
+    """One review per login, the most recent, so a superseded verdict cannot count."""
+    latest: dict[str, dict] = {}
+    for review in reviews:
+        login = review["login"]
+        if login not in latest or review["submitted_at"] > latest[login]["submitted_at"]:
+            latest[login] = review
+    return list(latest.values())
+
+
+def completed_at(
+    reviews: list[dict],
+    data_members: Iterable[str],
+    business_members: Iterable[str],
+) -> str | None:
+    """When coverage completed: the moment the SECOND group's first approval landed.
+
+    This is the date a ratification records. It is deliberately not "now" and not
+    the date someone typed a line: `win_users` was recorded as 2026-08-03, the day
+    it was authored, when coverage actually completed 2026-08-04.
+
+    Returns an ISO-8601 UTC timestamp, or None if either group is uncovered.
+    Each review is {"login", "state", "submitted_at"}.
+    """
+    approvals = [
+        r for r in _latest_per_reviewer(reviews) if r["state"] == "APPROVED" and not is_bot(r["login"])
+    ]
+    first_per_group: list[str] = []
+    for members in (data_members, business_members):
+        lowered = _lower(members)
+        stamps = sorted(r["submitted_at"] for r in approvals if r["login"].lower() in lowered)
+        if not stamps:
+            return None
+        first_per_group.append(stamps[0])
+    # Coverage is complete only once BOTH groups are in, so the later one wins.
+    return max(first_per_group)
+
+
+def completion_date(
+    reviews: list[dict],
+    data_members: Iterable[str],
+    business_members: Iterable[str],
+) -> str | None:
+    """`completed_at` as the UTC calendar date, which is what the sidecar stores."""
+    stamp = completed_at(reviews, data_members, business_members)
+    return stamp[:10] if stamp else None
+
+
 def _split_env(value: str | None) -> list[str]:
     if not value:
         return []

--- a/analytics/diagnostics/semantic_catalog/ratifications.py
+++ b/analytics/diagnostics/semantic_catalog/ratifications.py
@@ -18,6 +18,15 @@ safe inside the blocking catalog-freshness gate.
 MetricRecord: records are compared whole to build the Slack change diff, so a
 provenance-only edit would report the metric as changed with no diff line able
 to explain why.
+
+`upsert`'s optional `note` is written as a comment line prefixed with
+`AUTO_NOTE_PREFIX` ("auto-recorded: "), so the hook's own provenance note can
+be told apart from a human's hand-written reasoning in the same block. On the
+edit path (a metric whose sign-off went stale and is being re-earned) `upsert`
+strips any prior line carrying that prefix before writing the fresh one, so
+re-recording replaces the note instead of accumulating a second one; a human
+comment lacking the prefix is left untouched. A later module, `recording.py`,
+relies on this exact prefix constant to write its own auto-generated notes.
 """
 
 from __future__ import annotations
@@ -160,6 +169,14 @@ def ratified_by_merge(
 
 _WRITTEN_FIELDS = ("ratified", "definition_sha", "approved_by_pr")
 
+# Marks a comment line `upsert` wrote itself, as opposed to a human's reasoning
+# typed into the same block. Greppable and stable on purpose: `recording.py`
+# writes a note on every sign-off a merge earns, including a re-earned stale
+# one that already has a block, and needs to replace its own prior note there
+# without disturbing whatever a human wrote alongside it.
+AUTO_NOTE_PREFIX = "auto-recorded: "
+_AUTO_NOTE_RE = re.compile(rf"^\s{{2}}#\s*{re.escape(AUTO_NOTE_PREFIX)}")
+
 
 def _field_line(key: str, sign_off: Ratification) -> str:
     if key == "ratified":
@@ -190,7 +207,7 @@ def upsert(text: str, name: str, sign_off: Ratification, note: str = "") -> str:
     if start is None:
         block = f"{name}:\n"
         if note:
-            block += f"  # {note}\n"
+            block += f"  # {AUTO_NOTE_PREFIX}{note}\n"
         block += "".join(_field_line(k, sign_off) for k in _WRITTEN_FIELDS)
         separator = "" if text.endswith("\n\n") or not text else "\n"
         return text + separator + block
@@ -208,8 +225,19 @@ def upsert(text: str, name: str, sign_off: Ratification, note: str = "") -> str:
                 continue
             seen.add(key)
             rewritten.append(_field_line(key, sign_off))
+        elif _AUTO_NOTE_RE.match(line):
+            # Drop a prior auto-note so re-recording replaces it rather than
+            # accumulating a second one. A human's comment doesn't carry this
+            # prefix, so it never matches here and is left in `rewritten` as-is.
+            continue
         else:
             rewritten.append(line)
+
+    if note:
+        # rewritten[0] is always the block's own header line (`lines[start]`
+        # copied verbatim, since the loop above runs over lines[start:end]),
+        # so the note goes right after it -- inside the block, not above it.
+        rewritten.insert(1, f"  # {AUTO_NOTE_PREFIX}{note}\n")
 
     missing = [k for k in _WRITTEN_FIELDS if k not in seen]
     if missing:

--- a/analytics/diagnostics/semantic_catalog/ratifications.py
+++ b/analytics/diagnostics/semantic_catalog/ratifications.py
@@ -122,6 +122,101 @@ def apply(records: list[MetricRecord], sign_offs: dict[str, Ratification]) -> li
     return out
 
 
+def ratified_by_merge(
+    before: list[MetricRecord],
+    after: list[MetricRecord],
+    date: str,
+    pr_number: int,
+) -> dict[str, Ratification]:
+    """Sign-offs a merge earns, given that both review groups approved its PR.
+
+    A metric qualifies only when it has no trustworthy sign-off already (pending
+    or stale) AND its definition actually moved in this merge, judged by
+    fingerprint against the base, or it is new. Without the second condition a
+    PR editing one metric would ratify every other pending metric that happens
+    to live in the same file, which reviewers never looked at.
+
+    Deliberately conservative: a PR that changes only `owner` or `detail_doc` on
+    a pending metric earns nothing, because no definition was put in front of
+    anyone.
+    """
+    prev = {r.name: r for r in before}
+    earned: dict[str, Ratification] = {}
+    for rec in after:
+        if rec.retired:
+            continue
+        if rec.ratified and not rec.ratified_stale:
+            continue
+        old = prev.get(rec.name)
+        if old is not None and definition_sha(old) == definition_sha(rec):
+            continue
+        earned[rec.name] = Ratification(
+            ratified=date,
+            definition_sha=definition_sha(rec),
+            approved_by_pr=pr_number,
+        )
+    return earned
+
+
+_WRITTEN_FIELDS = ("ratified", "definition_sha", "approved_by_pr")
+
+
+def _field_line(key: str, sign_off: Ratification) -> str:
+    if key == "ratified":
+        return f"  ratified: {sign_off.ratified}\n"
+    if key == "definition_sha":
+        # Always quoted: an all-digit hash left bare reads back as an integer.
+        return f"  definition_sha: '{sign_off.definition_sha}'\n"
+    return f"  approved_by_pr: {sign_off.approved_by_pr}\n"
+
+
+def upsert(text: str, name: str, sign_off: Ratification, note: str = "") -> str:
+    """Write one entry into the sidecar's TEXT, leaving every other byte alone.
+
+    Deliberately not a YAML round-trip. This file carries the reasoning behind
+    each sign-off in comments, and dumping the parsed document would delete all
+    of it. An existing entry is edited field by field, which matters because a
+    metric whose sign-off went stale already has a block here; appending a
+    second one would produce a duplicate key that YAML resolves silently to the
+    last occurrence.
+    """
+    lines = text.splitlines(keepends=True)
+    start = next((i for i, line in enumerate(lines) if re.match(rf"^{re.escape(name)}:\s*$", line)), None)
+
+    if start is None:
+        block = f"{name}:\n"
+        if note:
+            block += f"  # {note}\n"
+        block += "".join(_field_line(k, sign_off) for k in _WRITTEN_FIELDS)
+        separator = "" if text.endswith("\n\n") or not text else "\n"
+        return text + separator + block
+
+    # The block runs to the next top-level key, ignoring comments and indented lines.
+    end = next((j for j in range(start + 1, len(lines)) if re.match(r"^[^\s#]", lines[j])), len(lines))
+
+    rewritten: list[str] = []
+    seen: set[str] = set()
+    for line in lines[start:end]:
+        match = re.match(r"^\s{2}(\w+):", line)
+        key = match.group(1) if match else None
+        if key in _WRITTEN_FIELDS:
+            if key in seen:
+                continue
+            seen.add(key)
+            rewritten.append(_field_line(key, sign_off))
+        else:
+            rewritten.append(line)
+
+    missing = [k for k in _WRITTEN_FIELDS if k not in seen]
+    if missing:
+        # Insert after the last field written, so new keys land inside the block
+        # rather than after any trailing blank line.
+        last = max(i for i, line in enumerate(rewritten) if re.match(r"^\s{2}\w+:", line))
+        rewritten[last + 1 : last + 1] = [_field_line(k, sign_off) for k in missing]
+
+    return "".join(lines[:start] + rewritten + lines[end:])
+
+
 def orphaned_keys(records: list[MetricRecord], sign_offs: dict[str, Ratification]) -> list[str]:
     """Sidecar keys matching no metric: a typo, or a metric renamed without its entry."""
     names = {rec.name for rec in records}

--- a/analytics/diagnostics/semantic_catalog/ratifications.py
+++ b/analytics/diagnostics/semantic_catalog/ratifications.py
@@ -242,8 +242,11 @@ def upsert(text: str, name: str, sign_off: Ratification, note: str = "") -> str:
     missing = [k for k in _WRITTEN_FIELDS if k not in seen]
     if missing:
         # Insert after the last field written, so new keys land inside the block
-        # rather than after any trailing blank line.
-        last = max(i for i, line in enumerate(rewritten) if re.match(r"^\s{2}\w+:", line))
+        # rather than after any trailing blank line. A block carrying only
+        # comments has no field line to anchor on, so fall back to index 0,
+        # which is always this block's own header.
+        field_lines = [i for i, line in enumerate(rewritten) if re.match(r"^\s{2}\w+:", line)]
+        last = max(field_lines) if field_lines else 0
         rewritten[last + 1 : last + 1] = [_field_line(k, sign_off) for k in missing]
 
     return "".join(lines[:start] + rewritten + lines[end:])

--- a/analytics/diagnostics/semantic_catalog/ratifications.py
+++ b/analytics/diagnostics/semantic_catalog/ratifications.py
@@ -167,7 +167,11 @@ def _field_line(key: str, sign_off: Ratification) -> str:
     if key == "definition_sha":
         # Always quoted: an all-digit hash left bare reads back as an integer.
         return f"  definition_sha: '{sign_off.definition_sha}'\n"
-    return f"  approved_by_pr: {sign_off.approved_by_pr}\n"
+    # `null`, not the bare word None: PyYAML has no notion of Python's None
+    # literal, so `approved_by_pr: None` would read back as the STRING "None"
+    # rather than as a missing PR number.
+    pr = sign_off.approved_by_pr if sign_off.approved_by_pr is not None else "null"
+    return f"  approved_by_pr: {pr}\n"
 
 
 def upsert(text: str, name: str, sign_off: Ratification, note: str = "") -> str:

--- a/analytics/diagnostics/semantic_catalog/recording.py
+++ b/analytics/diagnostics/semantic_catalog/recording.py
@@ -1,0 +1,51 @@
+"""Write earned sign-offs into the sidecar, and describe them for a PR body.
+
+This is the WRITE path. It is deliberately not part of `ratifications`, which
+`parser` imports on every parse including the blocking catalog-freshness gate;
+that module should stay small and read-only. Only one CLI command reaches here.
+"""
+
+from __future__ import annotations
+
+from semantic_catalog.ratifications import Ratification, upsert
+from semantic_catalog.records import MetricRecord
+
+# `upsert` writes this text as a comment line prefixed with
+# `ratifications.AUTO_NOTE_PREFIX` ("auto-recorded: "), so the rendered line
+# reads "auto-recorded: Sign-off landed on the merge of #800, ...". Phrased so
+# that prefix isn't redundant with the template's own opening words.
+NOTE_TEMPLATE = (
+    "Sign-off landed on the merge of #{pr}, once both review groups approved. "
+    "The date is when the second group's approval landed."
+)
+
+
+def apply(sidecar_text: str, earned: dict[str, Ratification], pr_number: int) -> str:
+    """Write every earned entry into the sidecar text.
+
+    Sorted by metric name so a re-run of the same merge produces byte-identical
+    output, which is what lets the workflow force-push the same branch without
+    churning the diff.
+    """
+    note = NOTE_TEMPLATE.format(pr=pr_number)
+    for name in sorted(earned):
+        sidecar_text = upsert(sidecar_text, name, earned[name], note=note)
+    return sidecar_text
+
+
+def manifest(
+    earned: dict[str, Ratification],
+    records: list[MetricRecord],
+    date: str | None,
+    pr_number: int,
+) -> dict:
+    """What the workflow reads to decide whether to open a PR, and what to say."""
+    labels = {r.name: r.label for r in records}
+    return {
+        "pr": pr_number,
+        "date": date,
+        "metrics": [
+            {"name": name, "label": labels.get(name, name), "definition_sha": earned[name].definition_sha}
+            for name in sorted(earned)
+        ],
+    }

--- a/analytics/diagnostics/semantic_catalog/recording.py
+++ b/analytics/diagnostics/semantic_catalog/recording.py
@@ -81,6 +81,12 @@ date as stale.
 
 def pr_body(manifest: dict, repo: str) -> str:
     """Render the body of the PR that carries an earned ratification record."""
+    if manifest["date"] is None:
+        raise ValueError(
+            "pr_body requires a date: manifest['date'] is None, which means no "
+            "ratification was actually earned. Rendering a PR body would silently "
+            "surface 'None' instead of failing loudly on a bad write."
+        )
     metrics = manifest["metrics"]
     count = f"{len(metrics)} metric" + ("s" if len(metrics) != 1 else "")
     rows = "\n".join(f"| `{m['name']}` | {manifest['date']} | `{m['definition_sha']}` |" for m in metrics)

--- a/analytics/diagnostics/semantic_catalog/recording.py
+++ b/analytics/diagnostics/semantic_catalog/recording.py
@@ -49,3 +49,39 @@ def manifest(
             for name in sorted(earned)
         ],
     }
+
+
+_BODY = """\
+## What
+
+Records the ratification for {count}, earned by [#{pr}](https://github.com/{repo}/pull/{pr}).
+
+| Metric | Ratified | Definition fingerprint |
+|---|---|---|
+{rows}
+
+## Why this is safe to approve on its own
+
+Both review groups approved #{pr}, so the definition itself is already ratified.
+The date recorded here, {date}, is when the second group's approval landed. All
+you are agreeing to is that the date matches the approval record on that PR.
+
+CODEOWNERS does not cover the ratification sidecar, so this PR re-requests no
+review team. Recording a sign-off is bookkeeping, and it should not re-tag the
+people who already gave it.
+
+## How this was produced
+
+Opened automatically by the semantic-layer publish job on the merge of #{pr}.
+The fingerprint is computed from the merged definition, so if the definition
+changes later without a new sign-off, every catalog projection will render this
+date as stale.
+"""
+
+
+def pr_body(manifest: dict, repo: str) -> str:
+    """Render the body of the PR that carries an earned ratification record."""
+    metrics = manifest["metrics"]
+    count = f"{len(metrics)} metric" + ("s" if len(metrics) != 1 else "")
+    rows = "\n".join(f"| `{m['name']}` | {manifest['date']} | `{m['definition_sha']}` |" for m in metrics)
+    return _BODY.format(count=count, pr=manifest["pr"], repo=repo, date=manifest["date"], rows=rows)

--- a/analytics/diagnostics/semantic_catalog/sigma_tasks.py
+++ b/analytics/diagnostics/semantic_catalog/sigma_tasks.py
@@ -11,12 +11,21 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
+from semantic_catalog import ratifications
 from semantic_catalog.records import MetricRecord
 
 
 def build_key(rec: MetricRecord) -> str:
-    """Dedupe key: metric name plus the ratified date it was shipped under."""
-    return f"{rec.name}@{rec.ratified}"
+    """Dedupe key: metric name plus the fingerprint of the definition to build.
+
+    Keyed on the DEFINITION, not on the ratified date. What someone has to build
+    in Sigma follows from what the metric means; correcting a date changes
+    nothing about the work. Keying on the date minted a rival task every time a
+    date moved, and DATA-2249's reconciliation produced three of them in two
+    days, each landing on an assignee for work already finished. A genuine
+    definition change still yields a new fingerprint, so it still yields a task.
+    """
+    return f"{rec.name}@{ratifications.definition_sha(rec)}"
 
 
 def task_url(task_id: str) -> str:

--- a/analytics/tests/test_semantic_catalog_auto_ratification.py
+++ b/analytics/tests/test_semantic_catalog_auto_ratification.py
@@ -14,7 +14,7 @@ def _review(login, state="APPROVED", at="2026-08-05T00:00:00Z"):
     return {"login": login, "state": state, "submitted_at": at}
 
 
-def _rec(name, definition="def", ratified=None, stale=False, retired=None):
+def _rec(name, definition="def", ratified=None, stale=False, retired=None, owner=None):
     return MetricRecord(
         name=name,
         label=name,
@@ -23,7 +23,7 @@ def _rec(name, definition="def", ratified=None, stale=False, retired=None):
         source="ref('m')",
         dimensions=(),
         filter=None,
-        owner=None,
+        owner=owner,
         ratified=ratified,
         detail_doc=None,
         retired=retired,
@@ -77,6 +77,26 @@ def test_superseded_approval_does_not_count():
     assert completion_date(reviews, DATA, BIZ) is None
 
 
+def test_changes_requested_is_superseded_by_a_later_approval():
+    # The other direction of "latest review counts": address feedback and
+    # re-approve, and the earlier rejection must not keep the group uncovered.
+    reviews = [
+        _review("amanda847"),
+        _review("danpelota", state="CHANGES_REQUESTED", at="2026-08-05T01:00:00Z"),
+        _review("danpelota", at="2026-08-05T02:00:00Z"),
+    ]
+    assert completion_date(reviews, DATA, BIZ) == "2026-08-05"
+
+
+def test_bot_listed_as_a_group_member_still_cannot_complete_coverage():
+    # "Bot accounts never count toward a group, even if listed as a member":
+    # a misconfigured team roster containing a bot login must not let the
+    # bot's own approval satisfy that group.
+    reviews = [_review("amanda847"), _review("delegate-reviewer[bot]")]
+    data_with_bot_as_member = [*DATA, "delegate-reviewer[bot]"]
+    assert completion_date(reviews, data_with_bot_as_member, BIZ) is None
+
+
 # --- what a merge earns ------------------------------------------------------
 
 
@@ -118,6 +138,33 @@ def test_stale_sign_off_is_re_earned_on_the_new_definition():
 def test_retired_metric_earns_nothing():
     after = [_rec("m", retired="2026-08-01")]
     assert ratifications.ratified_by_merge([], after, "2026-08-07", 800) == {}
+
+
+def test_untouched_stale_metric_in_a_touched_file_earns_nothing():
+    # Staleness can predate this merge entirely (an earlier hand-edit changed
+    # the definition without a re-ratification). The file-mates rule applies
+    # just as much to a stale bystander as to a pending one: no movement in
+    # THIS merge means this PR's reviewers never saw it.
+    before = [
+        _rec("edited", definition="old"),
+        _rec("stale_bystander", ratified="2026-08-01", stale=True),
+    ]
+    after = [
+        _rec("edited", definition="new"),
+        _rec("stale_bystander", ratified="2026-08-01", stale=True),
+    ]
+    earned = ratifications.ratified_by_merge(before, after, "2026-08-07", 800)
+    assert set(earned) == {"edited"}
+
+
+def test_metadata_only_change_does_not_earn_a_sign_off():
+    # owner/detail_doc are deliberately excluded from FINGERPRINT_FIELDS, so
+    # editing only owner is not "the definition moved" -- no one reviewed a
+    # changed definition, so a pending metric touched only this way earns
+    # nothing.
+    before = [_rec("m", owner="alice")]
+    after = [_rec("m", owner="bob")]
+    assert ratifications.ratified_by_merge(before, after, "2026-08-07", 800) == {}
 
 
 # --- writing it into the sidecar --------------------------------------------
@@ -190,3 +237,35 @@ def test_upsert_writes_an_all_digit_hash_quoted(tmp_path):
     # Unquoted, YAML reads it as an integer and the leading zero is gone.
     out = ratifications.upsert(EXISTING, "win_users", _sign_off(sha="0123456"))
     assert _loaded(tmp_path, out)["win_users"].definition_sha == "0123456"
+
+
+def test_upsert_into_an_empty_file_creates_a_single_loadable_entry(tmp_path):
+    # The very first ratification ever: no sidecar content exists yet.
+    out = ratifications.upsert("", "m", _sign_off())
+    assert _loaded(tmp_path, out) == {"m": ratifications.Ratification("2026-08-07", "abc1234", 800)}
+
+
+def test_upsert_with_a_note_adds_a_comment_that_survives_the_round_trip(tmp_path):
+    # Comments are load-bearing: a note passed alongside a brand-new entry
+    # must both appear in the text and not break parsing.
+    out = ratifications.upsert(EXISTING, "win_users", _sign_off(), note="Approved in #800.")
+    assert "# Approved in #800." in out
+    assert _loaded(tmp_path, out)["win_users"] == ratifications.Ratification("2026-08-07", "abc1234", 800)
+
+
+def test_upsert_writes_a_missing_pr_number_as_yaml_null(tmp_path):
+    # approved_by_pr is optional on Ratification (a hand-authored entry may
+    # lack a PR). Writing the bare word `None` would round-trip through
+    # load() as the STRING "None", not Python None, silently corrupting the
+    # type `load()` and the rest of the code expect.
+    sign_off = ratifications.Ratification("2026-08-07", "abc1234", None)
+    out = ratifications.upsert("", "m", sign_off)
+    assert _loaded(tmp_path, out)["m"].approved_by_pr is None
+
+
+def test_upsert_editing_to_a_missing_pr_number_writes_null(tmp_path):
+    # Same bug, the other code path: rewriting an existing field line rather
+    # than composing a brand-new block.
+    text = "m:\n  ratified: 2026-08-01\n  definition_sha: 'aaaaaaa'\n  approved_by_pr: 100\n"
+    out = ratifications.upsert(text, "m", ratifications.Ratification("2026-08-07", "abc1234", None))
+    assert _loaded(tmp_path, out)["m"].approved_by_pr is None

--- a/analytics/tests/test_semantic_catalog_auto_ratification.py
+++ b/analytics/tests/test_semantic_catalog_auto_ratification.py
@@ -1,0 +1,192 @@
+"""The auto-ratification hook's pure core: when coverage completed, what it
+earns, and how that lands in the sidecar text.
+"""
+
+from semantic_catalog import ratifications
+from semantic_catalog.composition import completed_at, completion_date
+from semantic_catalog.records import MetricRecord
+
+DATA = ["danpelota", "hhkarimi", "sanjayr1", "datawithtristan"]
+BIZ = ["amanda847", "audrey-gp"]
+
+
+def _review(login, state="APPROVED", at="2026-08-05T00:00:00Z"):
+    return {"login": login, "state": state, "submitted_at": at}
+
+
+def _rec(name, definition="def", ratified=None, stale=False, retired=None):
+    return MetricRecord(
+        name=name,
+        label=name,
+        definition=definition,
+        metric_type="simple",
+        source="ref('m')",
+        dimensions=(),
+        filter=None,
+        owner=None,
+        ratified=ratified,
+        detail_doc=None,
+        retired=retired,
+        yaml_file="sem_analytics__users_win.yml",
+        kind="metric",
+        ratified_stale=stale,
+    )
+
+
+# --- when coverage completed -------------------------------------------------
+
+
+def test_completion_is_the_later_group_not_the_first_approval():
+    # The real #749 shape: business approved first, data completed it the same
+    # day. The recorded date is when the SECOND group landed.
+    reviews = [
+        _review("amanda847", at="2026-08-04T14:20:29Z"),
+        _review("danpelota", at="2026-08-04T16:26:10Z"),
+    ]
+    assert completed_at(reviews, DATA, BIZ) == "2026-08-04T16:26:10Z"
+    assert completion_date(reviews, DATA, BIZ) == "2026-08-04"
+
+
+def test_completion_uses_each_groups_earliest_approval():
+    # A third approver piling on later must not push the completion date out.
+    reviews = [
+        _review("amanda847", at="2026-08-04T23:27:19Z"),
+        _review("danpelota", at="2026-08-05T02:07:22Z"),
+        _review("hhkarimi", at="2026-08-09T09:00:00Z"),
+    ]
+    assert completion_date(reviews, DATA, BIZ) == "2026-08-05"
+
+
+def test_no_completion_when_a_group_is_missing():
+    # The real #708 shape: business only, no data approval ever.
+    assert completion_date([_review("amanda847")], DATA, BIZ) is None
+
+
+def test_bot_approval_cannot_complete_a_group():
+    reviews = [_review("amanda847"), _review("delegate-reviewer[bot]")]
+    assert completion_date(reviews, DATA, BIZ) is None
+
+
+def test_superseded_approval_does_not_count():
+    # Same reviewer approved, then later requested changes.
+    reviews = [
+        _review("amanda847"),
+        _review("danpelota", at="2026-08-05T01:00:00Z"),
+        _review("danpelota", state="CHANGES_REQUESTED", at="2026-08-05T02:00:00Z"),
+    ]
+    assert completion_date(reviews, DATA, BIZ) is None
+
+
+# --- what a merge earns ------------------------------------------------------
+
+
+def test_new_metric_earns_a_sign_off():
+    earned = ratifications.ratified_by_merge([], [_rec("m")], "2026-08-07", 800)
+    assert earned["m"].ratified == "2026-08-07"
+    assert earned["m"].approved_by_pr == 800
+    assert earned["m"].definition_sha == ratifications.definition_sha(_rec("m"))
+
+
+def test_changed_definition_on_a_pending_metric_earns_a_sign_off():
+    before = [_rec("m", definition="old")]
+    after = [_rec("m", definition="new")]
+    assert "m" in ratifications.ratified_by_merge(before, after, "2026-08-07", 800)
+
+
+def test_untouched_pending_metric_in_a_touched_file_earns_nothing():
+    # The rule that stops one metric's PR from ratifying its file-mates.
+    before = [_rec("edited", definition="old"), _rec("bystander")]
+    after = [_rec("edited", definition="new"), _rec("bystander")]
+    earned = ratifications.ratified_by_merge(before, after, "2026-08-07", 800)
+    assert set(earned) == {"edited"}
+
+
+def test_already_ratified_metric_earns_nothing():
+    before = [_rec("m", ratified="2026-08-01")]
+    after = [_rec("m", definition="new", ratified="2026-08-01")]
+    assert ratifications.ratified_by_merge(before, after, "2026-08-07", 800) == {}
+
+
+def test_stale_sign_off_is_re_earned_on_the_new_definition():
+    before = [_rec("m", definition="old", ratified="2026-08-01")]
+    after = [_rec("m", definition="new", ratified="2026-08-01", stale=True)]
+    earned = ratifications.ratified_by_merge(before, after, "2026-08-07", 800)
+    assert earned["m"].ratified == "2026-08-07"
+    assert earned["m"].definition_sha == ratifications.definition_sha(_rec("m", definition="new"))
+
+
+def test_retired_metric_earns_nothing():
+    after = [_rec("m", retired="2026-08-01")]
+    assert ratifications.ratified_by_merge([], after, "2026-08-07", 800) == {}
+
+
+# --- writing it into the sidecar --------------------------------------------
+
+EXISTING = """\
+# Ratification sign-offs (header comment that must survive).
+
+activated_serve_users:
+  # Both groups approved #765, which contained the restatement.
+  ratified: 2026-08-05
+  definition_sha: '5e87555'
+  approved_by_pr: 765
+
+# win_activated_users is deliberately absent, so it reads pending.
+# win_activated_users:
+#   ratified: <date>
+"""
+
+
+def _sign_off(date="2026-08-07", sha="abc1234", pr=800):
+    return ratifications.Ratification(date, sha, pr)
+
+
+def _loaded(tmp_path, text):
+    """Read the written text back the way production does, not via raw yaml.
+
+    `load` normalizes an unquoted date, which YAML hands back as datetime.date,
+    into the string the records carry.
+    """
+    path = tmp_path / "ratifications.yml"
+    path.write_text(text)
+    return ratifications.load(path)
+
+
+def test_upsert_appends_a_new_entry_and_preserves_every_comment(tmp_path):
+    out = ratifications.upsert(EXISTING, "win_users", _sign_off())
+    assert "header comment that must survive" in out
+    assert "Both groups approved #765" in out
+    assert "# win_activated_users:" in out
+    loaded = _loaded(tmp_path, out)
+    assert loaded["win_users"] == ratifications.Ratification("2026-08-07", "abc1234", 800)
+    assert loaded["activated_serve_users"].approved_by_pr == 765
+
+
+def test_upsert_edits_an_existing_entry_in_place_without_duplicating_the_key(tmp_path):
+    # The stale case: the metric already has a block, so appending a second one
+    # would make a duplicate key that YAML silently resolves to the last.
+    out = ratifications.upsert(EXISTING, "activated_serve_users", _sign_off(pr=900))
+    assert out.count("activated_serve_users:") == 1
+    assert "Both groups approved #765" in out, "the human's note must survive a re-date"
+    assert _loaded(tmp_path, out)["activated_serve_users"] == ratifications.Ratification(
+        "2026-08-07", "abc1234", 900
+    )
+
+
+def test_upsert_adds_a_field_the_existing_entry_lacks(tmp_path):
+    text = "m:\n  ratified: 2026-08-01\n  definition_sha: 'aaaaaaa'\n"
+    out = ratifications.upsert(text, "m", _sign_off())
+    assert _loaded(tmp_path, out)["m"].approved_by_pr == 800
+
+
+def test_upsert_never_matches_a_commented_out_key(tmp_path):
+    text = "# win_activated_users:\n#   ratified: <date>\n"
+    out = ratifications.upsert(text, "win_activated_users", _sign_off())
+    assert out.startswith("# win_activated_users:"), "the commented block stays commented"
+    assert _loaded(tmp_path, out)["win_activated_users"].approved_by_pr == 800
+
+
+def test_upsert_writes_an_all_digit_hash_quoted(tmp_path):
+    # Unquoted, YAML reads it as an integer and the leading zero is gone.
+    out = ratifications.upsert(EXISTING, "win_users", _sign_off(sha="0123456"))
+    assert _loaded(tmp_path, out)["win_users"].definition_sha == "0123456"

--- a/analytics/tests/test_semantic_catalog_auto_ratification.py
+++ b/analytics/tests/test_semantic_catalog_auto_ratification.py
@@ -238,6 +238,15 @@ def test_upsert_adds_a_field_the_existing_entry_lacks(tmp_path):
     assert _loaded(tmp_path, out)["m"].approved_by_pr == 800
 
 
+def test_upsert_fills_in_a_block_that_has_only_comments(tmp_path):
+    # A header with no field lines gives the insert point nothing to anchor on.
+    # It has to fall back to the header itself rather than raise on an empty max().
+    text = "m:\n  # hand-written note, no fields yet\n"
+    out = ratifications.upsert(text, "m", _sign_off())
+    assert _loaded(tmp_path, out)["m"] == ratifications.Ratification("2026-08-07", "abc1234", 800)
+    assert "# hand-written note, no fields yet" in out, "the human's comment survives"
+
+
 def test_upsert_never_matches_a_commented_out_key(tmp_path):
     text = "# win_activated_users:\n#   ratified: <date>\n"
     out = ratifications.upsert(text, "win_activated_users", _sign_off())

--- a/analytics/tests/test_semantic_catalog_auto_ratification.py
+++ b/analytics/tests/test_semantic_catalog_auto_ratification.py
@@ -220,6 +220,18 @@ def test_upsert_edits_an_existing_entry_in_place_without_duplicating_the_key(tmp
     )
 
 
+def test_upsert_editing_an_entry_preserves_an_unrelated_trailing_comment_block(tmp_path):
+    # The edit path's block-end detection sweeps trailing comments (and blank
+    # lines) after the last rewritten field into the block being edited. It is
+    # correct today only because nothing in the rewrite loop touches a line
+    # that doesn't match a written field or the auto-note prefix -- a
+    # regression here would silently drop or reorder someone else's sidecar
+    # comment. Compare byte for byte, not just substring-contains.
+    trailing = EXISTING[EXISTING.index("\n# win_activated_users") :]
+    out = ratifications.upsert(EXISTING, "activated_serve_users", _sign_off(pr=900))
+    assert out.endswith(trailing)
+
+
 def test_upsert_adds_a_field_the_existing_entry_lacks(tmp_path):
     text = "m:\n  ratified: 2026-08-01\n  definition_sha: 'aaaaaaa'\n"
     out = ratifications.upsert(text, "m", _sign_off())
@@ -247,10 +259,44 @@ def test_upsert_into_an_empty_file_creates_a_single_loadable_entry(tmp_path):
 
 def test_upsert_with_a_note_adds_a_comment_that_survives_the_round_trip(tmp_path):
     # Comments are load-bearing: a note passed alongside a brand-new entry
-    # must both appear in the text and not break parsing.
+    # must both appear in the text, tagged with the auto-note prefix so
+    # recording.py can find and replace its own notes later, and not break
+    # parsing.
     out = ratifications.upsert(EXISTING, "win_users", _sign_off(), note="Approved in #800.")
-    assert "# Approved in #800." in out
+    assert f"# {ratifications.AUTO_NOTE_PREFIX}Approved in #800." in out
     assert _loaded(tmp_path, out)["win_users"] == ratifications.Ratification("2026-08-07", "abc1234", 800)
+
+
+def test_upsert_with_a_note_lands_on_an_edit(tmp_path):
+    # A re-earned stale sign-off already has a block, so it takes the edit
+    # path -- the note must not be silently dropped there.
+    text = "m:\n  ratified: 2026-08-01\n  definition_sha: 'aaaaaaa'\n  approved_by_pr: 100\n"
+    out = ratifications.upsert(text, "m", _sign_off(pr=200), note="Re-earned in #900.")
+    assert f"# {ratifications.AUTO_NOTE_PREFIX}Re-earned in #900." in out
+    assert _loaded(tmp_path, out)["m"] == ratifications.Ratification("2026-08-07", "abc1234", 200)
+
+
+def test_upsert_with_a_note_replaces_the_prior_auto_note_on_re_edit(tmp_path):
+    # Re-recording must not accumulate a second auto-note each time a metric
+    # goes stale and gets re-earned.
+    text = "m:\n  ratified: 2026-08-01\n  definition_sha: 'aaaaaaa'\n  approved_by_pr: 100\n"
+    once = ratifications.upsert(text, "m", _sign_off(pr=200), note="First re-earn, PR #900.")
+    twice = ratifications.upsert(once, "m", _sign_off(pr=300), note="Second re-earn, PR #901.")
+    assert twice.count(ratifications.AUTO_NOTE_PREFIX) == 1
+    assert "First re-earn" not in twice
+    assert f"# {ratifications.AUTO_NOTE_PREFIX}Second re-earn, PR #901." in twice
+    assert _loaded(tmp_path, twice)["m"].approved_by_pr == 300
+
+
+def test_upsert_with_a_note_leaves_a_human_comment_in_the_same_block_untouched(tmp_path):
+    # The auto-note and a human's hand-written reasoning must coexist: only
+    # the prefixed line is ours to replace.
+    out = ratifications.upsert(
+        EXISTING, "activated_serve_users", _sign_off(pr=900), note="Re-earned in #900."
+    )
+    assert "Both groups approved #765" in out
+    assert f"# {ratifications.AUTO_NOTE_PREFIX}Re-earned in #900." in out
+    assert _loaded(tmp_path, out)["activated_serve_users"].approved_by_pr == 900
 
 
 def test_upsert_writes_a_missing_pr_number_as_yaml_null(tmp_path):

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import yaml
 from semantic_catalog import cli
 from semantic_catalog.parser import parse_semantic_tree
 
@@ -284,6 +285,146 @@ def test_record_writes_nothing_when_a_review_group_is_missing(tmp_path, monkeypa
     assert sidecar.read_text() == "", "an uncovered merge must record nothing"
     assert json.loads(out.read_text())["metrics"] == []
     assert "coverage incomplete" in capsys.readouterr().out.lower()
+
+
+def _base_tree_with_moved_definition(tmp_path, metric: str):
+    """A base worktree identical to HEAD except that `metric`'s definition moved.
+
+    Copies only the sem_*.yml files, preserving their paths under the base, which
+    is all `parse_semantic_tree` walks. The point is a base where exactly one
+    metric's fingerprint differs, so `ratified_by_merge` earns exactly that one
+    and every other pending metric is correctly left alone.
+    """
+    base = tmp_path / "base"
+    moved = False
+    for root in cli.SEM_ROOTS:
+        for src in root.rglob("sem_*.yml"):
+            dest = base / src.relative_to(REPO_ROOT)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            doc = yaml.safe_load(src.read_text())
+            for entry in (doc or {}).get("metrics", []) or []:
+                if entry.get("name") == metric:
+                    # `description` is a fingerprint field. A YAML comment would
+                    # not do: the fingerprint is computed from parsed values.
+                    entry["description"] = (
+                        f"{entry.get('description', '')} Base-tree wording, since superseded."
+                    )
+                    moved = True
+            dest.write_text(yaml.safe_dump(doc, sort_keys=False))
+    assert moved, f"{metric} not found in any sem_*.yml, so the base tree is not actually different"
+    return base
+
+
+def _both_groups_approved(tmp_path):
+    return _reviews_file(
+        tmp_path,
+        [
+            {"login": "amanda847", "state": "APPROVED", "submitted_at": "2026-08-07T10:00:00Z"},
+            {"login": "danpelota", "state": "APPROVED", "submitted_at": "2026-08-07T11:00:00Z"},
+        ],
+    )
+
+
+def test_record_writes_the_earned_sign_off_and_self_verifies(tmp_path, monkeypatch, capsys):
+    # The only test that reaches the `if earned:` branch: sidecar write, catalog
+    # regeneration and the self-verify block that is the sole integrity check on
+    # the bot's own output, since catalog-freshness cannot run on its PR.
+    sidecar = _isolated_sidecar(tmp_path, monkeypatch)
+    written_targets = []
+    monkeypatch.setattr(cli, "write_region", lambda target, recs: written_targets.append(target))
+    base = _base_tree_with_moved_definition(tmp_path, "goodparty_win_rate")
+    out = tmp_path / "recorded.json"
+    body = tmp_path / "body.md"
+
+    rc = cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(_both_groups_approved(tmp_path)),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--base-dir",
+            str(base),
+            "--emit-recorded",
+            str(out),
+            "--emit-pr-body",
+            str(body),
+        ]
+    )
+
+    assert rc == 0, "a clean record must not red-fail the publish job"
+    text = sidecar.read_text()
+    assert "goodparty_win_rate:" in text
+    assert "ratified: 2026-08-07" in text, "the date is when the SECOND group approved"
+    assert "approved_by_pr: 800" in text
+    assert "goodparty_cumulative_wins" not in text, "a bystander in the same file must not be signed off"
+    manifest = json.loads(out.read_text())
+    assert [m["name"] for m in manifest["metrics"]] == ["goodparty_win_rate"]
+    assert body.exists(), "an earned sign-off must render a PR body to open with"
+    assert written_targets, "the catalog projections must be regenerated in the same pass"
+    assert "recorded 1" in capsys.readouterr().out
+
+
+def test_record_fails_loudly_when_its_own_write_does_not_read_back(tmp_path, monkeypatch, capsys):
+    # Self-verify is the only check the bot's output gets, so a write that does
+    # not read back as freshly ratified must exit 1, not pass quietly.
+    _isolated_sidecar(tmp_path, monkeypatch)
+    monkeypatch.setattr(cli, "write_region", lambda target, recs: None)
+    # Silently drop the write: the sidecar keeps its old contents, so the metric
+    # still reads pending on the re-parse.
+    monkeypatch.setattr(cli.recording, "apply", lambda text, earned, pr: text)
+    base = _base_tree_with_moved_definition(tmp_path, "goodparty_win_rate")
+
+    rc = cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(_both_groups_approved(tmp_path)),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--base-dir",
+            str(base),
+        ]
+    )
+
+    assert rc == 1
+    assert "does not read as freshly ratified" in capsys.readouterr().err
+
+
+def test_record_writes_nothing_when_the_base_tree_parses_no_metrics(tmp_path, monkeypatch, capsys):
+    # A base dir that exists but holds no sem files parses to zero metrics, which
+    # would make every pending metric look new. Same hazard as no base at all.
+    sidecar = _isolated_sidecar(tmp_path, monkeypatch)
+    empty_base = tmp_path / "empty-base"
+    empty_base.mkdir()
+
+    rc = cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(_both_groups_approved(tmp_path)),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--base-dir",
+            str(empty_base),
+        ]
+    )
+
+    assert rc == 0
+    assert sidecar.read_text() == ""
+    assert "parsed no metrics" in capsys.readouterr().out
 
 
 def test_record_writes_nothing_without_a_base_tree(tmp_path, monkeypatch, capsys):

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -286,6 +286,71 @@ def test_record_writes_nothing_when_a_review_group_is_missing(tmp_path, monkeypa
     assert "coverage incomplete" in capsys.readouterr().out.lower()
 
 
+def test_record_writes_nothing_without_a_base_tree(tmp_path, monkeypatch, capsys):
+    # Both groups approved, so coverage is complete, but with no base tree there
+    # is no way to tell which definition moved. Recording anyway would sign off
+    # every pending metric, including bystanders nobody reviewed.
+    sidecar = _isolated_sidecar(tmp_path, monkeypatch)
+    reviews = _reviews_file(
+        tmp_path,
+        [
+            {"login": "amanda847", "state": "APPROVED", "submitted_at": "2026-08-07T10:00:00Z"},
+            {"login": "danpelota", "state": "APPROVED", "submitted_at": "2026-08-07T11:00:00Z"},
+        ],
+    )
+    out = tmp_path / "recorded.json"
+    rc = cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(reviews),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--emit-recorded",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    assert sidecar.read_text() == "", "no base tree must record nothing"
+    assert json.loads(out.read_text())["metrics"] == []
+    assert "no base tree" in capsys.readouterr().out.lower()
+
+
+def test_record_writes_nothing_when_a_base_dir_is_missing_on_disk(tmp_path, monkeypatch, capsys):
+    # A --base-dir that does not exist parses as an empty tree, which is the same
+    # bystander hazard as omitting it entirely.
+    sidecar = _isolated_sidecar(tmp_path, monkeypatch)
+    reviews = _reviews_file(
+        tmp_path,
+        [
+            {"login": "amanda847", "state": "APPROVED", "submitted_at": "2026-08-07T10:00:00Z"},
+            {"login": "danpelota", "state": "APPROVED", "submitted_at": "2026-08-07T11:00:00Z"},
+        ],
+    )
+    rc = cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(reviews),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--base-dir",
+            str(tmp_path / "does-not-exist"),
+        ]
+    )
+    assert rc == 0
+    assert sidecar.read_text() == ""
+    assert "no base tree" in capsys.readouterr().out.lower()
+
+
 def test_record_writes_nothing_when_the_merge_changed_no_definition(tmp_path, monkeypatch, capsys):
     # Both groups approved, but every metric is already ratified and untouched,
     # so the merge earned nothing.

--- a/analytics/tests/test_semantic_catalog_cli.py
+++ b/analytics/tests/test_semantic_catalog_cli.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from semantic_catalog import cli
@@ -241,3 +242,106 @@ def test_reply_created_invokes_reply_in_thread(tmp_path, monkeypatch):
     assert seen["channel"] == "C999"
     assert seen["thread_ts"] == "1699.1"
     assert seen["tasks"][0]["metric"] == "win_users"
+
+
+def _reviews_file(tmp_path, reviews):
+    p = tmp_path / "reviews.json"
+    p.write_text(json.dumps(reviews))
+    return p
+
+
+def _isolated_sidecar(tmp_path, monkeypatch, body=""):
+    """Point the generator at a throwaway sidecar so tests never touch the repo's."""
+    sidecar = tmp_path / "ratifications.yml"
+    sidecar.write_text(body)
+    monkeypatch.setattr(cli.ratifications, "DEFAULT_PATH", sidecar)
+    return sidecar
+
+
+def test_record_writes_nothing_when_a_review_group_is_missing(tmp_path, monkeypatch, capsys):
+    sidecar = _isolated_sidecar(tmp_path, monkeypatch)
+    reviews = _reviews_file(
+        tmp_path,
+        [{"login": "amanda847", "state": "APPROVED", "submitted_at": "2026-08-07T10:00:00Z"}],
+    )
+    out = tmp_path / "recorded.json"
+    rc = cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(reviews),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--emit-recorded",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    assert sidecar.read_text() == "", "an uncovered merge must record nothing"
+    assert json.loads(out.read_text())["metrics"] == []
+    assert "coverage incomplete" in capsys.readouterr().out.lower()
+
+
+def test_record_writes_nothing_when_the_merge_changed_no_definition(tmp_path, monkeypatch, capsys):
+    # Both groups approved, but every metric is already ratified and untouched,
+    # so the merge earned nothing.
+    _isolated_sidecar(tmp_path, monkeypatch)
+    reviews = _reviews_file(
+        tmp_path,
+        [
+            {"login": "amanda847", "state": "APPROVED", "submitted_at": "2026-08-07T10:00:00Z"},
+            {"login": "danpelota", "state": "APPROVED", "submitted_at": "2026-08-07T11:00:00Z"},
+        ],
+    )
+    out = tmp_path / "recorded.json"
+    # No --base-dir, so `before` is empty and every current metric looks new;
+    # guard against that by pointing base-dir at the real tree (identical to HEAD).
+    rc = cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(reviews),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--base-dir",
+            str(REPO_ROOT),
+            "--emit-recorded",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    assert json.loads(out.read_text())["metrics"] == []
+
+
+def test_record_emits_the_pr_body_only_when_something_was_earned(tmp_path, monkeypatch):
+    _isolated_sidecar(tmp_path, monkeypatch)
+    reviews = _reviews_file(
+        tmp_path, [{"login": "amanda847", "state": "APPROVED", "submitted_at": "2026-08-07T10:00:00Z"}]
+    )
+    body = tmp_path / "body.md"
+    cli.main(
+        [
+            "--record-ratifications",
+            "--reviews",
+            str(reviews),
+            "--data-members",
+            "danpelota",
+            "--business-members",
+            "amanda847",
+            "--pr-number",
+            "800",
+            "--emit-recorded",
+            str(tmp_path / "recorded.json"),
+            "--emit-pr-body",
+            str(body),
+        ]
+    )
+    assert not body.exists(), "no PR body when there is no PR to open"

--- a/analytics/tests/test_semantic_catalog_recording.py
+++ b/analytics/tests/test_semantic_catalog_recording.py
@@ -1,0 +1,83 @@
+from semantic_catalog import ratifications, recording
+from semantic_catalog.records import MetricRecord
+
+SIDECAR = """\
+# Header comment that must survive.
+
+win_users:
+  # A human's note about this sign-off.
+  ratified: 2026-08-04
+  definition_sha: '865d003'
+  approved_by_pr: 749
+"""
+
+
+def _rec(name, definition="def", label=None):
+    return MetricRecord(
+        name=name,
+        label=label or name,
+        definition=definition,
+        metric_type="simple",
+        source="ref('m')",
+        dimensions=(),
+        filter=None,
+        owner=None,
+        ratified=None,
+        detail_doc=None,
+        retired=None,
+        yaml_file="sem_analytics__users_win.yml",
+        kind="metric",
+    )
+
+
+def _earned(name="serve_users", date="2026-08-07", sha="abc1234", pr=800):
+    return {name: ratifications.Ratification(date, sha, pr)}
+
+
+def test_apply_writes_each_earned_entry_with_a_provenance_note(tmp_path):
+    out = recording.apply(SIDECAR, _earned(), 800)
+    path = tmp_path / "r.yml"
+    path.write_text(out)
+    loaded = ratifications.load(path)
+    assert loaded["serve_users"] == ratifications.Ratification("2026-08-07", "abc1234", 800)
+    assert "#800" in out, "the entry must say where the sign-off came from"
+    assert "both review groups approved" in out
+
+
+def test_apply_preserves_existing_comments_and_entries(tmp_path):
+    out = recording.apply(SIDECAR, _earned(), 800)
+    assert "Header comment that must survive" in out
+    assert "A human's note about this sign-off" in out
+    path = tmp_path / "r.yml"
+    path.write_text(out)
+    assert ratifications.load(path)["win_users"].approved_by_pr == 749
+
+
+def test_apply_writes_entries_in_a_stable_order():
+    # Two metrics earned by one merge must land in a deterministic order, or a
+    # re-run produces a different diff and the branch churns.
+    earned = {
+        "b_metric": ratifications.Ratification("2026-08-07", "bbbbbbb", 800),
+        "a_metric": ratifications.Ratification("2026-08-07", "aaaaaaa", 800),
+    }
+    out = recording.apply(SIDECAR, earned, 800)
+    assert out.index("a_metric:") < out.index("b_metric:")
+
+
+def test_apply_is_idempotent():
+    once = recording.apply(SIDECAR, _earned(), 800)
+    twice = recording.apply(once, _earned(), 800)
+    assert once == twice
+
+
+def test_manifest_carries_what_the_pr_body_needs():
+    earned = _earned()
+    got = recording.manifest(earned, [_rec("serve_users", label="Serve Users")], "2026-08-07", 800)
+    assert got["pr"] == 800
+    assert got["date"] == "2026-08-07"
+    assert got["metrics"] == [{"name": "serve_users", "label": "Serve Users", "definition_sha": "abc1234"}]
+
+
+def test_manifest_is_empty_when_nothing_was_earned():
+    got = recording.manifest({}, [], None, 800)
+    assert got["metrics"] == []

--- a/analytics/tests/test_semantic_catalog_recording.py
+++ b/analytics/tests/test_semantic_catalog_recording.py
@@ -1,3 +1,4 @@
+import pytest
 from semantic_catalog import ratifications, recording
 from semantic_catalog.records import MetricRecord
 
@@ -102,9 +103,11 @@ def test_pr_body_explains_what_the_approver_is_agreeing_to():
     assert "date matches" in body.lower()
 
 
-def test_pr_body_carries_no_em_dash_or_emoji():
+def test_pr_body_is_pure_ascii():
     # DATA-2211 copy rule, and this text is machine-generated so nothing else
-    # catches a violation.
+    # catches a violation. Pure ASCII is the actual constraint: it rules out
+    # em dash, en dash, curly quotes, ellipsis, and emoji in one assertion,
+    # unlike a codepoint ceiling that some of those slip under.
     body = recording.pr_body(
         {
             "pr": 800,
@@ -113,5 +116,19 @@ def test_pr_body_carries_no_em_dash_or_emoji():
         },
         repo="o/r",
     )
-    assert "—" not in body
-    assert all(ord(ch) < 0x2190 for ch in body)
+    assert body.isascii()
+
+
+def test_pr_body_raises_when_date_is_none():
+    # A bad write must fail loudly, not degrade into a body that reads
+    # "The date recorded here, None, is when the second group's approval
+    # landed."
+    with pytest.raises(ValueError):
+        recording.pr_body(
+            {
+                "pr": 800,
+                "date": None,
+                "metrics": [{"name": "m", "label": "M", "definition_sha": "abc1234"}],
+            },
+            repo="o/r",
+        )

--- a/analytics/tests/test_semantic_catalog_recording.py
+++ b/analytics/tests/test_semantic_catalog_recording.py
@@ -81,3 +81,37 @@ def test_manifest_carries_what_the_pr_body_needs():
 def test_manifest_is_empty_when_nothing_was_earned():
     got = recording.manifest({}, [], None, 800)
     assert got["metrics"] == []
+
+
+def test_pr_body_names_each_metric_and_the_source_pr():
+    body = recording.pr_body(
+        {
+            "pr": 800,
+            "date": "2026-08-07",
+            "metrics": [{"name": "serve_users", "label": "Serve Users", "definition_sha": "abc1234"}],
+        },
+        repo="thegoodparty/gp-data-platform",
+    )
+    assert "serve_users" in body
+    assert "2026-08-07" in body
+    assert "thegoodparty/gp-data-platform/pull/800" in body
+
+
+def test_pr_body_explains_what_the_approver_is_agreeing_to():
+    body = recording.pr_body({"pr": 800, "date": "2026-08-07", "metrics": []}, repo="o/r")
+    assert "date matches" in body.lower()
+
+
+def test_pr_body_carries_no_em_dash_or_emoji():
+    # DATA-2211 copy rule, and this text is machine-generated so nothing else
+    # catches a violation.
+    body = recording.pr_body(
+        {
+            "pr": 800,
+            "date": "2026-08-07",
+            "metrics": [{"name": "m", "label": "M", "definition_sha": "abc1234"}],
+        },
+        repo="o/r",
+    )
+    assert "—" not in body
+    assert all(ord(ch) < 0x2190 for ch in body)

--- a/analytics/tests/test_semantic_catalog_sigma_tasks.py
+++ b/analytics/tests/test_semantic_catalog_sigma_tasks.py
@@ -70,23 +70,38 @@ def test_newly_ratified_excludes_pending_and_retired():
     assert sigma_tasks.newly_ratified(before, after) == []
 
 
-def test_build_key_is_name_at_ratified_date():
-    assert (
-        sigma_tasks.build_key(_rec("active_serve_users", ratified="2026-07-28"))
-        == "active_serve_users@2026-07-28"
-    )
+def test_build_key_is_name_at_definition_fingerprint():
+    from semantic_catalog import ratifications
+
+    rec = _rec("activated_serve_users", ratified="2026-07-28")
+    assert sigma_tasks.build_key(rec) == f"activated_serve_users@{ratifications.definition_sha(rec)}"
+
+
+def test_build_key_is_stable_when_only_the_date_is_corrected():
+    # The whole point: re-dating a metric must not mint a rival build task for
+    # work already done. Three of those landed on an assignee after DATA-2249.
+    early = _rec("win_users", ratified="2026-08-03")
+    corrected = _rec("win_users", ratified="2026-08-04")
+    assert sigma_tasks.build_key(early) == sigma_tasks.build_key(corrected)
+
+
+def test_build_key_changes_when_the_definition_changes():
+    # A real redefinition IS new build work, so it must still get a task.
+    old = _rec("win_users", ratified="2026-08-04", definition="old meaning")
+    new = _rec("win_users", ratified="2026-08-04", definition="new meaning")
+    assert sigma_tasks.build_key(old) != sigma_tasks.build_key(new)
 
 
 def test_task_payload_shape():
-    p = sigma_tasks.task_payload(
-        _rec("active_serve_users", ratified="2026-07-28", definition="count of active serve users")
-    )
-    assert p.build_key == "active_serve_users@2026-07-28"
+    rec = _rec("active_serve_users", ratified="2026-07-28", definition="count of active serve users")
+    p = sigma_tasks.task_payload(rec)
+    expected_key = sigma_tasks.build_key(rec)
+    assert p.build_key == expected_key
     assert "active_serve_users" in p.name
     assert p.name.startswith("Build in Sigma:")
     assert "count of active serve users" in p.markdown_description
     assert "2026-07-28" in p.markdown_description
-    assert "active_serve_users@2026-07-28" in p.markdown_description
+    assert expected_key in p.markdown_description
     # Org copy rule: no em dashes, no emoji in generated copy.
     assert "—" not in p.name and "—" not in p.markdown_description
 
@@ -121,15 +136,15 @@ class _FakeClient:
 
 def test_sync_creates_task_for_newly_ratified():
     client = _FakeClient()
-    result = sigma_tasks.sync(
-        client, "901", "field1", [_rec("m", ratified=None)], [_rec("m", ratified="2026-07-28")]
-    )
-    assert [p.build_key for p in client.created] == ["m@2026-07-28"]
+    after = [_rec("m", ratified="2026-07-28")]
+    result = sigma_tasks.sync(client, "901", "field1", [_rec("m", ratified=None)], after)
+    expected_key = sigma_tasks.build_key(after[0])
+    assert [p.build_key for p in client.created] == [expected_key]
     assert len(result.created) == 1
     task = result.created[0]
     assert task.metric_name == "m"
-    assert task.task_id == "id-m@2026-07-28"
-    assert task.url == "https://app.clickup.com/t/id-m@2026-07-28"
+    assert task.task_id == f"id-{expected_key}"
+    assert task.url == f"https://app.clickup.com/t/id-{expected_key}"
     assert result.skipped == ()
 
 
@@ -148,10 +163,9 @@ def test_sync_passes_assignee_ids_through_to_the_payload():
 
 def test_sync_is_idempotent_when_task_already_exists():
     # Same transition seen again on a workflow re-run: ClickUp already has the task.
-    client = _FakeClient(existing_keys={"m@2026-07-28"})
-    result = sigma_tasks.sync(
-        client, "901", "field1", [_rec("m", ratified=None)], [_rec("m", ratified="2026-07-28")]
-    )
+    after = [_rec("m", ratified="2026-07-28")]
+    client = _FakeClient(existing_keys={sigma_tasks.build_key(after[0])})
+    result = sigma_tasks.sync(client, "901", "field1", [_rec("m", ratified=None)], after)
     assert client.created == []
     assert result.created == ()
     assert result.skipped == ("m",)


### PR DESCRIPTION
## What

DATA-2249 moved `ratified` into a sidecar outside CODEOWNERS, which made the date writable by something other than a human PR. This makes it written.

On a merge whose PR both review groups approved, the publish job now derives the date coverage completed from the review record, writes the earned sign-offs into the sidecar working tree, regenerates both `canonical_metrics.md` projections, and opens a small follow-up PR carrying just that record. Reviewing a sign-off becomes a one-line bookkeeping PR instead of a hand-authored date.

Second payoff: the Sigma build task (DATA-2199) stops waiting on the bookkeeping. The record step runs before the Sigma step in the same job, so that step re-parses a tree already carrying the date and creates the build task on the earning merge.

## How it works

`composition.completed_at` returns the moment the second review group's first approval landed, counting only each reviewer's latest review and excluding bots. `completion_date` truncates it to the UTC date the sidecar stores. That is the fix for recording authorship instead of approval: `win_users` was written as 2026-08-03, the day someone typed it, when coverage actually completed 2026-08-04.

`ratifications.ratified_by_merge` is deliberately conservative. A metric qualifies only when it has no trustworthy sign-off already (pending or stale) *and* its definition actually moved in this merge, judged by fingerprint against the base. Without the second condition, a PR editing one metric would ratify every other pending metric sharing its file, which reviewers never looked at.

The write path lives in a separate `recording.py` rather than growing `ratifications.py`, because that module is the read path imported by `parser.py` on every parse, including the blocking `--check` gate. Keeping them apart stops the gate's import surface from growing.

Step ordering in the workflow: the record step sits after the thread-marker update and before the Sigma step. Before Sigma so the build task lands on this merge. After the marker update, rather than straight after the Slack post as originally planned, because the recorder exits 1 on a self-verification failure; between those two steps that failure would leave the thread unmarked and make a re-run double-post the merge summary to #data-alignment.

## Verification

468 tests pass, `actionlint` clean, pre-commit clean.

Dry-run against two real merges, using their live review records:

- **#777** correctly refused: `review coverage incomplete; recording nothing`, empty manifest, exit 0. The only approval on that PR came from `delegate-reviewer[bot]`, so this exercises the bot exclusion as well as the coverage guard.
- **#776** derived `2026-08-07` correctly, from the data group's first approval at 20:30Z and the business group's at 21:23Z, taking the later of the two.

The earned-set and write path were then exercised with #776's real reviews against a definition made to move, which recorded one metric, rewrote its sidecar entry with an `auto-recorded:` note, regenerated the Win catalog projection, passed self-verification, and rendered the PR body. Working tree restored afterwards.

## Known limits, stated rather than discovered

**`gh pr create` is unexercised.** Everything up to the rendered PR body is unit-tested and dry-runnable; the PR-opening call itself cannot run until a real governed merge with both approvals.

**`catalog-freshness` cannot run on the bot's PR**, because a PR opened with the default `GITHUB_TOKEN` does not trigger workflows. That is why the recorder self-verifies and exits 1 loudly rather than skipping: it is the only check the bot's own output gets. Using a PAT would restore the check and reintroduce recursion risk, which we are not doing.

**Replaying #776 records nothing, and that is correct.** The plan predicted a non-empty earned set there. `ratified_by_merge` skips metrics that already carry a trustworthy sign-off, and #776 hand-wrote its own dates, so no historical merge leaves a pending metric after both groups approved. The earned-set path is provable only synthetically, which is what the third dry run above does.

**Stale human prose can outlive a re-earned sign-off.** On a stale entry the `auto-recorded:` note is inserted above any pre-existing human comment, so the block can end up reading older reasoning next to newer values. Preserving human comments is deliberate, so this is a cost of that choice rather than a defect. Cheap to change later by having the note say it superseded a previous sign-off.

**A hand-authored sidecar PR still works.** The Sigma step keeps its file-edge trigger; this adds a path rather than replacing one.

Ticket: DATA-2276. Follows DATA-2249 (#776) and DATA-2130 (#777).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3f1b30fbb5e4e775b1d7903df2f81fe80a578e66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->