### PR TITLE
[DATA-2251] Land web-verification verdicts as a dated source snapshot

### DIFF
--- a/dbt/project/models/staging/__sources.yaml
+++ b/dbt/project/models/staging/__sources.yaml
@@ -1222,6 +1222,12 @@ sources:
         description: raw data load from voter turnout projections for 2028
       - name: voter_turnout_scores_20260730
         description: In-house per-voter turnout propensity scores (prob_vote) for 2026 General
+      - name: web_verify_verdicts_20260813
+        description: >
+          Web verification of uncorroborated Win signups against official election sources,
+          as of 2026-08-13. Label evidence, not model input: every verdict was established
+          by looking up what happened at or after the election. The four waves are separate
+          sampling frames and must not be pooled into a rate.
 
   - name: segment_storage_source
     database: segment_storage

--- a/dbt/project/models/staging/model_predictions_source/stg_model_predictions.yaml
+++ b/dbt/project/models/staging/model_predictions_source/stg_model_predictions.yaml
@@ -350,3 +350,165 @@ models:
         description: Modeled turnout probability in [0, 1] for the 2026 General
         data_tests:
           - not_null
+
+  - name: stg_model_predictions__web_verify_verdicts_20260813
+    description: >
+      Web verification of uncorroborated Win signups against official election sources
+      (filing lists, certified results, sample ballots, Ballotpedia, local news), as of
+      2026-08-13. Four waves of one blind protocol: a 30-row pilot and a 150-row
+      score-stratified run on 2026-08-07, then a full sweep of the high-confidence
+      flag population plus a mop-up of access-blocked rows on 2026-08-13.
+
+      This is label evidence, not model input. Every verdict was established by looking
+      up what happened at or after the election, so nothing here is knowable at signup
+      and no column is legal as a feature.
+
+      Two things a consumer must not do. First, do not pool the waves into a rate: they
+      are separate sampling frames (the sweep is high-score flags only, the stratified
+      run is 30 rows per score bin, the pilot mixes three groups), so condition on wave,
+      oof_hgb or score_bin. Second, do not read verification as corroboration: whether
+      web verification becomes a fourth corroboration channel is an open governance
+      question, and this snapshot deliberately changes no definition.
+
+      Grain is the campaign. One person holding two campaigns appears twice, so user_id
+      is intentionally not unique.
+    columns:
+      - name: verify_id
+        description: >
+          Batch bookkeeping id, unique within the snapshot. Prefixes are meaningful:
+          V pilot, S stratified, F sweep. Mop-up rows keep their original S id because
+          they are re-verifications of stratified rows, not new draws.
+        data_tests:
+          - not_null
+          - unique
+      - name: campaign_id
+        description: gp_api campaign under verification; the grain of this table
+        data_tests:
+          - not_null
+          - unique
+      - name: user_id
+        description: >
+          gp_api user who owns the campaign. Not unique by design: the verification ran
+          at campaign grain, and one person can hold two campaigns. Collapse on this
+          column before computing any person-level rate.
+        data_tests:
+          - not_null
+      - name: wave
+        description: Which verification run produced the verdict
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ["pilot", "stratified", "sweep", "mopup"]
+      - name: method_version
+        description: >
+          Protocol version and wave. One protocol across all four waves, so the version
+          is constant and only the wave suffix varies.
+        data_tests:
+          - not_null
+      - name: verdict
+        description: >
+          CONFIRMED (official filing, result or ballot evidence they ran), LIKELY
+          (strong but indirect evidence), CONTRADICTED (roster-level evidence they did
+          not run in the recorded race), NOT_FOUND (searched, nothing found),
+          NOT_FOUND_BUDGET (search ended before the evidence was exhausted, often a
+          source that was down). The last two are undecided, not negative.
+        data_tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [
+                  "CONFIRMED", "LIKELY", "CONTRADICTED",
+                  "NOT_FOUND", "NOT_FOUND_BUDGET",
+                ]
+      - name: evidence_url
+        description: >
+          Source backing the verdict. Null in the pilot and stratified waves, which
+          recorded no url, and null for not-found verdicts in the evidenced waves. Use
+          is_evidence_recorded to tell those two cases apart rather than reading the
+          null directly.
+      - name: source_type
+        description: Kind of evidence; null exactly where evidence_url is null
+        data_tests:
+          - accepted_values:
+              arguments:
+                values: [
+                  "official_filing", "certified_results", "ballot", "ballotpedia",
+                  "news", "campaign_site", "other",
+                ]
+      - name: is_evidence_recorded
+        description: >
+          Whether this row's wave captured evidence at all. False for the pilot and
+          stratified waves, which recorded the verdict only.
+        data_tests:
+          - not_null
+      - name: notes
+        description: >
+          Verifier narrative, left as written. Populated in the evidenced waves only.
+          This is the audit trail for the verdict, including the reasoning behind a
+          CONTRADICTED where a full roster was enumerated.
+      - name: adjudication_note
+        description: >
+          Populated only where a verdict or url was changed after the run, with the
+          reason. Null means the verifier's call stands as recorded. Five rows carry
+          one: three where the only evidence was a source derived from our own data
+          (a page on a corroboration channel, or our own site) and so could not
+          independently corroborate anything, one where an inference from a term cycle
+          was downgraded for want of a direct filing, and one where a wrong url was
+          corrected on re-verification.
+      - name: verified_at
+        description: Day the wave was completed
+        data_tests:
+          - not_null
+      - name: oof_hgb
+        description: >
+          Out-of-fold model score the row was sampled on. Sampling metadata: it defines
+          which rows were verified, so it can never be evidence about the group it
+          selected.
+        data_tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                max_value: 1
+      - name: is_cleanlab_flagged
+        description: Row was flagged as a probable label error. Sampling metadata.
+        data_tests:
+          - not_null
+      - name: is_high_confidence_flag
+        description: Row was in the high-confidence flag population. Sampling metadata.
+        data_tests:
+          - not_null
+      - name: score_bin
+        description: >
+          Score bin for the stratified frame only; null where the wave was not
+          bin-sampled. Non-null exactly where bin_population is.
+      - name: bin_population
+        description: Population of the row's score bin. Stratified frame only.
+        data_tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 1
+    data_tests:
+      # A decided verdict without a url would be an unfalsifiable claim, and a url in a
+      # wave that recorded none would mean the wave metadata is wrong. Both directions
+      # of the evidence contract are pinned here.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              case
+                  when not is_evidence_recorded then evidence_url is null
+                  when verdict in ('NOT_FOUND', 'NOT_FOUND_BUDGET') then evidence_url is null
+                  else evidence_url is not null
+              end
+          name: web_verify_verdicts_evidence_url_matches_wave_and_verdict
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: (evidence_url is null) = (source_type is null)
+          name: web_verify_verdicts_source_type_accompanies_url
+      # score_bin and bin_population are one fact about the stratified frame, so they
+      # must appear and disappear together.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: (score_bin is null) = (bin_population is null)
+          name: web_verify_verdicts_score_bin_pairs_with_population

