### PR TITLE
[DATA-2326] Window the sales feeds on vendor event time, not extract time

### DIFF
--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -525,17 +525,21 @@ models:
 
       - name: vendor_activity_at
         description: >
-          Latest TechSpeed event time for the candidacy: the max of the form row's
-          date_processed across its stages, clamped by that row's extract stamp.
-          Unlike the BallotReady leg this source carries no stable vendor creation
-          timestamp, so an implausible future form date can only be clamped to the
-          extract stamp, which does move with each delivery; that still beats
-          passing a future value through, since a future timestamp sits inside
-          every rolling window permanently. Additive and destination-facing --
-          created_at/updated_at stay extract stamps for the provider precedence
-          chain, so consumers that need real candidate activity (the sales export
-          windows) read this instead. Non-null: rows with no parseable form date
-          fall back to extract time, which every row has.
+          Latest TechSpeed event time for the candidacy: the max across its stages of
+          the form's date_processed, clamped by that stage row's extract stamp. Stages
+          whose form date did not parse contribute nothing, so one unparseable stage
+          cannot lift a whole candidacy to ingestion time; extract time substitutes
+          only where NO stage parsed, which is why this stays non-null. Unlike the
+          BallotReady leg this source carries no stable vendor creation timestamp, so
+          an implausible future form date can only be clamped to the extract stamp,
+          which does move with each delivery; that still beats passing a future value
+          through, since a future timestamp sits inside every rolling window
+          permanently. A meaningful share of form dates do not parse today because the
+          staging rule accepts slash-separated US dates but not hyphen-separated ones
+          (a known follow-up); those candidacies fall back to extract time. Additive
+          and destination-facing -- created_at/updated_at stay extract stamps for the
+          provider precedence chain, so consumers that need real candidate activity
+          (the sales export windows) read this instead.
         data_tests:
           - not_null
 
@@ -1381,17 +1385,37 @@ models:
         description: >
           Latest BallotReady event time for the candidacy: the max across its stages
           of the vendor's own candidacy_updated_at, or -- where that is implausibly
-          later than the extract that carried it -- the vendor's candidacy_created_at.
-          Both are stable across re-deliveries, which matters: anchoring an
-          implausible value to the extract stamp instead would drag it forward on
-          every weekly full-file re-delivery and keep the row perpetually fresh.
+          later than the row's extract stamp -- the vendor's candidacy_created_at.
+          Both values are vendor-owned, so neither is re-written by a re-delivery of
+          an unchanged record; anchoring an implausible value to the extract stamp
+          instead would drag it forward on every weekly full-file re-delivery and
+          keep the row perpetually fresh. Caveat: the COMPARISON bound is the row's
+          latest extract stamp rather than the delivery that first carried it
+          (Airbyte id-dedup keeps one row per id), so which of the two branches a
+          row takes can change across re-deliveries even though the values cannot.
           Additive and destination-facing -- created_at/updated_at stay extract
           stamps for the provider precedence chain, so consumers that need real
-          candidate activity (the sales export windows) read this instead. A
-          re-delivery of an unchanged record does not move it. Non-null: rows with no
-          usable vendor time at all fall back to extract time, which every row has.
+          candidate activity (the sales export windows) read this instead. Non-null:
+          extract time substitutes only for candidacies where NO stage carried a
+          usable vendor timestamp.
         data_tests:
           - not_null
+
+    data_tests:
+      # The one check that can see the clamp itself regressing. Every other guard
+      # compares vendor_activity_at against something derived from it, so if the
+      # expression started returning extract time they would all still pass. Here,
+      # equality with updated_at (which IS the extract stamp) means the vendor time
+      # was lost. Every row supplies a usable vendor timestamp today, so this is
+      # currently zero. Warn, not error: a non-zero result means the vendor stopped
+      # populating its own timestamps, which is worth surfacing but is not our bug
+      # and should not block a build.
+      - dbt_utils.expression_is_true:
+          name: br_candidacy_vendor_activity_at_is_not_the_extract_stamp
+          arguments:
+            expression: "vendor_activity_at != updated_at"
+          config:
+            severity: warn
 
   - name: int__civics_elected_official_ballotready
     description: >

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -523,6 +523,19 @@ models:
         data_tests:
           - not_null
 
+      - name: vendor_activity_at
+        description: >
+          Latest TechSpeed event time for the candidacy: the max of the form row's
+          date_processed across its stages, clamped to that row's extract time so a
+          future-dated form value settles at when we first saw it rather than
+          reading as perpetually fresh. Additive and destination-facing --
+          created_at/updated_at stay extract stamps for the provider precedence
+          chain, so consumers that need real candidate activity (the sales export
+          windows) read this instead. Non-null: the clamp falls back to extract
+          time, which every row has.
+        data_tests:
+          - not_null
+
     tests:
       - dbt_utils.expression_is_true:
           name: techspeed_candidacy_has_general_or_primary_date
@@ -1358,6 +1371,20 @@ models:
           - not_null
 
       - name: updated_at
+        data_tests:
+          - not_null
+
+      - name: vendor_activity_at
+        description: >
+          Latest BallotReady event time for the candidacy: the max of the vendor's
+          own candidacy_updated_at across its stages, clamped to that stage row's
+          extract time so the vendor's known future-dated values settle at when we
+          first saw them rather than reading as perpetually fresh. Additive and
+          destination-facing -- created_at/updated_at stay extract stamps for the
+          provider precedence chain, so consumers that need real candidate activity
+          (the sales export windows) read this instead. A re-delivery of an
+          unchanged record does not move it. Non-null: the clamp falls back to
+          extract time, which every row has.
         data_tests:
           - not_null
 

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -526,13 +526,16 @@ models:
       - name: vendor_activity_at
         description: >
           Latest TechSpeed event time for the candidacy: the max of the form row's
-          date_processed across its stages, clamped to that row's extract time so a
-          future-dated form value settles at when we first saw it rather than
-          reading as perpetually fresh. Additive and destination-facing --
+          date_processed across its stages, clamped by that row's extract stamp.
+          Unlike the BallotReady leg this source carries no stable vendor creation
+          timestamp, so an implausible future form date can only be clamped to the
+          extract stamp, which does move with each delivery; that still beats
+          passing a future value through, since a future timestamp sits inside
+          every rolling window permanently. Additive and destination-facing --
           created_at/updated_at stay extract stamps for the provider precedence
           chain, so consumers that need real candidate activity (the sales export
-          windows) read this instead. Non-null: the clamp falls back to extract
-          time, which every row has.
+          windows) read this instead. Non-null: rows with no parseable form date
+          fall back to extract time, which every row has.
         data_tests:
           - not_null
 
@@ -1376,15 +1379,17 @@ models:
 
       - name: vendor_activity_at
         description: >
-          Latest BallotReady event time for the candidacy: the max of the vendor's
-          own candidacy_updated_at across its stages, clamped to that stage row's
-          extract time so the vendor's known future-dated values settle at when we
-          first saw them rather than reading as perpetually fresh. Additive and
-          destination-facing -- created_at/updated_at stay extract stamps for the
-          provider precedence chain, so consumers that need real candidate activity
-          (the sales export windows) read this instead. A re-delivery of an
-          unchanged record does not move it. Non-null: the clamp falls back to
-          extract time, which every row has.
+          Latest BallotReady event time for the candidacy: the max across its stages
+          of the vendor's own candidacy_updated_at, or -- where that is implausibly
+          later than the extract that carried it -- the vendor's candidacy_created_at.
+          Both are stable across re-deliveries, which matters: anchoring an
+          implausible value to the extract stamp instead would drag it forward on
+          every weekly full-file re-delivery and keep the row perpetually fresh.
+          Additive and destination-facing -- created_at/updated_at stay extract
+          stamps for the provider precedence chain, so consumers that need real
+          candidate activity (the sales export windows) read this instead. A
+          re-delivery of an unchanged record does not move it. Non-null: rows with no
+          usable vendor time at all fall back to extract time, which every row has.
         data_tests:
           - not_null
 

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -526,15 +526,18 @@ models:
       - name: vendor_activity_at
         description: >
           Latest TechSpeed event time for the candidacy: the max across its stages of
-          the form's date_processed, clamped by that stage row's extract stamp. DAY
+          the form's date_processed, taken only where it is not implausibly later than
+          the extract that carried it (a day of slack for clock skew, matching the
+          BallotReady leg). DAY
           RESOLUTION ONLY -- the form captures a date, not a time, so values land at
           midnight and consumers sorting on this will see ties within a day.
-          NULLABLE BY DESIGN: null means the form date did not parse, and consumers
-          coalesce that to the canonical timestamps. Extract time is deliberately NOT
-          substituted -- as a non-null value it would outrank a correctly-dated
-          sibling provider wherever consumers take the greatest across providers, so
-          the next full-file re-delivery would sweep every unparsed candidacy back
-          into a recency window at once. Parse failures are not rare: the staging rule
+          NULLABLE BY DESIGN: null means the form date is missing, unparseable, or
+          implausibly future, and consumers coalesce that to the canonical timestamps.
+          Extract time is deliberately NOT substituted -- as a non-null value it would
+          outrank a correctly-dated sibling provider wherever consumers take the
+          greatest across providers, and because it advances with every delivery the
+          row would tick forward forever, sweeping the whole affected cohort back into
+          a recency window on each re-delivery. Parse failures are not rare: the staging rule
           accepts slash-separated US dates but not hyphen-separated ones, which is a
           known follow-up. Additive and destination-facing -- created_at/updated_at
           stay extract stamps for the provider precedence chain, so consumers that

