### PR TITLE
[DATA-2273] Unblock w_haystaq merges: stop fighting its hierarchical clustering, guard full refresh

### DIFF
--- a/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
+++ b/dbt/project/models/intermediate/l2/int__l2_nationwide_uniform_w_haystaq.py
@@ -34,7 +34,19 @@ def model(dbt, session: SparkSession) -> DataFrame:
         incremental_strategy="merge",
         unique_key="LALVOTERID",
         on_schema_change="append_new_columns",
-        auto_liquid_cluster=True,
+        # The prod table carries deliberate hierarchical liquid clustering
+        # (delta.liquid.hierarchicalClusteringColumns = voters_active,
+        # state_postal_code, set 2026-07-28 for serving-read performance).
+        # auto_liquid_cluster would issue ALTER TABLE CLUSTER BY AUTO, which
+        # Delta rejects against that property and fails the whole merge.
+        auto_liquid_cluster=False,
+        # A full refresh would rebuild without the retired vendor columns this
+        # table has accumulated (append_new_columns never drops), which the
+        # agent voter views still project by name, and would also wipe the
+        # clustering property above. Pin it off until the retired-column
+        # cleanup retargets the views first; that cleanup flips this
+        # deliberately.
+        full_refresh=False,
         tags=[
             "intermediate",
             "l2",


### PR DESCRIPTION
## Problem

The first real dbt run of `int__l2_nationwide_uniform_w_haystaq` since the race writer retired failed with `DELTA_ALTER_TABLE_CLUSTER_BY_MISMATCHED_HIERARCHICAL_COLUMNS`: the prod table carries deliberate hierarchical liquid clustering (`voters_active, state_postal_code`, set 2026-07-28 for serving-read performance), and `auto_liquid_cluster=True` makes incremental runs issue `ALTER TABLE CLUSTER BY AUTO`, which Delta rejects against that property. The merge dies before any rows land — which is currently blocking the 12 backfilled Haystaq states (DATA-2273) from reaching the serving layer.

## Changes

One model config block, two pins:

1. `auto_liquid_cluster=False` — dbt leaves the table's deliberate clustering choice alone; incremental merges proceed.
2. `full_refresh=False` — same guard the L2 sync-log loaders carry (#717 precedent). Without it, this PR's own on-merge `state:modified+ --full-refresh` build would rebuild the table without the ~100 retired vendor columns it has accumulated (`append_new_columns` never drops), which `win_agent_voters` and `serve_agent_voters` still project by name — breaking both serving views — and would also wipe the clustering property. The planned retired-column cleanup retargets the views first and flips this pin deliberately.

## Effect on merge

The on-merge build runs this model incrementally; its per-state watermarks pick up the 12 backfilled states (flags/scores Aug 11 vs stored December; uniform Aug 12 vs stored Jul 31), completing the DATA-2273 remediation's last hop into the serving layer.

## Testing

Config-only change (no unit-testable behavior; the failure mode is a live Databricks ALTER). Full dbt pytest suite green (152 passed), pre-commit clean. Verification is the post-merge incremental run, which will be checked for the 12-state merge landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a critical nationwide voter serving table and merge behavior, but the change is config-only with clear guards against schema/view breakage and clustering loss.
> 
> **Overview**
> Unblocks incremental merges on **`int__l2_nationwide_uniform_w_haystaq`**, which were failing with Delta’s hierarchical clustering mismatch when dbt tried to apply **`CLUSTER BY AUTO`**.
> 
> The model now sets **`auto_liquid_cluster=False`** so incremental runs stop altering clustering on the prod table (`voters_active`, `state_postal_code`). It also sets **`full_refresh=False`** so merge-triggered full refreshes cannot rebuild the table without legacy vendor columns still referenced by **`win_agent_voters`** / **`serve_agent_voters`**, or drop the existing clustering. Comments document both pins until retired-column cleanup retargets the views.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20ac6c7f975e5b7c67c63ddd9be4e8bd3a7ba0e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->