### PR TITLE
Populate Person.is_pledged and Person.gp_api_user_id in the election-api feed

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -775,6 +775,21 @@ models:
           - unique
       - name: br_person_id
         description: "BallotReady person databaseId; null for GP-native people."
+      - name: is_pledged
+        description: >
+          Whether the person took the GoodParty pledge on any candidacy, rolled
+          up from candidacy.is_pledged on gp_person_id. The API column is NOT
+          NULL DEFAULT false, so the unpledged must be false, never null.
+        tests:
+          - not_null
+      - name: gp_api_user_id
+        description: >
+          gp-api User.id for this person, carried from people.gp_api_user_id.
+          A digit string, not a uuid (the gp-api id is a numeric autoincrement).
+          gp-api reads it to set its own User.person_id, which is what unlocks
+          the public profile editor. Null when the person has no gp-api user, or
+          when the person's cluster maps to more than one gp-api user (people
+          only makes the id scalar when it is unambiguous).
 
   - name: m_election_api__office_holder
     description: >

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -92,6 +92,18 @@ with
                 partition by br_candidate_id order by office_holder_updated_at desc
             )
             = 1
+    ),
+
+    -- The API contract is "pledged on any candidacy", so roll the candidacy
+    -- flag up to person grain. Keyed on gp_person_id, not gp_candidate_id: the
+    -- two agree on 2026+ rows, but 2025 archive candidacies carry a
+    -- HubSpot-derived gp_candidate_id that would never match a person, dropping
+    -- their pledges. The group by keeps this one row per person.
+    pledged as (
+        select gp_person_id, bool_or(coalesce(is_pledged, false)) as is_pledged
+        from {{ ref("candidacy") }}
+        where gp_person_id is not null
+        group by gp_person_id
     )
 
 select
@@ -123,9 +135,14 @@ select
     people.phone,
     br_person.degrees,
     br_person.experiences,
-    people.state
+    people.state,
+    -- NOT NULL in the API, so emit false rather than null for the unpledged.
+    coalesce(pledged.is_pledged, false) as is_pledged,
+    -- Digit string, not a uuid: the gp-api User.id is a numeric autoincrement.
+    people.gp_api_user_id
 from public_people as people
 left join br_person on people.br_person_id_int = br_person.database_id
 left join
     office_holder_person as office_holder
     on people.br_person_id_int = office_holder.br_candidate_id
+left join pledged on people.gp_person_id = pledged.gp_person_id

--- a/dbt/project/models/marts/election_api/m_election_api__person.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__person.sql
@@ -96,9 +96,10 @@ with
 
     -- The API contract is "pledged on any candidacy", so roll the candidacy
     -- flag up to person grain. Keyed on gp_person_id, not gp_candidate_id: the
