### PR TITLE
[DATA-2235] Never cap a full refresh; it replaces the table

### DIFF
--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_filing_period.py
@@ -277,7 +277,8 @@ def model(dbt, session) -> DataFrame:
     if not ce_api_token:
         raise ValueError("Missing required secret: civic-engine-api-token")
 
-    # a run fetches at most this many ids, so no single run monopolizes the cluster
+    # How far an *incremental* run walks the backlog, so no single run monopolizes the
+    # cluster. It deliberately does not bound a full refresh — see the else branch below.
     max_ids_per_run = int(dbt.config.meta_get("max_ids_per_run", 100_000))
 
     # get unique filing period ids from race
@@ -321,7 +322,12 @@ def model(dbt, session) -> DataFrame:
             backlog_ids.orderBy(col("database_id").desc()).limit(headroom)
         )
     else:
-        filing_periods = referenced_ids.orderBy(col("database_id").desc()).limit(max_ids_per_run)
+        # A full refresh replaces the table, so it has to fetch every referenced id.
+        # `max_ids_per_run` bounds how far an incremental run walks the backlog; applying
+        # it here instead truncates the table to the newest ids and drops everything
+        # already stored, which is a silent, large data loss rather than a slow run.
+        logging.info("Full refresh: fetching every referenced id, uncapped")
+        filing_periods = referenced_ids
 
     # Trigger a cache to ensure these transformations are applied. This is important for incremental models to avoid unnecessary API calls
     filing_periods.cache()

--- a/dbt/project/models/intermediate/ballotready_api/int__ballotready_py.yaml
+++ b/dbt/project/models/intermediate/ballotready_api/int__ballotready_py.yaml
@@ -79,14 +79,18 @@ models:
       from the CivicEngine API. Races reference filing periods by id only, so this table
       is the lookup that turns a race into a filing deadline.
 
-      Each run fetches the ids referenced by recently updated races, then spends whatever
-      is left of `max_ids_per_run` on the backlog of referenced ids that are not here yet,
-      newest ids first since those carry the deadlines for current cycles. The recently
-      updated races are never capped away, so the fetch set is always a superset of what
-      the race watermark alone would have selected.
+      An incremental run fetches the ids referenced by recently updated races, then spends
+      whatever is left of `max_ids_per_run` on the backlog of referenced ids that are not
+      here yet, newest ids first since those carry the deadlines for current cycles. The
+      recently updated races are never capped away, so the fetch set is always a superset
+      of what the race watermark alone would have selected.
+
+      A full refresh is uncapped and fetches every referenced id, because it replaces the
+      table: bounding it would drop every id outside the bound rather than merely making
+      the run shorter. Expect roughly two hours.
 
       Because an id that fails to resolve simply stays absent, the next run picks it up
-      again and coverage converges over successive runs. Raise the bound with
+      again and coverage converges over successive runs. Raise the incremental bound with
       `--vars '{br_filing_period_max_ids_per_run: 250000}'` to close a large backlog
       faster, at the cost of a longer run on the shared cluster.
     config:


### PR DESCRIPTION
## What

Removes the per-run id cap from the full-refresh branch of `int__ballotready_filing_period`. The cap now bounds only how far an *incremental* run walks the backlog.

## Why

A full refresh drops and recreates an incremental table. Capping the ids it fetches therefore does not make the run shorter — it discards every id outside the cap. The next full refresh would have replaced **628,977** filing periods with roughly **92,000**, a net loss of ~537,000.

This was introduced by #793, not pre-existing: the prior code left the non-incremental branch uncapped, so a full refresh rebuilt the table completely (slowly). Adding `max_ids_per_run` to that branch turned a slow-but-complete rebuild into a fast-but-destructive one.

It nearly fired. The `dbt build on merge` job runs `dbt build --select state:modified+ --full-refresh`, and run 70471892570521 reached `1 of 1178 START python incremental model dbt.int__ballotready_filing_period` against `target='prod'` before being cancelled. The table was verified intact at 628,977 rows immediately after.

The tell was already visible and I misread it: the CI build in #793 produced a 92,164-row table, which I reported as a successful build. CI also runs `--full-refresh`, so that number *was* the truncation, in a throwaway PR schema.

[DATA-2235](https://app.clickup.com/t/86ajx85j2)

## How

- `else` branch is now `filing_periods = referenced_ids` — every referenced id, uncapped.
- Comment at the `max_ids_per_run` read states the cap is incremental-only and points at the else branch.
- Model description records that a full refresh is uncapped, why bounding it would drop rows rather than shorten the run, and the rough two-hour cost.

## Testing

- [x] `cd dbt && uv run pytest` → 122 passed.
- [x] `pre-commit run` clean on both changed files.
- [ ] **Not built against the warehouse.** Python dbt models cannot be built from a dev credential without workspace scope. The behavior this changes is branch selection inside `model()`, which needs a Spark session and Databricks secrets, so it is not reachable from the existing pure-helper unit tests.

## Notes

- **This should land before any further merges to main.** The model stays in `state:modified+` until prod successfully builds it, so every merge re-triggers the full-refresh job and re-arms the same truncation.
- The first successful prod full refresh after this merges will take roughly two hours and fetch all ~1.12M referenced ids. That is the intended behavior, and it should leave the table larger than today rather than smaller — expect somewhere near 940k rows at the ~84% resolve rate measured on #793.
- Worth considering separately: this model is rebuilt with `--full-refresh` on every merge that touches it, which is expensive for an API-bound model. Excluding it from the on-merge job, the way `write__l2_databricks_to_gp_api` already is, would avoid paying two hours per touch. Out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes prod full-refresh behavior for a CivicEngine API incremental table where a capped rebuild could replace ~629k rows with ~92k; the fix is small but merge jobs that full-refresh this model remain operationally sensitive until this lands.
> 
> **Overview**
> **Fixes silent mass data loss** when `int__ballotready_filing_period` runs as a full refresh (e.g. merge CI with `--full-refresh`). The non-incremental branch no longer applies `max_ids_per_run`; it fetches **all** race-referenced filing period ids instead of truncating to the newest ~100k.
> 
> `max_ids_per_run` now applies only to incremental backlog budgeting (leading edge + capped backlog). Comments and model YAML document that full refresh replaces the table, so capping would drop rows rather than shorten the run, with a rough ~two-hour uncapped cost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb4e71911075a525831802bc53d693415c566fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->