### PR TITLE
[DATA-2107] Land day-type and turnout projection columns on the race mart

### DIFF
--- a/dbt/project/models/intermediate/l2/int__election_calendar_primary_ballotready.sql
+++ b/dbt/project/models/intermediate/l2/int__election_calendar_primary_ballotready.sql
@@ -1,0 +1,172 @@
+-- Live-recomputed Primary date per (state, year), informed by BallotReady's
+-- scheduled-election data and treated as authoritative for Primary in
+-- m_election_api__election_calendar: this always reflects BallotReady's
+-- CURRENT data, so an edit there (a corrected date, a newly scheduled state)
+-- flows through to Election_Calendar on the next sync automatically -- no
+-- script to re-run. BallotReady's election table changes rarely, so
+-- recomputing this fully every run is cheap; there's no need for anything
+-- fancier than "always trust the current query result."
+--
+-- Even years only: `Primary` is specifically an even-year concept in this
+-- system (it exists to serve the even_year_primary turnout model). Odd-year
+-- races always resolve to LocalOrMunicipal regardless of what BallotReady
+-- calls them, so an odd-year "Primary"-named row here would be unused dead
+-- data at best and a confusing surprise match at worst.
+--
+-- Rule (validated to 55/55 against L2 ground truth for every (state, year)
+-- pair L2 could confirm as of 2024 + the 6 states L2 had already confirmed
+-- for 2026, then re-checked against the FULL even-year L2 history back to
+-- 2010: 198/202 matches, the only 4 misses being pre-2024 BallotReady data
+-- gaps/naming quirks with no bearing on current years. Rejected alternatives:
+-- max-race-count with no Wisconsin exception (53/55), and picking whichever
+-- candidate falls closest to the November general day (51/55)):
+--
+-- Filter to elections plausibly named as each state's Primary day, then per
+-- (state, year) the one with the MOST races wins -- except Wisconsin, which
+-- gets the OPPOSITE (fewest races), because WI statute runs two structurally
+-- distinct primaries every even year on two fixed calendar windows: a
+-- nonpartisan spring primary (Feb, Wis. Stat. secs. 5.02(21)/8.05, for
+-- local/judicial/school-board races that drew 3+ candidates -- thousands of
+-- races) and a partisan primary for state/federal partisan office (Aug, Wis.
+-- Stat. sec. 8.15 -- a few hundred races). Both are literally named
+-- "Wisconsin Primary Election" in BallotReady's data with nothing else
+-- distinguishing them, and the spring one always structurally outsizes the
+-- partisan one -- so "most races wins" is backwards specifically for
+-- Wisconsin. Confirmed against 3 independently L2-verified cycles (2020,
+-- 2022, 2024) before treating this as a rule rather than a coincidence.
+--
+-- Also excluded: a candidate whose date exactly equals that year's computed
+-- November general-election day (2 U.S.C. sec. 7 -- the Tuesday next after
+-- the first Monday in November). Found to be necessary for Louisiana
+-- specifically: LA has run an all-candidate "jungle primary" on the standard
+-- November election day itself since ~2010 (confirmed against L2, which
+-- stopped having a distinct Primary_YYYY column for LA around the same time)
+-- -- BallotReady still labels that event "Louisiana Primary Election," which
+-- would otherwise collide with LA's General row on the exact same (state,
+-- date) key. Checked across every year in BallotReady's table (2018-2030):
+-- only LA ever hits this, so it's a generic date-collision guard, not an
+-- LA-specific hardcode.
+--
+-- If the primary-day filter finds zero rows for a (state, year) -- confirmed
+-- to happen for DC in 2024, where BallotReady split that cycle into party-
+-- specific "Republican/Democratic Presidential Primary Election" rows with
+-- no plain "Primary Election" row at all -- fall back to including
+-- Presidential-named rows, same most/fewest-races logic. Generic, not DC-
+-- specific: DC's other cycles (2018-2030) all have a single plain "Primary
+-- Election" row and never hit this branch.
+{% set wisconsin_states = "('WI')" %}
+
+-- next_day(d, 'MON') returns the first Monday strictly after d, so
+-- subtracting a day from Nov 1 first means a Nov-1-is-a-Monday year still
+-- resolves to Nov 1 itself, not Nov 8.
+{% set computed_general_date_expr = "date_add(next_day(make_date(year(election_day), 11, 1) - interval 1 day, 'MON'), 1)" %}
+
+with
+    candidates_no_presidential as (
+        select
+            state,
+            election_day,
+            race_count,
+            database_id,
+            year(election_day) as election_year
+        from {{ ref("stg_airbyte_source__ballotready_api_election") }}
+        where
+            name like '%Primary%'
+            and name not like '%Runoff%'
+            and name not like '%Consolidated%'
+            and name not like '%Special%'
+            and name not like '%Presidential%'
+            and is_special = false
+            and race_count > 0
+            and year(election_day) % 2 = 0
+            and election_day != {{ computed_general_date_expr }}
+    ),
+
+    candidates_with_presidential as (
+        select
+            state,
+            election_day,
+            race_count,
+            database_id,
+            year(election_day) as election_year
+        from {{ ref("stg_airbyte_source__ballotready_api_election") }}
+        where
+            name like '%Primary%'
+            and name not like '%Runoff%'
+            and name not like '%Consolidated%'
+            and name not like '%Special%'
+            and is_special = false
+            and race_count > 0
+            and year(election_day) % 2 = 0
+            and election_day != {{ computed_general_date_expr }}
+    ),
+
+    ranked_no_presidential as (
+        select
+            *,
+            row_number() over (
+                partition by state, election_year
+                -- Wisconsin: fewest races wins (see header). Everyone else: most
+                -- races wins. Folding both into one ORDER BY direction (ASC) via
+                -- the sign flip keeps this a single ranked CTE instead of a
+                -- union of two differently-ordered ones.
+                -- election_day + database_id break race-count ties
+                -- deterministically: the mart is full-refresh + atomic swap, so
+                -- an unstable pick would flip a state's date (and its salted
+                -- UUID) between nightly runs whenever BallotReady data ties.
+                order by
+                    (
+                        case
+                            when state in {{ wisconsin_states }}
+                            then race_count
+                            else - race_count
+                        end
+                    ) asc,
+                    election_day asc,
+                    database_id asc
+            ) as rn
+        from candidates_no_presidential
+    ),
+
+    ranked_with_presidential as (
+        select
+            *,
+            row_number() over (
+                partition by state, election_year
+                order by
+                    (
+                        case
+                            when state in {{ wisconsin_states }}
+                            then race_count
+                            else - race_count
+                        end
+                    ) asc,
+                    election_day asc,
+                    database_id asc
+            ) as rn
+        from candidates_with_presidential
+    ),
+
+    picked_no_presidential as (
+        select state, election_year, election_day
+        from ranked_no_presidential
+        where rn = 1
+    ),
+
+    -- Only used for (state, year) keys picked_no_presidential has nothing for
+    -- (the DC-2024-style fallback) -- see the final select's coalesce.
+    picked_with_presidential as (
+        select state, election_year, election_day
+        from ranked_with_presidential
+        where rn = 1
+    )
+
+select
+    coalesce(a.state, b.state) as state,
+    coalesce(a.election_day, b.election_day) as election_date,
+    'Primary' as election_code
+from picked_no_presidential a
+full outer join
+    picked_with_presidential b
+    on a.state = b.state
+    and a.election_year = b.election_year

