### PR TITLE
[DATA-2326] Guard candidacy_stage against ambiguous TechSpeed codes

### DIFF
--- a/dbt/project/models/marts/civics/candidacy_stage.sql
+++ b/dbt/project/models/marts/civics/candidacy_stage.sql
@@ -88,8 +88,10 @@ with
         where c.br_candidacy_id is not null
     ),
 
-    -- Stage-stripped TS code -> person. E7 collapses a vendor person's
-    -- primary/general split, so a code maps to one person (min guards residue).
+    -- Stage-stripped TS code -> person, only where the code resolves to exactly
+    -- one. E7 normally collapses a vendor person's primary/general split, but a
+    -- mis-clustered stage record can split a code across two people; dropping
+    -- the ambiguous code lets the row fall back to its own BR / gp_api / DDHQ key.
     ts_code_person as (
         select
             {{ strip_ts_stage_suffix("substring_index(record_key, '|', -1)") }}
@@ -98,6 +100,7 @@ with
         from person_ids
         where record_key like 'techspeed|%'
         group by 1
+        having count(distinct gp_person_id) = 1
     ),
 
     -- gp_api campaign -> user -> person.


### PR DESCRIPTION
Unblocks the scheduled `dbt build` job, which has failed every run since
2026-08-15 00:02Z on `assert_candidacy_stage_one_person_per_br_candidate`
(FAIL 1) and skips 293 downstream nodes — both `mart_sales_reverse_etl` export
tables and all seven `m_election_api__*` marts are frozen at 08-14.

Ticket: https://app.clickup.com/t/86ak1ex50

## Root cause

`candidacy_stage` resolves a row's person from up to four native keys and takes
`least(...)` across them. The TechSpeed leg went through `ts_code_person`, which
maps a **stage-stripped** candidate code to a person:

```sql
min(gp_person_id) ... where record_key like 'techspeed|%' group by 1
```

`int__civics_person_canonical_ids` is keyed at *stage* grain
(`techspeed|<code>__primary`), but the mart only carries the stripped code. The
`min()` therefore asserts one person per code. Normally true — the E7 edge
collapses a vendor person's primary/general split — but it is not guaranteed:
if the two stage records land in **different** entity-resolution clusters, the
code spans two people and `min()` hands the lexically smaller id to every row
that touches the code.

That is what happened. The stripped code
`pat__taylor__kentucky__butler__city-council` spans two people:

| record key | person |
|---|---|
| `techspeed|pat__taylor__kentucky__butler__city-council__primary` | `93312c9b…` (London KY) |
| `techspeed|pat__taylor__kentucky__butler__city-council__general` | `4d7699b1…` (Butler KY) |

`min()` returns `4d7699b1…`, which then beat the correct `93312c9b…` inside
`least(...)` on the London primary row. BR candidate 933616 (Patrick Taylor,
London City Council KY) ended up with two people across its two stage rows, and
the test correctly caught it.

## The fix

Emit a person only where the stripped code resolves to exactly one:

```sql
group by 1
having count(distinct gp_person_id) = 1
```

The consuming join is a `LEFT JOIN` feeding `least(...)`, and Databricks
`least()` skips nulls, so an ambiguous code now contributes nothing and the row
falls back to its own BallotReady / gp_api / DDHQ key. This is the same guard
idiom `people.sql` already uses for scalar identifiers
(`case when count(distinct ts_code_val) = 1 then max(...)`).

### Why not the fuller "exact stage key first" version

Resolving the exact stage-grain TS key before falling back to the stripped code
would also rescue the one row noted below. It is not done here because the mart
does not carry that key: `int__civics_candidacy_stage_techspeed.source_candidate_id`
is `techspeed_candidate_code`, the attribute-derived code with no stage suffix.
The suffixed key exists only in `stg_er_source__clustered_candidacy_stages.source_id`,
so taking it would mean threading a new column through `ts_with_cluster` →
`merged_foj` → `foj`. That is a reasonable follow-up, but not what belongs in the
change that unfreezes a build.

## Sibling consumer audit

Every `strip_ts_stage_suffix` consumer was checked for the same collapse:

| Consumer | Pattern | Verdict |
|---|---|---|
| `candidacy_stage.sql` `ts_code_person` | `min()` per code → `least(...)` | **Fixed here** |
| `people.sql` | `case when count(distinct …) = 1 then max(…)` | Already guarded |
| `int__civics_person_edges.sql` (E7) | `is_conflict` exclusion on distinct `br_candidate_id` | Already guarded |
| `int__civics_er_canonical_ids.sql` | Join key at (code, election_date) grain, `qualify row_number()` — not a person collapse | Not applicable |
| `int__civics_candidate_techspeed.sql` `ts_person` | `min()` per code → `coalesce(tp, self-mint)` | **Same collapse, deliberately left alone** |
| `int__civics_candidacy_techspeed.sql` `ts_person` | same, and documented as "must match" the above | **Same collapse, deliberately left alone** |

The two TechSpeed intermediates carry the same `min()` but a materially
different consequence. There the value feeds `coalesce(tp.gp_person_id,
generate_salted_uuid(...))`, so guarding it does not degrade gracefully — it
mints a **new** person id, orphaning the record from both clusters and churning
`gp_candidate_id` (a published identity) for 11 codes, to no test's benefit.
In `candidacy_stage` the null instead falls through to a real, verified person
from another provider. Worth its own change with its own reasoning; flagged here
rather than folded in silently.

## Verification

Run against live prod data (`mart_civics.candidacy_stage`,
`dbt.int__civics_person_canonical_ids`) before and after.

**Baseline — the test's own query against prod:** returns exactly 1 row.

```
br_candidate_id  n_person  person_ids
933616           2         ["4d7699b1-…","93312c9b-…"]
```

**Ambiguity census** — stage-stripped TechSpeed codes by distinct person count:

```
n_person  n_codes  n_records
1         85445    87478
2         11       22
```

11 of 85,456 codes are ambiguous. All 11 are primary/general pairs.

**Coverage cost** — `candidacy_stage` rows sitting on one of those 11 codes:

```
rows_on_ambiguous_code       21
currently_have_person        21
has_br_key                   20
has_gp_api_key                2
has_ddhq_key                  2
ts_only_person_would_go_null  1
```

20 of 21 rows carry another person-bearing key and keep the same person. Exactly
one row loses `gp_person_id`: a TechSpeed-only row (Nathan Sanders, Cannon County
TN county-supervisor primary, `gp_candidacy_stage_id ffe84585-…`), where `min()`
had been choosing arbitrarily between two conflicting people. A null is the
honest answer there.

**Simulated outcome** — the model's person resolution rebuilt from the mart's own
native keys and run through the failing test, unguarded and guarded:

```
variant              br_candidate_id  n_person
unguarded (control)  933616           2
guarded (fix)        — no rows —
```

The control reproduces the live failure exactly, which establishes the
simulation is faithful; the guarded variant returns nothing across the whole
mart, so the fix resolves the violation without introducing a new one anywhere
else.

Post-guard, BR candidate 933616's primary row resolves via
`least(93312c9b…, null, null, 93312c9b…)` — its own BallotReady person, with
DDHQ `1019317_678125` independently agreeing.

## Operational notes

- The on-merge run builds `state:modified+`, which covers the test and the feeds'
  upstream chain. To get the two `mart_sales_reverse_etl` feeds themselves
  rebuilt promptly, trigger the scheduled `dbt build` job manually rather than
  waiting for the next 00:02Z/12:02Z slot.
- Post-rebuild checks: `max(added_to_mart_at)` on
  `mart_sales_reverse_etl.candidacy_hubspot` should be fresh, and the count of
  feed rows whose normalized phone already exists in `dbt.int__hubspot_contacts`
  should drop from ~2,008 to ~0. The stale feed is the reason this is
  time-sensitive — a pull against it re-uploads already-sent phone-only contacts
  as unmergeable duplicates.
- `load__l2_sftp_to_s3` is separately red in the same job (since 08-13, "Error
  polling for completion"). Unrelated, skips only its own L2 nodes, and needs its
  own ticket.

## Residual

The underlying bad cluster is still in `er_source.clustered_candidacy_stages`;
this change stops it leaking a wrong identity into the mart and the feeds, it
does not repair the cluster. That is left to the next entity-resolution
republish, tracked separately. The existing warn-level
`candidacy_stage_person_min_collision_warn` test keeps the residual visible and
is intentionally unchanged — it still reports the underlying disagreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
