### PR TITLE
Remove db_owned_columns from the election-api sync DAG

### DIFF
--- a/airflow/astro/dags/sync_election_api.py
+++ b/airflow/astro/dags/sync_election_api.py
@@ -8,11 +8,12 @@ transaction. Each table is one task group with the same build lifecycle:
 1. **build_staging** — drop & recreate `staging."<Table>_new"` LIKE the live
    target (no indexes — fast bulk-insert).
 2. **load_staging** — stream the source mart from Databricks into staging.
-   The column list is the live table's own columns (minus any
-   `db_owned_columns`), so the mart must publish matching names and types —
-   there is no per-table column mapping or row transform in this DAG. A live
-   column the mart lacks fails the load; a new live column whose data the
-   mart already publishes starts flowing automatically.
+   The column list is the live table's own columns, so the mart must publish
+   every one of them, with matching names and types — there is no per-table
+   column mapping, row transform, or exclusion list in this DAG. A live column
+   the mart lacks fails the load; a new live column whose data the mart already
+   publishes starts flowing automatically. Adding a column therefore lands
+   mart-side first, then in Postgres.
 3. **build_indexes_and_fk** — add PK, indexes, and FK constraints, generated
    from the table's declarative spec. Cross-table FKs reference the sibling
    STAGING table, so the staging set is self-contained and validates against
@@ -237,15 +238,7 @@ TABLES: tuple[MartSync, ...] = (
         ),
         source_model="m_election_api__person",
         partition_column="state",