--- a/dbt/project/models/intermediate/l2/int__election_calendar_primary_ballotready.sql
+++ b/dbt/project/models/intermediate/l2/int__election_calendar_primary_ballotready.sql
@@ -1,11 +1,11 @@
 -- Live-recomputed Primary date per (state, year), informed by BallotReady's
--- scheduled-election data and treated as authoritative for Primary in
--- m_election_api__election_calendar: this always reflects BallotReady's
--- CURRENT data, so an edit there (a corrected date, a newly scheduled state)
--- flows through to Election_Calendar on the next sync automatically -- no
--- script to re-run. BallotReady's election table changes rarely, so
--- recomputing this fully every run is cheap; there's no need for anything
--- fancier than "always trust the current query result."
+-- scheduled-election data and treated as authoritative for Primary in the
+-- race build: this always reflects BallotReady's CURRENT data, so an edit
+-- there (a corrected date, a newly scheduled state) flows through
+-- automatically on the next run -- no script to re-run. BallotReady's
+-- election table changes rarely, so recomputing this fully every run is
+-- cheap; there's no need for anything fancier than "always trust the
+-- current query result."
 --
 -- Even years only: `Primary` is specifically an even-year concept in this
 -- system (it exists to serve the even_year_primary turnout model). Odd-year
@@ -13,13 +13,8 @@
 -- calls them, so an odd-year "Primary"-named row here would be unused dead
 -- data at best and a confusing surprise match at worst.
 --
