### PR TITLE
Treat unattributed survey responses as null, not blank

### DIFF
--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1307,9 +1307,16 @@ models:
         data_tests:
           - not_null
       - name: hs_contact_id
-        description: HubSpot contact ID of the respondent
+        description: >
+          HubSpot contact ID of the respondent; null when the survey was
+          submitted without an associated contact.
         data_tests:
-          - not_null
+          # Unattributed responses are a real and expected outcome for a web
+          # survey, so a null here must not block the build. Severity warn keeps
+          # a rise in unattributed submissions visible without failing prod.
+          - not_null:
+              config:
+                severity: warn
           - relationships:
               arguments:
                 to: ref('stg_airbyte_source__hubspot_api_contacts')
@@ -1509,9 +1516,15 @@ models:
                 min_value: 1
                 max_value: 5
       - name: hs_contact_id
-        description: HubSpot contact ID of the respondent
+        description: >
+          HubSpot contact ID of the respondent; null when the survey was
+          submitted without an associated contact.
         data_tests:
-          - not_null
+          # Same rationale as the PMF survey mart: unattributed web-survey
+          # responses are expected, so surface them rather than blocking.
+          - not_null:
+              config:
+                severity: warn
           - relationships:
               arguments:
                 to: ref('stg_airbyte_source__hubspot_api_contacts')

--- a/dbt/project/models/marts/analytics/pmf_survey_responses.sql
+++ b/dbt/project/models/marts/analytics/pmf_survey_responses.sql
@@ -77,7 +77,11 @@ with
             s.pmf_additional_feedback,
 
             -- respondent info (from submission)
-            s.hs_contact_id,
+            -- A web survey can be submitted without an associated HubSpot
+            -- contact; HubSpot emits '' rather than null for those. Normalise to
+            -- null so "unattributed" is explicit and the contact relationship
+            -- test skips the row instead of failing on an id that cannot exist.
+            nullif(s.hs_contact_id, '') as hs_contact_id,
             s.contact_email,
             s.contact_first_name,
             s.contact_last_name,

--- a/dbt/project/models/marts/analytics/win_user_satisfaction_responses.sql
+++ b/dbt/project/models/marts/analytics/win_user_satisfaction_responses.sql
@@ -41,7 +41,9 @@ with
             s.survey_additional_notes,
 
             -- respondent info
-            s.hs_contact_id,
+            -- Same unattributed-submission handling as the PMF survey mart:
+            -- HubSpot emits '' for a response with no associated contact.
+            nullif(s.hs_contact_id, '') as hs_contact_id,
             s.contact_email,
             s.contact_first_name,
             s.contact_last_name,


### PR DESCRIPTION
## Problem

A single PMF survey response was failing the production `dbt build`:

```
relationships_pmf_survey_responses_hs_contact_id__id__ref_stg_airbyte_source__hubspot_api_contacts_
```

A PMF web survey can be submitted without an associated HubSpot contact. HubSpot emits `''` rather than `null` for those, which means:

- `not_null` passes, because a blank string is not null
- `relationships` fails, because `''` can never match a contact id

One anonymous response out of 210 was enough to turn the whole build red.

## Fix

Normalise the blank to `null` in both survey marts, so "unattributed" is represented explicitly. dbt's `relationships` test skips nulls, so it now passes on real data.

That makes the column genuinely nullable, so its `not_null` test moves to `severity: warn` rather than being removed. This follows the existing pattern in `_sales_reverse_etl__models.yml` for single-row upstream edges: stay visible, don't block. A rise in unattributed submissions still surfaces in the warnings.

`win_user_satisfaction_responses` has no blanks today across its 12 rows, but is structurally identical and would break the same way on its first anonymous response, so it gets the same handling.

## Verification

`dbt build --select "pmf_survey_responses win_user_satisfaction_responses"`

```
Done. PASS=23 WARN=1 ERROR=0 SKIP=0 NO-OP=0 REUSED=0 TOTAL=24
```

The previously failing relationships test passes. The one warning is the single anonymous response, which is the intended behaviour.

Confirmed against live data before and after:

| | before | after |
|---|---|---|
| `relationships` failures | 1 | 0 |
| rows with null `hs_contact_id` | 0 | 1 (warns) |

## Note

This was not the most common cause of `dbt build` failures. Of the last 8 failed runs, 5 failed on `relationships_m_election_api__position_district_id__id__ref_m_election_api__district_`, which currently passes in prod (0 orphans across 286,419 rows) and looks like an intermittent build-ordering or staleness window. That needs a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)