--- a/dbt/project/models/intermediate/civics/int__civics.yaml
+++ b/dbt/project/models/intermediate/civics/int__civics.yaml
@@ -526,22 +526,19 @@ models:
       - name: vendor_activity_at
         description: >
           Latest TechSpeed event time for the candidacy: the max across its stages of
-          the form's date_processed, clamped by that stage row's extract stamp. Stages
-          whose form date did not parse contribute nothing, so one unparseable stage
-          cannot lift a whole candidacy to ingestion time; extract time substitutes
-          only where NO stage parsed, which is why this stays non-null. Unlike the
-          BallotReady leg this source carries no stable vendor creation timestamp, so
-          an implausible future form date can only be clamped to the extract stamp,
-          which does move with each delivery; that still beats passing a future value
-          through, since a future timestamp sits inside every rolling window
-          permanently. A meaningful share of form dates do not parse today because the
-          staging rule accepts slash-separated US dates but not hyphen-separated ones
-          (a known follow-up); those candidacies fall back to extract time. Additive
-          and destination-facing -- created_at/updated_at stay extract stamps for the
-          provider precedence chain, so consumers that need real candidate activity
-          (the sales export windows) read this instead.
-        data_tests:
-          - not_null
+          the form's date_processed, clamped by that stage row's extract stamp. DAY
+          RESOLUTION ONLY -- the form captures a date, not a time, so values land at
+          midnight and consumers sorting on this will see ties within a day.
+          NULLABLE BY DESIGN: null means the form date did not parse, and consumers
+          coalesce that to the canonical timestamps. Extract time is deliberately NOT
+          substituted -- as a non-null value it would outrank a correctly-dated
+          sibling provider wherever consumers take the greatest across providers, so
+          the next full-file re-delivery would sweep every unparsed candidacy back
+          into a recency window at once. Parse failures are not rare: the staging rule
+          accepts slash-separated US dates but not hyphen-separated ones, which is a
+          known follow-up. Additive and destination-facing -- created_at/updated_at
+          stay extract stamps for the provider precedence chain, so consumers that
+          need real candidate activity (the sales export windows) read this instead.
 
     tests:
       - dbt_utils.expression_is_true:
@@ -1384,38 +1381,20 @@ models:
       - name: vendor_activity_at
         description: >
           Latest BallotReady event time for the candidacy: the max across its stages
-          of the vendor's own candidacy_updated_at, or -- where that is implausibly
-          later than the row's extract stamp -- the vendor's candidacy_created_at.
-          Both values are vendor-owned, so neither is re-written by a re-delivery of
-          an unchanged record; anchoring an implausible value to the extract stamp
-          instead would drag it forward on every weekly full-file re-delivery and
-          keep the row perpetually fresh. Caveat: the COMPARISON bound is the row's
-          latest extract stamp rather than the delivery that first carried it
-          (Airbyte id-dedup keeps one row per id), so which of the two branches a
-          row takes can change across re-deliveries even though the values cannot.
-          Additive and destination-facing -- created_at/updated_at stay extract
-          stamps for the provider precedence chain, so consumers that need real
-          candidate activity (the sales export windows) read this instead. Non-null:
-          extract time substitutes only for candidacies where NO stage carried a
-          usable vendor timestamp.
-        data_tests:
-          - not_null
-
-    data_tests:
-      # The one check that can see the clamp itself regressing. Every other guard
-      # compares vendor_activity_at against something derived from it, so if the
-      # expression started returning extract time they would all still pass. Here,
-      # equality with updated_at (which IS the extract stamp) means the vendor time
-      # was lost. Every row supplies a usable vendor timestamp today, so this is
-      # currently zero. Warn, not error: a non-zero result means the vendor stopped
-      # populating its own timestamps, which is worth surfacing but is not our bug
-      # and should not block a build.
-      - dbt_utils.expression_is_true:
-          name: br_candidacy_vendor_activity_at_is_not_the_extract_stamp
-          arguments:
-            expression: "vendor_activity_at != updated_at"
-          config:
-            severity: warn
+          of the vendor's own candidacy_updated_at, or -- where that sits implausibly
+          later than the row's extract stamp -- the vendor's candidacy_created_at,
+          with a day of slack for ordinary clock skew between the vendor's clock and
+          ours. Both values are vendor-owned, so a re-delivery of an unchanged record
+          does not move them; anchoring to the extract stamp instead would drag the
+          value forward on every weekly full-file re-delivery and keep the row
+          perpetually fresh. NULLABLE BY DESIGN: null means this provider supplied no
+          usable event time, and consumers coalesce that to the canonical timestamps.
+          Extract time is deliberately NOT substituted here -- as a non-null value it
+          would outrank a correctly-dated sibling provider wherever consumers take
+          the greatest across providers. Additive and destination-facing:
+          created_at/updated_at stay extract stamps for the provider precedence
+          chain, so consumers that need real candidate activity (the sales export
+          windows) read this instead.
 
   - name: int__civics_elected_official_ballotready
     description: >

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
@@ -87,15 +87,25 @@ with
             ) as is_special,
             -- Vendor event time, kept separate from created_at/updated_at (which
             -- are extract stamps, so a re-delivery of an unchanged record reads
-            -- as fresh). Clamped to this row's own extract time because the
-            -- vendor ships some future-dated updates: clamping to when we first
-            -- saw the version is stable, whereas clamping to "now" would leave
-            -- such rows perpetually fresh.
-            least(
-                coalesce(
-                    try_cast(candidacies.candidacy_updated_at as timestamp),
-                    candidacies._airbyte_extracted_at
-                ),
+            -- as fresh). Preference order matters: an implausible future update
+            -- time falls back to the vendor's own creation time, NOT to our
+            -- extract stamp. The extract stamp moves forward on every weekly
+            -- full-file re-delivery, so anchoring to it would drag such a row
+            -- along with it and keep it perpetually fresh -- the exact failure
+            -- this guards against. Both vendor timestamps are stable across
+            -- re-deliveries; the extract stamp is only the last resort, for rows
+            -- carrying no usable vendor time at all.
+            coalesce(
+                case
+                    when
+                        try_cast(candidacies.candidacy_updated_at as timestamp)
+                        <= candidacies._airbyte_extracted_at
+                    then try_cast(candidacies.candidacy_updated_at as timestamp)
+                    when
+                        candidacies.candidacy_created_at
+                        <= candidacies._airbyte_extracted_at
+                    then candidacies.candidacy_created_at
+                end,
                 candidacies._airbyte_extracted_at
             ) as vendor_activity_at
         from candidacies

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
@@ -89,23 +89,25 @@ with
             -- are extract stamps, so a re-delivery of an unchanged record reads
             -- as fresh). An implausible future update time falls back to the
             -- vendor's own creation time rather than to our extract stamp, which
-            -- advances on every full-file re-delivery and would drag the row
-            -- along with it. NULL where neither vendor timestamp is usable: the
-            -- rollup below substitutes extract time only for candidacies with no
-            -- usable vendor time on ANY stage, so one unusable stage cannot lift
-            -- a whole candidacy to ingestion time.
-            -- NB the comparison bound is the LATEST extract of this row, not the
-            -- delivery that first carried it -- Airbyte id-dedup keeps one row
-            -- per id -- so which branch a row takes can change across
-            -- re-deliveries. The values themselves are vendor-owned and stable.
+            -- advances on every full-file re-delivery and would drag the row along
+            -- with it. NULL, never an extract stamp, where neither vendor timestamp
+            -- is usable: ingestion time here would outrank a correctly-dated
+            -- sibling provider in the feeds' greatest(). A null result means "no
+            -- vendor signal", and consumers coalesce it to the canonical
+            -- timestamps, keeping those rows on documented status-quo behavior.
+            -- The day of slack absorbs ordinary clock and pipeline skew between the
+            -- vendor's clock and ours: without it a record updated minutes after
+            -- the file was cut would fall to its creation time, months earlier, and
+            -- flip back the following week -- a row leaving and re-entering the
+            -- window is a duplicate send, since the window IS the interim dedup.
             case
                 when
                     try_cast(candidacies.candidacy_updated_at as timestamp)
-                    <= candidacies._airbyte_extracted_at
+                    <= candidacies._airbyte_extracted_at + interval 1 day
                 then try_cast(candidacies.candidacy_updated_at as timestamp)
                 when
                     candidacies.candidacy_created_at
-                    <= candidacies._airbyte_extracted_at
+                    <= candidacies._airbyte_extracted_at + interval 1 day
                 then candidacies.candidacy_created_at
             end as vendor_activity_at
         from candidacies
@@ -193,13 +195,11 @@ with
                 max(case when is_primary then election_result end)
             ) as raw_election_result,
 
-            -- Latest usable vendor event across the candidacy's stages. max(),
-            -- not any_value(): the value has to be deterministic because a
-            -- destination-facing recency window filters on it. Extract time is
-            -- substituted only when NO stage carried a usable vendor timestamp.
-            coalesce(
-                max(vendor_activity_at), max(_airbyte_extracted_at)
-            ) as vendor_activity_at,
+            -- Latest usable vendor event across the candidacy's stages. max(), not
+            -- any_value(): the value has to be deterministic because a
+            -- destination-facing recency window filters on it. Null where no stage
+            -- carried a usable vendor timestamp; max() skips nulls.
+            max(vendor_activity_at) as vendor_activity_at,
 
             -- BallotReady native IDs (one per stage; take any for candidacy grain)
             any_value(br_candidacy_id) as br_candidacy_id,
