### PR TITLE
[DATA-2325] Materialize all election-api mart models as tables

### DIFF
--- a/dbt/project/models/marts/election_api/m_election_api.yaml
+++ b/dbt/project/models/marts/election_api/m_election_api.yaml
@@ -192,17 +192,6 @@ models:
         tests:
           - not_null
           - unique
-      - name: source_updated_at
-        description: >
-          Un-bumped source updated_at, carried separately from updated_at so
-          the model's incremental watermark stays in the source-time domain.
-          updated_at is bumped to wall-clock when a row is new to the mart or
-          its slug changed (the election-api write model's publish gate);
-          gating ingestion on those bumped values would skip later source
-          updates whose BallotReady stamps lag wall-clock. Not published to
-          election-api (the writer's Place upsert selects explicit columns).
-        tests:
-          - not_null
 
   - name: m_election_api__position
     description: "Mart model that serves the Election API"

--- a/dbt/project/models/marts/election_api/m_election_api__candidacy.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__candidacy.sql
@@ -1,12 +1,3 @@
-{{
-    config(
-        materialized="table",
-        unique_key="id",
-        auto_liquid_cluster=true,
-    )
-}}
-
-
 with
     active_candidacy as (
         select

--- a/dbt/project/models/marts/election_api/m_election_api__district.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__district.sql
@@ -1,29 +1,14 @@
-{{
-    config(
-        materialized="incremental",
-        unique_key="id",
-        on_schema_change="fail",
-        auto_liquid_cluster=True,
-    )
-}}
-
 with
     turnout_districts as (
         select distinct
             state, district_type as l2_district_type, district_name as l2_district_name
         from {{ ref("int__model_prediction_voter_turnout") }}
-        {% if is_incremental() %}
-            where inference_at >= (select max(updated_at) from {{ this }})
-        {% endif %}
     ),
     l2_data as (
         select
             state_postal_code,
             {{ get_l2_district_columns(use_backticks=true, cast_to_string=true) }}
         from {{ ref("int__l2_nationwide_uniform") }}
-        {% if is_incremental() %}
-            where loaded_at >= (select max(updated_at) from {{ this }})
-        {% endif %}
     ),
     l2_data_districts as (
         select distinct
@@ -44,9 +29,6 @@ with
             'State' as l2_district_type,
             state_postal_code as l2_district_name
         from {{ ref("int__l2_nationwide_uniform") }}
-        {% if is_incremental() %}
-            where loaded_at >= (select max(updated_at) from {{ this }})
-        {% endif %}
     ),
     unioned_w_id_districts as (
         select
@@ -89,9 +71,7 @@ with
 
 select
     districts.id,
-    {% if is_incremental() %} coalesce(existing.created_at, now()) as created_at,
-    {% else %} now() as created_at,
-    {% endif %}
+    now() as created_at,
     current_timestamp() as updated_at,
     districts.state,
     districts.l2_district_type,
@@ -107,17 +87,4 @@ select
 from districts
 left join
     {{ ref("int__l2_district_aggregations") }} as tbl_agg on districts.id = tbl_agg.id
-{% if is_incremental() %}
-    left join
-        {{ this }} as existing
-        on {{
-            generate_salted_uuid(
-                fields=[
-                    "districts.state",
-                    "districts.l2_district_type",
-                    "districts.l2_district_name",
-                ]
-            )
-        }} = existing.id
-{% endif %}
 qualify row_number() over (partition by districts.id order by updated_at desc) = 1

--- a/dbt/project/models/marts/election_api/m_election_api__issue.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__issue.sql
@@ -1,13 +1,3 @@
-{{
-    config(
-        materialized="incremental",
-        incremental_strategy="merge",
-        unique_key="id",
-        auto_liquid_cluster=true,
-    )
-}}
-
-
 with
     new_issues as (
         select
@@ -21,9 +11,6 @@ with
             tbl_new_issue.name
         -- tbl_all_issues.parent_id
         from {{ ref("int__ballotready_issue") }} as tbl_new_issue
-        {% if is_incremental() %}
-            where tbl_new_issue.updated_at > (select max(updated_at) from {{ this }})
-        {% endif %}
     )
 
 select

--- a/dbt/project/models/marts/election_api/m_election_api__place.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__place.sql
@@ -1,13 +1,3 @@
-{{
-    config(
-        materialized="incremental",
-        incremental_strategy="merge",
-        unique_key="id",
-        on_schema_change="append_new_columns",
-        auto_liquid_cluster=true,
-    )
-}}
-
 with
     place_ids_in_races as (
         select distinct place_id from {{ ref("int__enhanced_race") }}
@@ -27,10 +17,6 @@ with
         from {{ ref("int__enhanced_place_w_parent") }} as tbl_parent
         where tbl_parent.id in (select grandparent_id from grandparent_ids)
     ),
-    -- The full place universe, deliberately not incremental-sliced: slug
-    -- ownership below is a global property of the universe, so it must be
-    -- recomputed over all rows every run. The incremental filter is applied
-    -- to the outcome instead (see the final select).
     enriched_place_and_lineage as (
         select
             tbl_place.id,
@@ -105,19 +91,7 @@ with
 select
     tbl_place.id,
     tbl_place.created_at,
-    -- Bump updated_at when a row is new to the mart or its slug changed, so
-    -- the election-api write model's incremental filter (updated_at greater
-    -- than the postgres max) actually publishes it: recovered collision
-    -- losers and re-slugged rows keep a source updated_at that predates the
-    -- watermark and would otherwise never land.
-    {% if is_incremental() %}
-        case
-            when tbl_prev.id is null or tbl_place.slug <> tbl_prev.slug
-            then current_timestamp()
-            else tbl_place.updated_at
-        end as updated_at,
-    {% else %} tbl_place.updated_at,
-    {% endif %}
+    tbl_place.updated_at,
     tbl_place.br_database_id,
     tbl_place.name,
     tbl_place.slug,
@@ -131,23 +105,5 @@ select
     tbl_place.income_household_median,
     tbl_place.unemployment_rate,
     tbl_place.home_value,
-    tbl_place.parent_id,
-    -- The un-bumped source timestamp, kept separate so the incremental
-    -- watermark below stays in the source-time domain: bumped updated_at
-    -- values are wall-clock (ahead of BallotReady's event-time stamps by
-    -- days), and gating on them would silently skip later source updates
-    -- whose stamps land inside that gap. Not published: the election-api
-    -- writer's Place upsert selects its columns explicitly.
-    tbl_place.updated_at as source_updated_at
+    tbl_place.parent_id
 from slug_disambiguated as tbl_place
-{% if is_incremental() %}
-    left join {{ this }} as tbl_prev on tbl_place.id = tbl_prev.id
-    where
-        tbl_prev.id is null
-        or tbl_place.slug <> tbl_prev.slug
-        -- Per-row coalesce: rows written before source_updated_at existed
-        -- carry their (never-bumped) updated_at; bumped rows contribute
-        -- their source stamp, not the wall-clock bump.
-        or tbl_place.updated_at
-        > (select max(coalesce(source_updated_at, updated_at)) from {{ this }})
-{% endif %}

--- a/dbt/project/models/marts/election_api/m_election_api__position.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__position.sql
@@ -1,12 +1,3 @@
-{{
-    config(
-        materialized="incremental",
-        unique_key="id",
-        on_schema_change="append_new_columns",
-        auto_liquid_cluster=true,
-    )
-}}
-
 with
     matched_positions as (
         select distinct
@@ -59,12 +50,6 @@ with
                     and tbl_match.confidence >= 90
                 )
             )
-            {% if is_incremental() %}
-                and (
-                    tbl_position.updated_at > (select max(updated_at) from {{ this }})
-                    or tbl_override.br_database_id is not null
-                )
-            {% endif %}
     ),
 
     -- Inject a match from the override seed for positions absent from the LLM
@@ -95,7 +80,6 @@ with
                 from {{ ref("stg_model_predictions__llm_l2_br_match_20260126") }}
                 where br_database_id is not null
             )
-    -- No incremental filter: re-emit every run so seed edits always propagate.
     ),
 
     unmatched_br_positions as (
@@ -121,9 +105,6 @@ with
                 from override_injected_positions
                 where br_database_id is not null
             )