-    -- two agree on 2026+ rows, but 2025 archive candidacies carry a
-    -- HubSpot-derived gp_candidate_id that would never match a person, dropping
-    -- their pledges. The group by keeps this one row per person.
+    -- two ids agree only on candidate_id_source = 'gp_api' rows (2026+), while
+    -- every pre-2026 archive row carries its legacy source id, which never
+    -- matches a person. Joining on gp_candidate_id would therefore resolve 8.7k
+    -- of 35.4k pledged people. The group by keeps this one row per person.
     pledged as (
         select gp_person_id, bool_or(coalesce(is_pledged, false)) as is_pledged
         from {{ ref("candidacy") }}

--- a/dbt/project/models/write/write__election_api_db.py
+++ b/dbt/project/models/write/write__election_api_db.py
@@ -194,7 +194,9 @@ PERSON_UPSERT_QUERY = """
         phone,
         degrees,
         experiences,
-        state
+        state,
+        is_pledged,
+        gp_api_user_id
     )
     SELECT
         id::uuid,
@@ -219,7 +221,9 @@ PERSON_UPSERT_QUERY = """
         phone,
         degrees::jsonb,
         experiences::jsonb,
-        state
+        state,
+        is_pledged,
+        gp_api_user_id
     FROM {staging_schema}."Person"
     ON CONFLICT (id) DO UPDATE SET
         updated_at = now(),
@@ -242,7 +246,9 @@ PERSON_UPSERT_QUERY = """
         phone = EXCLUDED.phone,
         degrees = EXCLUDED.degrees,
         experiences = EXCLUDED.experiences,
-        state = EXCLUDED.state
+        state = EXCLUDED.state,
+        is_pledged = EXCLUDED.is_pledged,
+        gp_api_user_id = EXCLUDED.gp_api_user_id
 """
 
 OFFICEHOLDER_UPSERT_QUERY = """


### PR DESCRIPTION
Two columns on the election-api Postgres `Person` table — `is_pledged` and `gp_api_user_id` — exist, have their migrations applied, and are already read by both `gp-marketing` and `gp-api`. The ETL that populates `Person` never selected or wrote either one, so both have sat at their defaults since they were added. This adds them to the mart and the writer. **No schema change on either side.**

Filed by another team (product/marketing side) rather than data, because the gap was found while debugging the two symptoms below. Happy to hand off or reassign — see "What we could not verify" for what still needs a warehouse.

## Why — two user-visible symptoms

1. **No pledge badge can ever render** on a `/people/*` profile. `gp-marketing` reads `person.isPledged`; election-api returns the column verbatim; the column is `false` for everyone. Sampled `GET /v1/persons?state=<st>&columns=id,isPledged` across 15 states (MI, FL, CA, NH, TX, NY, PA, OH, GA, AZ, NC, VA, WA, CO, MA) covering **69,385 person rows — 0 with `isPledged: true`.**
2. **Nobody can claim a profile at all.** `gp_api_user_id` is the only channel by which gp-api learns which of its users maps to which canonical person. With it null, gp-api never sets its own `User.person_id`, the profile editor stays permanently locked, and `POST /v1/person-profiles` returns 409 for every real user. `GET /v1/public-person-profiles/published` returns `[]` and `.../unlisted` returns `[]` — **production has never had a single published person profile.**

Both apps are behaving exactly as designed given the data they are served, and gp-api's own code anticipates the empty column (`person-profiles.controller.ts` notes the backfill "is a graceful no-op (returns null) until the data platform populates the linkage"). Nothing needs to change in `gp-marketing` or `gp-api`.

## What changed

Three files, ~24 added lines.

**`marts/election_api/m_election_api__person.sql`** — a `pledged` CTE rolling `candidacy.is_pledged` up to person grain with `bool_or`, left-joined, plus two columns on the final select: `coalesce(pledged.is_pledged, false) as is_pledged` and `people.gp_api_user_id`.

**`models/write/write__election_api_db.py`** (`PERSON_UPSERT_QUERY`) — both columns added to the `INSERT` column list, the `SELECT`, **and** the `ON CONFLICT (id) DO UPDATE SET` clause. The `DO UPDATE SET` half is the important one: without it only newly inserted rows would ever pick the values up, which looks like a working fix and is much nastier to debug than the current clean failure. `Person` is fully re-upserted every run (never incremental-filtered), so existing rows converge on the first run after this merges.

**`marts/election_api/m_election_api.yaml`** — both columns documented, plus a `not_null` test on `is_pledged`.

The `gp_api_user_id` half is pure plumbing: `marts/civics/people.sql` already computes it and simply never carried it through.

## One deliberate deviation from the handoff doc

The handoff proposed keying the pledge rollup on `candidacy.gp_candidate_id`. **This uses `candidacy.gp_person_id` instead.** Reasons:

- `gp_person_id` is the column `m_civics.yaml` documents as "Canonical person (FK to `people.gp_person_id`)", and it already carries a `relationships` test to `ref('people')`. It is the intended join key; `gp_candidate_id` is documented only as "Foreign key to candidate table".
- The two ids agree only on `candidate_id_source = 'gp_api'` rows (2026+); every pre-2026 row carries its legacy source id, which never matches a person. **Measured against the warehouse, keying on `gp_candidate_id` resolves 8,708 of 35,363 pledged people — it would silently drop roughly three quarters of them.** (`marts/civics/README.md` describes this as the 2026+ / 2025-archive split; the measured discriminator is `candidate_id_source`, which is the more precise statement.)
- `candidacy.gp_person_id` is resolved for archive rows too (via `'hubspot|' || hubspot_contact_id` in the `candidacy_person` CTE), so this is strictly more coverage, not different semantics. The contract stays the one the Prisma comment states: "a person is pledged if pledged on any candidacy."

Everything else follows the handoff as written.

## Assumptions verified (statically — no warehouse access, see below)

**Grain / fan-out.** `candidacy` is `gp_candidacy_id` grain, so a person with three candidacies has three rows. The `bool_or` + `group by gp_person_id` collapses the CTE to exactly one row per person before the join, so it cannot fan out the person feed regardless of how the id space behaves. The model's existing `unique` and `not_null` tests on `id` are the safety net if that reasoning is ever wrong — a duplicated person row fails the build rather than corrupting the feed. `dbt list` confirms both tests are still registered alongside the new one.

**`is_pledged` is genuinely populated upstream** (this was the one that could have made the whole PR pointless). Traced to two live sources, not another unwritten column:
- 2026+: `candidacy.is_pledged` ← `int__civics_candidacy_gp_api` ← `campaigns.is_pledged` ← `details:pledged::boolean`. In gp-api, `updateCampaign.schema.ts` declares `details.pledged: z.boolean()`, `campaigns.controller.ts` reads `body.details.pledged` on write, and `crmCampaigns.service.ts` forwards it to HubSpot as `pledge_status`. It is an app-written field.
- 2025 archive: `int__civics_candidacy_2025` ← HubSpot `pledge_status` (a real HubSpot enumeration property; it is in `hubspot_contact_property_columns.csv`).

It is also already consumed downstream by `prospects.sql` (`or c.is_pledged`), `candidacy_scored.sql`, and `leads_win_candidacy.sql`, which would be inert if the column were universally null. **Since confirmed by measurement: 35,363 distinct pledged people.** So this fix has real population behind it — it is not a second unwritten column.

**`gp_api_user_id` stays text, never uuid.** In `people.sql` it is `max(gp_api_id_val)` where `gp_api_id_val` is `substring_index(record_key, '|', -1)` — a string, no cast. Nothing casts it downstream: the mart selects it bare, and the writer's `SELECT` casts only `id::uuid` / `degrees::jsonb` / `experiences::jsonb`. Matches election-api, where the migration is `ADD COLUMN "gp_api_user_id" TEXT` and Prisma has `gpApiUserId String?` — the gp-api `User.id` is a numeric autoincrement and election-api validates the filter against `/^\d+$/`.

**No staging DDL to update.** `_load_data_to_postgres` writes the DataFrame with `.mode("overwrite")`, which recreates the staging table from the DataFrame schema; the only DDL in the writer is `CREATE SCHEMA IF NOT EXISTS`. The person DataFrame is passed as `dbt.ref("m_election_api__person")` with no column projection, so the two new mart columns reach staging automatically. Confirmed there is no explicit staging DDL or column list anywhere in the file.

**Target column constraints.** Prisma: `isPledged Boolean @default(false)` (NOT NULL — hence the `coalesce(..., false)` and the `not_null` test) and `gpApiUserId String?` with an index on it. Nullable, so partial coverage is fine.

## Validation I ran

- `pre-commit run --all-files` — **all hooks pass** (trailing-whitespace, end-of-file-fixer, check-yaml, mixed-line-ending, check-case-conflict, detect-private-key, ruff, ruff-format, mypy, sqlfmt). sqlfmt left the SQL unchanged.
- `cd dbt && uv run pytest` — **99 passed**, which is exactly what the `dbt` CI workflow runs.
- `dbt parse` on the whole project (dbt 1.12.0 / dbt-databricks 1.12.4, throwaway parse-only profile, no connection) — **succeeds**, so the Jinja renders, `ref("candidacy")` resolves, and the new yaml column entries and test are valid. Only pre-existing semantic-layer warnings.
- `dbt list --select m_election_api__person --resource-type test` shows the new `not_null_m_election_api__person_is_pledged` alongside the existing `unique` / `not_null` / `is_uuid` on `id`.

## What we could **not** verify, and what you need to run

**Please do not read a green CI as validation of this change.** The `dbt` workflow only runs `pytest` and `mypy` against `dbt/tests` — it never builds a model and never touches the warehouse. The `pre-commit` check is lint and formatting only. Neither one executes a line of this SQL.

The `dbt Cloud` check is the one that might genuinely build something, but I can't see its selector from the repo, so I don't know whether it builds `state:modified+`, nor whether `write__*` is excluded from that selection. **Please confirm the writer is out of scope before treating that check as either meaningful or safe.** PR #683 modified this same writer file and its `dbt Cloud` check went green, so this carries the same risk profile as that merged precedent. Note also that the check routinely takes 7–8 hours to settle on this repo (#683 and #787 both did), so it being amber for a long while is normal, not stuck.

I have no Databricks credentials and deliberately did not go looking for any, and **did not run the writer** — it writes production `Person` rows over JDBC and that is your call, not ours.

What needs a human with warehouse access:

1. `dbt build --select m_election_api__person` (a dev target is fine) — confirms it compiles against real schemas and that the new `not_null` on `is_pledged` holds.
2. **Cross-check the pledged count.** The source side has been measured — `select count(distinct gp_person_id) from mart_civics.candidacy where is_pledged and gp_person_id is not null` returns **35,363**. After the build, `select count(*) from <schema>.m_election_api__person where is_pledged` should be that number narrowed by the mart's own person scoping (`is_candidate or is_elected_official` plus a non-null name part) — materially lower than 35,363 is fine, near zero is not.
3. Run the writer (`write__election_api_db`) on your normal schedule.
4. Then the handoff doc's acceptance checks, in order: pledge flag reaches the API (`GET /v1/persons?state=MI&columns=id,isPledged` returns a non-zero true count) → linkage reaches the API (`GET /v1/persons?gpApiUserId=<id>&columns=id`, M2M token, returns exactly one person) → the editor unlocks (`GET /v1/person-profiles/mine` returns `canCreate: true`, immediately via the lazy backfill or after the 4am reconcile cron) → **a real user can `POST /v1/person-profiles` (201, no longer 409), publish, and `/people/<first-last>-<id8>` renders the claimed template**, with `GET /v1/public-person-profiles/published` no longer `[]`. That last step is the one that proves the whole chain.
5. Idempotency: a second ETL run must not flip `is_pledged` back or null out `gp_api_user_id`. That is what the `DO UPDATE SET` additions guarantee, and it is worth confirming once.

## Residual population question — a measurement request, not a blocker

`people.sql` only makes the identifier scalar when the cluster is unambiguous:

```sql
case when count(distinct gp_api_id_val) = 1 then max(gp_api_id_val) end as gp_api_user_id
```

A person cluster mapping to two or more gp-api users yields **null**, silently. Those users still cannot claim a profile after this fix. Could you measure how large that group is?

```sql
select count(*)
from mart_civics.people as p
where (p.is_candidate or p.is_elected_official)
  and p.gp_api_user_id is null
  and exists (
      select 1
      from mart_civics.person_identifiers as pi
      where pi.gp_person_id = p.gp_person_id
        and pi.source_name = 'gp_api'
  )
```

If that number is large it needs upstream de-duplication rather than a change here, and it deserves its own ticket.

**Separate coverage gap, also out of scope:** gp-api has a second pledge signal — `pledgedAt` on the elected-office record, set by Serve users via `electedOffice.controller.ts`. It is not ingested into the data platform at all (no `pledged_at` anywhere in `dbt/`), so a Serve officeholder who pledged but has no pledged candidacy will still read `is_pledged = false`. Consistent with the Prisma contract ("rolled up from their candidacies"), but worth a ticket if the pledge badge is meant to cover Serve.

## Notes

- Branch/title do not carry a `DATA-XXXX` ticket because this was filed from outside the data team and we don't have one; happy to rename if you'd like it attached to a ticket first. There is recent precedent for ticketless PR titles on `main` (#804).
- One **product** question, not a defect: once `is_pledged` is true, a pledged person who has never authored a profile renders the pledge badge *and* the unclaimed framing with the claim CTA. That is correct per the current Figma states (claimed-ness is overlay presence; pledging is a separate factual flag), but if it reads wrong it is a design decision, not something to fix in the pipeline.
