### PR TITLE
Fix candidacy_hubspot nested-loop anti-join (~25 min -> ~30 s)

### DIFF
--- a/.claude/skills/dbt-databricks-cost-audit/SKILL.md
+++ b/.claude/skills/dbt-databricks-cost-audit/SKILL.md
@@ -47,7 +47,7 @@ commit generated `cost_dashboard.*`; commit only the tool.
 | cost by product / month + week | `system.billing.usage` × `list_prices` | overall trend, SQL vs ALL_PURPOSE vs APPS… |
 | dbt exec-hr by node type | `system.query.history` (`statement_text` node_id) | **testing vs model vs snapshot cost** |
 | warehouse exec-hr by consumer | `system.query.history` `client_application` | dbt vs airbyte vs BI vs dev |
-| top dbt nodes | `system.query.history` | the specific expensive models/tests |
+| top dbt nodes | `system.query.history` | the specific expensive models/tests, and whether each is scan- or compute-bound |
 | high-freq-job estimate | exec-hr in the 4-hourly-only UTC windows ×6/4 | is killing it sufficient? |
 
 $ for the dbt/consumer views is the **SQL-warehouse bill prorated by query
@@ -63,9 +63,26 @@ figures are an allocation, not a metered per-query charge. State that.
   mart emits pretty/spaced column names (e.g. a reverse-ETL contract like
   `First Name`), a Delta table rejects them (`DELTA_INVALID_CHARACTERS`) — add
   `+tblproperties: {delta.columnMapping.mode: "name"}` to keep the names.
+- **Compute-bound nodes (nested-loop joins):** read the `hr/TB` and `profile`
+  columns before proposing a fix. A node with a *high* `hr/TB` (say >200) is
+  burning CPU without reading much — the plan is wrong, and pruning, partitioning,
+  clustering and incremental will all miss it. The usual cause is a join Spark
+  could not hash: most often a correlated `not exists` / `not in` whose predicate
+  **ORs together several different keys**, which cannot become a hash anti-join and
+  plans as `BroadcastNestedLoopJoin LeftAnti` (left rows × right rows comparisons,
+  with any `regexp_replace`/`lower`/`trim` in the predicate re-evaluated per pair).
+  Confirm with `EXPLAIN <compiled sql> | grep -i nestedloop`, then rewrite as one
+  hash anti-join per key against pre-normalized `distinct` key sets, unioned or
+  left-joined and filtered on `is null`. Normalizing each side once in a CTE is
+  half the win; making the join hashable is the other half.
 - **Frequency is a multiplier:** the dbt Cloud models-built meter = models/run ×
   runs. A job of N models run 6×/day bills 6N. Incremental materialization cuts
   Databricks compute but **not** the models-built count.
+- **Reach for incremental only when the cost is in the write.** If a node writes
+  little but reads or computes a lot, incremental adds state and reload complexity
+  without touching the bill. It is also the wrong tool for a *rolling-window
+  exclusion feed* (rows must leave as they age out or get claimed downstream) —
+  an append would retain stale rows, and a merge-with-deletes rescans anyway.
 - **Is slowing the high-freq job enough?** Compare its estimate against total
   testing cost. If tests (which also run in the twice-daily main job) exceed the
   high-freq job, no — you must also decouple the full test suite from every build.
@@ -82,3 +99,18 @@ figures are an allocation, not a metered per-query charge. State that.
 - `system.query.history` column is `statement_text` (not `query_text`); dbt stamps
   each query with `"node_id": "..."` in a leading comment — regexp-extract it to
   attribute cost to a model/test.
+- **Use `execution_duration_ms`, not `total_duration_ms`.** The total also carries
+  `waiting_at_capacity_duration_ms` (queued behind other statements) and
+  `waiting_for_compute_duration_ms` (warehouse starting). On a saturated warehouse
+  that inflates cheap statements that merely queued behind an expensive one, and
+  you end up "fixing" the wrong node. Pull the components alongside the total when
+  a duration looks implausible for the work involved.
+- **Statement count is not build count.** dbt stamps its `SHOW`/`OPTIMIZE`/metadata
+  statements with the same `node_id` as the build itself, so a node showing ~800
+  statements may be ~150 real builds plus ~650 trivial ones. Use the `>60s` column,
+  or filter `statement_type` (`REPLACE`/`MERGE`/`CREATE`), before concluding
+  anything about frequency.
+- **The same `node_id` spans environments.** `target_name` in the dbt comment
+  separates `prod` from `ci` from a developer's own runs. A node that looks
+  expensive can be mostly PR-CI rebuilds in `dbt_cloud_pr_*` schemas, which is a
+  different problem (and a different fix) than an expensive production job.