--- a/dbt/project/models/staging/model_predictions_source/stg_model_predictions__web_verify_verdicts_20260813.sql
+++ b/dbt/project/models/staging/model_predictions_source/stg_model_predictions__web_verify_verdicts_20260813.sql
@@ -1,0 +1,36 @@
+with
+    source as (
+        select * from {{ source("model_predictions", "web_verify_verdicts_20260813") }}
+    ),
+    renamed as (
+        select
+            verify_id,
+            campaign_id,
+            user_id,
+            wave,
+            method_version,
+            verdict,
+            -- Means *admissible* evidence, and a null means two different things
+            -- depending on the wave. The flag below keeps them separable: early
+            -- waves recorded no url at all, while in an evidenced wave a null
+            -- url is exactly a not-found verdict.
+            evidence_url,
+            source_type,
+            wave in ('sweep', 'mopup') as is_evidence_recorded,
+            notes,
+            -- Set only where a verdict or url was changed after the run. Null
+            -- means the verifier's call stands as recorded.
+            adjudication_note,
+            verified_at,
+            -- Sampling metadata, not row properties. The waves are separate
+            -- frames, so a rate pooled across them is a composition artifact;
+            -- these are what a consumer conditions on to avoid that.
+            oof_hgb,
+            is_cleanlab_flagged,
+            is_high_confidence_flag,
+            score_bin,
+            bin_population
+        from source
+    )
+select *
+from renamed


### PR DESCRIPTION
Lands the web-verification verdicts for uncorroborated Win signups as a dated source snapshot plus a staging model, so the label-correction work has something to consume.

**Source only.** This changes no corroboration definition. Whether web verification should become a fourth corroboration channel is a separate governance decision and is deliberately not touched here.

## What landed

`model_predictions.web_verify_verdicts_20260813` → `stg_model_predictions__web_verify_verdicts_20260813`.

The snapshot is the complete verified set, not just the final sweep. Three waves of one blind protocol:

| wave | n | date | evidence recorded |
|---|---|---|---|
| pilot | 30 | 2026-08-07 | no |
| stratified | 136 | 2026-08-07 | no |
| sweep | 603 | 2026-08-13 | yes |
| mopup | 14 | 2026-08-13 | yes |

The mop-up re-verified 14 stratified rows that were access-blocked on 08-07, and those verdicts supersede the originals, so the union is `617 + 30 + 150 - 14 = 783`, unique at `campaign_id`.

## Why it is shaped this way

**Grain is the campaign, so `user_id` is intentionally not unique.** The verification ran per campaign, and one person can hold two campaigns — there is a known instance of the same person, same office, same election, two campaign rows, both CONTRADICTED. Both are kept, because the snapshot is a faithful record at the grain the work ran. Anyone computing person-level rates has to collapse on `user_id` first.