--- Rule (validated to 55/55 against L2 ground truth for every (state, year)
--- pair L2 could confirm as of 2024 + the 6 states L2 had already confirmed
--- for 2026, then re-checked against the FULL even-year L2 history back to
--- 2010: 198/202 matches, the only 4 misses being pre-2024 BallotReady data
--- gaps/naming quirks with no bearing on current years. Rejected alternatives:
--- max-race-count with no Wisconsin exception (53/55), and picking whichever
--- candidate falls closest to the November general day (51/55)):
+-- Rule (validated against L2 ground truth across even cycles back to 2010;
+-- full writeup on the original branch PR):
 --
 -- Filter to elections plausibly named as each state's Primary day, then per
 -- (state, year) the one with the MOST races wins -- except Wisconsin, which

--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -472,13 +472,13 @@ models:
   - name: int__election_calendar_primary_ballotready
     description: >
       Live-recomputed per (state, election_year) Primary date, informed by
-      BallotReady's scheduled-election data (DATA-2015) and treated as
-      authoritative for Primary in m_election_api__election_calendar --
-      recomputes every run, so an edit to BallotReady's election table flows
-      through automatically. Even years only. See the model file's header
-      comment for the full rule (max-race-count winner, Wisconsin exception,
-      Presidential fallback, the Louisiana general-day collision guard) and
-      its validation writeup.
+      BallotReady's scheduled-election data and treated as authoritative for
+      Primary in the race build -- recomputes every run, so an edit to
+      BallotReady's election table flows through automatically. Even years
+      only. See the model file's header comment for the full rule
+      (max-race-count winner, Wisconsin exception, Presidential fallback, the
+      Louisiana general-day collision guard); validation writeup on the
+      original branch PR.
     columns:
       - name: state
         description: State postal code

--- a/dbt/project/models/intermediate/l2/int__l2.yaml
+++ b/dbt/project/models/intermediate/l2/int__l2.yaml
@@ -468,3 +468,40 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "length(trim(district_name)) > 0"
+
+  - name: int__election_calendar_primary_ballotready
+    description: >
+      Live-recomputed per (state, election_year) Primary date, informed by
+      BallotReady's scheduled-election data (DATA-2015) and treated as
+      authoritative for Primary in m_election_api__election_calendar --
+      recomputes every run, so an edit to BallotReady's election table flows
+      through automatically. Even years only. See the model file's header
+      comment for the full rule (max-race-count winner, Wisconsin exception,
+      Presidential fallback, the Louisiana general-day collision guard) and
+      its validation writeup.
+    columns:
+      - name: state
+        description: State postal code
+        data_tests:
+          - not_null
+      - name: election_date
+        description: The Primary date for this state/year, per BallotReady
+        data_tests:
+          - not_null
+      - name: election_code
+        description: Always 'Primary' -- this model only ever emits Primary rows
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["Primary"]
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - state
+              - year(election_date)
+      - dbt_utils.expression_is_true:
+          name: election_calendar_even_years_only
+          arguments:
+            expression: "year(election_date) % 2 = 0"

--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -429,6 +429,57 @@ models:
           STATE / TOWNSHIP); office_level uses the civics taxonomy and can
           be null even when positionLevel is populated. Aggregated from
           mart_civics.candidacy by gp_election_id.