--- a/.claude/skills/dbt-databricks-cost-audit/scripts/cost_audit.py
+++ b/.claude/skills/dbt-databricks-cost-audit/scripts/cost_audit.py
@@ -144,14 +144,31 @@ def label_principal(principal, spmap):
 
 def q_topnodes(since, wh, dbt_app):
     node = 'regexp_extract(statement_text, \'"node_id": ?"([^"]+)"\', 1)'
+    # `q` counts every statement dbt stamped with this node_id, most of which are
+    # trivial (SHOW/OPTIMIZE/metadata SELECTs). `heavy_q` counts only statements
+    # over a minute, which is the number that tracks "how often did this actually
+    # build". Ranking or reasoning on `q` alone badly misattributes cost.
+    #
+    # hr_per_tb separates the two failure modes: scan-bound nodes (wide reads,
+    # low ratio) want pruning/partitioning; compute-bound nodes (tiny reads, high
+    # ratio) are usually a bad join plan and pruning will not touch them.
     return (
         f"select {node} node, element_at(split({node},'[.]'),1) t, "
         f"round(sum(execution_duration_ms)/3600000,1) exec_hr, count(*) q, "
-        f"round(sum(read_bytes)/1e12,2) tb "
+        f"sum(case when execution_duration_ms>60000 then 1 else 0 end) heavy_q, "
+        f"round(sum(read_bytes)/1e12,2) tb, "
+        f"round((sum(execution_duration_ms)/3600000.0)"
+        f"/nullif(sum(read_bytes)/1e12,0),1) hr_per_tb "
         f"from system.query.history where compute.warehouse_id='{wh}' "
         f"and client_application='{dbt_app}' and start_time>='{since}' "
         f"and {node}!='' group by 1,2 order by exec_hr desc limit 25"
     )
+
+
+def short_node(node_id):
+    """`model.proj.name` / `test.proj.name.abc123` -> `name` (drops the test hash)."""
+    parts = (node_id or "").split(".")
+    return parts[2] if len(parts) > 2 else (parts[-1] if parts else node_id)
 
 
 def q_freq_windows(since, wh, dbt_app):
@@ -212,11 +229,15 @@ def collect(profile, warehouse, since, dbt_app):
         }
     data["topnodes"] = [
         {
-            "node": r[0].split(".")[-1],
+            # node_id is <type>.<project>.<name>[.<hash>]; generic tests carry a
+            # trailing hash, so taking the last segment renders them as bare hashes.
+            "node": short_node(r[0]),
             "type": r[1],
             "hr": float(r[2] or 0),
             "q": int(r[3]),
-            "tb": float(r[4] or 0),
+            "heavy_q": int(r[4] or 0),
+            "tb": float(r[5] or 0),
+            "hr_per_tb": float(r[6] or 0),
         }
         for r in run_sql(profile, warehouse, q_topnodes(since, warehouse, dbt_app))
     ]

--- a/.claude/skills/dbt-databricks-cost-audit/scripts/dashboard_template.html
+++ b/.claude/skills/dbt-databricks-cost-audit/scripts/dashboard_template.html
@@ -67,7 +67,7 @@
 
   <h2>Top dbt nodes by execution time <span class="muted" id="nodespan"></span></h2>
   <div class="chartbox">
-    <table id="nodes"><thead><tr><th>node</th><th>type</th><th>exec-hr</th><th>runs</th><th>TB read</th></tr></thead><tbody></tbody></table>
+    <table id="nodes"><thead><tr><th>node</th><th>type</th><th>exec-hr</th><th>stmts</th><th>&gt;60s</th><th>TB read</th><th>hr/TB</th><th>profile</th></tr></thead><tbody></tbody></table>
   </div>
 </div>
 <div class="tt" id="tt"></div>