@@ -377,7 +377,18 @@ with
     -- by construction; the candidate <-> candidacy relationships tests guard
     -- the invariant.
     deduplicated as (
-        select *
+        select
+            * except (vendor_activity_at),
+            -- Re-max at gp_candidacy_id grain. The rollup above groups on
+            -- (br_candidate_id, br_position_id, election_year), but the published
+            -- grain is the cluster-derived id, and two rollup groups can mint the
+            -- same one -- which is why the picker below exists. Without this the
+            -- picker would discard the losing group's vendor event time, so a
+            -- candidacy could lose its most recent vendor activity and drop out of
+            -- a destination window. Mirrors the TechSpeed sibling.
+            max(vendor_activity_at) over (
+                partition by gp_candidacy_id
+            ) as vendor_activity_at
         from candidacies_with_ids
         qualify
             row_number() over (partition by gp_candidacy_id order by updated_at desc)

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
@@ -84,7 +84,20 @@ with
             -- to distinct IDs (matching int__civics_election_stage_ballotready).
             coalesce(
                 lower(candidacies.election_name) like '%special%', false
-            ) as is_special
+            ) as is_special,
+            -- Vendor event time, kept separate from created_at/updated_at (which
+            -- are extract stamps, so a re-delivery of an unchanged record reads
+            -- as fresh). Clamped to this row's own extract time because the
+            -- vendor ships some future-dated updates: clamping to when we first
+            -- saw the version is stable, whereas clamping to "now" would leave
+            -- such rows perpetually fresh.
+            least(
+                coalesce(
+                    try_cast(candidacies.candidacy_updated_at as timestamp),
+                    candidacies._airbyte_extracted_at
+                ),
+                candidacies._airbyte_extracted_at
+            ) as vendor_activity_at
         from candidacies
         left join
             candidacy_mint as cm
@@ -171,6 +184,11 @@ with
             ) as raw_election_result,
 
             max(candidacy_updated_at) as candidacy_updated_at,
+
+            -- Latest vendor event across the candidacy's stages. max(), not
+            -- any_value(): the value has to be deterministic because a
+            -- destination-facing recency window filters on it.
+            max(vendor_activity_at) as vendor_activity_at,
 
             -- BallotReady native IDs (one per stage; take any for candidacy grain)
             any_value(br_candidacy_id) as br_candidacy_id,
@@ -319,9 +337,13 @@ with
             cast(null as int) as win_number,
             cast(null as string) as win_number_model,
 
-            -- Timestamps
+            -- Timestamps. created_at/updated_at are extract stamps and stay that
+            -- way: the whole provider precedence chain and every civics consumer
+            -- reads them. vendor_activity_at is the additive event-time column
+            -- for consumers that need real candidate activity instead.
             _airbyte_extracted_at as created_at,
-            _airbyte_extracted_at as updated_at
+            _airbyte_extracted_at as updated_at,
+            vendor_activity_at
 
         from candidacies_enriched
         left join
@@ -382,5 +404,6 @@ select
     win_number,
     win_number_model,
     created_at,
-    updated_at
+    updated_at,
+    vendor_activity_at
 from deduplicated

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_ballotready.sql
@@ -87,27 +87,27 @@ with
             ) as is_special,
             -- Vendor event time, kept separate from created_at/updated_at (which
             -- are extract stamps, so a re-delivery of an unchanged record reads
-            -- as fresh). Preference order matters: an implausible future update
-            -- time falls back to the vendor's own creation time, NOT to our
-            -- extract stamp. The extract stamp moves forward on every weekly
-            -- full-file re-delivery, so anchoring to it would drag such a row
-            -- along with it and keep it perpetually fresh -- the exact failure
-            -- this guards against. Both vendor timestamps are stable across
-            -- re-deliveries; the extract stamp is only the last resort, for rows
-            -- carrying no usable vendor time at all.
-            coalesce(
-                case
-                    when
-                        try_cast(candidacies.candidacy_updated_at as timestamp)
-                        <= candidacies._airbyte_extracted_at
-                    then try_cast(candidacies.candidacy_updated_at as timestamp)
-                    when
-                        candidacies.candidacy_created_at
-                        <= candidacies._airbyte_extracted_at
-                    then candidacies.candidacy_created_at
-                end,
-                candidacies._airbyte_extracted_at
-            ) as vendor_activity_at
+            -- as fresh). An implausible future update time falls back to the
+            -- vendor's own creation time rather than to our extract stamp, which
+            -- advances on every full-file re-delivery and would drag the row
+            -- along with it. NULL where neither vendor timestamp is usable: the
+            -- rollup below substitutes extract time only for candidacies with no
+            -- usable vendor time on ANY stage, so one unusable stage cannot lift
+            -- a whole candidacy to ingestion time.
+            -- NB the comparison bound is the LATEST extract of this row, not the
+            -- delivery that first carried it -- Airbyte id-dedup keeps one row
+            -- per id -- so which branch a row takes can change across
+            -- re-deliveries. The values themselves are vendor-owned and stable.
+            case
+                when
+                    try_cast(candidacies.candidacy_updated_at as timestamp)
+                    <= candidacies._airbyte_extracted_at
+                then try_cast(candidacies.candidacy_updated_at as timestamp)
+                when
+                    candidacies.candidacy_created_at
+                    <= candidacies._airbyte_extracted_at
+                then candidacies.candidacy_created_at
+            end as vendor_activity_at
         from candidacies
         left join
             candidacy_mint as cm
@@ -193,12 +193,13 @@ with
                 max(case when is_primary then election_result end)
             ) as raw_election_result,
 
-            max(candidacy_updated_at) as candidacy_updated_at,
-
-            -- Latest vendor event across the candidacy's stages. max(), not
-            -- any_value(): the value has to be deterministic because a
-            -- destination-facing recency window filters on it.
-            max(vendor_activity_at) as vendor_activity_at,
+            -- Latest usable vendor event across the candidacy's stages. max(),
+            -- not any_value(): the value has to be deterministic because a
+            -- destination-facing recency window filters on it. Extract time is
+            -- substituted only when NO stage carried a usable vendor timestamp.
+            coalesce(
+                max(vendor_activity_at), max(_airbyte_extracted_at)
+            ) as vendor_activity_at,
 
             -- BallotReady native IDs (one per stage; take any for candidacy grain)
             any_value(br_candidacy_id) as br_candidacy_id,

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
@@ -222,13 +222,14 @@ with
 
             -- Vendor event time, kept separate from created_at/updated_at (which
             -- are extract stamps, so a re-delivery of an unchanged record reads
-            -- as fresh). NULL where the form date did not parse, so the rollup
-            -- below can tell "no vendor signal" apart from a real date and one
-            -- unparseable stage cannot lift a whole candidacy to ingestion time.
-            -- Unlike the BallotReady leg this source carries no stable vendor
-            -- creation timestamp, so an implausible future form date can only be
-            -- clamped to our own extract stamp; that still beats passing a future
-            -- value through, which would sit inside every window permanently.
+            -- as fresh). NULL, never an extract stamp, where the form date did not
+            -- parse: ingestion time here would outrank a correctly-dated sibling
+            -- provider in the feeds' greatest(), so the next full-file re-delivery
+            -- would sweep every unparsed candidacy back into the window at once --
+            -- the flood this column exists to prevent. A null result means "no
+            -- vendor signal", and consumers coalesce it to the canonical
+            -- timestamps, keeping those rows on documented status-quo behavior.
+            -- Day resolution only: the form captures a date, not a time.
             case
                 when date_processed_date is not null
                 then