+      - name: election_code
+        description: >
+          Day type of the race's own election date: the even-year November
+          rule (Tuesday after the first Monday in November) says General; a
+          date matching the state's derived primary day says Primary;
+          everything else is LocalOrMunicipal. Provenance for the projection
+          join; spelled in the API's ElectionCode enum vocabulary.
+          ConsolidatedGeneral is deliberately never emitted: the frozen
+          consolidated rows are a legacy serving-path concept.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["General", "Primary", "LocalOrMunicipal"]
+      - name: projected_turnout
+        description: >
+          Projected ballots for this race's (district, year, day type) from
+          the turnout model output, integer-cast for the Postgres delivery
+          contract. NULL when the race's year is outside the model horizon or
+          its district has no model coverage: no fallback, nothing invented.
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 3
+                inclusive: true
+      - name: projected_turnout_lower
+        description: >
+          Lower prediction bound (p25) from the same model row as the point.
+          NULL exactly when projected_turnout is NULL.
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 3
+                inclusive: true
+      - name: projected_turnout_upper
+        description: >
+          Upper prediction bound (p95), the risk-relevant band for win-number
+          planning. NULL exactly when projected_turnout is NULL.
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 3
+                inclusive: true
+      - name: inference_at
+        description: >
+          When the joined projection was produced (freshness stamp; staleness
+          is detectable on the row rather than only in pipeline logs). NULL
+          exactly when projected_turnout is NULL. Accepted skew: race
+          attributes and projections are joined from the same nightly build,
+          but BallotReady race edits land next-build; that skew is bounded to
+          one build and matches the legacy serving path's behavior.
 
   - name: m_election_api__zip_to_position
     description: >

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -70,9 +70,11 @@ with
     -- which excludes November-general collisions, so the two branches are
     -- disjoint. The state that picks the calendar row is the resolved
     -- district's (override-corrected) state where a district exists, the
-    -- race's own state otherwise — the same state the projection join is
-    -- keyed by, so tag and join can never disagree about whose primary day
-    -- applies. model_election_code speaks the model-output vocabulary for
+    -- race's own state otherwise. Where a district exists that is the same
+    -- state the projection join is keyed by, so tag and join can never
+    -- disagree about whose primary day applies; a no-district race carries a
+    -- NULL join tuple that never matches, so only its tag is served.
+    -- model_election_code speaks the model-output vocabulary for
     -- the join; election_code lands the API's enum spelling on the race row.
     race_projection_key as (
         select
@@ -239,8 +241,9 @@ left join
     and tbl_projection_key.model_election_code = tbl_projection.election_code
 where
     -- serve races from 6 years past through 2 years out, so recently-passed and
-    -- historical races stay queryable. This is the sole election_date window for
-    -- the Race table; the sync DAG loads whatever the mart emits
+    -- historical races stay queryable. This window is duplicated in
+    -- race_projection_key above — keep the two predicates in sync. The nightly
+    -- race sync's staged swap delivers whatever the mart emits
     tbl_race.election_date
     between current_date() - interval '6 years' and current_date() + interval '2 years'
     -- Race -> Position -> District -> ProjectedTurnout is the chain the API

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -62,6 +62,66 @@ with
         from {{ ref("candidacy") }}
         where gp_election_id is not null
         group by gp_election_id
+    ),
+
+    -- Day type + projection key, derived together. The November rule is the
+    -- fixed federal expression (Tuesday after the first Monday in November,
+    -- even years); the state's primary day comes from the derived calendar,
+    -- which excludes November-general collisions, so the two branches are
+    -- disjoint. The state that picks the calendar row is the resolved
+    -- district's (override-corrected) state where a district exists, the
+    -- race's own state otherwise — the same state the projection join is
+    -- keyed by, so tag and join can never disagree about whose primary day
+    -- applies. model_election_code speaks the model-output vocabulary for
+    -- the join; election_code lands the API's enum spelling on the race row.
+    race_projection_key as (
+        select
+            tbl_race.id,
+            tbl_district.state as district_state,
+            tbl_district.l2_district_type,
+            tbl_district.l2_district_name,
+            case
+                when
+                    year(tbl_race.election_date) % 2 = 0
+                    and cast(tbl_race.election_date as date) = date_add(
+                        next_day(
+                            make_date(year(tbl_race.election_date), 11, 1)
+                            - interval 1 day,
+                            'MON'
+                        ),
+                        1
+                    )
+                then 'General'
+                when tbl_primary.state is not null
+                then 'Primary'
+                else 'Local_or_Municipal'
+            end as model_election_code,
+            case
+                when model_election_code = 'Local_or_Municipal'
+                then 'LocalOrMunicipal'
+                else model_election_code
+            end as election_code
+        from {{ ref("int__enhanced_race") }} as tbl_race
+        left join
+            {{ ref("m_election_api__position") }} as tbl_position
+            on cast(tbl_race.br_position_database_id as string)
+            = tbl_position.br_database_id
+        left join
+            {{ ref("m_election_api__district") }} as tbl_district
+            on tbl_position.district_id = tbl_district.id
+        left join
+            {{ ref("int__election_calendar_primary_ballotready") }} as tbl_primary
+            on coalesce(tbl_district.state, tbl_race.state) = tbl_primary.state
+            and cast(tbl_race.election_date as date) = tbl_primary.election_date
+        where
+            -- same serving window as the main query (keep the two predicates in
+            -- sync): the base relation is a view over the full race graph, and
+            -- an unwindowed second traversal would roughly double the mart's
+            -- dominant nightly work on a common-subexpression gamble
+            tbl_race.election_date
+            between current_date()
+            - interval '6 years' and current_date()
+            + interval '2 years'
     )
 
 select
