### PR TITLE
[DATA-2273] Haystaq loader: isolate per-state failures and self-heal unlogged S3 uploads

### DIFF
--- a/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
@@ -77,22 +77,33 @@ def _select_latest_zip_file(file_list: list[str], file_pattern: re.Pattern) -> s
 
 def _resolve_pickup_action(
     tab_file_name: str,
+    s3_state_prefix: str,
     s3_keys: list[str],
     logged_file_names: set[str],
-) -> Literal["download", "self_heal", "skip"]:
+) -> tuple[Literal["download", "self_heal", "skip"], str | None]:
     """
     Decide how to handle the latest SFTP file. "In S3" alone is not proof of
     completion: a run that dies after uploading but before its sync-log append
     leaves the file in S3 with no log row, and the downstream Databricks load
     only consumes logged files. Such orphans must be re-logged ("self_heal"),
     not skipped.
+
+    Returns (action, matched_file_name). Matching is case-insensitive, but the
+    returned name is the S3 key's exact suffix after `s3_state_prefix`: S3 GETs
+    are case-sensitive and downstream reads prefix + logged name verbatim, so
+    only the spelling that actually exists in S3 may be logged.
     """
     tab_lower = tab_file_name.lower()
-    if not any(key.lower().endswith(f"/{tab_lower}") for key in s3_keys):
-        return "download"
-    if tab_lower in {name.lower() for name in logged_file_names}:
-        return "skip"
-    return "self_heal"
+    matched_key = next(
+        (key for key in s3_keys if key.lower().endswith(f"/{tab_lower}")),
+        None,
+    )
+    if matched_key is None:
+        return "download", None
+    matched_file_name = matched_key[len(s3_state_prefix) :]
+    if matched_file_name.lower() in {name.lower() for name in logged_file_names}:
+        return "skip", matched_file_name
+    return "self_heal", matched_file_name
 
 
 def _locate_extracted_tab(extracted_names: list[str], temp_dir: str) -> str | None:
@@ -141,12 +152,20 @@ def _collect_load_details(
 
 def _finalize_load_details(details: list[dict[str, Any]], failures: list[str]) -> list[dict[str, Any]]:
     """
-    Fail loudly when any state failed. The raise discards this run's log rows,
-    but nothing is lost: completed uploads sit in S3 unlogged and the next
-    run's self-heal path re-logs them without re-downloading.
+    Persist partial progress; fail only on a total wipeout. Raising on any
+    failure would discard every successful row, so one persistently bad state
+    could starve the other states' log rows indefinitely. When at least one
+    extraction succeeded, log the failures and return the successes (failed
+    states retry next run: their files are re-pulled or self-healed). When
+    every extraction failed, something systemic broke (e.g. SFTP outage);
+    there is nothing to persist, so fail the run loudly.
     """
+    if failures and not details:
+        raise RuntimeError(f"all {len(failures)} extraction(s) failed: {'; '.join(failures)}")
     if failures:
-        raise RuntimeError(f"{len(failures)} state extraction(s) failed: {'; '.join(failures)}")
+        logging.error(
+            f"{len(failures)} state extraction(s) failed and will retry next run: {'; '.join(failures)}"
+        )
     return details
 
 
@@ -213,18 +232,22 @@ def _extract_and_load_w_params(
             s3_state_prefix = f"{s3_prefix}/{state_id.upper()}/{haystaq_kind}/"
             s3_file_list = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_state_prefix)
             s3_keys = [f["Key"] for f in s3_file_list.get("Contents", [])]
-            action = _resolve_pickup_action(tab_file_name, s3_keys, logged_file_names)
+            action, matched_file_name = _resolve_pickup_action(
+                tab_file_name, s3_state_prefix, s3_keys, logged_file_names
+            )
             if action == "skip":
-                logging.info(f"{haystaq_kind} file already in S3 and logged for {state_id}: {tab_file_name}")
+                logging.info(
+                    f"{haystaq_kind} file already in S3 and logged for {state_id}: {matched_file_name}"
+                )
                 return EMPTY_LOAD_DETAILS
             if action == "self_heal":
                 logging.warning(
                     f"{haystaq_kind} file for {state_id} is in S3 but has no sync-log row "
-                    f"(a prior run died before logging it); re-logging without re-download: {tab_file_name}"
+                    f"(a prior run died before logging it); re-logging without re-download: {matched_file_name}"
                 )
                 return {
                     "state_id": state_id,
-                    "source_file_names": [tab_file_name],
+                    "source_file_names": [matched_file_name],
                     "source_zip_file": source_zip_file_name,
                     "loaded_at": datetime.now(),
                     "s3_state_prefix": s3_state_prefix,
@@ -277,10 +300,15 @@ def _extract_and_load_w_params(
 
                 extracted_tab_name = os.path.basename(local_tab_path)
                 if extracted_tab_name.lower() != tab_file_name.lower():
+                    # Upload under the zip-derived name regardless: every future
+                    # run derives that name from the SFTP listing to decide
+                    # skip/self-heal, so uploading the extracted spelling would
+                    # never be found again and the file would re-download and
+                    # re-log on every run.
                     logging.warning(
-                        f"Extracted tab name {extracted_tab_name} does not match expected {tab_file_name}; uploading extracted name."
+                        f"Extracted tab name {extracted_tab_name} does not match expected "
+                        f"{tab_file_name}; uploading under the expected name."
                     )
-                    tab_file_name = extracted_tab_name
 
                 s3_key = f"{s3_state_prefix}{tab_file_name}"
                 s3_client.upload_file(Filename=local_tab_path, Bucket=s3_bucket, Key=s3_key)

--- a/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
@@ -303,11 +303,11 @@ def _extract_and_load_w_params(
 
         except Exception as e:
             logging.error(f"Error processing state {state_id} ({haystaq_kind}): {e!s}")
-            error_details = traceback.format_exc()
-            logging.error(f"Full exception details:\n{error_details}")
-            raise Exception(
-                f"Error processing state {state_id} ({haystaq_kind}): {e!s}\nFull traceback:\n{error_details}"
-            ) from e
+            logging.error(f"Full exception details:\n{traceback.format_exc()}")
+            # Re-raise unwrapped: the caller prefixes state/kind onto str(e) for
+            # the end-of-run summary, and wrapping here would duplicate that
+            # context and stuff the whole traceback into the summary line.
+            raise
         finally:
             if sftp_client is not None:
                 sftp_client.close()

--- a/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/project/models/load/load__l2_haystaq_sftp_to_s3.py
@@ -75,6 +75,81 @@ def _select_latest_zip_file(file_list: list[str], file_pattern: re.Pattern) -> s
     return matches[0][0]
 
 
+def _resolve_pickup_action(
+    tab_file_name: str,
+    s3_keys: list[str],
+    logged_file_names: set[str],
+) -> Literal["download", "self_heal", "skip"]:
+    """
+    Decide how to handle the latest SFTP file. "In S3" alone is not proof of
+    completion: a run that dies after uploading but before its sync-log append
+    leaves the file in S3 with no log row, and the downstream Databricks load
+    only consumes logged files. Such orphans must be re-logged ("self_heal"),
+    not skipped.
+    """
+    tab_lower = tab_file_name.lower()
+    if not any(key.lower().endswith(f"/{tab_lower}") for key in s3_keys):
+        return "download"
+    if tab_lower in {name.lower() for name in logged_file_names}:
+        return "skip"
+    return "self_heal"
+
+
+def _locate_extracted_tab(extracted_names: list[str], temp_dir: str) -> str | None:
+    """
+    Return the extracted `.tab`'s local path. None means the zip listed exactly
+    one tab but the file never materialized — seen with partial zips while the
+    vendor is mid-upload — which callers treat as retryable (a later run gets
+    the completed file). Any other member count is a contract violation and
+    raises.
+    """
+    tab_names = [name for name in extracted_names if name.lower().endswith(".tab")]
+    if len(tab_names) != 1:
+        raise ValueError(f"Expected 1 .tab in zip, got {len(tab_names)}: {tab_names}")
+
+    # `ZipFile.extractall` preserves any directory structure inside the zip, so
+    # the extracted file may not live at the root of `temp_dir`.
+    local_tab_path = os.path.join(temp_dir, tab_names[0])
+    if not os.path.isfile(local_tab_path):
+        return None
+    return local_tab_path
+
+
+def _collect_load_details(
+    state_ids: list[str],
+    extract_fns: dict[str, Callable[[str], dict[str, Any]]],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """
+    Run every state through every extractor, isolating failures so one bad
+    state cannot abort the rest (a mid-loop crash used to strand every
+    already-uploaded file unlogged). Returns (details, failures).
+    """
+    all_load_details: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for state_id in state_ids:
+        for kind, extract_fn in extract_fns.items():
+            try:
+                result = extract_fn(state_id)
+            except Exception as e:
+                logging.error(f"Extraction failed for state {state_id} ({kind}): {e!s}")
+                failures.append(f"{state_id} ({kind}): {e!s}")
+                continue
+            if result["state_id"] is not None:
+                all_load_details.append({"state_id": state_id, "load_details": result})
+    return all_load_details, failures
+
+
+def _finalize_load_details(details: list[dict[str, Any]], failures: list[str]) -> list[dict[str, Any]]:
+    """
+    Fail loudly when any state failed. The raise discards this run's log rows,
+    but nothing is lost: completed uploads sit in S3 unlogged and the next
+    run's self-heal path re-logs them without re-downloading.
+    """
+    if failures:
+        raise RuntimeError(f"{len(failures)} state extraction(s) failed: {'; '.join(failures)}")
+    return details
+
+
 def _extract_and_load_w_params(
     sftp_host: str,
     sftp_port: int,
@@ -87,6 +162,7 @@ def _extract_and_load_w_params(
     databricks_volume_directory: str,
     remote_dir: str,
     haystaq_kind: Literal["flags", "scores"],
+    logged_file_names: set[str],
 ) -> Callable[[str], dict[str, Any]]:
     """
     Creates a function that downloads a single state's Haystaq zip from SFTP, extracts the `.tab`,
@@ -137,9 +213,22 @@ def _extract_and_load_w_params(
             s3_state_prefix = f"{s3_prefix}/{state_id.upper()}/{haystaq_kind}/"
             s3_file_list = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=s3_state_prefix)
             s3_keys = [f["Key"] for f in s3_file_list.get("Contents", [])]
-            if any(key.endswith(f"/{tab_file_name}") for key in s3_keys):
-                logging.info(f"{haystaq_kind} file already exists in S3 for {state_id}: {tab_file_name}")
+            action = _resolve_pickup_action(tab_file_name, s3_keys, logged_file_names)
+            if action == "skip":
+                logging.info(f"{haystaq_kind} file already in S3 and logged for {state_id}: {tab_file_name}")
                 return EMPTY_LOAD_DETAILS
+            if action == "self_heal":
+                logging.warning(
+                    f"{haystaq_kind} file for {state_id} is in S3 but has no sync-log row "
+                    f"(a prior run died before logging it); re-logging without re-download: {tab_file_name}"
+                )
+                return {
+                    "state_id": state_id,
+                    "source_file_names": [tab_file_name],
+                    "source_zip_file": source_zip_file_name,
+                    "loaded_at": datetime.now(),
+                    "s3_state_prefix": s3_state_prefix,
+                }
 
             full_zip_path = os.path.join(remote_dir, source_zip_file_name)
 
@@ -177,26 +266,21 @@ def _extract_and_load_w_params(
                     logging.error(f"Failed to extract {local_zip_path}. Skipping for now.")
                     return EMPTY_LOAD_DETAILS
 
-                # Expect exactly one .tab file
-                tab_names = [name for name in extracted_names if name.lower().endswith(".tab")]
-                if len(tab_names) != 1:
-                    raise ValueError(
-                        f"Expected 1 .tab in {source_zip_file_name}, got {len(tab_names)}: {tab_names}"
+                local_tab_path = _locate_extracted_tab(extracted_names, temp_dir)
+                if local_tab_path is None:
+                    # Zip was likely partial (vendor mid-upload); retry on a later run.
+                    logging.error(
+                        f"Extracted tab missing for {state_id} ({haystaq_kind}) from "
+                        f"{source_zip_file_name}. Skipping for now."
                     )
+                    return EMPTY_LOAD_DETAILS
 
-                extracted_tab_member = tab_names[0]
-                extracted_tab_name = os.path.basename(extracted_tab_member)
+                extracted_tab_name = os.path.basename(local_tab_path)
                 if extracted_tab_name.lower() != tab_file_name.lower():
                     logging.warning(
                         f"Extracted tab name {extracted_tab_name} does not match expected {tab_file_name}; uploading extracted name."
                     )
                     tab_file_name = extracted_tab_name
-
-                # `ZipFile.extractall` preserves any directory structure inside the zip, so the
-                # extracted file may not live at the root of `temp_dir`.
-                local_tab_path = os.path.join(temp_dir, extracted_tab_member)
-                if not os.path.isfile(local_tab_path):
-                    raise FileNotFoundError(f"Extracted tab file not found at {local_tab_path}")
 
                 s3_key = f"{s3_state_prefix}{tab_file_name}"
                 s3_client.upload_file(Filename=local_tab_path, Bucket=s3_bucket, Key=s3_key)
@@ -291,6 +375,17 @@ def model(dbt, session: SparkSession) -> DataFrame:
     state_list = [row.state_id for row in states.select("state_id").collect()]
     logging.info(f"States included: {', '.join(sorted(state_list))}")
 
+    # "Already handled" must mean "logged", not merely "uploaded to S3" — the
+    # downstream Databricks load only consumes logged files. Read this model's
+    # own log so files stranded in S3 by an interrupted run get re-logged.
+    logged_file_names: set[str] = set()
+    if dbt.is_incremental:
+        logged_file_names = {
+            row.source_file_name.lower()
+            for row in session.table(f"{dbt.this}").select("source_file_name").collect()
+            if row.source_file_name is not None
+        }
+
     extract_flags = _extract_and_load_w_params(
         sftp_host=sftp_host,
         sftp_port=sftp_port,
@@ -303,6 +398,7 @@ def model(dbt, session: SparkSession) -> DataFrame:
         databricks_volume_directory=databricks_volume_directory,
         remote_dir=flags_remote_dir,
         haystaq_kind="flags",
+        logged_file_names=logged_file_names,
     )
 
     extract_scores = _extract_and_load_w_params(
@@ -317,17 +413,14 @@ def model(dbt, session: SparkSession) -> DataFrame:
         databricks_volume_directory=databricks_volume_directory,
         remote_dir=scores_remote_dir,
         haystaq_kind="scores",
+        logged_file_names=logged_file_names,
     )
 
-    all_load_details: list[dict[str, Any]] = []
-    for state_id in state_list:
-        flags_result = extract_flags(state_id)
-        if flags_result["state_id"] is not None:
-            all_load_details.append({"state_id": state_id, "load_details": flags_result})
-
-        scores_result = extract_scores(state_id)
-        if scores_result["state_id"] is not None:
-            all_load_details.append({"state_id": state_id, "load_details": scores_result})
+    all_load_details, failures = _collect_load_details(
+        state_ids=state_list,
+        extract_fns={"flags": extract_flags, "scores": extract_scores},
+    )
+    all_load_details = _finalize_load_details(all_load_details, failures)
 
     # schema matches `load__l2_sftp_to_s3`
     load_details_schema = StructType(

--- a/dbt/tests/test_load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/tests/test_load__l2_haystaq_sftp_to_s3.py
@@ -11,53 +11,79 @@ from dbt.project.models.load.load__l2_haystaq_sftp_to_s3 import (
 
 
 class TestResolvePickupAction:
+    PREFIX = "l2_data/from_sftp_server/Haystaq/prod/AZ/flags/"
     S3_KEYS: ClassVar[list[str]] = [
         "l2_data/from_sftp_server/Haystaq/prod/AZ/flags/az_haystaqdnaflags_20260520.tab",
     ]
 
     def test_downloads_when_tab_not_in_s3(self):
-        action = _resolve_pickup_action(
+        action, matched = _resolve_pickup_action(
             tab_file_name="az_haystaqdnaflags_20260601.tab",
+            s3_state_prefix=self.PREFIX,
             s3_keys=self.S3_KEYS,
             logged_file_names=set(),
         )
         assert action == "download"
+        assert matched is None
 
     def test_skips_when_tab_in_s3_and_logged(self):
-        action = _resolve_pickup_action(
+        action, matched = _resolve_pickup_action(
             tab_file_name="az_haystaqdnaflags_20260520.tab",
+            s3_state_prefix=self.PREFIX,
             s3_keys=self.S3_KEYS,
             logged_file_names={"az_haystaqdnaflags_20260520.tab"},
         )
         assert action == "skip"
+        assert matched == "az_haystaqdnaflags_20260520.tab"
 
     def test_self_heals_when_tab_in_s3_but_never_logged(self):
         # The May 2026 incident: a run died after uploading to S3 but before
         # appending its sync-log rows, so the file looked "done" forever.
-        action = _resolve_pickup_action(
+        action, matched = _resolve_pickup_action(
             tab_file_name="az_haystaqdnaflags_20260520.tab",
+            s3_state_prefix=self.PREFIX,
             s3_keys=self.S3_KEYS,
             logged_file_names=set(),
         )
         assert action == "self_heal"
+        assert matched == "az_haystaqdnaflags_20260520.tab"
 
-    def test_matching_is_case_insensitive(self):
-        action = _resolve_pickup_action(
+    def test_matching_is_case_insensitive_but_returns_exact_s3_spelling(self):
+        # S3 GETs are case-sensitive: the caller must log the spelling that
+        # actually exists in S3, not the SFTP-derived one it searched with.
+        action, matched = _resolve_pickup_action(
             tab_file_name="AZ_HaystaqDnaFlags_20260520.TAB",
+            s3_state_prefix=self.PREFIX,
             s3_keys=self.S3_KEYS,
-            logged_file_names={"AZ_haystaqdnaflags_20260520.tab"},
+            logged_file_names=set(),
         )
-        assert action == "skip"
+        assert action == "self_heal"
+        assert matched == "az_haystaqdnaflags_20260520.tab"
+
+    def test_matched_name_preserves_nesting_under_the_state_prefix(self):
+        # Downstream builds its read path as prefix + logged name, so the
+        # matched name must be the key's suffix after the prefix, not its
+        # basename.
+        action, matched = _resolve_pickup_action(
+            tab_file_name="az_haystaqdnaflags_20260520.tab",
+            s3_state_prefix=self.PREFIX,
+            s3_keys=[f"{self.PREFIX}nested/az_haystaqdnaflags_20260520.tab"],
+            logged_file_names=set(),
+        )
+        assert action == "self_heal"
+        assert matched == "nested/az_haystaqdnaflags_20260520.tab"
 
     def test_does_not_match_tab_name_suffix_of_other_file(self):
         # "…/az_haystaqdnaflags_20260520.tab" must not satisfy a lookup for
         # "flags_20260520.tab"; only a full path segment counts.
-        action = _resolve_pickup_action(
+        action, matched = _resolve_pickup_action(
             tab_file_name="flags_20260520.tab",
+            s3_state_prefix=self.PREFIX,
             s3_keys=self.S3_KEYS,
             logged_file_names=set(),
         )
         assert action == "download"
+        assert matched is None
 
 
 class TestLocateExtractedTab:
@@ -166,10 +192,16 @@ class TestFinalizeLoadDetails:
         details = [{"state_id": "AZ", "load_details": _details_for("AZ", "flags")}]
         assert _finalize_load_details(details, failures=[]) is details
 
-    def test_raises_summary_naming_each_failed_state(self):
-        with pytest.raises(
-            RuntimeError, match=r"2 state extraction\(s\) failed.*MI \(flags\).*WI \(scores\)"
-        ):
+    def test_partial_failure_still_returns_successful_details(self):
+        # A persistently failing state must not starve the others: successful
+        # states' rows persist this run instead of being discarded by a raise.
+        details = [{"state_id": "AZ", "load_details": _details_for("AZ", "flags")}]
+        assert _finalize_load_details(details, failures=["MI (flags): extracted tab not found"]) is details
+
+    def test_raises_only_when_every_extraction_failed(self):
+        # Nothing succeeded means nothing would be lost by failing the run, and
+        # a total wipeout (e.g. SFTP outage) should be loud, not a green no-op.
+        with pytest.raises(RuntimeError, match=r"all 2 extraction\(s\) failed.*MI \(flags\).*WI \(scores\)"):
             _finalize_load_details(
                 [],
                 failures=["MI (flags): extracted tab not found", "WI (scores): boom"],

--- a/dbt/tests/test_load__l2_haystaq_sftp_to_s3.py
+++ b/dbt/tests/test_load__l2_haystaq_sftp_to_s3.py
@@ -1,0 +1,176 @@
+from typing import ClassVar
+
+import pytest
+from dbt.project.models.load.load__l2_haystaq_sftp_to_s3 import (
+    EMPTY_LOAD_DETAILS,
+    _collect_load_details,
+    _finalize_load_details,
+    _locate_extracted_tab,
+    _resolve_pickup_action,
+)
+
+
+class TestResolvePickupAction:
+    S3_KEYS: ClassVar[list[str]] = [
+        "l2_data/from_sftp_server/Haystaq/prod/AZ/flags/az_haystaqdnaflags_20260520.tab",
+    ]
+
+    def test_downloads_when_tab_not_in_s3(self):
+        action = _resolve_pickup_action(
+            tab_file_name="az_haystaqdnaflags_20260601.tab",
+            s3_keys=self.S3_KEYS,
+            logged_file_names=set(),
+        )
+        assert action == "download"
+
+    def test_skips_when_tab_in_s3_and_logged(self):
+        action = _resolve_pickup_action(
+            tab_file_name="az_haystaqdnaflags_20260520.tab",
+            s3_keys=self.S3_KEYS,
+            logged_file_names={"az_haystaqdnaflags_20260520.tab"},
+        )
+        assert action == "skip"
+
+    def test_self_heals_when_tab_in_s3_but_never_logged(self):
+        # The May 2026 incident: a run died after uploading to S3 but before
+        # appending its sync-log rows, so the file looked "done" forever.
+        action = _resolve_pickup_action(
+            tab_file_name="az_haystaqdnaflags_20260520.tab",
+            s3_keys=self.S3_KEYS,
+            logged_file_names=set(),
+        )
+        assert action == "self_heal"
+
+    def test_matching_is_case_insensitive(self):
+        action = _resolve_pickup_action(
+            tab_file_name="AZ_HaystaqDnaFlags_20260520.TAB",
+            s3_keys=self.S3_KEYS,
+            logged_file_names={"AZ_haystaqdnaflags_20260520.tab"},
+        )
+        assert action == "skip"
+
+    def test_does_not_match_tab_name_suffix_of_other_file(self):
+        # "…/az_haystaqdnaflags_20260520.tab" must not satisfy a lookup for
+        # "flags_20260520.tab"; only a full path segment counts.
+        action = _resolve_pickup_action(
+            tab_file_name="flags_20260520.tab",
+            s3_keys=self.S3_KEYS,
+            logged_file_names=set(),
+        )
+        assert action == "download"
+
+
+class TestLocateExtractedTab:
+    def test_returns_path_when_single_tab_present(self, tmp_path):
+        tab = tmp_path / "az_haystaqdnaflags_20260520.tab"
+        tab.write_text("LALVOTERID\th1\n")
+        found = _locate_extracted_tab(
+            extracted_names=["az_haystaqdnaflags_20260520.tab"],
+            temp_dir=str(tmp_path),
+        )
+        assert found == str(tab)
+
+    def test_returns_path_for_tab_nested_in_zip_subdirectory(self, tmp_path):
+        nested = tmp_path / "inner"
+        nested.mkdir()
+        tab = nested / "az_haystaqdnaflags_20260520.tab"
+        tab.write_text("LALVOTERID\th1\n")
+        found = _locate_extracted_tab(
+            extracted_names=["inner/az_haystaqdnaflags_20260520.tab"],
+            temp_dir=str(tmp_path),
+        )
+        assert found == str(tab)
+
+    def test_returns_none_when_tab_file_missing_on_disk(self, tmp_path):
+        # The exact May 2026 failure: the zip listed a tab member but the file
+        # never materialized (vendor was mid-upload). Must be a retryable skip,
+        # not an exception that kills the whole run.
+        found = _locate_extracted_tab(
+            extracted_names=["az_haystaqdnaflags_20260520.tab"],
+            temp_dir=str(tmp_path),
+        )
+        assert found is None
+
+    def test_raises_when_zip_has_no_tab(self, tmp_path):
+        with pytest.raises(ValueError, match="Expected 1 .tab"):
+            _locate_extracted_tab(extracted_names=["readme.txt"], temp_dir=str(tmp_path))
+
+    def test_raises_when_zip_has_multiple_tabs(self, tmp_path):
+        with pytest.raises(ValueError, match="Expected 1 .tab"):
+            _locate_extracted_tab(
+                extracted_names=["a_20260520.tab", "b_20260520.tab"],
+                temp_dir=str(tmp_path),
+            )
+
+
+def _details_for(state_id: str, kind: str) -> dict:
+    return {
+        "state_id": state_id,
+        "source_file_names": [f"{state_id.lower()}_haystaqdna{kind}_20260520.tab"],
+        "source_zip_file": f"{state_id.lower()}_haystaqdna{kind}_20260520.tab.zip",
+        "loaded_at": None,
+        "s3_state_prefix": f"prefix/{state_id}/{kind}/",
+    }
+
+
+class TestCollectLoadDetails:
+    def test_collects_details_for_every_state_and_kind(self):
+        details, failures = _collect_load_details(
+            state_ids=["AZ", "MI"],
+            extract_fns={
+                "flags": lambda st: _details_for(st, "flags"),
+                "scores": lambda st: _details_for(st, "scores"),
+            },
+        )
+        assert failures == []
+        assert [(d["state_id"], d["load_details"]["source_zip_file"]) for d in details] == [
+            ("AZ", "az_haystaqdnaflags_20260520.tab.zip"),
+            ("AZ", "az_haystaqdnascores_20260520.tab.zip"),
+            ("MI", "mi_haystaqdnaflags_20260520.tab.zip"),
+            ("MI", "mi_haystaqdnascores_20260520.tab.zip"),
+        ]
+
+    def test_skipped_states_are_excluded_from_details(self):
+        details, failures = _collect_load_details(
+            state_ids=["AZ"],
+            extract_fns={
+                "flags": lambda st: dict(EMPTY_LOAD_DETAILS),
+                "scores": lambda st: _details_for(st, "scores"),
+            },
+        )
+        assert failures == []
+        assert [d["load_details"]["source_zip_file"] for d in details] == [
+            "az_haystaqdnascores_20260520.tab.zip"
+        ]
+
+    def test_one_failing_state_does_not_stop_later_states(self):
+        # Regression for the May 2026 incident: MI's failure must not prevent
+        # the remaining states from being processed.
+        def flags(st):
+            if st == "MI":
+                raise FileNotFoundError("extracted tab not found")
+            return _details_for(st, "flags")
+
+        details, failures = _collect_load_details(
+            state_ids=["AZ", "MI", "NV"],
+            extract_fns={"flags": flags, "scores": lambda st: _details_for(st, "scores")},
+        )
+        processed = [(d["state_id"], d["load_details"]["source_zip_file"]) for d in details]
+        assert ("NV", "nv_haystaqdnaflags_20260520.tab.zip") in processed
+        assert ("MI", "mi_haystaqdnascores_20260520.tab.zip") in processed
+        assert failures == ["MI (flags): extracted tab not found"]
+
+
+class TestFinalizeLoadDetails:
+    def test_returns_details_when_no_failures(self):
+        details = [{"state_id": "AZ", "load_details": _details_for("AZ", "flags")}]
+        assert _finalize_load_details(details, failures=[]) is details
+
+    def test_raises_summary_naming_each_failed_state(self):
+        with pytest.raises(
+            RuntimeError, match=r"2 state extraction\(s\) failed.*MI \(flags\).*WI \(scores\)"
+        ):
+            _finalize_load_details(
+                [],
+                failures=["MI (flags): extracted tab not found", "WI (scores): boom"],
+            )


### PR DESCRIPTION
## Root cause this fixes

On May 27 the 00:02 scheduled run of `load__l2_haystaq_sftp_to_s3` started while the vendor was mid-upload of the May 2026 drop. It uploaded fresh files for 12 states to S3, then died on the 13th state's partial zip (`Extracted tab file not found`). Because the sync-log rows only append when the whole model succeeds, those 24 uploads were never logged — and the skip check (`file already in S3`) then treated them as complete on every later run. `load__l2_haystaq_s3_to_databricks` is log-driven, so the 12 states' Databricks tables kept serving the December 2025 drop while the other 39 states moved to May 2026 (ticket: DATA-2273).

## Changes

1. **Per-state error isolation with durable partial progress** (`_collect_load_details` / `_finalize_load_details`): one state's failure no longer aborts the loop, and the successful states' log rows persist that same run (failures are logged with a summary and retry on the next run via re-pull or self-heal). The run fails loudly only when *every* extraction failed — a systemic signal (e.g. SFTP outage) where there is nothing to persist anyway.
2. **Partial zips are retryable** (`_locate_extracted_tab`): a zip whose single `.tab` never materialized (vendor mid-upload — the exact May failure) is now a logged skip like the existing locked-zip and failed-extract paths. A zip with a wrong member count still raises (contract violation, becomes a collected failure).
3. **Skip requires a log row, not just S3 presence** (`_resolve_pickup_action`): a file in S3 with no sync-log row means a prior run died between upload and append; it is re-logged without re-download ("self_heal"). The logged name is the S3 key's exact suffix after the state prefix (S3 GETs are case-sensitive; downstream reads prefix + logged name verbatim).
4. **Canonical upload naming**: the S3 object is always uploaded under the zip-derived filename. Previously a zip whose extracted member name differed was uploaded under the extracted spelling, which no future run's skip check could ever find — an endless re-download/re-log loop (pre-existing bug).

## Adversarial review (independent model)

A sandboxed read-only review by a separate model returned five findings. Findings 1–3 (raise-at-end starves healthy states under a persistently failing state; self-heal could log a spelling that 404s downstream; the member-name mismatch loop) are fixed in the last commit and are what shaped changes 1, 3, and 4 above. Finding 4 (SFTP-wide outage costs ~17 min of per-state connection retries) is partially mitigated by the total-failure raise; a circuit breaker was declined as statefulness a twice-daily batch loader doesn't warrant. Finding 5 (failed old-version deletion hidden by self-heal) was declined: the consequence is unread storage cruft that the next vendor drop's download path deletes anyway.

## Testing

- 17 unit tests in `dbt/tests/test_load__l2_haystaq_sftp_to_s3.py` (TDD; house pattern of testing module helpers), including regressions for the exact incident (mid-loop failure not stopping later states; in-S3-but-unlogged resolving to self-heal) and for the review findings (partial failure persists successes; total failure raises; exact-spelling and nested-key propagation).
- Full dbt suite: 99 passed. `uv run mypy tests` clean. pre-commit (ruff, ruff-format) clean.
- CI cannot execute these models (`tag:load` is excluded from the CI job); prod-shape verification was done operationally during the incident remediation: the 12 states' log rows were backfilled and loaded via a targeted job run, and both sync logs were restored to full 51-state coverage.

## Deployment notes

- Both load models pin `full_refresh: false`, so the on-merge `state:modified+ --full-refresh` build runs them incrementally; the only dbt-graph descendant is `load__l2_haystaq_s3_to_databricks`.
- The sync-log restoration this change depends on (the 39 fresh states' rows, wiped by pre-#717 full refreshes) is already completed, so the first post-merge run's self-heal check is a no-op for healthy states.
- Known limitation: self-heal derives the expected filename from the latest zip on the SFTP, so an orphan whose zip has been rotated off the SFTP is not recovered (warning only). Acceptable for now; the vendor keeps drops up for months.

## Same-class risk in the sibling loader (deliberately out of scope)

`load__l2_sftp_to_s3` (the weekly VM2 uniform loader) has the same two structural patterns this PR fixes in the Haystaq loader: an S3-existence-only skip check and a per-state exception that aborts the whole run. It is exposed to the same upload-interrupted orphan class. Kept out of this PR per smallest-fix scoping (the quantified incident is Haystaq-only); the helpers here are written to be portable to it. Follow-up ticket recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
