### PR TITLE
[DATA-2107] Tolerate the Race projection columns deploying ahead of their data

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -468,9 +468,18 @@ RACE_COLUMNS = [
 ]
 
 # Live columns Prisma owns that the loader deliberately does not supply.
-# Empty today; the projection-columns step will extend it when those columns
-# deploy ahead of their data.
-RACE_DB_OWNED_COLUMNS: frozenset[str] = frozenset()
+# The projection columns deploy ahead of their data: the migration adds them
+# as nullable, the gate tolerates them here (each nightly swap leaves them
+# NULL), and the delivery step moves them into RACE_COLUMNS.
+RACE_DB_OWNED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "projected_turnout",
+        "projected_turnout_lower",
+        "projected_turnout_upper",
+        "election_code",
+        "inference_at",
+    }
+)
 
 
 def _race_constraint_ddl() -> list[str]:

--- a/airflow/astro/tests/test_sync_election_api.py
+++ b/airflow/astro/tests/test_sync_election_api.py
@@ -36,6 +36,7 @@ from dags.sync_election_api import (  # noqa: E402
     EOS_COLUMNS,
     PT_COLUMNS,
     RACE_COLUMNS,
+    RACE_DB_OWNED_COLUMNS,
     ZTP_SOURCE_COLUMNS,
     ZTP_TARGET_COLUMNS,
     _pt_quality_gate,
@@ -181,6 +182,24 @@ def test_race_columns_match_prisma_shape():
     # round-trip the loader comment documents.
     assert RACE_COLUMNS[0] == "id"
     assert {"frequency", "position_names"} <= set(RACE_COLUMNS)
+
+
+def test_race_projection_columns_bridge():
+    """The projection columns deploy to live Race ahead of their data: the
+    gate must tolerate them as live-extra (each nightly swap leaves them
+    NULL until the loader delivers them), and they must not be
+    loader-supplied yet. NB the migration itself must not land mid-run:
+    staging is LIKE-cloned from live at run start, so a mid-run migration
+    is silently undone by that night's swap."""
+    expected = {
+        "projected_turnout",
+        "projected_turnout_lower",
+        "projected_turnout_upper",
+        "election_code",
+        "inference_at",
+    }
+    assert expected == RACE_DB_OWNED_COLUMNS
+    assert expected.isdisjoint(set(RACE_COLUMNS))
 
 
 def test_pt_quality_gate_refuses_duplicate_keys():


### PR DESCRIPTION
## What

Extends `RACE_DB_OWNED_COLUMNS` (empty today) with the five Race projection columns the
upcoming engineering migration adds as nullable: `projected_turnout`,
`projected_turnout_lower`, `projected_turnout_upper`, `election_code`, `inference_at`.
One frozenset + its unit test; `RACE_COLUMNS` (the delivery list) is untouched, so the
loader still does not supply these columns.

## Why

The race group's schema gate fails closed when live `Race` has columns the loader does
not supply ("a swap would NULL them"). The projection columns deploy ahead of their data
by design: the migration adds them nullable, this allowlist lets the nightly stay green
while every swap leaves them NULL, and a follow-up PR moves them into `RACE_COLUMNS`
when the mart delivers values. This is the bridge the gate's own error message and the
allowlist's comment anticipate.

State transitions:
- Before the migration: complete no-op (the set only ever subtracts from live-extra
  columns that do not exist yet).
- After the migration: keeps the nightly green with NULL projection columns until the
  delivery PR merges.

## Ordering notes (load-bearing)

1. Merge this BEFORE the engineering columns migration deploys.
2. The migration itself deploys only inside the coordinated window: race swap set to
   rehearsal, `sync_election_api` PAUSED AND DRAINED (no active, queued, or retrying
   run — pausing alone does not stop an in-flight run, and a mid-run migration is
   silently undone by that run's swap; staging is cloned from live at run start).

## Verification

TDD red→green on the new unit test; full airflow suite 105 passed, 2 skipped
(pre-existing, unrelated); mypy clean.

Part of the turnout-on-the-race-row work (steps 1 + 5 of the serving TDD). Do not merge
without the owner's say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Race schema-contract gate for the nightly election-api sync. Incorrect allowlisting could mask real schema drift or leave projection columns NULL longer than intended.
> 
> **Overview**
> **Bridges the Race projection-column migration** by allowlisting five upcoming live columns in `RACE_DB_OWNED_COLUMNS`: `projected_turnout`, `projected_turnout_lower`, `projected_turnout_upper`, `election_code`, and `inference_at`.
> 
> The Race quality gate fails closed when live has columns the loader does not supply. This keep the nightly swap green after those nullable columns land, while `RACE_COLUMNS` stays unchanged so the loader still does not deliver them. A follow-up moves them into the delivery list when the mart has values.
> 
> Adds `test_race_projection_columns_bridge` to pin the allowlist and assert it stays disjoint from `RACE_COLUMNS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b809e6307ed20eb48c40edbfb6d0bef00e90a2dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->