@@ -134,7 +194,17 @@ select
     tbl_civics.is_partisan,
     tbl_civics.office_type,
     tbl_civics.official_office_name,
-    tbl_civics.office_level
+    tbl_civics.office_level,
+    tbl_projection_key.election_code,
+    -- Delivery contract: the Postgres projection columns are integers (same
+    -- as the legacy served table); cast at the landing site so the loader
+    -- never relies on implicit numeric coercion.
+    cast(tbl_projection.ballots_projected as int) as projected_turnout,
+    cast(tbl_projection.ballots_projected_lower as int) as projected_turnout_lower,
+    cast(tbl_projection.ballots_projected_upper as int) as projected_turnout_upper,
+    -- Freshness stamp: when the joined projection was produced. NULL exactly
+    -- where the projection columns are NULL (no projection joined).
+    tbl_projection.inference_at
 from {{ ref("int__enhanced_race") }} as tbl_race
 -- Inner join: a race whose place is absent from the place mart cannot be
 -- served (Race.placeId must resolve), and this is also where the race picks
@@ -153,6 +223,20 @@ left join
 left join
     {{ ref("election_api_race_filing_address_overrides") }} as filing_overrides
     on tbl_race.br_database_id = filing_overrides.br_database_id
+inner join
+    race_projection_key as tbl_projection_key on tbl_race.id = tbl_projection_key.id
+-- One projection row per (district, year, day type): the model output is
+-- unique on that key per model_version, and the build asserts a single
+-- model_version. Years outside the model's horizon and districts it does
+-- not cover simply do not join: those races carry NULL projections by
+-- design (no fallback, nothing invented).
+left join
+    {{ ref("int__voter_turnout_inference") }} as tbl_projection
+    on tbl_projection_key.district_state = tbl_projection.state
+    and tbl_projection_key.l2_district_type = tbl_projection.district_type
+    and tbl_projection_key.l2_district_name = tbl_projection.district_name
+    and year(tbl_race.election_date) = tbl_projection.election_year
+    and tbl_projection_key.model_election_code = tbl_projection.election_code
 where
     -- serve races from 6 years past through 2 years out, so recently-passed and
     -- historical races stay queryable. This is the sole election_date window for

--- a/dbt/project/tests/assert_race_election_code_matches_day_rule.sql
+++ b/dbt/project/tests/assert_race_election_code_matches_day_rule.sql
@@ -1,0 +1,43 @@
+-- Recompute each race's day type from first principles (the federal November
+-- expression + the calendar model) and fail on any row whose stored
+-- election_code disagrees. The recompute resolves the calendar state the same
+-- way the mart's key CTE does (district's corrected state where a district
+-- exists, else the race's own): this pins the derivation against wiring
+-- regressions in the mart's join or CASE order.
+with
+    expected as (
+        select
+            tbl_race.id,
+            case
+                when
+                    year(tbl_race.election_date) % 2 = 0
+                    and cast(tbl_race.election_date as date) = date_add(
+                        next_day(
+                            make_date(year(tbl_race.election_date), 11, 1)
+                            - interval 1 day,
+                            'MON'
+                        ),
+                        1
+                    )
+                then 'General'
+                when tbl_primary.state is not null
+                then 'Primary'
+                else 'LocalOrMunicipal'
+            end as expected_code
+        from {{ ref("m_election_api__race") }} as tbl_race
+        left join
+            {{ ref("m_election_api__position") }} as tbl_position
+            on tbl_race.position_id = tbl_position.id
+        left join
+            {{ ref("m_election_api__district") }} as tbl_district
+            on tbl_position.district_id = tbl_district.id
+        left join
+            {{ ref("int__election_calendar_primary_ballotready") }} as tbl_primary
+            on coalesce(tbl_district.state, tbl_race.state) = tbl_primary.state
+            and cast(tbl_race.election_date as date) = tbl_primary.election_date
+    )
+
+select tbl_race.id, tbl_race.election_code, expected.expected_code
+from {{ ref("m_election_api__race") }} as tbl_race
+inner join expected on tbl_race.id = expected.id
+where tbl_race.election_code != expected.expected_code