-        # Prisma-owned columns the loader does not select or supply:
-        # is_pledged keeps its DEFAULT false, gp_api_user_id stays NULL. Both
-        # are unpopulated today; when their ETL lands, the mart must start
-        # supplying them and this allowlist shrinks.
-        gate=QualityGate(
-            cold_start_floor=200_000,
-            min_id_overlap=_GRAPH_ID_OVERLAP,
-            db_owned_columns=frozenset({"is_pledged", "gp_api_user_id"}),
-        ),
+        gate=QualityGate(cold_start_floor=200_000, min_id_overlap=_GRAPH_ID_OVERLAP),
     ),
     MartSync(
         group_id="position",
@@ -277,22 +270,7 @@ TABLES: tuple[MartSync, ...] = (
         source_model="m_election_api__race",
         # ~1M rows; one state at a time bounds worker memory.
         partition_column="state",
-        # The projection columns deploy ahead of their data: the migration adds
-        # them nullable, the loader leaves them alone, and the delivery step
-        # drops them from this allowlist once the mart publishes them.
-        gate=QualityGate(
-            cold_start_floor=100_000,
-            min_id_overlap=_GRAPH_ID_OVERLAP,
-            db_owned_columns=frozenset(
-                {
-                    "projected_turnout",
-                    "projected_turnout_lower",
-                    "projected_turnout_upper",
-                    "election_code",
-                    "inference_at",
-                }
-            ),
-        ),
+        gate=QualityGate(cold_start_floor=100_000, min_id_overlap=_GRAPH_ID_OVERLAP),
         parents=("place", "position"),
     ),
     MartSync(
@@ -383,7 +361,7 @@ TABLES: tuple[MartSync, ...] = (
         # No id-overlap floor: nothing references ZipToPosition ids (PK only;
         # the API reads by zip/position), and this change re-mints them (the
         # mart now derives them from the natural key).
-        gate=QualityGate(cold_start_floor=1_000, db_owned_columns=frozenset({"created_at"})),
+        gate=QualityGate(cold_start_floor=1_000),
         extra_checks=_ztp_extra_checks,
         parents=("position",),
     ),
@@ -407,7 +385,6 @@ TABLES: tuple[MartSync, ...] = (
         partition_column="issue",
         gate=QualityGate(
             cold_start_floor=100_000,
-            db_owned_columns=frozenset({"created_at"}),
             # The mart's LEFT JOIN to haystaq_issue_tags only emits NULL flags
             # on drift; belt-and-suspenders over the dbt-side tests.
             not_null_columns=("is_local", "is_regional", "is_state", "is_federal"),
@@ -487,10 +464,9 @@ def _build_group(table: MartSync) -> dict:
             catalog = Variable.get("databricks_catalog")
             schema = Variable.get("election_api_source_schema", default="dbt")
             with _open_pg() as conn:
-                # The live table's own columns drive the load: dbt must
-                # publish matching names and types, and db-owned columns are
-                # left to their Postgres defaults.
-                columns = staging_columns(conn, spec, exclude=table.gate.db_owned_columns)
+                # The live table's own columns drive the load: dbt must publish
+                # every one of them, with matching names and types.
+                columns = staging_columns(conn, spec)
                 col_list = ", ".join(f"`{c}`" for c in columns)
                 query = f"SELECT {col_list} " f"FROM `{catalog}`.`{schema}`.`{table.source_model}`"
                 return bulk_insert_from_databricks(

--- a/airflow/astro/include/custom_functions/election_api_utils.py
+++ b/airflow/astro/include/custom_functions/election_api_utils.py
@@ -126,9 +126,6 @@ class QualityGate:
     # table whose ids external consumers may hold. None skips the check
     # (tables whose ids legitimately re-mint, e.g. model-version keyed).
     min_id_overlap: float | None = None
-    # Live columns excluded from the load (Prisma-owned; their Postgres
-    # defaults carry them, e.g. Person.is_pledged).
-    db_owned_columns: frozenset[str] = frozenset()
     # Belt-and-braces NULL probes over the staged rows.
     not_null_columns: tuple[str, ...] = ()
 
@@ -172,11 +169,10 @@ def check_nulls(null_rows: int, gate: QualityGate, table: str) -> None:
         )
 
 
-def staging_columns(conn, spec: TableSyncSpec, exclude: frozenset[str] = frozenset()) -> list[str]:
+def staging_columns(conn, spec: TableSyncSpec) -> list[str]:
     """Ordered column names of the staging clone (which mirrors the live
     table). The loader selects exactly these from the mart, so dbt must
-    publish matching names and types; `exclude` holds the db-owned columns
-    whose Postgres defaults carry them."""
+    publish every one of them, with matching names and types."""
     cur = conn.cursor()
     try:
         cur.execute(
@@ -185,7 +181,7 @@ def staging_columns(conn, spec: TableSyncSpec, exclude: frozenset[str] = frozens
             "ORDER BY ordinal_position",
             (spec.staging_schema, spec.new_table),
         )
-        columns = [r[0] for r in cur.fetchall() if r[0] not in exclude]
+        columns = [r[0] for r in cur.fetchall()]
     finally:
         cur.close()
     if not columns:

--- a/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__zip_to_position.sql
@@ -115,13 +115,15 @@ with
             = 1
     )
 
--- id and updated_at satisfy the election-api ZipToPosition Postgres contract.
--- The id is deterministic on the natural key, so it is stable across rebuilds.
+-- id and the timestamps satisfy the election-api ZipToPosition Postgres
+-- contract. The id is deterministic on the natural key, so it is stable across
+-- rebuilds. The sync rebuilds the table every run, so created_at restates to
+-- the build time rather than tracking a first-seen date.
 select
     {{
         generate_salted_uuid(
             fields=["zip_code", "position_id", "election_date"],
             salt="zip_to_position",
         )
-    }} as id, current_timestamp() as updated_at, *
+    }} as id, current_timestamp() as created_at, current_timestamp() as updated_at, *
 from officepicker


### PR DESCRIPTION
Follow-up to #805, which added `is_pledged` and `gp_api_user_id` to `m_election_api__person` but did not deliver them. The writer it also patched was disabled by #798 the day before, and the live path (the `sync_election_api` swap DAG) explicitly excluded both columns.

## The bug

The person entry carried `db_owned_columns=frozenset({"is_pledged", "gp_api_user_id"})`. `staging_columns()` subtracts that set, and the swap creates staging as `LIKE public."Person" INCLUDING DEFAULTS` then renames it into place. So every run produces a Person table with `is_pledged` at `DEFAULT false` and `gp_api_user_id` NULL, regardless of what the mart holds.

Verified against production:

| | mart | prod Postgres |
|---|---|---|
| rows | 261,792 | 261,792 |
| `is_pledged` true | 34,340 | 0 |
| `gp_api_user_id` non-null | 60,859 | 0 |

Both columns exist in prod Postgres with the `Person_gp_api_user_id_idx` index. The data just never arrives.

## Why remove the whole mechanism, not just the person entry

Under a swap, excluding a column preserves nothing. The staging table is built fresh and renamed over the live one, so an excluded column gets its Postgres default, not its previous value. `created_at` was already being restated on every run either way, which is what the two `created_at` entries were nominally protecting.

The only thing the allowlist actually did was let a live Postgres column exist that no mart publishes. That is precisely the drift the DAG's docstring says should fail the load.

## Coverage check

Every live Postgres column is now published by its mart, checked across all thirteen tables:

```
Place OK   District OK   Issue OK   Person OK   Position OK   Race OK
Candidacy OK   OfficeHolder OK   Stance OK   ZipToPosition OK
DistrictTopIssue OK   Elected_Office_Support OK   Projected_Turnout OK
```

Two of the four allowlists were already inert:

- `DistrictTopIssue.created_at` — the mart publishes `current_timestamp() as created_at` and has all along.
- The five `Race` projection columns (`projected_turnout`, `_lower`, `_upper`, `election_code`, `inference_at`) do not exist on `Race` in prod or dev. `staging_columns` reads the staging clone, so those names were never returned and the exclusion never fired. They live on the separate `Projected_Turnout` table, which the DAG already syncs in full.

The one real gap was `ZipToPosition.created_at`, which no mart published. Added here, matching how the district-top-issues mart already supplies it.

## Tradeoff

The `Race` entry existed to let a migration deploy ahead of its data. Removing it means a Postgres migration that adds a column before the mart publishes it will fail the load, and since #798 made all thirteen tables swap in one transaction, that blocks the whole set.

The fix is to reverse the ordering: land the mart column first, then the migration. That direction needs no coordination at all, because the loader selects the live table's column list from the mart, so an extra mart column is simply ignored until Postgres has it. Mart-first is the safe ordering and it needs no allowlist. Documented in the DAG docstring.

## Validation

- `airflow`: 84 passed, 2 skipped
- `dbt`: 152 passed
- `pre-commit` on the changed files: all hooks pass
- `dbt build --select m_election_api__zip_to_position` in dev: PASS=14 ERROR=0, `created_at` populated on all 1,351,674 rows

## After merge

Once Astro deploys and the next swap runs, the pledge badge reaches 34,340 people and profile claiming unblocks for the 60,859 with a gp-api user link. Worth confirming `select count(*) filter (where is_pledged), count(gp_api_user_id) from "Person"` in prod after the first run.

Two items left out, both from #805's own open questions: the dead `PERSON_UPSERT_QUERY` edits go with the retired writer's removal, and the count of person clusters mapping to multiple gp-api users (which silently yields NULL in `people.sql`) still needs measuring and its own ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production data delivery for Person and other tables on the next swap; a Postgres column added before its mart column will fail the whole atomic 13-table swap.
> 
> **Overview**
> Removes the **`db_owned_columns`** mechanism from the election-api Databricks→Postgres swap pipeline so every live Postgres column must come from its dbt mart on each load. **`staging_columns()`** no longer subtracts an exclusion set, and per-table **`QualityGate`** entries for Person, Race, ZipToPosition, and DistrictTopIssue drop their allowlists.
> 
> The DAG docstring now states that marts must publish **all** live columns (mart-first for new columns) and that there is no per-table column mapping or exclusion list.
> 
> **`m_election_api__zip_to_position`** adds **`created_at`** (`current_timestamp()`), closing the one real mart gap that had relied on the allowlist; Person **`is_pledged`** / **`gp_api_user_id`** and other previously excluded fields will flow from the mart on the next swap instead of being reset to Postgres defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d746da4806c09db3bfd0bd3fc4970c7d4c23fcdf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->