@@ -256,17 +257,13 @@ with
     deduplicated as (
         select
             * except (vendor_activity_at),
-            -- Latest REAL vendor event across the candidacy's stages, so the
-            -- picker below (which keeps the latest-EXTRACTED stage row) cannot
-            -- discard a sibling stage carrying a later processing date. A stage
-            -- whose form date did not parse contributes nothing rather than
-            -- contributing its delivery stamp, which would otherwise lift the
-            -- candidacy to ingestion time and re-create the staleness this
-            -- column exists to remove. Extract time substitutes only where NO
-            -- stage parsed.
-            coalesce(
-                max(vendor_activity_at) over (partition by gp_candidacy_id),
-                max(updated_at) over (partition by gp_candidacy_id)
+            -- Latest vendor event across the candidacy's stages, so the picker
+            -- below (which keeps the latest-EXTRACTED stage row) cannot discard a
+            -- sibling stage carrying a later processing date. Null where no stage
+            -- parsed; max() skips nulls, so a single unparsed stage cannot drag
+            -- the candidacy anywhere.
+            max(vendor_activity_at) over (
+                partition by gp_candidacy_id
             ) as vendor_activity_at
         from candidacies
         qualify

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
@@ -218,7 +218,17 @@ with
             cast(null as string) as win_number_model,
 
             _airbyte_extracted_at as created_at,
-            _airbyte_extracted_at as updated_at
+            _airbyte_extracted_at as updated_at,
+
+            -- Vendor event time, kept separate from created_at/updated_at (which
+            -- are extract stamps, so a re-delivery of an unchanged record reads
+            -- as fresh). Clamped to this row's own extract time so a
+            -- future-dated form value settles at when we first saw it rather
+            -- than staying perpetually fresh.
+            least(
+                coalesce(cast(date_processed_date as timestamp), _airbyte_extracted_at),
+                _airbyte_extracted_at
+            ) as vendor_activity_at
 
         from source
         left join
@@ -239,7 +249,14 @@ with
     ),
 
     deduplicated as (
-        select *
+        select
+            * except (vendor_activity_at),
+            -- Latest vendor event across the candidacy's stages, so the picker
+            -- below (which keeps the latest-EXTRACTED stage row) cannot discard
+            -- a sibling stage that carries a later processing date.
+            max(vendor_activity_at) over (
+                partition by gp_candidacy_id
+            ) as vendor_activity_at
         from candidacies
         qualify
             row_number() over (

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
@@ -222,15 +222,18 @@ with
 
             -- Vendor event time, kept separate from created_at/updated_at (which
             -- are extract stamps, so a re-delivery of an unchanged record reads
-            -- as fresh). Unlike the BallotReady leg this source carries no stable
-            -- vendor creation timestamp, so an implausible future form date can
-            -- only be clamped to our own extract stamp. That anchor moves with
-            -- each delivery, but it still beats passing a future value through:
-            -- a future timestamp sits inside every rolling window permanently.
-            least(
-                coalesce(cast(date_processed_date as timestamp), _airbyte_extracted_at),
-                _airbyte_extracted_at
-            ) as vendor_activity_at
+            -- as fresh). NULL where the form date did not parse, so the rollup
+            -- below can tell "no vendor signal" apart from a real date and one
+            -- unparseable stage cannot lift a whole candidacy to ingestion time.
+            -- Unlike the BallotReady leg this source carries no stable vendor
+            -- creation timestamp, so an implausible future form date can only be
+            -- clamped to our own extract stamp; that still beats passing a future
+            -- value through, which would sit inside every window permanently.
+            case
+                when date_processed_date is not null
+                then
+                    least(cast(date_processed_date as timestamp), _airbyte_extracted_at)
+            end as vendor_activity_at
 
         from source
         left join
@@ -253,11 +256,17 @@ with
     deduplicated as (
         select
             * except (vendor_activity_at),
-            -- Latest vendor event across the candidacy's stages, so the picker
-            -- below (which keeps the latest-EXTRACTED stage row) cannot discard
-            -- a sibling stage that carries a later processing date.
-            max(vendor_activity_at) over (
-                partition by gp_candidacy_id
+            -- Latest REAL vendor event across the candidacy's stages, so the
+            -- picker below (which keeps the latest-EXTRACTED stage row) cannot
+            -- discard a sibling stage carrying a later processing date. A stage
+            -- whose form date did not parse contributes nothing rather than
+            -- contributing its delivery stamp, which would otherwise lift the
+            -- candidacy to ingestion time and re-create the staleness this
+            -- column exists to remove. Extract time substitutes only where NO
+            -- stage parsed.
+            coalesce(
+                max(vendor_activity_at) over (partition by gp_candidacy_id),
+                max(updated_at) over (partition by gp_candidacy_id)
             ) as vendor_activity_at
         from candidacies
         qualify

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
@@ -222,9 +222,11 @@ with
 
             -- Vendor event time, kept separate from created_at/updated_at (which
             -- are extract stamps, so a re-delivery of an unchanged record reads
-            -- as fresh). Clamped to this row's own extract time so a
-            -- future-dated form value settles at when we first saw it rather
-            -- than staying perpetually fresh.
+            -- as fresh). Unlike the BallotReady leg this source carries no stable
+            -- vendor creation timestamp, so an implausible future form date can
+            -- only be clamped to our own extract stamp. That anchor moves with
+            -- each delivery, but it still beats passing a future value through:
+            -- a future timestamp sits inside every rolling window permanently.
             least(
                 coalesce(cast(date_processed_date as timestamp), _airbyte_extracted_at),
                 _airbyte_extracted_at

--- a/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
+++ b/dbt/project/models/intermediate/civics/int__civics_candidacy_techspeed.sql
@@ -222,18 +222,23 @@ with
 
             -- Vendor event time, kept separate from created_at/updated_at (which
             -- are extract stamps, so a re-delivery of an unchanged record reads
-            -- as fresh). NULL, never an extract stamp, where the form date did not
-            -- parse: ingestion time here would outrank a correctly-dated sibling
-            -- provider in the feeds' greatest(), so the next full-file re-delivery
-            -- would sweep every unparsed candidacy back into the window at once --
-            -- the flood this column exists to prevent. A null result means "no
-            -- vendor signal", and consumers coalesce it to the canonical
-            -- timestamps, keeping those rows on documented status-quo behavior.
-            -- Day resolution only: the form captures a date, not a time.
+            -- as fresh). NULL, never an extract stamp, where the form date is
+            -- missing, unparseable, or implausibly later than the extract that
+            -- carried it: ingestion time here would outrank a correctly-dated
+            -- sibling provider in the feeds' greatest(), and because it advances
+            -- with every delivery the row would tick forward forever -- the flood
+            -- this column exists to prevent. A null result means "no vendor
+            -- signal", and consumers coalesce it to the canonical timestamps,
+            -- keeping those rows on documented status-quo behavior. The day of
+            -- slack and the null-on-implausible shape both match the BallotReady
+            -- leg; a missing date needs no explicit guard because a null
+            -- comparison is not true. Day resolution only: the form captures a
+            -- date, not a time.
             case
-                when date_processed_date is not null
-                then
-                    least(cast(date_processed_date as timestamp), _airbyte_extracted_at)
+                when
+                    cast(date_processed_date as timestamp)
+                    <= _airbyte_extracted_at + interval 1 day
+                then cast(date_processed_date as timestamp)
             end as vendor_activity_at
 
         from source

--- a/dbt/project/models/marts/sales_reverse_etl/_sales_reverse_etl__models.yml
+++ b/dbt/project/models/marts/sales_reverse_etl/_sales_reverse_etl__models.yml
@@ -48,12 +48,16 @@ models:
       - name: last_activity_at
         description: >
           Basis of the 16-day rolling window, and the recency value ops sorts on. The
-          greatest available provider EVENT time: the vendor intermediates'
-          vendor_activity_at, or the product timestamps for gp_api rows, falling back to
-          the canonical candidacy timestamps only where no provider supplies one.
-          Deliberately NOT the canonical created_at/updated_at, which for vendor-sourced
-          rows are pipeline extract stamps -- a vendor re-delivering its whole file would
-          otherwise re-stamp its entire universe as active today and flood this feed.
+          greatest of every provider EVENT time available for the candidacy, taken
+          simultaneously rather than in precedence order: the BallotReady intermediate's
+          vendor_activity_at, and the canonical product timestamps where gp_api is the
+          source. Falls back to the canonical timestamps only where no provider supplies
+          one. Deliberately NOT the canonical created_at/updated_at, which for
+          vendor-sourced rows are pipeline extract stamps -- a vendor re-delivering its
+          whole file would otherwise re-stamp its entire universe as active today and
+          flood this feed. The window is bounded above as well as below, so a
+          future-dated product timestamp cannot park a row on every export forever.
+          This feed has no TechSpeed leg by construction; see the model header.
         data_tests:
           - not_null
 
@@ -119,11 +123,14 @@ models:
       - name: last_activity_at
         description: >
           Basis of the 30-day rolling window, and the recency value ops sorts on. The
-          greatest available provider EVENT time: the vendor intermediates'
-          vendor_activity_at, or the product timestamps for gp_api rows, falling back to
-          the canonical candidacy timestamps only where no provider supplies one.
-          Deliberately NOT the canonical created_at/updated_at, which for vendor-sourced
-          rows are pipeline extract stamps -- a vendor re-delivering its whole file would
-          otherwise re-stamp its entire universe as active today and flood this feed.
+          greatest of every provider EVENT time available for the candidacy, taken
+          simultaneously rather than in precedence order: both vendor intermediates'
+          vendor_activity_at, and the canonical product timestamps where gp_api is the
+          source. Falls back to the canonical timestamps only where no provider supplies
+          one. Deliberately NOT the canonical created_at/updated_at, which for
+          vendor-sourced rows are pipeline extract stamps -- a vendor re-delivering its
+          whole file would otherwise re-stamp its entire universe as active today and
+          flood this feed. The window is bounded above as well as below, so a
+          future-dated product timestamp cannot park a row on every export forever.
         data_tests:
           - not_null

--- a/dbt/project/models/marts/sales_reverse_etl/_sales_reverse_etl__models.yml
+++ b/dbt/project/models/marts/sales_reverse_etl/_sales_reverse_etl__models.yml
@@ -45,6 +45,17 @@ models:
         description: True when candidate_code is non-null; the reverse-ETL diff filters on this.
         data_tests:
           - not_null
+      - name: last_activity_at
+        description: >
+          Basis of the 16-day rolling window, and the recency value ops sorts on. The
+          greatest available provider EVENT time: the vendor intermediates'
+          vendor_activity_at, or the product timestamps for gp_api rows, falling back to
+          the canonical candidacy timestamps only where no provider supplies one.
+          Deliberately NOT the canonical created_at/updated_at, which for vendor-sourced
+          rows are pipeline extract stamps -- a vendor re-delivering its whole file would
+          otherwise re-stamp its entire universe as active today and flood this feed.
+        data_tests:
+          - not_null
 
   - name: candidacy_hubspot
     description: >
@@ -105,3 +116,14 @@ models:
                 max_value: 5
               config:
                 where: "viability_rating_2_0 is not null"
+      - name: last_activity_at
+        description: >
+          Basis of the 30-day rolling window, and the recency value ops sorts on. The
+          greatest available provider EVENT time: the vendor intermediates'
+          vendor_activity_at, or the product timestamps for gp_api rows, falling back to
+          the canonical candidacy timestamps only where no provider supplies one.
+          Deliberately NOT the canonical created_at/updated_at, which for vendor-sourced
+          rows are pipeline extract stamps -- a vendor re-delivering its whole file would
+          otherwise re-stamp its entire universe as active today and flood this feed.
+        data_tests:
+          - not_null

--- a/dbt/project/models/marts/sales_reverse_etl/_sales_reverse_etl__models.yml
+++ b/dbt/project/models/marts/sales_reverse_etl/_sales_reverse_etl__models.yml
@@ -57,6 +57,8 @@ models:
           whole file would otherwise re-stamp its entire universe as active today and
           flood this feed. The window is bounded above as well as below, so a
           future-dated product timestamp cannot park a row on every export forever.
+          Resolution is uneven by source: TechSpeed captures a date rather than a time,
+          so those rows land at midnight and sorting on this column ties within a day.
           This feed has no TechSpeed leg by construction; see the model header.
         data_tests:
           - not_null
@@ -132,5 +134,7 @@ models:
           whole file would otherwise re-stamp its entire universe as active today and
           flood this feed. The window is bounded above as well as below, so a
           future-dated product timestamp cannot park a row on every export forever.
+          Resolution is uneven by source: TechSpeed captures a date rather than a time,
+          so those rows land at midnight and sorting on this column ties within a day.
         data_tests:
           - not_null

--- a/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
@@ -8,8 +8,8 @@
 -- vendor re-delivering its whole file re-stamps its entire universe as active today
 -- and floods this feed with old candidacies. The vendor intermediates' additive
 -- vendor_activity_at columns carry the event time instead; gp_api rows already carry
--- real product timestamps, and DDHQ supplies no event time (the coalesce below keeps
--- those rows on status-quo behavior).
+-- real product timestamps. The DDHQ intermediate exposes no event-time column, so
+-- DDHQ-only rows fall through the coalesce below and keep status-quo behavior.
 with
     icp_ts_offices as (
         select
@@ -211,7 +211,13 @@ with
     in_window as (
         select *
         from civics_base
-        where feed_activity_at >= current_date() - interval 30 day
+        where
+            feed_activity_at >= current_date() - interval 30 day
+            -- Bounded above as well: gp_api product timestamps and the canonical
+            -- fallback are not clamped the way the vendor legs are, and a single
+            -- future-dated value would otherwise satisfy the lower bound forever,
+            -- putting one row on every export indefinitely.
+            and feed_activity_at <= current_date() + interval 1 day
     ),
 
     -- Not-already-in-HubSpot, as three hash anti-joins instead of one correlated

--- a/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
@@ -205,9 +205,15 @@ with
     ),
 
     -- Recency filter lives here rather than in civics_base's WHERE so the window
-    -- basis is defined exactly once: the same expression is filtered on and
-    -- emitted, and the two cannot drift apart. The candidacy-only predicates stay
-    -- above, where they still push down to the scan.
+    -- basis is defined exactly once: the same expression is filtered on and emitted,
+    -- and the two cannot drift apart.
+    --
+    -- This costs real work. The old basis referenced only the candidacy relation, so
+    -- it pushed into that scan and pruned before any join; the new one spans the two
+    -- vendor intermediates and cannot push below them wherever it is written, so the
+    -- join tree now processes roughly 2.5-3x more rows. The remaining candidacy-only
+    -- predicates above still push down. Judged worth it: a duplicated expression can
+    -- drift between filter and output, which is the defect class being fixed here.
     in_window as (
         select *
         from civics_base

--- a/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
+++ b/dbt/project/models/marts/sales_reverse_etl/candidacy_hubspot.sql
@@ -1,8 +1,15 @@
 -- Civics -> HubSpot lead feed (reverse-ETL mart `candidacy_hubspot`). One row per
 -- gp_candidacy_id regardless of whether BallotReady, TechSpeed, DDHQ, or gp_api
 -- identified the candidacy, replacing the per-provider legacy feeds. Output is the
--- Title-Case HubSpot import contract with owner/Type set for all rows. 30-day rolling
--- window on greatest(created_at, updated_at).
+-- Title-Case HubSpot import contract with owner/Type set for all rows.
+--
+-- WINDOW: 30-day rolling on feed_activity_at -- the latest real provider EVENT time.
+-- For vendor-sourced rows created_at/updated_at are pipeline extract stamps, so a
+-- vendor re-delivering its whole file re-stamps its entire universe as active today
+-- and floods this feed with old candidacies. The vendor intermediates' additive
+-- vendor_activity_at columns carry the event time instead; gp_api rows already carry
+-- real product timestamps, and DDHQ supplies no event time (the coalesce below keeps
+-- those rows on status-quo behavior).
 with
     icp_ts_offices as (
         select
@@ -120,6 +127,22 @@ with
             ts_int.election_type as election_type_ts,
             br_int.br_candidacy_id,
             br_int.br_race_id as br_race_id_br,
+            -- Destination-facing recency: greatest available provider EVENT time,
+            -- falling back to the extract-stamped canonical timestamps only where
+            -- no provider supplies one (DDHQ-only rows). Both greatest() calls
+            -- skip nulls, so the fallback fires only when every leg is null,
+            -- which keeps this non-null.
+            coalesce(
+                greatest(
+                    br_int.vendor_activity_at,
+                    ts_int.vendor_activity_at,
+                    case
+                        when cy.candidate_id_source = 'gp_api'
+                        then greatest(cy.created_at, cy.updated_at)
+                    end
+                ),
+                greatest(cy.created_at, cy.updated_at)
+            ) as feed_activity_at,
             e.population,
             e.city,
             e.district,
@@ -164,9 +187,8 @@ with
             {{ ref("int__civics_candidacy_techspeed") }} as ts_int
             on cy.gp_candidacy_id = ts_int.gp_candidacy_id
         where
-            greatest(cy.created_at, cy.updated_at) >= current_date() - interval 30 day
             -- HS-eligible: has email or phone
-            and (
+            (
                 (c.email is not null and c.email != '')
                 or (c.phone_number is not null and c.phone_number != '')
             )
@@ -182,6 +204,16 @@ with
             and cy.hubspot_contact_id is null
     ),
 
+    -- Recency filter lives here rather than in civics_base's WHERE so the window
+    -- basis is defined exactly once: the same expression is filtered on and
+    -- emitted, and the two cannot drift apart. The candidacy-only predicates stay
+    -- above, where they still push down to the scan.
+    in_window as (
+        select *
+        from civics_base
+        where feed_activity_at >= current_date() - interval 30 day
+    ),
+
     -- Not-already-in-HubSpot, as three hash anti-joins instead of one correlated
     -- `not exists` that ORs the three keys together. Spark cannot hash-join an OR
     -- across disjoint keys, so the OR form planned as a
@@ -189,7 +221,7 @@ with
     -- against every HubSpot contact, with the phone regexp re-evaluated per pair.
     not_in_hubspot as (
         select b.*
-        from civics_base as b
+        from in_window as b
         left join hs_email_keys as he on b.hs_email_key = he.email_key
         left join hs_phone_keys as hp on b.hs_phone_key = hp.phone_key
         left join hs_br_candidacy_ids as hb on b.hs_br_candidacy_id = hb.br_candidacy_id
@@ -326,5 +358,7 @@ select
         )
     ) as election_year,
     b.election_stage,
-    greatest(b.created_at, b.updated_at) as last_activity_at
+    -- Name kept: ops sorts and filters on it. Only the basis improves -- it is now
+    -- the provider event time rather than the pipeline extract stamp.
+    b.feed_activity_at as last_activity_at
 from not_in_hubspot as b

--- a/dbt/project/models/marts/sales_reverse_etl/candidacy_techspeed.sql
+++ b/dbt/project/models/marts/sales_reverse_etl/candidacy_techspeed.sql
@@ -8,9 +8,13 @@
 -- Appended: match-back key (candidate_code), reverse-ETL tracking-key inputs
 -- (election_year, election_stage), gp_candidacy_id, is_keyable, last_activity_at.
 --
--- WINDOW: 16-day rolling on greatest(created_at, updated_at) -- interim/manual-era
--- dedup; the reverse-ETL sent_log anti-join replaces it later (the ALREADY-SENT swap
--- point below).
+-- WINDOW: 16-day rolling on feed_activity_at -- interim/manual-era dedup; the
+-- reverse-ETL sent_log anti-join replaces it later (the ALREADY-SENT swap point
+-- below). feed_activity_at is the latest real provider EVENT time: for vendor-sourced
+-- rows created_at/updated_at are pipeline extract stamps, so a vendor re-delivering
+-- its whole file re-stamps its entire universe as active today and floods this feed.
+-- The vendor intermediates' additive vendor_activity_at columns carry the event time
+-- instead; gp_api rows already carry real product timestamps.
 with
     civics_base as (
         select
@@ -34,13 +38,34 @@ with
             e.seats_available,
             br_int.br_candidacy_id,
             br_int.br_race_id,
-            br_int.br_position_database_id
+            br_int.br_position_database_id,
+            -- Destination-facing recency: greatest available provider EVENT time,
+            -- falling back to the extract-stamped canonical timestamps only where
+            -- no provider supplies one (DDHQ-only rows). Both greatest() calls
+            -- skip nulls, so the fallback fires only when every leg is null,
+            -- which keeps this non-null.
+            coalesce(
+                greatest(
+                    br_int.vendor_activity_at,
+                    ts_int.vendor_activity_at,
+                    case
+                        when cy.candidate_id_source = 'gp_api'
+                        then greatest(cy.created_at, cy.updated_at)
+                    end
+                ),
+                greatest(cy.created_at, cy.updated_at)
+            ) as feed_activity_at
         from {{ ref("candidacy") }} as cy
         join {{ ref("candidate") }} as c on cy.gp_candidate_id = c.gp_candidate_id
         left join {{ ref("election") }} as e on cy.gp_election_id = e.gp_election_id
         left join
             {{ ref("int__civics_candidacy_ballotready") }} as br_int
             on cy.gp_candidacy_id = br_int.gp_candidacy_id
+        -- LEFT JOIN, never INNER: an INNER join here silently collapses this
+        -- provider-agnostic feed to TechSpeed-sourced candidacies only.
+        left join
+            {{ ref("int__civics_candidacy_techspeed") }} as ts_int
+            on cy.gp_candidacy_id = ts_int.gp_candidacy_id
         where
             -- missing at least one of email/phone (legacy: phone='' OR email='')
             not (
@@ -60,9 +85,6 @@ with
                 cy.general_election_date > current_date() + interval 3 day
                 or cy.primary_election_date > current_date() + interval 3 day
             )
-            -- 16-day rolling window
-            and greatest(cy.created_at, cy.updated_at)
-            >= current_date() - interval 16 day
             -- belt-and-suspenders not-already-in-HubSpot
             and cy.hubspot_contact_id is null
             and not exists (
@@ -93,6 +115,15 @@ with
             -- has already touched -- the most current source signal that they hold
             -- the data.
             and not array_contains(cy.source_systems, 'techspeed')
+    ),
+
+    -- Recency filter lives here rather than in civics_base's WHERE so the window
+    -- basis is defined exactly once: the same expression is filtered on and
+    -- emitted, and the two cannot drift apart.
+    in_window as (
+        select *
+        from civics_base
+        where feed_activity_at >= current_date() - interval 16 day
     )
 
 select
@@ -180,5 +211,7 @@ select
     end as election_stage,
     b.gp_candidacy_id,
     b.gp_candidate_id,
-    greatest(b.created_at, b.updated_at) as last_activity_at
-from civics_base as b
+    -- Name kept: ops sorts and filters on it. Only the basis improves -- it is now
+    -- the provider event time rather than the pipeline extract stamp.
+    b.feed_activity_at as last_activity_at
+from in_window as b

--- a/dbt/project/models/marts/sales_reverse_etl/candidacy_techspeed.sql
+++ b/dbt/project/models/marts/sales_reverse_etl/candidacy_techspeed.sql
@@ -13,8 +13,12 @@
 -- below). feed_activity_at is the latest real provider EVENT time: for vendor-sourced
 -- rows created_at/updated_at are pipeline extract stamps, so a vendor re-delivering
 -- its whole file re-stamps its entire universe as active today and floods this feed.
--- The vendor intermediates' additive vendor_activity_at columns carry the event time
--- instead; gp_api rows already carry real product timestamps.
+-- The BallotReady intermediate's additive vendor_activity_at column carries the event
+-- time instead; gp_api rows already carry real product timestamps. There is no
+-- TechSpeed leg -- the ALREADY-SENT filter below excludes exactly the candidacies one
+-- could match -- so this feed's recency is BallotReady's event time or the canonical
+-- fallback. The window is bounded above as well, since the non-vendor legs are not
+-- clamped and one future-dated value would otherwise never leave the window.
 with
     civics_base as (
         select
@@ -41,13 +45,17 @@ with
             br_int.br_position_database_id,
             -- Destination-facing recency: greatest available provider EVENT time,
             -- falling back to the extract-stamped canonical timestamps only where
-            -- no provider supplies one (DDHQ-only rows). Both greatest() calls
-            -- skip nulls, so the fallback fires only when every leg is null,
-            -- which keeps this non-null.
+            -- no provider supplies one. greatest() skips nulls, so the fallback
+            -- fires only when every leg is null, which keeps this non-null.
+            --
+            -- No TechSpeed leg here, deliberately: the ALREADY-SENT filter below
+            -- keeps only candidacies with no 'techspeed' in source_systems, and
+            -- the candidacy mart sets that flag exactly when a row exists in the
+            -- TechSpeed intermediate -- so a join to it can never match. Add the
+            -- leg back when that filter becomes the sent_log anti-join.
             coalesce(
                 greatest(
                     br_int.vendor_activity_at,
-                    ts_int.vendor_activity_at,
                     case
                         when cy.candidate_id_source = 'gp_api'
                         then greatest(cy.created_at, cy.updated_at)
@@ -61,11 +69,6 @@ with
         left join
             {{ ref("int__civics_candidacy_ballotready") }} as br_int
             on cy.gp_candidacy_id = br_int.gp_candidacy_id
-        -- LEFT JOIN, never INNER: an INNER join here silently collapses this
-        -- provider-agnostic feed to TechSpeed-sourced candidacies only.
-        left join
-            {{ ref("int__civics_candidacy_techspeed") }} as ts_int
-            on cy.gp_candidacy_id = ts_int.gp_candidacy_id
         where
             -- missing at least one of email/phone (legacy: phone='' OR email='')
             not (
@@ -123,7 +126,13 @@ with
     in_window as (
         select *
         from civics_base
-        where feed_activity_at >= current_date() - interval 16 day
+        where
+            feed_activity_at >= current_date() - interval 16 day
+            -- Bounded above as well: gp_api product timestamps and the canonical
+            -- fallback are not clamped the way the vendor legs are, and a single
+            -- future-dated value would otherwise satisfy the lower bound forever,
+            -- putting one row on every export indefinitely.
+            and feed_activity_at <= current_date() + interval 1 day
     )
 
 select

--- a/dbt/project/tests/assert_candidacy_hubspot_vendor_recency_basis.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_vendor_recency_basis.sql
@@ -12,18 +12,14 @@
 -- time; and it has no date arithmetic, so it cannot false-fail when tests run a day
 -- or more after the table was built.
 --
--- greatest() skips nulls on Spark, so rows with no vendor leg at all (DDHQ-only, and
--- the null-vendor tail) drop out on the is-not-null guard. Those keep status-quo
+-- greatest() skips nulls on Spark, so rows where no provider supplied an event time
+-- yield null and the inequality below filters them out. Those keep status-quo
 -- behavior by design and are not asserted here.
 --
 -- gp_api rows are excluded because their leg IS the canonical product timestamps, so
 -- for them the emitted value legitimately differs from the vendor legs. The source is
 -- read from candidacy_scored, the same relation the model gates on, rather than from
 -- the feed's Title-Case import-contract column, which ops owns and may relabel.
---
--- Residual, named so nobody assumes otherwise: this cannot detect the clamp itself
--- regressing to extract time, because the emitted value and vendor_activity_at would
--- move together. The warn-severity check on the intermediate covers that.
 select
     f.gp_candidacy_id,
     f.last_activity_at,
@@ -38,5 +34,4 @@ left join
     on f.gp_candidacy_id = ts.gp_candidacy_id
 where
     coalesce(cy.candidate_id_source, '') != 'gp_api'
-    and greatest(br.vendor_activity_at, ts.vendor_activity_at) is not null
     and f.last_activity_at != greatest(br.vendor_activity_at, ts.vendor_activity_at)

--- a/dbt/project/tests/assert_candidacy_hubspot_vendor_recency_basis.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_vendor_recency_basis.sql
@@ -1,34 +1,42 @@
--- A vendor record that was merely re-delivered unchanged must not read as recent
--- activity. BallotReady began re-sending its entire candidate file weekly, and
--- because the vendor intermediates stamp created_at/updated_at from the pipeline's
--- extract time, each re-delivery re-marked the whole vendor universe as active
--- today and flooded this feed with thousands of long-dormant candidacies. The
--- window now runs on the vendor's own event time, so no row may be in the feed
--- whose only claim to being in-window is the extract stamp.
+-- Wherever a vendor supplies an event time, the feed's emitted recency MUST be that
+-- event time -- never the pipeline's extract stamp. That is the incident this fix
+-- exists to prevent: the vendor began re-sending its whole candidate file weekly, and
+-- because the intermediates stamp created_at/updated_at from extract time, each
+-- re-delivery re-marked the entire vendor universe as active today and flooded this
+-- feed with long-dormant candidacies.
 --
--- This is not a restatement of the model's WHERE clause: it asserts against the
--- intermediates' vendor_activity_at, so it also fires if a vendor join is dropped,
--- if the clamp starts overwriting vendor time with extract time, or if the window
--- basis is reverted while the emitted column is left alone. The intermediates'
--- not_null tests on vendor_activity_at keep it from passing vacuously.
+-- Stated as an identity rather than a staleness cutoff, which buys three things:
+-- it covers every row with a vendor leg instead of only the BallotReady-only ones;
+-- it fires if the window basis is reverted to the canonical timestamps, or if either
+-- vendor join is dropped, because both make the emitted value fall back to extract
+-- time; and it has no date arithmetic, so it cannot false-fail when tests run a day
+-- or more after the table was built.
 --
--- gp_api rows are excluded because their leg of the recency expression is a real
--- product timestamp, so one can legitimately be in-window with a stale vendor leg.
--- DDHQ-only rows have no vendor leg at all and keep status-quo behavior; the inner
--- join below already leaves them out.
+-- greatest() skips nulls on Spark, so rows with no vendor leg at all (DDHQ-only, and
+-- the null-vendor tail) drop out on the is-not-null guard. Those keep status-quo
+-- behavior by design and are not asserted here.
 --
--- 31 rather than 30 days: model and test can straddle a midnight rollover, which
--- moves current_date() forward a day between them. The cohort this guards is
--- months stale, so a day of slack costs nothing.
-select f.gp_candidacy_id, f.last_activity_at, br.vendor_activity_at
+-- gp_api rows are excluded because their leg IS the canonical product timestamps, so
+-- for them the emitted value legitimately differs from the vendor legs. The source is
+-- read from candidacy_scored, the same relation the model gates on, rather than from
+-- the feed's Title-Case import-contract column, which ops owns and may relabel.
+--
+-- Residual, named so nobody assumes otherwise: this cannot detect the clamp itself
+-- regressing to extract time, because the emitted value and vendor_activity_at would
+-- move together. The warn-severity check on the intermediate covers that.
+select
+    f.gp_candidacy_id,
+    f.last_activity_at,
+    greatest(br.vendor_activity_at, ts.vendor_activity_at) as vendor_basis
 from {{ ref("candidacy_hubspot") }} as f
-inner join
+inner join {{ ref("candidacy_scored") }} as cy on f.gp_candidacy_id = cy.gp_candidacy_id
+left join
     {{ ref("int__civics_candidacy_ballotready") }} as br
     on f.gp_candidacy_id = br.gp_candidacy_id
 left join
     {{ ref("int__civics_candidacy_techspeed") }} as ts
     on f.gp_candidacy_id = ts.gp_candidacy_id
 where
-    f.`Candidate ID Source` != 'gp_api'
-    and br.vendor_activity_at < current_date() - interval 31 day
-    and ts.vendor_activity_at is null
+    coalesce(cy.candidate_id_source, '') != 'gp_api'
+    and greatest(br.vendor_activity_at, ts.vendor_activity_at) is not null
+    and f.last_activity_at != greatest(br.vendor_activity_at, ts.vendor_activity_at)

--- a/dbt/project/tests/assert_candidacy_hubspot_vendor_recency_basis.sql
+++ b/dbt/project/tests/assert_candidacy_hubspot_vendor_recency_basis.sql
@@ -1,0 +1,34 @@
+-- A vendor record that was merely re-delivered unchanged must not read as recent
+-- activity. BallotReady began re-sending its entire candidate file weekly, and
+-- because the vendor intermediates stamp created_at/updated_at from the pipeline's
+-- extract time, each re-delivery re-marked the whole vendor universe as active
+-- today and flooded this feed with thousands of long-dormant candidacies. The
+-- window now runs on the vendor's own event time, so no row may be in the feed
+-- whose only claim to being in-window is the extract stamp.
+--
+-- This is not a restatement of the model's WHERE clause: it asserts against the
+-- intermediates' vendor_activity_at, so it also fires if a vendor join is dropped,
+-- if the clamp starts overwriting vendor time with extract time, or if the window
+-- basis is reverted while the emitted column is left alone. The intermediates'
+-- not_null tests on vendor_activity_at keep it from passing vacuously.
+--
+-- gp_api rows are excluded because their leg of the recency expression is a real
+-- product timestamp, so one can legitimately be in-window with a stale vendor leg.
+-- DDHQ-only rows have no vendor leg at all and keep status-quo behavior; the inner
+-- join below already leaves them out.
+--
+-- 31 rather than 30 days: model and test can straddle a midnight rollover, which
+-- moves current_date() forward a day between them. The cohort this guards is
+-- months stale, so a day of slack costs nothing.
+select f.gp_candidacy_id, f.last_activity_at, br.vendor_activity_at
+from {{ ref("candidacy_hubspot") }} as f
+inner join
+    {{ ref("int__civics_candidacy_ballotready") }} as br
+    on f.gp_candidacy_id = br.gp_candidacy_id
+left join
+    {{ ref("int__civics_candidacy_techspeed") }} as ts
+    on f.gp_candidacy_id = ts.gp_candidacy_id
+where
+    f.`Candidate ID Source` != 'gp_api'
+    and br.vendor_activity_at < current_date() - interval 31 day
+    and ts.vendor_activity_at is null

--- a/dbt/project/tests/assert_candidacy_techspeed_vendor_recency_basis.sql
+++ b/dbt/project/tests/assert_candidacy_techspeed_vendor_recency_basis.sql
@@ -1,34 +1,27 @@
--- The sibling of assert_candidacy_hubspot_vendor_recency_basis, for the other feed.
--- A vendor record that was merely re-delivered unchanged must not read as recent
--- activity here either. This feed has its own window predicate and its own vendor
--- joins, so the sibling test does not cover it: a reverted window basis or a dropped
--- vendor join on this model alone would otherwise go unnoticed.
+-- The sibling of assert_candidacy_hubspot_vendor_recency_basis, for the other feed:
+-- wherever a vendor supplies an event time, this feed's emitted recency MUST be that
+-- event time and never the pipeline's extract stamp. This model has its own window
+-- predicate and its own vendor join, so the sibling test does not cover it.
 --
--- Asserted against the intermediates' vendor_activity_at rather than the model's own
--- filter, so it also fires if the clamp starts overwriting vendor time with extract
--- time. The intermediates' not_null tests on that column keep it from passing
--- vacuously.
+-- Only the BallotReady leg is asserted because it is the only vendor leg this feed
+-- has: the ALREADY-SENT filter keeps candidacies with no 'techspeed' in
+-- source_systems, and the candidacy mart sets that flag exactly when a row exists in
+-- the TechSpeed intermediate, so a TechSpeed leg here can never be populated. When
+-- that filter becomes the sent_log anti-join, add the leg to both the model and here.
 --
--- gp_api rows are excluded because their leg of the recency expression is a real
--- product timestamp, so one can legitimately be in-window with a stale vendor leg.
--- This feed does not emit the source (its column contract is fixed), so the source
--- comes from the candidacy mart.
+-- Stated as an identity rather than a staleness cutoff, so it covers every row with a
+-- vendor leg, fires if the window basis is reverted or the vendor join dropped, and
+-- carries no date arithmetic that could false-fail when tests run after the build day.
 --
--- 17 rather than 16 days: model and test can straddle a midnight rollover, which
--- moves current_date() forward a day between them. The cohort this guards is months
--- stale, so a day of slack costs nothing.
+-- gp_api rows are excluded because their leg IS the canonical product timestamps. The
+-- source is read from the candidacy mart, the relation this model gates on; this
+-- feed's own output cannot carry it, because its 42-column shape is a fixed contract.
 select f.gp_candidacy_id, f.last_activity_at, br.vendor_activity_at
 from {{ ref("candidacy_techspeed") }} as f
+inner join {{ ref("candidacy") }} as cy on f.gp_candidacy_id = cy.gp_candidacy_id
 inner join
     {{ ref("int__civics_candidacy_ballotready") }} as br
     on f.gp_candidacy_id = br.gp_candidacy_id
-inner join {{ ref("candidacy") }} as cy on f.gp_candidacy_id = cy.gp_candidacy_id
-left join
-    {{ ref("int__civics_candidacy_techspeed") }} as ts
-    on f.gp_candidacy_id = ts.gp_candidacy_id
 where
-    -- coalesce, not a bare !=: candidate_id_source is nullable on the mart, and a
-    -- bare comparison would silently drop null-source rows from the guard.
     coalesce(cy.candidate_id_source, '') != 'gp_api'
-    and br.vendor_activity_at < current_date() - interval 17 day
-    and ts.vendor_activity_at is null
+    and f.last_activity_at != br.vendor_activity_at

--- a/dbt/project/tests/assert_candidacy_techspeed_vendor_recency_basis.sql
+++ b/dbt/project/tests/assert_candidacy_techspeed_vendor_recency_basis.sql
@@ -1,0 +1,34 @@
+-- The sibling of assert_candidacy_hubspot_vendor_recency_basis, for the other feed.
+-- A vendor record that was merely re-delivered unchanged must not read as recent
+-- activity here either. This feed has its own window predicate and its own vendor
+-- joins, so the sibling test does not cover it: a reverted window basis or a dropped
+-- vendor join on this model alone would otherwise go unnoticed.
+--
+-- Asserted against the intermediates' vendor_activity_at rather than the model's own
+-- filter, so it also fires if the clamp starts overwriting vendor time with extract
+-- time. The intermediates' not_null tests on that column keep it from passing
+-- vacuously.
+--
+-- gp_api rows are excluded because their leg of the recency expression is a real
+-- product timestamp, so one can legitimately be in-window with a stale vendor leg.
+-- This feed does not emit the source (its column contract is fixed), so the source
+-- comes from the candidacy mart.
+--
+-- 17 rather than 16 days: model and test can straddle a midnight rollover, which
+-- moves current_date() forward a day between them. The cohort this guards is months
+-- stale, so a day of slack costs nothing.
+select f.gp_candidacy_id, f.last_activity_at, br.vendor_activity_at
+from {{ ref("candidacy_techspeed") }} as f
+inner join
+    {{ ref("int__civics_candidacy_ballotready") }} as br
+    on f.gp_candidacy_id = br.gp_candidacy_id
+inner join {{ ref("candidacy") }} as cy on f.gp_candidacy_id = cy.gp_candidacy_id
+left join
+    {{ ref("int__civics_candidacy_techspeed") }} as ts
+    on f.gp_candidacy_id = ts.gp_candidacy_id
+where
+    -- coalesce, not a bare !=: candidate_id_source is nullable on the mart, and a
+    -- bare comparison would silently drop null-source rows from the guard.
+    coalesce(cy.candidate_id_source, '') != 'gp_api'
+    and br.vendor_activity_at < current_date() - interval 17 day
+    and ts.vendor_activity_at is null


### PR DESCRIPTION
## Problem

Both sales export feeds windowed and emitted "recent activity" as
`greatest(created_at, updated_at)`. On the BallotReady and TechSpeed intermediates those
two columns are *both* set to the Airbyte extraction timestamp, so they tracked when the
pipeline last saw a record rather than when anything happened to the candidacy.

BallotReady switched to re-sending its entire candidate file weekly. In the 2026+ slice of
BR staging, **101,373 of 103,823 rows carry a single extract day**, against a prior
weekly-delta norm of 8-319 rows:

| Extract day | Rows |
|---|---|
| 2026-08-17 | 101,373 |
| 2026-08-10 | 82 |
| 2026-08-03 | 58 |
| 2026-07-27 | 8 |
| 2026-07-20 | 23 |

Every weekly sync therefore re-marked the whole vendor universe as active today and
flooded both exports with long-dormant candidacies, which produced duplicate contacts in
HubSpot. The vendor's own `candidacy_updated_at` is untouched by re-delivery — on the same
rows it spreads across ten months — so the real signal was there all along and being
discarded.

## Change

Destination-facing only. **Canonical `created_at` / `updated_at` are not redefined** —
they feed every civics consumer through the provider precedence chain, so the blast radius
of changing them is the whole mart.

**1. New additive `vendor_activity_at` on both vendor intermediates,** carrying the
vendor's own event time: `candidacy_updated_at` for BallotReady (falling back to that
vendor's `candidacy_created_at` where the update time sits implausibly later than the row's
extract stamp, with a day of slack for ordinary clock skew), and the form's
`date_processed` for TechSpeed. `max()`-rolled to the candidacy grain, then re-maxed at the
published `gp_candidacy_id` grain so the dedup picker cannot discard a colliding rollup
group's value.

**Nullable by design.** Null means the provider supplied no usable event time. Extract time
is deliberately *not* substituted: as a non-null value it would outrank a correctly-dated
sibling provider wherever consumers take the greatest across providers, so an unparsed row
would beat an accurate one, and the next full-file re-delivery would sweep the whole
unparsed cohort back into the window at once.

**2. Both feeds window on, and emit, `feed_activity_at`:**

```sql
coalesce(
    greatest(br_vendor_activity_at, ts_vendor_activity_at, gp_api_case),
    greatest(created_at, updated_at)
)
```

`greatest()` skips nulls on Spark, so the coalesce fires only where no provider supplies an
event time — DDHQ-only and null-vendor rows, which keep documented status-quo behavior. The
window is bounded above as well as below: the gp_api leg and the canonical fallback are not
clamped, and one future-dated value would otherwise satisfy the lower bound forever.

**3. `candidacy_techspeed` has no TechSpeed leg, deliberately.** The candidacy mart sets
`'techspeed'` in `source_systems` exactly when a row exists in that intermediate, and this
model's ALREADY-SENT filter keeps only candidacies without it, so such a join can never
match (verified 0 of 2,030 rows). It becomes live when that filter becomes the sent_log
anti-join; a comment in the model records that.

**4. The emitted column keeps the name `last_activity_at`** in both feeds. Ops already
sorts and filters on it; the semantics improve, the contract does not break.

### Why the recency filter sits in its own CTE

It is defined once and both filtered on and emitted, so the two cannot drift apart — drift
between exactly those is the defect class being fixed. This costs real work: the old basis
referenced only the candidacy relation so it pushed into that scan, while the new one spans
the vendor intermediates and cannot push below them wherever it is written. The remaining
candidacy-only predicates still push down. See runtime below.

## Verification

`dbt build --favor-state` over the four changed models: **PASS=57, WARN=1, ERROR=0,
SKIP=0.** The one warning is the pre-existing
`assert_candidacy_hubspot_candidate_code_collision` at 2 rows, against 105 colliding codes
in prod under the old basis.

### Before / after

Each feed's **compiled** SQL run twice against identical upstream relations and the same
`current_date()`, swapping only the window basis so both arms keep an identical window
structure. The delta is attributable to the basis and nothing else.

| Feed | Before (extract-stamp basis) | After (vendor-event basis) | Delta |
|---|---|---|---|
| `candidacy_hubspot` | 7,102 | 4,190 | −2,912 (−41.0%) |
| `candidacy_techspeed` | 3,130 | 2,025 | −1,105 (−35.3%) |

### The recency is now entirely vendor-derived

| Measure | Result |
|---|---|
| `candidacy_hubspot` rows | 4,190 |
| …resolving to a real vendor event time | **4,190 (100%)** |
| …resolving to the extract-stamp fallback | **0** |
| Future-dated rows, either feed | **0** |
| Rows outside their own window, either feed | **0** |

Per-source composition of the surviving cohorts:

| Feed | Source | Rows | Activity range |
|---|---|---|---|
| `candidacy_hubspot` | ballotready | 1,754 | 2026-07-20 → 2026-08-16 |
| `candidacy_hubspot` | techspeed | 2,436 | 2026-07-20 → 2026-08-07 |
| `candidacy_techspeed` | (all) | 2,025 | 2026-08-02 → 2026-08-15 |

Every surviving row has genuine vendor activity inside its window, and the TechSpeed-return
cohort is retained.

## Operational notes

**Runtime.** Multiple samples, because a single cold build is misleading here:

| Model | Prod baseline | This branch (dev CTAS samples) |
|---|---|---|
| `candidacy_hubspot` | 22s (post anti-join refactor) | 23s, 24s, 39s, 34s |
| `candidacy_techspeed` | 48s min / 79s avg / 138s max over 25 builds | 113s, 65s, 61s, 60s |
| `int__civics_candidacy_ballotready` | not previously reported | ~27s |
| `int__civics_candidacy_techspeed` | not previously reported | ~28s |

`candidacy_techspeed`'s steady state (~60s) sits **inside** its existing prod band. An
earlier revision of this description reported 148s as a roughly 2x regression; that was a
cold first build, not a trend. `candidacy_hubspot` rises modestly from a 22s base. The
window predicate no longer prunes at the scan, so the join tree does process more rows, but
the measured cost is smaller than that suggests.

**Both feeds emit substantially fewer rows**, which is the point, but the first post-merge
run will look like a large volume drop to anyone watching export counts rather than the
incident.

**Uneven resolution.** TechSpeed captures a date, not a time, so 58.2% of
`candidacy_hubspot` rows land at midnight and sorting on `last_activity_at` ties within a
day. Stated in the column descriptions.

**Match-back completeness falls.** Rows with neither `candidate_code` nor `candidacy_id` go
from 9.8% to 15.3%, because event-time recency selects for TechSpeed-only rows over
BallotReady ones. A composition effect distinct from the volume drop: ops can reconcile
outcomes back to civics for a smaller share of the export, falling back to the internal
`gp_candidacy_id`.

**Reproducing locally** needs `--favor-state`. Without it, dbt Cloud's deferral prefers a
relation that already exists in your dev schema over production's, and a stale copy of
`stg_airbyte_source__techspeed_gdrive_candidates` predating `date_processed_date` fails the
build with `UNRESOLVED_COLUMN`. CI is unaffected — a fresh preview schema has nothing to
shadow.

## Tests

- **One singular regression test per feed, stated as a basis identity**: wherever a vendor
  supplies an event time, the feed's emitted recency must equal it, never the pipeline's
  extract stamp. Phrasing it as an identity rather than a staleness cutoff means it covers
  every row with a vendor leg (100% of the feed, 0 violations), fires if the window basis is
  reverted or either vendor join is dropped, and carries no date arithmetic that could
  false-fail when tests run after the build day. gp_api rows are excluded because their leg
  *is* the canonical product timestamps.
- `not_null` on the emitted `last_activity_at` in both feeds.
- No test mirrors a model's `WHERE` clause.

## Review history

Three rounds beyond the initial delegate pass: the delegate reviewer, Cursor Bugbot, an
independent model via the Codex CLI, and two high-effort in-repo review passes. They found
four real defects that CI and the first approval both missed, and corrected several claims
in earlier versions of this description. Every accepted finding, every decline with its
reason, and the owner decisions are recorded in the ticket's decision ledger so later rounds
cannot silently re-litigate them.

What the rounds changed, briefly:

1. The future-date clamp anchored to `_airbyte_extracted_at`, which is *last*-seen on an
   id-deduped table and so advances weekly — it did not deliver its own stated intent.
   Re-anchored to vendor-owned timestamps.
2. The dead TechSpeed join (above), and a regression test that asserted 630 of 4,245 rows
   while being structurally blind to the TechSpeed leg. Both tests rewritten as identities.
3. The extract-time substitution described above, which reintroduced the incident through
   the column built to remove it. Removing it also deleted three tests round 2 had added,
   including one that was itself unsound: it compared the fallback's `max()` of the extract
   stamp against `updated_at`'s `any_value()` of the same column, so it passed green for the
   22% of rollup groups spanning more than one extract.

## Known residuals and accepted tradeoffs

- **Eligibility narrows.** Because `sent_log` does not exist yet, the recency window is
  simultaneously the dedup mechanism and the eligibility gate, so tightening recency also
  narrows eligibility for leads not already in HubSpot. The "correctly suppressed re-send"
  and "never-sent new lead" halves cannot be separated without first-seen data, which this
  pipeline does not retain. **Accepted as a known tradeoff by the owner**, on the grounds
  that sent_log lands within a few sprints and separates the two concerns properly.
- **DDHQ still windows on extract stamps.** That intermediate exposes no event-time column,
  so DDHQ-only rows fall through to the canonical fallback — 538 reach this feed's base, 530
  sharing a single day, which is the bulk-restamp signature. The spec accepts status-quo for
  providers with no event time; closing it needs a DDHQ event-time column and is a separate
  ticket.
- **A future-dated row is excluded rather than capped**, so it is silently absent instead of
  visibly wrong. Capping was rejected because the only available anchor advances daily,
  which would re-cap the row fresh on every build and send it forever. 0 rows affected.
- **Routed as follow-ups:** the staging `date_processed` parse rule (accepts slash- but not
  hyphen-separated dates; recovers 3,757 of 6,335 unparsed rows), casting
  `candidacy_updated_at` in staging rather than the intermediate, moving the recency
  expression into `candidacy.sql`, and converting `candidacy_techspeed`'s correlated OR
  anti-join to the three hash anti-joins `candidacy_hubspot` already uses.

## Out of scope

`sent_log`, the person-graph email/phone tiers, any change to canonical `created_at` /
`updated_at`, the wider `any_value` determinism cleanup, and `added_to_mart_at` (already
documented as misleading and retired with the reverse-ETL work).