--- a/dbt/project/tests/assert_race_projection_two_way_inference_parity.sql
+++ b/dbt/project/tests/assert_race_projection_two_way_inference_parity.sql
@@ -1,0 +1,73 @@
+-- Two-way, district-level: (a) any race whose (district, year, day type)
+-- exists in the model output must carry that row's values (a NULL or a
+-- mismatch means the join silently missed or served stale numbers);
+-- (b) any race carrying values must trace back to an identical model-output
+-- row (nothing fabricated, nothing stale). Zero tolerance both ways.
+-- The joins below are LEFT so a race with no position/district match stays
+-- in scope: its NULL tuple can never match a model row, so if it somehow
+-- carries values, direction (b) flags it instead of losing it.
+-- This equality transfer is also what makes ordering, paired nullness, and
+-- pre-horizon nullness hold on the mart without their own tests: the model
+-- output enforces them at the source, and every served value must equal a
+-- model row here.
+with
+    race_key as (
+        select
+            tbl_race.id,
+            tbl_race.projected_turnout,
+            tbl_race.projected_turnout_lower,
+            tbl_race.projected_turnout_upper,
+            tbl_race.inference_at,
+            tbl_district.state,
+            tbl_district.l2_district_type,
+            tbl_district.l2_district_name,
+            year(tbl_race.election_date) as election_year,
+            case
+                when tbl_race.election_code = 'LocalOrMunicipal'
+                then 'Local_or_Municipal'
+                else tbl_race.election_code
+            end as model_election_code
+        from {{ ref("m_election_api__race") }} as tbl_race
+        left join
+            {{ ref("m_election_api__position") }} as tbl_position
+            on tbl_race.position_id = tbl_position.id
+        left join
+            {{ ref("m_election_api__district") }} as tbl_district
+            on tbl_position.district_id = tbl_district.id
+    )
+
+select race_key.id, 'race missing or mismatching its model row' as failure
+from race_key
+inner join
+    {{ ref("int__voter_turnout_inference") }} as projections
+    on race_key.state = projections.state
+    and race_key.l2_district_type = projections.district_type
+    and race_key.l2_district_name = projections.district_name
+    and race_key.election_year = projections.election_year
+    and race_key.model_election_code = projections.election_code
+where
+    race_key.projected_turnout
+    is distinct from cast(projections.ballots_projected as int)
+    or race_key.projected_turnout_lower
+    is distinct from cast(projections.ballots_projected_lower as int)
+    or race_key.projected_turnout_upper
+    is distinct from cast(projections.ballots_projected_upper as int)
+    or race_key.inference_at is distinct from projections.inference_at
+union all
+select race_key.id, 'race carries values with no model row behind them' as failure
+from race_key
+left join
+    {{ ref("int__voter_turnout_inference") }} as projections
+    on race_key.state = projections.state
+    and race_key.l2_district_type = projections.district_type
+    and race_key.l2_district_name = projections.district_name
+    and race_key.election_year = projections.election_year
+    and race_key.model_election_code = projections.election_code
+where
+    (
+        race_key.projected_turnout is not null
+        or race_key.projected_turnout_lower is not null
+        or race_key.projected_turnout_upper is not null
+        or race_key.inference_at is not null
+    )
+    and projections.state is null


### PR DESCRIPTION
**The five NEW columns are delivery-inert until they join RACE_COLUMNS (a follow-up PR) — the loader selects a fixed column list. The mart's EXISTING delivery surface (row membership, existing columns) continues to swap nightly as with any mart change; the membership-parity validation below plus the mart's grain tests are what bound that surface. Merge order: after the turnout-inference PR's post-merge gate passes — that gate PASSED 2026-08-13 (green nightly run 70471892610579; full-key propagation exact on all 744,954 keys; recorded in the repo validation file).**

## Design