@@ -164,8 +164,12 @@ function renderChart(){
 
 function renderNodes(){
   const tb=document.querySelector("#nodes tbody");
+  // >200 hr/TB means the node burns compute without reading much: usually a join
+  // that could not be hashed (an OR'd anti-join planning as a nested loop), not a
+  // scan problem. Pruning/partitioning will not help those; the plan has to change.
+  const profile=n=>n.tb<0.01?"—":(n.hr_per_tb>200?"compute-bound":(n.hr_per_tb<20?"scan-bound":"mixed"));
   tb.innerHTML=DATA.topnodes.map(n=>
-    `<tr><td>${n.node}</td><td class="muted">${n.type}</td><td>${n.hr.toFixed(1)}</td><td>${n.q.toLocaleString()}</td><td>${n.tb.toFixed(2)}</td></tr>`).join("");
+    `<tr><td>${n.node}</td><td class="muted">${n.type}</td><td>${n.hr.toFixed(1)}</td><td class="muted">${n.q.toLocaleString()}</td><td>${(n.heavy_q||0).toLocaleString()}</td><td>${n.tb.toFixed(2)}</td><td>${(n.hr_per_tb||0).toFixed(0)}</td><td class="muted">${profile(n)}</td></tr>`).join("");
 }
 
 document.getElementById("grain").addEventListener("click",e=>{const b=e.target.closest("button");if(!b)return;

--- a/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
@@ -57,6 +57,26 @@ with
             ) as ts_office
     ),
 
+    -- HubSpot de-dupe keys, normalized once per contact rather than once per
+    -- comparison. Each set is distinct, so the anti-joins below cannot fan out.
+    hs_email_keys as (
+        select distinct lower(trim(email)) as email_key
+        from {{ ref("int__hubspot_contacts") }}
+        where email is not null
+    ),
+
+    hs_phone_keys as (
+        select distinct regexp_replace(phone_number, '[^0-9]', '') as phone_key
+        from {{ ref("int__hubspot_contacts") }}
+        where length(regexp_replace(phone_number, '[^0-9]', '')) >= 10
+    ),
+
+    hs_br_candidacy_ids as (
+        select distinct br_candidacy_id
+        from {{ ref("int__hubspot_contacts") }}
+        where br_candidacy_id is not null
+    ),
+
     civics_base as (
         select
             cy.gp_candidacy_id,
@@ -115,7 +135,20 @@ with
                 then 'primary'
                 when cy.general_election_date >= current_date()
                 then 'general'
-            end as election_stage
+            end as election_stage,
+            -- Candidate-side de-dupe keys. Null where the leg does not apply, so
+            -- the anti-joins below simply do not match (null never equals a key).
+            case
+                when c.email is not null and c.email != '' then lower(trim(c.email))
+            end as hs_email_key,
+            case
+                when
+                    c.phone_number is not null
+                    and c.phone_number != ''
+                    and length(regexp_replace(c.phone_number, '[^0-9]', '')) >= 10
+                then regexp_replace(c.phone_number, '[^0-9]', '')
+            end as hs_phone_key,
+            try_cast(br_int.br_candidacy_id as int) as hs_br_candidacy_id
         from {{ ref("candidacy_scored") }} as cy
         join {{ ref("candidate") }} as c on cy.gp_candidate_id = c.gp_candidate_id
         left join {{ ref("election") }} as e on cy.gp_election_id = e.gp_election_id
@@ -147,27 +180,21 @@ with
             )
             -- belt-and-suspenders not-already-in-HubSpot
             and cy.hubspot_contact_id is null
-            and not exists (
-                select 1
-                from {{ ref("int__hubspot_contacts") }} as hs
-                where
-                    (
-                        c.email is not null
-                        and c.email != ''
-                        and lower(trim(hs.email)) = lower(trim(c.email))
-                    )
-                    or (
-                        c.phone_number is not null
-                        and c.phone_number != ''
-                        and length(regexp_replace(c.phone_number, '[^0-9]', '')) >= 10
-                        and regexp_replace(hs.phone_number, '[^0-9]', '')
-                        = regexp_replace(c.phone_number, '[^0-9]', '')
-                    )
-                    or (
-                        br_int.br_candidacy_id is not null
-                        and hs.br_candidacy_id = try_cast(br_int.br_candidacy_id as int)
-                    )
-            )
+    ),
+
+    -- Not-already-in-HubSpot, as three hash anti-joins instead of one correlated
+    -- `not exists` that ORs the three keys together. Spark cannot hash-join an OR
+    -- across disjoint keys, so the OR form planned as a
+    -- BroadcastNestedLoopJoin LeftAnti -- every candidacy in the window compared
+    -- against every HubSpot contact, with the phone regexp re-evaluated per pair.
+    not_in_hubspot as (
+        select b.*
+        from civics_base as b
+        left join hs_email_keys as he on b.hs_email_key = he.email_key
+        left join hs_phone_keys as hp on b.hs_phone_key = hp.phone_key
+        left join hs_br_candidacy_ids as hb on b.hs_br_candidacy_id = hb.br_candidacy_id
+        where
+            he.email_key is null and hp.phone_key is null and hb.br_candidacy_id is null
     )
 
 select