-            {% if is_incremental() %}
-                and tbl_position.updated_at > (select max(updated_at) from {{ this }})
-            {% endif %}
     ),
 
     all_positions as (

--- a/dbt/project/models/marts/election_api/m_election_api__projected_turnout.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__projected_turnout.sql
@@ -1,11 +1,3 @@
-{{
-    config(
-        materialized="table",
-        unique_key="id",
-        auto_liquid_cluster=true,
-    )
-}}
-
 with
     projected_turnout as (
         select

--- a/dbt/project/models/marts/election_api/m_election_api__race.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__race.sql
@@ -1,12 +1,3 @@
-{{
-    config(
-        materialized="table",
-        unique_key="id",
-        auto_liquid_cluster=true,
-    )
-}}
-
-
 with
     -- Pre-aggregate civics.election_stage to one row per br_race_id. The
     -- mart has known duplicates on br_race_id (TS-found-race sentinels like

--- a/dbt/project/models/marts/election_api/m_election_api__stance.sql
+++ b/dbt/project/models/marts/election_api/m_election_api__stance.sql
@@ -1,11 +1,3 @@
-{{
-    config(
-        materialized="table",
-        unique_key="id",
-        auto_liquid_cluster=true,
-    )
-}}
-
 with
     exploded_stances as (
         select


### PR DESCRIPTION
Closes DATA-2325.

Every model in `models/marts/election_api/` is now a plain table with no model-level `{{ config() }}` block. 13 models, 8 config blocks removed.

## Why

The incremental machinery in this directory is legacy. The dbt writer was retired and all 13 election-api tables load through the Airflow set-wise atomic swap DAG, which reads the full mart on every run. The watermark filters and `{{ this }}` self-joins in `issue`, `district`, `place`, and `position` no longer serve a purpose, and an incremental mart feeding a full-read loader is a source of drift rather than a saving.

The remaining four config blocks (`candidacy`, `race`, `projected_turnout`, `stance`) were already `table`, and every key in them was redundant:

- `materialized` — `marts: +materialized: table` in `dbt_project.yml` covers the subtree
- `auto_liquid_cluster` — already set catalog-wide on `goodparty_data_catalog`
- `unique_key`, `incremental_strategy`, `on_schema_change` — meaningless once the model is not incremental

No `dbt_project.yml` change was needed. The `marts` default already applies to this directory, so adding an `election_api:` key would only restate it.

## What changed per model

`district` — dropped three upstream watermark filters, the self-join to `{{ this }}`, and the `coalesce(existing.created_at, now())` fallback.

`place` — dropped the wall-clock `updated_at` bump and the incremental self-join filter. Also removed `source_updated_at`: it existed only to keep the watermark in the source-time domain, its own description said it was not published to election-api, and the sync DAG loads the live Postgres table's own columns, so nothing consumed it.

`position`, `issue` — dropped their watermark filters.

`candidacy`, `race`, `projected_turnout`, `stance` — config block removed, no SQL change.

No tags existed anywhere in the directory.

## Verification

Full mart build in a dev schema. All 13 models built as tables.

Wall clock for 13 models and 153 tests: **2m51s** on 4 threads (433s of model time, 171s of test time). `stance` was skipped in that run behind a failed upstream test and built separately in 10.2s, 9 tests passing.

| model | seconds |
|---|---|
| district_top_issues | 155.0 |
| projected_turnout | 39.1 |
| race | 37.6 |
| district | 37.1 |
| place | 32.9 |
| zip_to_position | 27.4 |
| candidacy | 23.0 |
| position | 22.3 |
| elected_official_support | 18.9 |
| person | 15.5 |
| office_holder | 13.0 |
| issue | 11.6 |
| stance | 10.2 |

`district_top_issues` dominates the critical path at 155s; everything else is under 40s.

152 of 153 tests passed. Two notes, neither caused by this change:

**`not_null_m_election_api__candidacy_gp_candidate_id`** failed in dev with 6,890 nulls against its `error_if: ">1000"` threshold. This is stale dev state, not the materialization change. Dev and prod both produce exactly 248,480 candidacy rows, but prod has 616 nulls. Of the 6,890 dev nulls, 6,274 resolve in prod and the remaining 616 are prod's own known nulls. Cause: the dev schema held an old copy of `int__civics_person_canonical_ids` (951,339 rows / 460,669 BallotReady keys) so the run used it instead of deferring to prod (1,085,714 / 466,807). `gp_candidate_id` reads only that crosswalk, which this PR does not touch.

**`eos_support_never_exceeds_total_constituents`** warned on 2 rows. It is configured `severity: warn` and matches prod.

## Operational note for the cutover

The first production run rebuilds `place`, `district`, `position`, and `issue` from scratch rather than merging. Two consequences worth watching on that run:

- `place` and `district` will drop any rows that accumulated incrementally but no longer derive from current upstream. That is the intended correction, but it means the swap DAG's `min_id_overlap` quality gate sees its largest movement on this run.
- `district` recomputes `created_at` as `now()` for every row, since the `coalesce(existing.created_at, ...)` path is gone. The column becomes build time rather than first-seen time. Nothing downstream reads it, and the swap replaces the table wholesale either way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cutover rebuilds formerly incremental marts and changes `place`/`district` timestamp semantics; first production swap may show large overlap movement and shed rows that only existed under incremental merges.
> 
> **Overview**
> **Aligns election-api marts with full-table loads** by stripping model-level `{{ config() }}` blocks and incremental machinery across `models/marts/election_api/`. The Airflow swap DAG already reads entire marts each run, so watermark filters and `{{ this }}` self-joins were drift risk, not savings.
> 
> **`district`, `issue`, `place`, and `position`** no longer slice upstream on `updated_at` / `loaded_at` / `inference_at`, and no longer merge against prior mart rows. **`place`** also drops the wall-clock `updated_at` bump for slug changes and the unpublished `source_updated_at` column (and its schema test). **`district`** always sets `created_at` to `now()` instead of preserving first-seen timestamps via a self-join.
> 
> **`candidacy`, `race`, `projected_turnout`, and `stance`** only lose redundant config; SQL is unchanged. First prod run after cutover fully rebuilds the four formerly incremental tables—expect possible row churn vs stale incremental state and a larger `min_id_overlap` movement on the swap DAG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 171dcbfd52cfc43bc1ba5605812c53b2e59fd763. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->