- Adopts the BallotReady primary-day calendar model `int__election_calendar_primary_ballotready` from the closed calendar-lookup branch at its head (research-authored adoption commit + a scoped description cleanup). One row per (state, even year): the derived statewide primary date, with November-general collisions excluded by construction so the General/Primary branches are disjoint. The superseded pieces of that branch (seed, calendar mart, its tests, the sync group) are deliberately not adopted.
- `m_election_api__race` gains a `race_projection_key` CTE that derives the day-type tag and the projection join key together from one resolved traversal, so tag and join can never disagree about whose primary day applies. The state that picks the calendar row is the resolved district's (override-corrected) state where a district exists, the race's own state otherwise. Day rule: even-year Tuesday-after-first-Monday-in-November → `General`; a date matching the state's derived primary day → `Primary`; everything else → `LocalOrMunicipal`. The row lands the API's `ElectionCode` enum spelling; the join speaks the model-output vocabulary (`Local_or_Municipal`). `ConsolidatedGeneral` is deliberately never emitted — it is a legacy serving-path concept.
- Five landed columns: `election_code`, `projected_turnout`, `projected_turnout_lower`, `projected_turnout_upper` (int-cast at the landing site for the Postgres delivery contract), and `inference_at` (freshness stamp, NULL exactly where the projections are NULL). Values join directly from `int__voter_turnout_inference` on (district tuple, year, day type). Years outside the model horizon and districts without model coverage simply do not join: those races carry NULL projections by design — no fallback, nothing invented.
- The CTE repeats the mart's serving-window predicate (cross-referenced comments keep the two in sync) so the second traversal of the race view stays bounded to the serving window.

## Gates

- yaml: `not_null` + `accepted_values` on `election_code`; `accepted_range` (min 3, the model's serving floor) on all three value columns.
- `assert_race_election_code_matches_day_rule`: recomputes every race's tag from first principles (the federal November expression + the calendar model), independently of the mart's own CASE — catches join/CASE/translation wiring regressions. Zero tolerance.
- `assert_race_projection_two_way_inference_parity`: two-way anti-join — (a) any race whose (district, year, day type) exists in the model output must carry that row's exact values; (b) any race carrying any of the four values must trace back to an identical model row. The inference model's ordering, paired-nullness, floor, and horizon contracts transfer to the mart through this equality, which is why no separate model-level expression tests ship.
- Deliberately not shipped: a segment-coverage test. Every formulation is impossible or self-blessing today (e.g. the model's (2028, General) slice is structurally empty inside the serving window until the calendar rolls forward). Slice-level coverage is a validation-time table read with window/vendor context instead.

## Validation so far (dev build, prod-deferred upstreams)

- Mart + 21 tests green, including both singular tests, against the full dev build.
- Grain untouched: dev row count = prod row count = 1,013,467 exactly.
- `election_code` fully populated with exactly the three enum spellings; 307,938 of 359,474 in-horizon races carry projections; zero pre-horizon rows carry values.

The value-parity harness (preview mart vs an emulation of today's serving path, whole window) runs on this PR's CI preview schema; results will be posted as a PR comment and recorded in the repo validation file BEFORE any merge decision.

## Merge order

1. This PR merges only after the value-parity results are posted and reviewed. Its first prod nightly then materializes the columns in the prod mart (verified by query) — that check is the delivery PR's opening gate.
2. The delivery PR (moving the five columns into `RACE_COLUMNS`) stays unmerged until the coordinated migration window (race sync paused AND drained; the Postgres migration deploys alone; DDL verified executably). Until then the loader ignores the new mart columns — they are extra columns outside its fixed select list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core race mart semantics and joins turnout inference with state-specific primary calendar rules; extensive dbt tests limit regression risk, but mis-tagged day types would surface wrong projections for campaign strategy.
> 
> **Overview**
> Adds **`int__election_calendar_primary_ballotready`**, which derives each state’s even-year **Primary** date from BallotReady elections (max race count, Wisconsin inverted, presidential-name fallback, November-general collision exclusion), with dbt tests on grain and even years only.
> 
> **`m_election_api__race`** gains a bounded **`race_projection_key`** CTE that tags each race as **General**, **Primary**, or **LocalOrMunicipal** and joins **`int__voter_turnout_inference`** for **`election_code`**, integer **`projected_turnout`** / bounds, and **`inference_at`** (NULL when outside model coverage—no invented values). Mart YAML documents the new columns; **`assert_race_election_code_matches_day_rule`** and **`assert_race_projection_two_way_inference_parity`** guard day-type wiring and projection parity.
> 
> Per the PR description, these columns stay **delivery-inert** until a follow-up adds them to the loader’s fixed column list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeeddeca0cebcad9e616cb14562f7bb09d688a44. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->