### PR TITLE
[DATA-2317] Env-scope the loader's S3 export prefix

### DIFF
--- a/people-api-loader/src/loader/people_api/config.py
+++ b/people-api-loader/src/loader/people_api/config.py
@@ -271,8 +271,14 @@ class LoaderConfig(BaseLoaderConfig):
     def bastion_enabled(self) -> bool:
         return bool(self.bastion_host)
 
+    # Env-scoped for the same reason as the dated identifiers below, and more urgently: this prefix
+    # namespaces `_manifest/{step}.json`, and a step short-circuits when its manifest exists. Dev and
+    # prod share this bucket, so an un-scoped prefix let a same-date run in one env adopt the other's
+    # manifests and skip every step. Observed: a dev run consumed a prod run's manifests end to end
+    # and reported success having done nothing. The dangerous ordering is the reverse: prod skipping
+    # unload/copy while `provision` still builds a cluster, then promoting serving onto empty tables.
     def export_prefix(self, run_date: str) -> str:
-        return f"voter_export_{run_date}"
+        return f"voter_export_{run_date}_{self.db_env}"
 
     # Dated identifiers are env-scoped (gp-people-db-{date}-{env}[-role]). Dev and prod provision
     # into the same AWS account and `provision` is idempotent by name, so an un-scoped name would

--- a/people-api-loader/tests/test_config.py
+++ b/people-api-loader/tests/test_config.py
@@ -97,6 +97,22 @@ def test_provisioned_identifiers_are_env_scoped(monkeypatch: pytest.MonkeyPatch)
     assert LoaderConfig.from_env().new_cluster_id("20260707") == "gp-people-db-20260707-prod"
 
 
+def test_export_prefix_is_env_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The prefix namespaces `_manifest/{step}.json`, and a step short-circuits when its manifest
+    # exists. Dev and prod share the bucket, so an un-scoped prefix let a same-date run in one env
+    # adopt the other's manifests and skip every step while reporting success.
+    monkeypatch.setenv("LOADER_S3_BUCKET", "gp-people-loader-us-west-2")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    dev = LoaderConfig.from_env()
+    monkeypatch.setenv("ENVIRONMENT", "prod")
+    prod = LoaderConfig.from_env()
+
+    assert dev.export_prefix("20260707") == "voter_export_20260707_dev"
+    assert prod.export_prefix("20260707") == "voter_export_20260707_prod"
+    # The whole point: same date, different env, no shared manifest key.
+    assert dev.manifest_key("20260707", "unload") != prod.manifest_key("20260707", "unload")
+
+
 def test_people_api_mart_fqns_default(monkeypatch: pytest.MonkeyPatch) -> None:
     import os
 


### PR DESCRIPTION
Closes [DATA-2317](https://app.clickup.com/t/86ak0ngr6).

## The bug

`LoaderConfig.export_prefix()` returned `voter_export_{run_date}` with no environment component. That prefix namespaces `_manifest/{step}.json`, and every loader step short-circuits when its manifest already exists. Dev and prod share `LOADER_S3_BUCKET`, so a same-date run in either environment silently adopted the other's manifests and skipped the entire pipeline while reporting success.

The dated cluster identifiers directly below it are all `{date}-{env}`, and their comment describes this exact hazard. The export prefix was the one that was missed.

## Observed

A manual `load_people_api` run on astro-dev went fully green in minutes with every step logging `manifest already complete`. It had adopted a prod run's manifests from earlier the same day: `provision.json` named `gp-people-db-20260813-prod`, and `unload.json` listed the four tables prod had exported. Nothing was unloaded, copied, or indexed for dev, and all twelve tasks reported success.

That ordering failed safe. The reverse does not: prod would skip `unload` and `copy` while `provision` still builds a real cluster under its own env-scoped name, and `promote` would cut serving over to a database that was never loaded.

## The change

```python
def export_prefix(self, run_date: str) -> str:
    return f"voter_export_{run_date}_{self.db_env}"
```

plus `test_export_prefix_is_env_scoped`, which asserts dev and prod produce different `manifest_key`s for the same run date. It sits next to the existing `test_provisioned_identifiers_are_env_scoped` that already guards this property for cluster names.

## Checked before changing it

Two things could have made a one-line prefix change unsafe, and neither applies:

- No production code references the `voter_export` literal. Only tests, and they inject their own `export_prefix` lambdas.
- The `rds-s3-import-people-loader` role grants `s3:GetObject` on `gp-people-loader-us-west-2/*` with no path condition, so a changed prefix cannot trip IAM.

## Verification

- Loader suite: 359 passed, 5 skipped (Postgres integration tests needing a local PG)
- `ruff check`, `ruff format --check`, `ty check` all clean

## Note for whoever merges

Existing manifests on the old prefix are orphaned, so a run already in flight will redo its completed steps. The steps are idempotent so this is safe, but it is worth not being surprised by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)