@@ -300,4 +327,4 @@ select
     ) as election_year,
     b.election_stage,
     greatest(b.created_at, b.updated_at) as last_activity_at
-from civics_base as b
+from not_in_hubspot as b


### PR DESCRIPTION
## What

`candidacy_hubspot` was the single most expensive node in the project: **45.6 execution-hours over the last 30 days**, across 154 full rebuilds averaging **17.6 minutes** each (max 34).

The cost was not data volume. Each rebuild reads ~460 MB and writes ~0.65 MB. It was one predicate — the not-already-in-HubSpot de-dupe, which ORs three different join keys together:

```sql
and not exists (
    select 1 from int__hubspot_contacts hs
    where (... lower(trim(hs.email)) = lower(trim(c.email)))
       or (... regexp_replace(hs.phone_number,'[^0-9]','') = regexp_replace(c.phone_number,'[^0-9]',''))
       or (... hs.br_candidacy_id = try_cast(br_int.br_candidacy_id as int))
)
```

Spark cannot hash-join an OR across disjoint keys. `EXPLAIN` confirms it planned as `PhotonBroadcastNestedLoopJoin LeftAnti` — every other join in the plan is a hash join.

| | |
|---|---|
| Candidacies in the 30-day window | 240,293 |
| ...surviving the other `where` predicates, i.e. entering the anti-join | 28,106 |
| HubSpot contacts | 309,101 |
| **Comparisons per rebuild** | **~8.7 billion** |
| Rows emitted | 8,668 |

with `regexp_replace` re-evaluated on both sides per pair.

## How

Normalize each key once into its own `distinct` CTE, then apply three hash anti-joins.

Row semantics are unchanged:
- each key set is `distinct`, so the left joins cannot fan out;
- candidate-side keys are `null` exactly where the original OR leg did not apply, and `null` never equals a key, so those rows fall through identically;
- the phone `>= 10` digit guard moves to the HubSpot side too, which is equivalent — the original required it on the candidate side, and the two values must be equal to match.

## Results

| | before | after |
|---|---|---|
| model build | ~25 min | **~30 s** |
| `dbt build --select candidacy_hubspot` (model + 9 tests) | — | **38 s** |

At current cadence (10–17 rebuilds/day, up from 1–4 in late July) this is roughly **$275/month** of serverless SQL, and it stops being the long pole that delays the rest of the DAG.

## Verification

- `dbt build --select "candidacy_hubspot"` — `PASS=8 WARN=2 ERROR=0`. Both warnings are pre-existing (`assert_candidacy_hubspot_candidate_code_collision` at 94 rows, matching production exactly; the `trim` expression test at 1 row).
- Ran the old and new filter forms side by side against production data over the **full eligible population (28,106 rows)**: **8,671 rows each, zero rows in either symmetric difference**. A 3,000-row sample run was likewise exact (901 each).
- Dev build emits 8,673 rows vs production's 8,668 — consistent with the 30-day `current_date()` window and upstream drift between the two build times, not a semantic change.
- `pre-commit run --all-files` passes.

### Note on `incremental`

Deliberately not used. The output is a rolling *exclusion* feed — rows must leave as they age out or get claimed into HubSpot — so an append would retain stale leads and a merge-with-deletes rescans anyway. The cost was never in the write (0.65 MB/rebuild); it was in the join plan.

## Also: cost-audit skill enhancements

The audit skill ranked nodes in a way that hid this. Changes so the next occurrence is obvious:

- **`hr/TB` ratio + `scan-bound` / `compute-bound` label** on the top-nodes table. This node reads 635 hr/TB; the L2 snapshot beside it reads 2. That single column separates "reads too much" (wants pruning) from "bad join plan" (pruning won't touch it).
- **`>60s` statement count.** dbt stamps trivial `SHOW`/`OPTIMIZE` statements with the same `node_id` as the build, so this node showed ~800 statements for ~150 real rebuilds. Raw counts overstate build frequency ~5x and misled the first pass of this investigation.
- **Fixed test node names rendering as bare hashes** (`0607546a35`) — `node_id` carries a trailing hash for generic tests, so taking the last segment lost the name.
- **Documented** the nested-loop antipattern and its `EXPLAIN` check, why `incremental` is the wrong tool for compute-bound or rolling-window nodes, `execution_duration_ms` vs `total_duration_ms` (the latter includes queue and provisioning time), and that `target_name` separates prod from PR-CI runs.

For context, the skill's existing view-test guidance already worked: the July change materializing these marts as tables dropped dbt test hours from 60.9/week to 10.5/week, and tests are now only ~5% of Databricks spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
