### PR TITLE
[DATA-2133] Ratify serve_users

### DIFF
--- a/analytics/diagnostics/semantic_catalog/config/ratifications.yml
+++ b/analytics/diagnostics/semantic_catalog/config/ratifications.yml
@@ -30,6 +30,22 @@ activated_serve_users:
   definition_sha: '5e87555'
   approved_by_pr: 765
 
+# serve_users is DELIBERATELY COMMENTED OUT until this PR is approved, so the
+# recorded date can be the real one. Its definition merged in #764 with only a
+# bot approval, so neither review group has ever signed it off, and the
+# auto-ratification hook cannot fill this in: it earns a sign-off only when a
+# definition MOVES in the merge, and this one is unchanged since #764.
+#
+# BEFORE MERGING: uncomment the three lines and set `ratified` to the UTC date
+# the SECOND group approved this PR. The fingerprint below is precomputed from
+# the merged definition and needs no change. #776 merged with an entry left
+# commented out and needed follow-up #777 to record it; do not repeat that.
+#
+# serve_users:
+#   ratified: <UTC date the second review group approved this PR>
+#   definition_sha: '0b06710'
+#   approved_by_pr: <this PR>
+
 win_activated_users:
   # Coverage completed across two PRs. The business group approved #708 on
   # 2026-07-29, but no data-group approval existed, so the 2026-07-28 date that


### PR DESCRIPTION
## What you are approving

`serve_users` is encoded and live but has never been ratified. This PR is the vehicle for that sign-off: **an approval here IS the ratification** of the definition as fingerprinted below.

| | |
|---|---|
| Metric | `serve_users` (Serve Users) |
| Value today | 1,846 |
| Owner | `semantic-layer-business` |
| Definition fingerprint | `0b06710` |
| Definition merged in | #764 (`26284fd`) |

**Definition:** count of Serve users, internal accounts excluded in the measure itself. Time-bucketed reads anchor on `eo_activated_at` via a measure-level `agg_time_dimension`.

## Why an approval is needed rather than a date

#764 merged with only `delegate-reviewer[bot]`'s approval. No human from either review group ever signed the definition off, so no date can honestly be written yet.

The auto-ratification hook (#796) cannot fill this in either. It earns a sign-off only for a metric whose definition **moved** in the merge, judged by fingerprint against the base. `serve_users` is unchanged since #764, so a merge of this PR earns nothing automatically. That is the hook working as designed, not a gap: it will not ratify a definition this merge did not put in front of anyone.

So this is a hand-authored sidecar record, the same pattern DATA-2249 used for `win_activated_users` on #776.

## What the reviewers should check

One thing in particular, because this week every governed metric examined had a label that did not match its computation, four for four.

`serve_users` retains the roughly 820 users who have no first-poll date. It is **not** a superset shaped like `activated_serve_users` (1,026) with the same anchor. Both now carry the internal-account exclusion, which is what makes 1,846 and 1,026 comparable at all, but they answer different questions: this one counts Serve users, the other counts users past the activation gate. Approve the population you think you are approving.

## Required approvals

The soft two-group gate wants at least one approval from each group. **Both are required for this to be a real ratification.**

- `semantic-layer-data`: Dan, Hugh or Sanjay. Not Tristan, who authored this.
- `semantic-layer-business`: Amanda, Audrey or Joe. This metric is business-owned, so this is the substantive sign-off.

CODEOWNERS does not fire on this PR, because the sidecar sits outside its glob by design, so neither team was auto-requested and no #data-alignment thread opened. Reviewers need asking directly.

**Do not merge on the bot's approval alone.** `delegate-reviewer[bot]` satisfies GitHub's `reviewDecision` and can turn this PR green with no human sign-off, which is exactly how #764 slipped through. Bot approvals are excluded from coverage by `composition.evaluate`, so merging without both groups leaves the metric pending and fires no Sigma build task.

## Before merging

The entry is committed **commented out**, with its fingerprint precomputed. Last action before merge:

1. Uncomment the three lines.
2. Set `ratified` to the UTC date the **second** group approved. That date is the record; the date someone types is not.
3. Set `approved_by_pr` to this PR number.

#776 merged with an entry left commented out and needed follow-up #777 to record it. This is the step that gets forgotten.

Once merged with a real date, the pending-to-dated edge creates the Sigma build task for Audrey automatically (DATA-2199).

Ticket: DATA-2133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only sidecar comment with no metric definition or runtime logic changes; risk is mainly forgetting to uncomment before merge.
> 
> **Overview**
> Adds a **commented-out** `serve_users` entry to `ratifications.yml` so both review groups can sign off the metric that merged in #764 with only bot approval.
> 
> The fingerprint `0b06710` is precomputed. Before merge, the entry must be uncommented and filled with the second group's approval date and this PR number—same hand-authored sidecar pattern used for `win_activated_users`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a16b3748fb1f569c00dff6918d1f383e4e72d16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->