**Sampling metadata is carried on purpose.** `wave`, `oof_hgb`, `score_bin` and `bin_population` are here because the waves are *different sampling frames* — the sweep is high-score flags only, the stratified run is 30 rows per score bin, the pilot mixes three groups. A rate computed across all 783 rows is a composition artifact. These columns are what a consumer conditions on to avoid that. They are sampling metadata, never features.

**Nothing is aggregated.** No is-real flag, no trust tier. Grouping CONFIRMED+LIKELY as "real" is a downstream modelling choice, not a property of the evidence, and freezing one reading into the source would be the wrong place for it.

**`evidence_url` means admissible evidence**, and `is_evidence_recorded` exists so a null can be read correctly: the early waves recorded no url at all, while in an evidenced wave a null url is exactly a not-found verdict.

## Adjudications

Five rows were adjudicated before landing; each carries its reason in `adjudication_note`, and the raw inputs were not edited.

| row | change | why |
|---|---|---|
| circular evidence (1) | CONFIRMED → LIKELY | Only evidence was a page on a corroboration channel we already build the label from. It cannot corroborate a row that same channel failed to corroborate — it evidences an ER match-miss. Url kept: real but indirect, which is what LIKELY means. |
| self-referential evidence (2) | LIKELY → NOT_FOUND | Only evidence was our own site, which is derived from the record under test. Nothing admissible survives, so the url was cleared and preserved in the note. |
| inference-based (1) | CONFIRMED → LIKELY | Current-roster page plus a two-year term-cycle inference. Re-checked, no direct 2025 filing or result found. |
| url mismatch (1) | url corrected | Pointed at a co-candidate's page in the correct race. Re-verified: the subject is independently listed as a candidate in that same race, so CONFIRMED stands. |

## Verification

The dbt Cloud **dev** credential is currently rejecting with `Invalid access token`, so `dbt build` could not run against my dev target. Every test predicate was instead executed directly against the landed table, and CI will run the real build.

Load, against the parquet the build script produced:

```
landed: 783 rows, 783 campaigns, 783 verify_ids
CONFIRMED 444 | CONTRADICTED 211 | LIKELY 68 | NOT_FOUND 44 | NOT_FOUND_BUDGET 16
sweep 603 | stratified 136 | pilot 30 | mopup 14
```

783 is the expected union count, asserted in the build script and re-asserted after load — a build with fewer rows would be a regression, not a pass.

All 12 test predicates run as SQL against the landed table:

```
PASS row count (783)                     PASS accepted_values verdict
PASS unique campaign_id                  PASS accepted_values source_type
PASS unique verify_id                    PASS range oof_hgb 0..1
PASS not_null (all required cols)        PASS range bin_population >= 1
PASS accepted_values wave                PASS evidence_url matches wave and verdict
PASS source_type accompanies url         PASS score_bin pairs with population
```

The evidence-contract test earns its keep: it pins the biconditional in both directions, and on first run it **failed on 2 rows** — the two downgraded-to-NOT_FOUND rows whose inadmissible url had been left attached. The build script's own check had only asserted one direction and passed. Both sides now state the full contract.

## Operational notes

- The table is immutable once landed. Four rows are `NOT_FOUND_BUDGET` because a county election site was down for a whole batch, not because evidence is absent; retrying those produces a new dated snapshot rather than an edit to this one.
- All 783 rows sit inside the uncorroborated class (verified). Nothing here says anything about corroborated signups, and no false-positive rate for the existing channels can be read from it.
- Verification requires a searchable name, so garbled and gibberish names concentrate in the not-found classes. The confirmed-or-likely share overstates realness for the uncorroborated class as a whole.
- The build and load scripts live in the analytics project directory and are not part of this PR, matching how that project has operated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive staging-only dbt change with no corroboration or production logic changes; main risk is downstream misuse of label-evidence or pooled wave rates, which the docs and tests explicitly guard against.
> 
> **Overview**
> Adds **`model_predictions.web_verify_verdicts_20260813`** as a dbt source and **`stg_model_predictions__web_verify_verdicts_20260813`**, exposing campaign-grain web verification verdicts for uncorroborated Win signups as **label evidence** (not model features or corroboration policy changes).
> 
> The staging model passes through verdict, wave, sampling metadata (`oof_hgb`, `score_bin`, etc.), and derives **`is_evidence_recorded`** so null `evidence_url` can mean “wave didn’t record URLs” vs “not found” in sweep/mopup. YAML documents grain (**`campaign_id`** unique, **`user_id`** not), wave semantics, and adds tests (uniqueness, accepted values, evidence URL ↔ wave/verdict, `source_type` pairing, `score_bin`/`bin_population`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f011151b0b535ae92d5435f990b068296f13f825. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->