### PR TITLE
[DATA-2318] Make the candidacy HubSpot company id assertion snapshot-safe

### DIFF
--- a/dbt/project/tests/assert_candidacy_hubspot_company_ids_populated.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_company_ids_populated.sql
@@ -2,15 +2,27 @@
 -- as hubspot_company_ids. gp_api stores the HubSpot COMPANY id on the campaign;
 -- the mart must expose it. Failures mean the company id was dropped for current
 -- candidacies.
+--
+-- Keyed on gp_candidacy_id, the grain the mart's coalesce actually operates on.
+-- product_campaign_id is not that grain: the 2025 HubSpot archive reuses
+-- campaign ids under different candidacy ids, so matching on it pairs an
+-- archive candidacy against an unrelated gp_api one.
+--
+-- The record-version guard keeps this snapshot-safe. gp-api creates the HubSpot
+-- company and only then writes its id back onto the campaign, so a campaign is
+-- legitimately company-id-less for a while after it is created. A CI run reads
+-- the mart from its own schema and this intermediate from prod, where the
+-- scheduled job keeps refreshing it, so the two sides can land on either side of
+-- that write-back. Comparing only rows built from the same gp_api record version
+-- drops the versions that carry no information about the join, without excluding
+-- any row on its own merits.
 select cand.gp_candidacy_id
 from {{ ref("candidacy") }} as cand
+inner join
+    {{ ref("int__civics_candidacy_gp_api") }} as gp
+    on cand.gp_candidacy_id = gp.gp_candidacy_id
+    and cand.updated_at = gp.updated_at
 where
     (cand.hubspot_company_ids is null or trim(cand.hubspot_company_ids) in ('', '[]'))
-    and exists (
-        select 1
-        from {{ ref("int__civics_candidacy_gp_api") }} as gp
-        where
-            gp.product_campaign_id = cand.product_campaign_id
-            and gp.hubspot_company_ids is not null
-            and trim(gp.hubspot_company_ids) not in ('', '[]')
-    )
+    and gp.hubspot_company_ids is not null
+    and trim(gp.hubspot_company_ids) not in ('', '[]')


### PR DESCRIPTION
## Root cause

The assertion is not snapshot-safe, and it matches on the wrong key. Nothing is dropped in the join.

`candidacy.sql:115` is fine. Campaign `326446` resolves end to end: prod `candidacy` has `gp_candidacy_id = 3b251bbd-abae-d862-1c48-2f920f7f1d4b` with `hubspot_company_ids = ["57496181344"]` and `source_systems = [gp_api]`, matching `int__civics_candidacy_gp_api` exactly. All 12,122 gp_api intermediate rows are present in the mart; none are dropped by the 4-way full outer join or the dedup.

Two independent defects in the assertion itself:

**It compares two relations across a write-back window.** gp-api creates the HubSpot company and only then writes its id back onto the campaign (`crmCampaigns.service.ts`, `trackCampaign`). Campaign `326446` was created at 18:35 and got its `hubspotId` at 19:47, a 72 minute gap. During that window a null company id is correct. A CI run reads `candidacy` from its own schema while `int__civics_candidacy_gp_api` is unmodified and defers to prod, where the scheduled job keeps refreshing it underneath the run, so the two sides can land on opposite sides of that write-back. In prod both are built in the same job (01:39 and 01:44 on the day this was filed), which is why the failure only ever shows up in CI, on unrelated PRs, and heals on its own.

**It matches on `product_campaign_id`, which is not the join grain.** The 2025 HubSpot archive reuses campaign ids under different candidacy ids: 134 campaign ids are shared between the archive rows and the gp_api rows, and in all 134 cases the two carry different `gp_candidacy_id`s. So the assertion can pair an archive candidacy against an unrelated gp_api one and fail on a row where nothing was lost. Zero trip today, but it is the same bug class waiting.

## The fix

Key on `gp_candidacy_id`, the grain the coalesce at `candidacy.sql:115` actually operates on, and assert only where the mart row was built from the same gp_api record version (`cand.updated_at = gp.updated_at`; gp_api wins `updated_at` in the mart's coalesce chain).

The version guard is deliberate narrowing, not relaxation, and it is not a per-row exclusion: it drops record versions that carry no information about whether the join dropped anything. Equality rather than `>=` is intentional, since the product clears `hubspotId` back to null on a HubSpot update error, so a newer mart version can legitimately hold a null the intermediate does not.

## Verification

| Check | Result |
|---|---|
| gp_api intermediate rows | 12,122 |
| Present in the mart, joined on `gp_candidacy_id` | 12,122 (0 dropped) |
| Same record version on both sides, settled prod | 12,122 |
| Covered by the assertion (gp_api row has a company id) | 12,100 |
| Uncovered | 22, all campaigns with a genuinely null `hubspot_id`, created 2023-24 |
| Assertion failures, prod | 0 |
| Assertion failures, fresh dev build of `candidacy` | 0 |

`dbt build --select candidacy` in dev: `PASS=32 WARN=1 ERROR=0` (the warn is the pre-existing `relationships_candidacy_gp_election_id` warn-only test at 279 rows, untouched by this change).

The assertion keeps its teeth: injecting five dropped `hubspot_company_ids` into otherwise-matching rows is detected as five failures.
