### PR TITLE
[DATA-2286] Null out blank HubSpot contact rollups in PMF survey staging

### DIFF
--- a/dbt/project/models/marts/analytics/m_analytics.yaml
+++ b/dbt/project/models/marts/analytics/m_analytics.yaml
@@ -1322,9 +1322,16 @@ models:
                 to: ref('stg_airbyte_source__hubspot_api_contacts')
                 field: id
       - name: contact_email
-        description: Email address of the respondent
+        description: >
+          Email address of the respondent; null when the survey was
+          submitted without an associated contact.
         data_tests:
-          - not_null
+          # Same rationale as hs_contact_id above: an unattributed response
+          # has no contact to source an email from, so a null here must not
+          # block the build.
+          - not_null:
+              config:
+                severity: warn
       - name: icp_win
         description: >
           Whether the respondent's office qualifies for the Win ICP. Sourced

--- a/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_feedback_submissions.sql
+++ b/dbt/project/models/staging/airbyte_source/hubspot_api/stg_airbyte_source__hubspot_api_feedback_submissions.sql
@@ -14,9 +14,12 @@ select
     properties:hs_content::string as response_content,
     properties:hs_submission_url::string as submission_url,
 
-    -- contact details (denormalized from HubSpot)
-    properties:hs_contact_id::string as hs_contact_id,
-    properties:hs_contact_email_rollup::string as contact_email,
+    -- contact details (denormalized from HubSpot). A submission can lose its
+    -- associated contact (e.g. deleted/merged in HubSpot) after the fact, which
+    -- blanks these rollup properties to '' rather than null; nullif keeps
+    -- "no linked contact" honestly null instead of an empty string.
+    nullif(properties:hs_contact_id::string, '') as hs_contact_id,
+    nullif(properties:hs_contact_email_rollup::string, '') as contact_email,
     properties:hs_contact_firstname::string as contact_first_name,
     properties:hs_contact_lastname::string as contact_last_name,
 


### PR DESCRIPTION
## Problem

HubSpot feedback-survey submissions carry a denormalized rollup of their associated contact (`hs_contact_id` and a contact-email rollup). When a submission's linked contact is later deleted or merged in HubSpot, HubSpot blanks that rollup to an empty string rather than `null`. The staging model that loads these submissions extracted both properties with no empty-string handling, so the blank survived as `''`. An empty string reads as "populated" to a `not_null` test but matches no real contact id, so the `relationships` test against the HubSpot contacts staging table fails wherever it runs — dev, CI, and the nightly prod build alike, for the one submission affected.

## Fix

A same-day companion PR (#804) already added a mart-side `nullif(..., '')` for `hs_contact_id` on the two survey marts that consume this staging model, and downgraded that column's `not_null` test to `severity: warn`, which resolved the immediate build failure for `hs_contact_id`.

This PR moves that normalization to its source — the staging model itself — so `nullif('')` is applied once, to both affected properties (`hs_contact_id` and its email-rollup counterpart), for every current and future consumer, rather than each mart re-deriving it. This follows the project's convention that casting/cleaning happens once in staging. It also extends the same not_null-severity treatment #804 established for `hs_contact_id` to `contact_email` on `pmf_survey_responses`: the affected submission is blank on both fields, and the same "expected, don't block" rationale applies now that `contact_email` is genuinely nullable too. (`win_user_satisfaction_responses`, the other consumer, doesn't test `contact_email`, so it needs no test change.)

Why this shape:
- `null` is the honest representation of "no linked contact" — excluding these submissions instead would silently drop real survey feedback.
- dbt's `relationships` test already skips nulls by design, so normalizing to null is sufficient on its own.
- The `not_null` tests on `hs_contact_id` and `contact_email` move to (or, for `hs_contact_id`, already are at) `severity: warn` rather than being removed — an unattributed response is an expected, visible-but-non-blocking occurrence, not a hard invariant violation.

## Verification

`dbt build --select "stg_airbyte_source__hubspot_api_feedback_submissions pmf_survey_responses"` in a dev schema: `PASS=22 WARN=2 ERROR=0`.
- `relationships_pmf_survey_responses_hs_contact_id__id__ref_stg_airbyte_source__hubspot_api_contacts_` — now **PASS** (previously the failing test).
- `not_null_pmf_survey_responses_hs_contact_id` and `not_null_pmf_survey_responses_contact_email` — each **WARN 1**, on the one affected row, as intended.

Direct query against the dev schema: exactly 1 row with `hs_contact_id IS NULL` (submission `549475821591`, the known affected submission), and `contact_email` on that same row is confirmed genuinely `NULL` (not an empty string, via an explicit `IS NULL` / `length()` check). Dev's total row count (210) matches prod's `mart_analytics.pmf_survey_responses` (210) exactly, confirming the change only reclassifies two column values on one existing row — no rows added or dropped.

## Note on scope

Because #804 merged first and already fixed the build-breaking symptom for `hs_contact_id`, this PR is a structural follow-up rather than what unblocks any currently-red build. Its marginal effect: single-source normalization in staging instead of per-mart, and closing the parallel `contact_email` gap #804's narrower fix didn't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small staging cleanup and dbt test severity/docs only; no auth or row-count logic changes beyond reclassifying empty strings as null on one known edge case.
> 
> **Overview**
> HubSpot feedback submissions can lose their linked contact (delete/merge) and HubSpot then stores **empty strings** on `hs_contact_id` and the email rollup instead of `null`. That broke `relationships` tests and made unattributed rows look “populated.”
> 
> **Staging** (`stg_airbyte_source__hubspot_api_feedback_submissions`) now applies `nullif(..., '')` to **`hs_contact_id`** and **`contact_email`** so “no linked contact” is a real null for every downstream consumer, not re-done per mart.
> 
> **`pmf_survey_responses` contract** (`m_analytics.yaml`): `contact_email`’s `not_null` is **`severity: warn`** (same pattern as `hs_contact_id`) and column docs note null when there is no associated contact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25586bcc4778d814332f104c5234d666e1df6b7b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->